### PR TITLE
perf(dashboard): index webhook receipt expiry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Indexed webhook receipt expiry by receipt time to avoid scanning and sorting retained history on each accepted delivery, preserving 30-day retention and transactional cleanup.
 - Bounded apply/proof/comment-sync record retention to selected records and paired dependencies, avoiding unrelated archive loads during ledger finalization without changing close guards.
 - Kept projected GitHub reads out of the durable ETag cache so incompatible response shapes cannot hide requested reviewers from close guards. Thanks @goutamadwant! (#1242)
 - Normalized unexpected exact-review failures at the Worker boundary without weakening Durable Object transaction rollback. Thanks @yetval and @vincentkoc! (#1240)

--- a/dashboard/github-webhook-read-model.ts
+++ b/dashboard/github-webhook-read-model.ts
@@ -272,6 +272,10 @@ export class GithubWebhookReadModelStore {
        ) STRICT`,
     );
     this.storage.sql.exec(
+      `CREATE INDEX IF NOT EXISTS github_webhook_read_model_deliveries_received_at_v1
+         ON github_webhook_read_model_deliveries_v1 (received_at)`,
+    );
+    this.storage.sql.exec(
       `CREATE TABLE IF NOT EXISTS github_webhook_read_model_classes_v1 (
          event_class TEXT PRIMARY KEY,
          delivery_count INTEGER NOT NULL CHECK (delivery_count > 0),

--- a/docs/github-webhook-read-model.md
+++ b/docs/github-webhook-read-model.md
@@ -4,7 +4,7 @@
 - Owner: ClawSweeper dashboard and queue maintainers
 - Source of truth: `dashboard/github-webhook-read-model.ts`, `dashboard/worker.ts`, and `dashboard/exact-review-queue.ts`
 - Last verified: this document's repository revision
-- Update when: ingress coverage, App subscriptions, snapshot schema, TTLs, repair policy, or consumer safety boundaries change
+- Update when: ingress coverage, App subscriptions, snapshot schema or indexes, TTLs, repair policy, or consumer safety boundaries change
 
 The queue Durable Object materializes signed GitHub App deliveries into a bounded, freshness-labelled read model. It serves planning, discovery, hydration, and dashboard reads through publisher-HMAC endpoints. Each response says which webhook watermark it represents, whether the required event class has ever been observed, and whether the object is stale.
 
@@ -27,13 +27,23 @@ Subscription readiness is detected per event class. A class remains unavailable 
 
 ## Stored schema and bounds
 
-The Durable Object assigns one monotonic repository-wide watermark to every unique GitHub delivery GUID. Per-object rows retain the source `updated_at`, delivery GUID, object watermark, receipt time, and normalized JSON. Older or duplicate deliveries can advance the global observation watermark but cannot replace a newer object row.
+The Durable Object assigns one monotonic repository-wide watermark to every unique GitHub delivery GUID. Per-object rows retain the source `updated_at`, delivery GUID, object watermark, receipt time, and normalized JSON. Older deliveries with previously unseen GUIDs advance the global observation watermark but cannot replace a newer object row.
 
 - One item row per repository and issue/PR number.
 - Comments ordered by numeric ID, including deletion tombstones; at most 500 rows per item and 64 KiB per comment body.
 - Reviews and inline review comments stored separately with tombstones, counts, and a stable activity digest; at most 500 rows per item.
 - Workflow runs, jobs, check runs, and check suites; at most 1,000 current/recent objects.
 - Delivery GUID receipts retained for 30 days.
+
+Receipt cleanup uses a single-column `received_at` index, added idempotently by
+the store initializer for both new and existing databases. Each accepted unique
+delivery and repair still prunes at most 256 receipts strictly older than the
+30-day cutoff, ordered by receipt time; equal timestamps have no specified tie
+order. Retained GUIDs return their original watermark without pruning, and a
+GUID can be accepted again after its receipt is pruned. The index changes only
+the SQLite access path, not retention, constraints, transaction rollback, or
+the public read-model contract. Building it on existing history has a one-time
+initialization cost and adds storage and receipt-write work.
 
 Item snapshots are stale after 15 minutes, comment and review collections after 30 minutes, and workflow state after 5 minutes. Placeholder discovery additionally requires a successful repair census within 6 hours. Missing, stale, incomplete, unsubscribed, or gap-detected snapshots fall back to GitHub and repair the Durable Object before later reads reuse it.
 

--- a/scripts/proof-webhook-expiry-index.mjs
+++ b/scripts/proof-webhook-expiry-index.mjs
@@ -1,0 +1,509 @@
+// Local production-store proof. Usage: node scripts/proof-webhook-expiry-index.mjs BASE_SHA /tmp/FRESH_DIR
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { copyFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const [baseRef, outputPath, extra] = process.argv.slice(2);
+assert.ok(baseRef && outputPath && !extra, "expected BASE_SHA and a fresh /tmp output directory");
+assert.equal(process.version, "v24.19.0", "use the measured Node 24.19 runtime");
+const out = path.resolve(outputPath);
+assert.ok(out.startsWith("/tmp/") || out.startsWith(`${os.tmpdir()}/`), "output must be temporary");
+mkdirSync(out); // Fail if output exists: never overwrite earlier evidence.
+const git = (...args) => execFileSync("git", args, { cwd: root, encoding: "utf8" }).trim();
+const base = git("rev-parse", "--verify", `${baseRef}^{commit}`);
+const hash = (bytes) => createHash("sha256").update(bytes).digest("hex");
+const save = (name, value) =>
+  writeFileSync(path.join(out, name), JSON.stringify(value, null, 2) + "\n", { flag: "wx" });
+const table = "github_webhook_read_model_deliveries_v1";
+const index = "github_webhook_read_model_deliveries_received_at_v1";
+const meta = "github_webhook_read_model_meta_v1";
+const classes = "github_webhook_read_model_classes_v1";
+const items = "github_webhook_read_model_items_v1";
+const workflows = "github_webhook_read_model_workflows_v1";
+const now = Date.parse("2026-08-26T12:00:00Z");
+const cutoff = now - 30 * 24 * 60 * 60_000;
+const sources = ["dashboard/github-webhook-read-model.ts", "src/stable-json.ts"];
+const manifest = {
+  base,
+  head: git("rev-parse", "HEAD"),
+  sources: {},
+  harnessSha256: hash(readFileSync(fileURLToPath(import.meta.url))),
+};
+const modules = {};
+for (const variant of ["baseline", "patched"]) {
+  const dir = path.join(out, variant);
+  mkdirSync(dir);
+  writeFileSync(path.join(dir, "package.json"), '{"type":"module"}\n');
+  manifest.sources[variant] = {};
+  for (const file of sources) {
+    const bytes =
+      variant === "baseline"
+        ? execFileSync("git", ["show", `${base}:${file}`], { cwd: root })
+        : readFileSync(path.join(root, file));
+    const destination = path.join(dir, file);
+    mkdirSync(path.dirname(destination), { recursive: true });
+    writeFileSync(destination, bytes);
+    manifest.sources[variant][file] = { sha256: hash(bytes), bytes: bytes.length };
+  }
+  modules[variant] = await import(pathToFileURL(path.join(dir, sources[0])).href);
+}
+const baselineSource = readFileSync(path.join(out, "baseline", sources[0]), "utf8");
+const patchedSource = readFileSync(path.join(out, "patched", sources[0]), "utf8");
+const addition = `    this.storage.sql.exec(
+      \`CREATE INDEX IF NOT EXISTS ${index}
+         ON ${table} (received_at)\`,
+    );
+`;
+assert.ok(!baselineSource.includes(index), "baseline already contains the index");
+assert.ok(patchedSource.includes(addition));
+assert.equal(
+  patchedSource.replace(addition, ""),
+  baselineSource,
+  "only the frozen index addition may differ",
+);
+assert.deepEqual(manifest.sources.baseline[sources[1]], manifest.sources.patched[sources[1]]);
+save("source-manifest.json", manifest);
+
+function timed(fn) {
+  const cpu = process.cpuUsage();
+  const start = process.hrtime.bigint();
+  const value = fn();
+  const wallMs = Number(process.hrtime.bigint() - start) / 1e6;
+  const usage = process.cpuUsage(cpu);
+  return { wallMs, cpuMs: (usage.user + usage.system) / 1000, value };
+}
+function summary(samples) {
+  return Object.fromEntries(
+    ["wallMs", "cpuMs"].map((field) => {
+      const values = samples.map((sample) => sample[field]).sort((a, b) => a - b);
+      return [
+        field,
+        {
+          median: values[Math.floor(values.length / 2)],
+          p95: values[Math.ceil(values.length * 0.95) - 1],
+          min: values[0],
+          max: values.at(-1),
+        },
+      ];
+    }),
+  );
+}
+function connect(variant, file = ":memory:") {
+  const db = new DatabaseSync(file);
+  const adapter = {
+    trace: null,
+    deleted: 0,
+    failAfterPrune: false,
+    indexBuild: null,
+    sql: {
+      exec(query, ...bindings) {
+        if (adapter.failAfterPrune && query.startsWith(`DELETE FROM ${workflows}`)) {
+          adapter.failAfterPrune = false;
+          throw new Error("injected failure after receipt prune");
+        }
+        const run = () => {
+          const stmt = db.prepare(query);
+          if (/^\s*(?:SELECT|WITH|EXPLAIN)\b/i.test(query)) return stmt.all(...bindings);
+          const changes = Number(stmt.run(...bindings).changes);
+          if (query.startsWith(`DELETE FROM ${table} `)) adapter.deleted = changes;
+          return [];
+        };
+        const rows = query.includes(`CREATE INDEX IF NOT EXISTS ${index}`)
+          ? (adapter.indexBuild = timed(run)).value
+          : run();
+        adapter.trace?.push({ query, bindings });
+        return rows;
+      },
+    },
+    transactionSync(fn) {
+      db.exec("BEGIN IMMEDIATE");
+      try {
+        const value = fn();
+        db.exec("COMMIT");
+        return value;
+      } catch (error) {
+        db.exec("ROLLBACK");
+        throw error;
+      }
+    },
+  };
+  const store = new modules[variant].GithubWebhookReadModelStore(adapter);
+  return { db, adapter, store };
+}
+function delivery(id = "new-delivery", received = now, updated = received) {
+  const iso = new Date(updated).toISOString();
+  const value = modules.patched.githubWebhookReadModelDeliveryFromWebhook({
+    event: "issues",
+    deliveryId: id,
+    receivedAt: new Date(received).toISOString(),
+    payload: {
+      action: "edited",
+      repository: { full_name: "openclaw/openclaw", private: false, default_branch: "main" },
+      issue: {
+        number: 1,
+        title: id,
+        body: "synthetic local issue ".repeat(100),
+        state: "open",
+        locked: false,
+        comments: 0,
+        updated_at: iso,
+        created_at: iso,
+        labels: [],
+        user: { login: "fixture" },
+      },
+    },
+  });
+  assert.ok(value);
+  return value;
+}
+const guid = (i) => {
+  const hex = hash(`receipt:${i}`).slice(0, 32);
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+};
+const sql = {};
+for (const variant of Object.keys(modules)) {
+  const c = connect(variant);
+  c.adapter.trace = [];
+  c.store.ensureSchemaSync();
+  c.store.ingest(delivery(), now);
+  const trace = c.adapter.trace;
+  sql[variant] = {
+    schema: trace.filter(({ query }) => query.startsWith("CREATE ")),
+    insert: trace.find(({ query }) => query.startsWith(`INSERT INTO ${table}`)).query,
+    item: trace.find(({ query }) => query.startsWith(`INSERT INTO ${items}`)).query,
+    prune: trace.find(({ query }) => query.startsWith(`DELETE FROM ${table} `)),
+  };
+  c.db.close();
+}
+assert.deepEqual(sql.baseline.prune, sql.patched.prune);
+assert.equal(sql.baseline.insert, sql.patched.insert);
+save("production-sql.json", sql);
+const prune = sql.baseline.prune.query;
+const select = prune.slice(prune.indexOf("SELECT delivery_id"), prune.lastIndexOf(")")).trim();
+function snapshot(db) {
+  return Object.fromEntries(
+    db
+      .prepare(
+        "SELECT name FROM sqlite_schema WHERE type='table' AND name LIKE 'github_webhook_read_model_%' ORDER BY name",
+      )
+      .all()
+      .map(({ name }) => [name, db.prepare(`SELECT * FROM ${name} ORDER BY rowid`).all()]),
+  );
+}
+function seed(c, n, expired, tied = false) {
+  c.store.ensureSchemaSync();
+  c.adapter.transactionSync(() => {
+    const insert = c.db.prepare(sql.baseline.insert);
+    for (let i = 0; i < n; i += 1) {
+      insert.run(
+        guid(i),
+        "issues",
+        "edited",
+        i < expired ? cutoff - (tied ? 1 : expired - i) : now - 7 * 86400000 + i * 1000,
+        i + 1,
+      );
+    }
+    c.db
+      .prepare(`UPDATE ${meta} SET watermark=?, created_at=?, updated_at=?`)
+      .run(n, now - 31 * 86400000, now - 1000);
+    c.db
+      .prepare(`INSERT INTO ${classes} VALUES ('issues',?,?,?,?)`)
+      .run(n, cutoff - 600, now - 1000, n);
+    const insertItem = c.db.prepare(sql.baseline.item);
+    for (let i = 1; i <= 128; i += 1)
+      insertItem.run(
+        "openclaw/openclaw",
+        i,
+        "issue",
+        now - 1000,
+        JSON.stringify(delivery().objects[0].snapshot),
+        guid(n - i),
+        n - i + 1,
+        now - 1000,
+      );
+    const insertWorkflow = c.db.prepare(`INSERT INTO ${workflows} VALUES (?,?,?,?,?,?,?,?,?)`);
+    for (let i = 1; i <= 100; i += 1)
+      insertWorkflow.run(
+        "openclaw/openclaw",
+        "workflow_job",
+        i,
+        1,
+        now - 1000,
+        JSON.stringify({ id: i, status: "completed" }),
+        guid(n - i),
+        n - i + 1,
+        now - 1000,
+      );
+  });
+  assert.equal(c.db.prepare(`SELECT count(*) n FROM ${table}`).get().n, n);
+  assert.equal(
+    c.db.prepare(`SELECT count(*) n FROM ${table} WHERE received_at < ?`).get(cutoff).n,
+    expired,
+  );
+}
+function plans(c, variant) {
+  const result = {
+    delete: c.db.prepare(`EXPLAIN QUERY PLAN ${prune}`).all(cutoff),
+    select: c.db.prepare(`EXPLAIN QUERY PLAN ${select}`).all(cutoff),
+  };
+  const details = result.select.map((row) => row.detail).join("\n");
+  if (variant === "patched") {
+    assert.match(details, new RegExp(`SEARCH ${table} USING INDEX ${index} \\(received_at<\\?\\)`));
+    assert.doesNotMatch(details, /SCAN |USE TEMP B-TREE/);
+  } else {
+    assert.match(details, new RegExp(`SCAN ${table}`));
+    assert.match(details, /USE TEMP B-TREE FOR ORDER BY/);
+  }
+  return result;
+}
+// Restore exact rowids and touched rows outside timings; each ingest still commits normally.
+function restorer(c) {
+  const expiredRows = c.db
+    .prepare(`SELECT rowid AS rid,* FROM ${table} WHERE delivery_id IN (${select})`)
+    .all(cutoff);
+  const insert = c.db.prepare(
+    `INSERT INTO ${table}(rowid,delivery_id,event,action,received_at,watermark) VALUES(?,?,?,?,?,?)`,
+  );
+  const rows = [
+    [meta, "singleton_id=1"],
+    [classes, "event_class='issues'"],
+    [items, "repository='openclaw/openclaw' AND number=1"],
+  ].map(([name, where]) => {
+    const row = c.db.prepare(`SELECT rowid AS rid,* FROM ${name} WHERE ${where}`).get();
+    const columns = Object.keys(row).filter((key) => key !== "rid");
+    const stmt = c.db.prepare(
+      `UPDATE ${name} SET ${columns.map((key) => `${key}=?`).join(",")} WHERE rowid=?`,
+    );
+    return () => stmt.run(...columns.map((key) => row[key]), row.rid);
+  });
+  const remove = c.db.prepare(`DELETE FROM ${table} WHERE delivery_id='new-delivery'`);
+  return () =>
+    c.adapter.transactionSync(() => {
+      remove.run();
+      for (const row of expiredRows)
+        insert.run(row.rid, row.delivery_id, row.event, row.action, row.received_at, row.watermark);
+      for (const restore of rows) restore();
+    });
+}
+const probe = new DatabaseSync(":memory:");
+const result = {
+  manifest,
+  startedAt: new Date().toISOString(),
+  provider: "local Node DatabaseSync",
+  runtime: process.version,
+  sqlite: probe.prepare("SELECT sqlite_version() version, sqlite_source_id() source_id").get(),
+  compileOptions: probe.prepare("PRAGMA compile_options").all(),
+  platform: `${os.platform()} ${os.release()} ${os.arch()}`,
+  cpu: os.cpus()[0].model,
+  loadStart: os.loadavg(),
+  method:
+    "5 warmups + 60 alternating rounds; wall/process CPU; DELETE prepare/execute excludes transaction; ingest includes commit; exact restore and assertions outside timing. File copies are reopened connections, not disk-cold. No global SQLite changes or scan-count claims.",
+  limits:
+    "Synthetic local Node SQLite only, not Cloudflare capacity, production cardinality/rate, or sole overload cause. Tied IDs compare this runtime only. No Bay schema, public fields, UI or controls change.",
+  cases: [],
+  semantics: [],
+};
+probe.close();
+const payload = delivery();
+for (const n of [1000, 10000, 100000])
+  for (const expired of [0, 600]) {
+    const seedFile = path.join(out, `seed-${n}-${expired}.sqlite`);
+    const diskSeed = connect("baseline", seedFile);
+    seed(diskSeed, n, expired);
+    diskSeed.db.close();
+    const pairs = Object.keys(modules).map((variant) => {
+      const c = connect(variant);
+      seed(c, n, expired);
+      return { variant, c, restore: restorer(c), before: snapshot(c.db), delete: [], ingest: [] };
+    });
+    for (let round = 0; round < 65; round += 1)
+      for (const row of round % 2 ? [...pairs].reverse() : pairs) {
+        const { c } = row;
+        c.db.exec("BEGIN IMMEDIATE");
+        const deletion = timed(() => c.adapter.sql.exec(prune, cutoff));
+        assert.equal(c.adapter.deleted, expired ? 256 : 0);
+        c.db.exec("ROLLBACK");
+        const ingest = timed(() => c.store.ingest(payload, now));
+        assert.deepEqual(ingest.value, { accepted: true, deduped: false, watermark: n + 1 });
+        assert.equal(c.adapter.deleted, expired ? 256 : 0);
+        row.restore();
+        if (round >= 5) {
+          row.delete.push(deletion);
+          row.ingest.push(ingest);
+        }
+      }
+    const states = [];
+    for (const row of pairs) {
+      const { c, variant } = row;
+      assert.deepEqual(snapshot(c.db), row.before);
+      const entry = {
+        n,
+        expired,
+        variant,
+        plans: plans(c, variant),
+        delete: { summary: summary(row.delete), samples: row.delete },
+        ingest: { summary: summary(row.ingest), samples: row.ingest },
+        initialization: [],
+        drain: [],
+      };
+      for (let i = 0; i < 4; i += 1) {
+        const before = c.db
+          .prepare(`SELECT delivery_id FROM ${table}`)
+          .all()
+          .map((r) => r.delivery_id);
+        c.store.ingest(delivery(`drain-${i}`, now + i), now + i);
+        const retained = new Set(
+          c.db
+            .prepare(`SELECT delivery_id FROM ${table}`)
+            .all()
+            .map((r) => r.delivery_id),
+        );
+        const deleted = before.filter((id) => !retained.has(id)).sort();
+        assert.deepEqual(
+          deleted,
+          Array.from({ length: Math.min(256, Math.max(0, expired - i * 256)) }, (_, j) =>
+            guid(i * 256 + j),
+          ).sort(),
+        );
+        const state = snapshot(c.db);
+        if (variant === "baseline") states.push(state);
+        else assert.deepEqual(state, states[i]);
+        entry.drain.push({ deleted, stateSha256: hash(JSON.stringify(state)) });
+      }
+      c.db.close();
+      for (let repeat = 0; repeat < 5; repeat += 1) {
+        const file = path.join(out, `${n}-${expired}-${variant}-${repeat}.sqlite`);
+        copyFileSync(seedFile, file);
+        const reopened = connect(variant, file);
+        const before = snapshot(reopened.db);
+        const pagesBefore = reopened.db.prepare("PRAGMA page_count").get().page_count;
+        const init = timed(() => reopened.store.ensureSchemaSync());
+        const indexBuild = reopened.adapter.indexBuild;
+        const repeated = Array.from({ length: 5 }, () =>
+          timed(() => reopened.store.ensureSchemaSync()),
+        );
+        assert.deepEqual(snapshot(reopened.db), before);
+        const pagesAfter = reopened.db.prepare("PRAGMA page_count").get().page_count;
+        const pageSize = reopened.db.prepare("PRAGMA page_size").get().page_size;
+        const ingest = timed(() => reopened.store.ingest(payload, now));
+        assert.deepEqual(ingest.value, { accepted: true, deduped: false, watermark: n + 1 });
+        assert.equal(reopened.adapter.deleted, expired ? 256 : 0);
+        assert.equal(reopened.db.prepare("PRAGMA integrity_check").get().integrity_check, "ok");
+        entry.initialization.push({
+          init,
+          indexBuild,
+          repeated,
+          addedBytes: (pagesAfter - pagesBefore) * pageSize,
+          reopenedIngest: ingest,
+        });
+        reopened.db.close();
+      }
+      result.cases.push(entry);
+      console.log(
+        JSON.stringify({
+          n,
+          expired,
+          variant,
+          delete: entry.delete.summary,
+          ingest: entry.ingest.summary,
+        }),
+      );
+    }
+  }
+// Runtime controls complement the existing test owner's late-object/watermark coverage.
+for (const tied of [false, true]) {
+  const controls = [];
+  for (const variant of Object.keys(modules)) {
+    const c = connect(variant);
+    seed(c, 1000, 600, tied);
+    c.db.prepare(`UPDATE ${table} SET received_at=? WHERE delivery_id=?`).run(cutoff, guid(600));
+    c.db
+      .prepare(`UPDATE ${table} SET received_at=? WHERE delivery_id=?`)
+      .run(cutoff + 1, guid(601));
+    const before = snapshot(c.db);
+    assert.deepEqual(c.store.ingest(delivery(guid(0)), now), {
+      accepted: true,
+      deduped: true,
+      watermark: 1,
+    });
+    assert.deepEqual(snapshot(c.db), before);
+    c.adapter.failAfterPrune = true;
+    assert.throws(() => c.store.ingest(payload, now), /injected failure after receipt prune/);
+    assert.equal(c.adapter.deleted, 256);
+    assert.deepEqual(snapshot(c.db), before);
+    const batches = [];
+    for (let i = 0; i < 4; i += 1) {
+      const previous = new Set(
+        c.db
+          .prepare(`SELECT delivery_id FROM ${table}`)
+          .all()
+          .map((r) => r.delivery_id),
+      );
+      assert.deepEqual(c.store.ingest(delivery(`semantic-${i}`), now), {
+        accepted: true,
+        deduped: false,
+        watermark: 1001 + i,
+      });
+      const remaining = new Set(
+        c.db
+          .prepare(`SELECT delivery_id FROM ${table}`)
+          .all()
+          .map((r) => r.delivery_id),
+      );
+      const deleted = [...previous].filter((id) => !remaining.has(id)).sort();
+      assert.equal(deleted.length, [256, 256, 88, 0][i]);
+      batches.push({ deleted, state: snapshot(c.db) });
+    }
+    assert.deepEqual(
+      c.db
+        .prepare(`SELECT delivery_id FROM ${table} WHERE received_at<=? ORDER BY received_at`)
+        .all(cutoff + 1)
+        .map((r) => r.delivery_id),
+      [guid(600), guid(601)],
+    );
+    const drained = snapshot(c.db);
+    assert.deepEqual(c.store.ingest(delivery("semantic-0"), now), {
+      accepted: true,
+      deduped: true,
+      watermark: 1001,
+    });
+    assert.deepEqual(snapshot(c.db), drained);
+    assert.deepEqual(c.store.ingest(delivery(guid(0)), now), {
+      accepted: true,
+      deduped: false,
+      watermark: 1005,
+    });
+    controls.push({ batches, replayed: snapshot(c.db) });
+    c.db.close();
+  }
+  assert.deepEqual(controls[1], controls[0]);
+  result.semantics.push({
+    tied,
+    rollbackAndReplay: "passed",
+    batches: controls[0].batches.map(({ deleted, state }) => ({
+      deleted,
+      stateSha256: hash(JSON.stringify(state)),
+    })),
+    replayedSha256: hash(JSON.stringify(controls[0].replayed)),
+  });
+}
+for (const file of sources)
+  assert.equal(
+    hash(readFileSync(path.join(root, file))),
+    manifest.sources.patched[file].sha256,
+    "working source changed during proof",
+  );
+assert.equal(hash(readFileSync(fileURLToPath(import.meta.url))), manifest.harnessSha256);
+result.finishedAt = new Date().toISOString();
+result.loadEnd = os.loadavg();
+result.result = "PASS";
+save("results.json", result);
+console.log(
+  `PASS: source identity, indexed plans, exact deleted IDs/full states, upgrade/idempotence, cutoff/replay and rollback. Artifacts: ${out}`,
+);

--- a/test/github-webhook-read-model.test.ts
+++ b/test/github-webhook-read-model.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { createHmac } from "node:crypto";
+import { createHash, createHmac } from "node:crypto";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 
@@ -87,6 +87,194 @@ test("read model dedupes GUIDs, keeps object watermarks monotonic, tombstones, a
   assert.equal(stale.usable, false);
   assert.equal((stale.freshness as Record<string, unknown>).stale, true);
 });
+
+test("receipt expiry upgrades existing databases idempotently and uses a SQLite range search", (t) => {
+  const { storage, store, now } = receiptExpiryFixture();
+  storage.sql.exec(`DROP INDEX ${receiptTimeIndex}`);
+  const before = readModelState(storage);
+  const queries: { query: string; bindings: unknown[] }[] = [];
+  const exec = storage.sql.exec.bind(storage.sql);
+  t.mock.method(storage.sql, "exec", (query: string, ...bindings: unknown[]) => {
+    queries.push({ query, bindings });
+    return exec(query, ...bindings);
+  });
+  new GithubWebhookReadModelStore(storage).ensureSchemaSync();
+  store.ensureSchemaSync();
+  assert.deepEqual(readModelState(storage), before);
+  assert.deepEqual(
+    [...exec(`SELECT name FROM pragma_index_info('${receiptTimeIndex}')`)].map((row) => row.name),
+    ["received_at"],
+  );
+  store.ingest(receiptDelivery("plan", now), now);
+  const prune = queries.find(({ query }) => query.startsWith(`DELETE FROM ${receiptTable} `));
+  assert.ok(prune);
+  const plan = [...exec(`EXPLAIN QUERY PLAN ${prune.query}`, ...prune.bindings)]
+    .map((row) => row.detail)
+    .join("\n");
+  assert.match(plan, new RegExp(`SEARCH ${receiptTable} USING INDEX ${receiptTimeIndex}`));
+  assert.doesNotMatch(plan, new RegExp(`SCAN ${receiptTable}|USE TEMP B-TREE FOR ORDER BY`));
+  assert.throws(
+    () => exec(`INSERT INTO ${receiptTable} VALUES ('retained', 'issues', 'edited', ?, 9999)`, now),
+    /UNIQUE constraint failed/,
+  );
+  assert.throws(
+    () => exec(`INSERT INTO ${receiptTable} VALUES ('other', 'issues', 'edited', ?, 1)`, now),
+    /UNIQUE constraint failed/,
+  );
+});
+
+for (const tied of [false, true]) {
+  test(`receipt expiry preserves bounded drain, cutoff and replay (tied=${tied})`, () => {
+    const controls = [false, true].map((indexed) => {
+      const fixture = receiptExpiryFixture(tied);
+      if (!indexed) fixture.storage.sql.exec(`DROP INDEX ${receiptTimeIndex}`);
+      return fixture;
+    });
+    const outcomes = controls.map(({ storage, store, now, cutoff }) => {
+      const before = readModelState(storage);
+      assert.deepEqual(store.ingest(receiptDelivery(expiredReceiptId(0), now), now), {
+        accepted: true,
+        deduped: true,
+        watermark: 2,
+      });
+      assert.deepEqual(readModelState(storage), before, "expired but retained GUID skips prune");
+      const batches = [];
+      for (let i = 0; i < 4; i += 1) {
+        const previous = receiptIds(storage);
+        assert.deepEqual(store.ingest(receiptDelivery(`drain-${i}`, now), now), {
+          accepted: true,
+          deduped: false,
+          watermark: 604 + i,
+        });
+        const remaining = new Set(receiptIds(storage));
+        const deleted = previous.filter((id) => !remaining.has(id));
+        assert.equal(deleted.length, [256, 256, 88, 0][i]);
+        if (!tied) {
+          assert.deepEqual(
+            deleted,
+            Array.from({ length: deleted.length }, (_, j) => expiredReceiptId(i * 256 + j)).sort(),
+          );
+        }
+        batches.push({ deleted, state: readModelState(storage) });
+      }
+      assert.deepEqual(
+        [
+          ...storage.sql.exec(
+            `SELECT delivery_id FROM ${receiptTable} WHERE received_at <= ? ORDER BY received_at`,
+            cutoff + 1,
+          ),
+        ].map((row) => row.delivery_id),
+        ["at-cutoff", "after-cutoff"],
+      );
+      const drained = readModelState(storage);
+      assert.deepEqual(store.ingest(receiptDelivery("drain-0", now), now), {
+        accepted: true,
+        deduped: true,
+        watermark: 604,
+      });
+      assert.deepEqual(
+        readModelState(storage),
+        drained,
+        "duplicate cannot regress global watermark",
+      );
+      assert.deepEqual(store.ingest(receiptDelivery(expiredReceiptId(0), now), now), {
+        accepted: true,
+        deduped: false,
+        watermark: 608,
+      });
+      return { batches, replayed: readModelState(storage) };
+    });
+    // A local SQLite control, not a promise of SQL tie order across engines.
+    assert.deepEqual(outcomes[1], outcomes[0]);
+  });
+}
+
+test("receipt expiry and watermark writes roll back together after a later prune failure", (t) => {
+  const { storage, store, now } = receiptExpiryFixture();
+  const before = readModelState(storage);
+  const exec = storage.sql.exec.bind(storage.sql);
+  let pruned = 0;
+  t.mock.method(storage.sql, "exec", (query: string, ...bindings: unknown[]) => {
+    const result = exec(query, ...bindings);
+    if (query.startsWith(`DELETE FROM ${receiptTable} `)) pruned = result.rowsWritten;
+    return result;
+  });
+  storage.failNextSql(/DELETE FROM github_webhook_read_model_workflows_v1/);
+  assert.throws(() => store.ingest(receiptDelivery("retry", now), now), /injected SQL failure/);
+  assert.equal(pruned, 256, "failure occurs after receipt pruning");
+  assert.deepEqual(readModelState(storage), before);
+  assert.deepEqual(store.ingest(receiptDelivery("retry", now), now), {
+    accepted: true,
+    deduped: false,
+    watermark: 604,
+  });
+  assert.equal(receiptIds(storage).length, 603 + 1 - 256);
+});
+
+const receiptTable = "github_webhook_read_model_deliveries_v1";
+const receiptTimeIndex = "github_webhook_read_model_deliveries_received_at_v1";
+
+function receiptDelivery(id: string, now: number) {
+  const receivedAt = new Date(now).toISOString();
+  return requiredDelivery("issues", id, receivedAt, {
+    action: "edited",
+    repository,
+    issue: issue(42, id, receivedAt),
+  });
+}
+
+function expiredReceiptId(i: number) {
+  return createHash("sha256").update(`expired-${i}`).digest("hex");
+}
+
+function receiptExpiryFixture(tied = false) {
+  const storage = new MemoryDurableStorage();
+  const store = new GithubWebhookReadModelStore(storage);
+  const now = Date.parse("2026-08-26T12:00:00Z");
+  const cutoff = now - 30 * 24 * 60 * 60_000;
+  store.ensureSchemaSync();
+  store.ingest(receiptDelivery("retained", now - 1_000), now - 1_000);
+  storage.transactionSync(() => {
+    for (let i = 0; i < 600; i += 1) {
+      storage.sql.exec(
+        `INSERT INTO ${receiptTable} VALUES (?, 'issues', 'edited', ?, ?)`,
+        expiredReceiptId(i),
+        tied ? cutoff - 1 : cutoff - 600 + i,
+        i + 2,
+      );
+    }
+    storage.sql.exec(
+      `INSERT INTO ${receiptTable} VALUES ('at-cutoff', 'issues', 'edited', ?, 602)`,
+      cutoff,
+    );
+    storage.sql.exec(
+      `INSERT INTO ${receiptTable} VALUES ('after-cutoff', 'issues', 'edited', ?, 603)`,
+      cutoff + 1,
+    );
+    storage.sql.exec(
+      `UPDATE github_webhook_read_model_meta_v1 SET watermark = 603, created_at = ?, updated_at = ?`,
+      now - 1_000,
+      now - 1_000,
+    );
+  });
+  return { storage, store, now, cutoff };
+}
+
+function receiptIds(storage: MemoryDurableStorage) {
+  return [...storage.sql.exec(`SELECT delivery_id FROM ${receiptTable} ORDER BY delivery_id`)].map(
+    (row) => String(row.delivery_id),
+  );
+}
+
+function readModelState(storage: MemoryDurableStorage) {
+  return Object.fromEntries(
+    [
+      ...storage.sql.exec(
+        "SELECT name FROM sqlite_schema WHERE type = 'table' AND name LIKE 'github_webhook_read_model_%' ORDER BY name",
+      ),
+    ].map(({ name }) => [name, [...storage.sql.exec(`SELECT * FROM ${name} ORDER BY rowid`)]]),
+  );
+}
 
 test("comment-count gaps force a repair poll and a complete repair heals the collection", async () => {
   const storage = new MemoryDurableStorage();


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where accepted GitHub webhooks scan and sort the entire retained receipt history during expiry cleanup, even when nothing is expired. LIMIT 256 bounds deletion but does not bound the unindexed scan. This is one measured source of shared Durable Object CPU work, not an established sole or dominant cause of production overload.

## Why This Change Was Made

Add one idempotent index on received_at immediately after delivery-table creation in GithubWebhookReadModelStore.ensureSchemaSync. Keep the v1 table and columns, primary/unique constraints, 30-day retention, strict less-than cutoff, ORDER BY received_at ASC, LIMIT 256, prune frequency, and transaction rollback unchanged. No composite index, schema-version bump, global SQLite setting, queue/cache/heartbeat refactor, sharding, retry, concurrency or policy change.

The single-column index removes the measured scan/sort without the composite index's larger storage and changed tied-batch membership in the earlier diagnostic. Equal timestamps still have no SQL ordering guarantee. Existing databases build the index once; older code can ignore it on rollback.

## User Impact

Less local SQLite CPU work for expiry cleanup at substantial retained receipt populations. Deduplication, replay after pruning, object/global watermarks and cleanup outcomes remain unchanged in the tested runtime. No public API or UI changes. Added storage, insertion maintenance and one-time index-build cost are the tradeoffs; Deployed Cloudflare capacity is not measured here; the actual workerd Durable Object upgrade proof is recorded below.

## OpenClaw Bay Impact

No Bay change is needed: this is an internal SQL access-path optimization with no read-model data-contract, public field, UI, navigation or control change. Bay remains observer-only.

## Documentation Impact

Updated the active owning reference, `docs/github-webhook-read-model.md`, for index ownership, idempotent upgrade, strict-cutoff pruning, retained/pruned GUID behavior and initialization cost. Its owner remains the dashboard and queue maintainers. Added the expected concise maintainer changelog entry for **openclaw/clawsweeper**.

Policy scope: [CONTRIBUTING.md lines 16–19](https://github.com/openclaw/clawsweeper/blob/a5fdc6606095eeadef03b15191043e95d7b68c85/CONTRIBUTING.md#L16-L19) explicitly restricts normal changelog edits for **openclaw/openclaw**, then directs ClawSweeper PRs to this repository's release-note policy. Read [AGENTS.md lines 50–52](https://github.com/openclaw/clawsweeper/blob/a5fdc6606095eeadef03b15191043e95d7b68c85/AGENTS.md#L50-L52) in that scope; it is not a blanket ban on this maintainer-authored ClawSweeper entry. All existing memory-fix and contributor changelog entries are preserved.

## Evidence

Final head: `a5fdc6606095eeadef03b15191043e95d7b68c85`; tested base and direct parent: `5cb6777eea2da37e2c2481e15215c2f8be9c774f`. The rebase added no implementation changes: the four non-changelog task files remain byte-identical to the independently reviewed versions; the only conflict was additive changelog text, resolved by keeping every entry.

On the final committed head, **Node 24.19.0 with pinned pnpm 11.10.0** passed `pnpm run build:node`, `pnpm run check:static` (including docs, formatting, limits and strict dashboard), focused lint below, and all **14 webhook tests**. The four new expiry tests cover database upgrade/repeated initialization, real SQLite range-search plans, preserved constraints, 256/256/88/0 drain, strict cutoff, retained/pruned replay, tied timestamps and atomic rollback after receipt pruning. Existing late-object/global-watermark coverage is reused. There are no timing thresholds.

```sh
# Node 24.19.0 and repository-pinned pnpm 11.10.0 must be selected.
pnpm run build:node
node --test test/github-webhook-read-model.test.ts
pnpm run check:static
pnpm exec oxlint dashboard/github-webhook-read-model.ts test/github-webhook-read-model.test.ts scripts/proof-webhook-expiry-index.mjs --deny-warnings --report-unused-disable-directives -D correctness -D preserve-caught-error
git diff --check 5cb6777eea2da37e2c2481e15215c2f8be9c774f...a5fdc6606095eeadef03b15191043e95d7b68c85
```

Earlier, the local full `pnpm run check` was invoked once and exited **1: 3,695 passed, 48 failed, 9 skipped, 0 cancelled**. Static checks, builds, lint and the 12-test focused coverage gate passed before the broad test stage. The failures match the known host baseline modes: 42 missing synthetic `origin/main` refs (2 command, 3 git-repo-utils, 37 target-validation) and 6 offline pnpm/@pnpm/exe 10.33.0 resolution failures from a v11 mirror. The full suite was not rerun on this rebased head; no unrelated tests, package pins, offline behavior, global SQLite/Git settings or timeouts were changed. **No full-green claim is made.**

Independent precommit and committed-branch Codex reviews are **CLEAN**, with no accepted/actionable findings. The parent independently reran the 14 tests and real SQLite proof. [Exact-head hosted CI 33035001782](https://github.com/openclaw/clawsweeper/actions/runs/33035001782) is **green**, including full `pnpm check`, sparse repair build, and Windows launcher; CodeQL is also green. The local baseline failures above remain a failed local run, not relabeled success. The new actual Durable Object proof and finding disposition below require a fresh review of this unchanged head and updated body before landing.

## Real Behavior Proof — Node SQLite performance and semantics

**Claim and surface:** the additive `received_at` index removes the expiry scan and temporary sort while preserving production-store outcomes. The [committed proof harness](https://github.com/openclaw/clawsweeper/blob/a5fdc6606095eeadef03b15191043e95d7b68c85/scripts/proof-webhook-expiry-index.mjs) directly imports baseline and final `GithubWebhookReadModelStore` source snapshots with the real payload converter and unchanged `stable-json` dependency, and executes the production store through a local Node `DatabaseSync` storage adapter. It reads baseline source from Git object `5cb6777eea2da37e2c2481e15215c2f8be9c774f` and asserts that final source differs by exactly the four index lines. Source/harness hashes are checked before and after execution and match committed head `a5fdc6606095eeadef03b15191043e95d7b68c85`.

**Environment:** actual provider `local Node DatabaseSync`, Node **v24.19.0**, SQLite **3.53.4**, macOS (`darwin 27.0.0 arm64`), Apple M3 Ultra. The harness explicitly requires this measured Node patch version; another Node 24 patch is not silently substituted. No container image, Crabbox provider, remote lease, workerd, credentials, network, production data or live mutation was used. This is local macOS proof, not the Windows/container recipe. The measured run was serial: no build or other validation ran concurrently. Host one-minute load was 57.15 → 54.20; outliers were retained.

**Corpus and method:** six fixtures span 1k/10k/100k deterministic UUID-shaped receipts, with zero or 600 expired receipts, plus 128 synthetic item snapshots (~2 KiB bodies) and 100 workflow jobs. Actual production INSERTs seed history. Each accepted delivery updates one issue and receipt/global/class/item state, then performs both cleanup queries in a committed transaction. Five warmups precede 60 alternating baseline/final samples. DELETE measurements include prepare/execute but exclude BEGIN/ROLLBACK; full ingest includes commit and index write maintenance. Exact rowids and touched rows are restored outside timing so batches do not drain between samples; full state is checked afterward. Five fresh file copies per case measure existing-database initialization, index creation, five repeated initializations and reopened committed ingest. These are reopened connections, not physical disk-cold requests; OS caches were not flushed.

**Reproduce once from the final checkout**, with Node 24.19.0 on PATH. This portable Node command creates a fresh parent temp directory and passes a nonexistent child to the harness, which refuses existing output. It executes the entry exactly once, then asserts the resulting artifact; a terminal proof plan should use this one execution followed by its assertions, not run the entry again in a second step.

```sh
node --input-type=module <<'NODE'
import assert from 'node:assert/strict';
import { execFileSync } from 'node:child_process';
import { mkdtempSync, readFileSync } from 'node:fs';
import { tmpdir } from 'node:os';
import { join } from 'node:path';
assert.equal(process.version, 'v24.19.0');
const base = '5cb6777eea2da37e2c2481e15215c2f8be9c774f';
const head = 'a5fdc6606095eeadef03b15191043e95d7b68c85';
assert.equal(execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim(), head);
const parent = mkdtempSync(join(tmpdir(), 'clawsweeper-webhook-expiry-'));
const output = join(parent, 'proof');
execFileSync(process.execPath, ['scripts/proof-webhook-expiry-index.mjs', base, output], { stdio: 'inherit' });
const result = JSON.parse(readFileSync(join(output, 'results.json'), 'utf8'));
assert.equal(result.result, 'PASS');
assert.equal(result.manifest.base, base);
assert.equal(result.manifest.head, head);
console.log('PASS: committed-head proof assertions; artifacts:', output);
NODE
```

**Observed query plans:** the captured production expiry DELETE and cutoff binding are identical. Every fixture replaces the inner scan/sort with the same indexed range search; the outer DELETE retains the delivery-ID primary-key access path. Cursor return counts are not treated as examined-row counts.

```text
baseline expiry subquery:
  SCAN github_webhook_read_model_deliveries_v1
  USE TEMP B-TREE FOR ORDER BY
final expiry subquery:
  SEARCH github_webhook_read_model_deliveries_v1 USING INDEX github_webhook_read_model_deliveries_received_at_v1 (received_at<?)
```

**Observed measurements**, medians in milliseconds (baseline → final):

| Receipts | Expired | DELETE wall | Full ingest wall | Full ingest process CPU |
| --- | --- | --- | --- | --- |
| 1,000 | 0 | 0.033 → 0.010 | 0.125 → 0.104 | 0.126 → 0.105 |
| 1,000 | 600 | 0.297 → 0.289 | 0.404 → 0.397 | 0.404 → 0.399 |
| 10,000 | 0 | 0.225 → 0.010 | 0.316 → 0.104 | 0.318 → 0.104 |
| 10,000 | 600 | 0.591 → 0.376 | 0.689 → 0.486 | 0.689 → 0.487 |
| 100,000 | 0 | 2.410 → 0.014 | 2.603 → 0.129 | 2.593 → 0.130 |
| 100,000 | 600 | 3.130 → 0.598 | 3.220 → 0.670 | 3.224 → 0.674 |

At 100k unexpired receipts, median ingest wall was **2.603459 → 0.128625 ms**. Small fixture differences are not a universal promised speedup; no performance thresholds gate tests.

**One-time build, storage and write costs:** at 100k receipts, five reopened files per variant produced these wall-time measurements:

| Variant | Expired | Index-build median (min–max), ms | Repeated initializer median, ms | Added bytes | Reopened ingest median (min–max), ms |
| --- | --- | --- | --- | --- | --- |
| baseline | 0 | none | 0.107 | 0 | 5.558 (5.265–6.113) |
| patched | 0 | 26.030 (25.927–220.184) | 0.137 | 1,482,752 | 1.611 (1.353–5.744) |
| baseline | 600 | none | 0.120 | 0 | 21.480 (19.636–182.306) |
| patched | 600 | 26.072 (23.541–298.473) | 0.137 | 1,482,752 | 24.907 (18.848–29.445) |

The index adds **1,482,752 bytes (~1.414 MiB)** at 100k in this fixture. Median build cost was about 26 ms, with retained outliers up to **298.473 ms**. The 100k/600-expired reopened ingest median was slower with the index (24.907 vs 21.480 ms); this proof does not promise a cold/reopened wall-time improvement. Receipt writes must maintain the new index; full-ingest measurements include that cost. Isolated insertion-only overhead was not remeasured, so no per-write numeric claim is made. Process CPU includes process background/GC work, not isolated SQLite CPU. These are rollout costs and noisy local observations, not Cloudflare initialization latency or billing evidence.

**Behavior:** all six baseline/final fixture pairs matched exact deleted IDs and full logical table state at every drain step, using deep equality during execution. Expired batches drained 256/256/88/0; no-expired fixtures deleted zero. Separate distinct/tied timestamp controls passed strict cutoff (cutoff−1 deleted, cutoff and cutoff+1 retained), retained GUID replay without state changes, pruned GUID acceptance at the next watermark, and rollback of all tables after a failure injected after receipt deletion, followed by successful retry. Existing-database initialization preserves rows, repeated initialization is idempotent, and SQLite `integrity_check` passes. Matching tied IDs is a control for this SQLite runtime, **not an ordering guarantee across engines**.

**Durable proof artifact:** the sanitized JSON summary and tables below/above are in this main PR body, with reproducible source and artifact hashes. Full raw samples, exact query plans, deletion-ID arrays, state hashes, compile options, source snapshots and seed/reopened databases are generated by the linked committed harness and retained by the PR owner; they are not represented as publicly downloadable attachments. The inline artifact is a compact summary, not a claim that hashes alone publish those raw files.

```json
{
  "result": "PASS",
  "base": "5cb6777eea2da37e2c2481e15215c2f8be9c774f",
  "head": "a5fdc6606095eeadef03b15191043e95d7b68c85",
  "provider": "local Node DatabaseSync",
  "runtime": "v24.19.0",
  "sqlite": "3.53.4",
  "platform": "darwin 27.0.0 arm64",
  "cpu": "Apple M3 Ultra",
  "startedAt": "2026-08-27T02:56:31.978Z",
  "finishedAt": "2026-08-27T02:56:50.363Z",
  "load1m": [57.14892578125,54.2041015625],
  "fixtures": {"receipts":[1000,10000,100000],"expired":[0,600],"itemSnapshots":128,"workflowJobs":100,"warmups":5,"samplesPerVariantPerFixture":60},
  "assertions": {"exactFourLineSourceDelta":true,"sourceHashesStable":true,"indexedPlansWithoutScanOrSort":6,"exactDeletionAndFullStatePairs":6,"expiredDrain":[256,256,88,0],"unexpiredDrain":[0,0,0,0],"cutoffReplayRollback":["distinct timestamps: PASS","tied timestamps: PASS"],"upgradeRepeatedInitIntegrity":"PASS"},
  "artifactSha256": {"results.json":"359c3e8b93ff791188414c57defe3b093f28fc779aaac8ccfaf495ffcf7eca38","production-sql.json":"f82457e13fab68f35e3358162d0b1b2ae0f376b127b487a0a9f70099a9a35236","source-manifest.json":"21c187c1c8d0ecd0784b32333241d54bf11a2d4839923452a4534798b7319c41"}
}
```

| Source | Baseline SHA-256 | Final SHA-256 |
| --- | --- | --- |
| `dashboard/github-webhook-read-model.ts` | `3caf3ebe8e14a14c117a32fd688517ca875da321667c320074c702ec018bd5fc` | `a0b8b4467d5f000ee44c8db270d3889ed4eea57107807c43daad376572085044` |
| `src/stable-json.ts` | `68e64b18ff6f9b874dfbbace8ea29552ffb40a1ba489d719a43540f2e08bcd05` | `68e64b18ff6f9b874dfbbace8ea29552ffb40a1ba489d719a43540f2e08bcd05` |

Harness SHA-256: `0eaf2f913bc7ac748f6585252cf2b327d2f69116cf9a2ccadc9fee256f709f37`.

**Scope, rollback and limits:** no table, column, primary-key, unique-constraint or public-schema change, no schema-version bump and no data migration: only an additive index. Retention, strict cutoff, `ORDER BY received_at ASC`, `LIMIT 256`, prune frequency and transaction behavior remain exactly unchanged. Older code can ignore the extra index on rollback; there is no destructive rollback step. Queue/cache/heartbeat behavior, concurrency, retries, sharding and policy are untouched. OpenClaw Bay is unaffected: no data-contract, public field, UI, navigation or control change, and its observer-only boundary is unchanged.

This establishes a synthetic local SQLite cost and preserved behavior. It does **not** establish production receipt cardinality/rate, Cloudflare planner/runtime capacity, shared-object queueing delay, deployment readiness, or whole overload recovery; expiry cleanup is not established as the sole/dominant overload cause. No production load test or deployment was performed. The separate actual Durable Object upgrade proof below addresses the runtime boundary; production rollout remains a later verification step.


## Real Behavior Proof — actual workerd Durable Object upgrade

**Addressed:** the review requested proof beyond Node `DatabaseSync`. The unchanged PR head `a5fdc6606095eeadef03b15191043e95d7b68c85` now passed an actual persisted Durable Object upgrade on **AWS Crabbox**, lease `cbx_3fb7fbda687f`, [run `run_cadacc18e31f`](https://crabbox.openclaw.ai/portal/runs/run_cadacc18e31f), exit 0. The command completed in 29.329 seconds; this is a functional upgrade test, not a performance benchmark. Runtime: Linux, Node `v24.18.1`, pnpm `11.10.0`, Wrangler `4.107.0`, workerd `1.20260701.1`, compatibility date `2026-05-11`.

The fixture subclasses the **unchanged production `ExactReviewQueue`**. An ordinary `super.fetch()` invokes its real `ensureReady`/`initializeStorage`/`blockConcurrencyWhile` path. The test uses the production `GithubWebhookReadModelStore` instance with native Durable Object `SqlStorage` and `transactionSync`: **no fake storage adapter or Node SQLite**. It warms initialization, removes only the new index in an isolated fixture database to model the legacy physical layout, seeds 1,000 receipts (600 expired) plus item/class/meta rows and watermark 1,000, then fully stops Wrangler/workerd. A new process opens the **same persisted files and named DO identity** using the candidate initializer. A third process checks idempotent reopening. This models legacy persisted layout; it does not claim to execute the entire base revision.

All assertions passed: the single-column index was created; every preexisting read-model table hash was preserved across upgrade; production store ingestions drained **256/256/88/0**; cutoff and cutoff+1 survived; retained GUIDs returned their original watermark without pruning; a pruned GUID was reaccepted; an injected failure after actual production pruning rolled back receipts, item/class state and watermark together; retry succeeded; the final restart retained identical state and index. The fixed fixture clock is passed through the store's existing parameter, not a global clock replacement. The temporary failure hook calls the real pruning method before throwing. Fixture-only routes are never deployed.

| Check | Observed result |
| --- | --- |
| Legacy → upgraded state | Same 1,000 receipts, 600 expired, watermark 1,000 and state SHA-256 `b3022b9990f0e5e11828220fa06170de8e05056eea00b1aac4074911198cbfa0` |
| Native receipt-selector counters | Legacy: 1,600 rows read / 256 returned; upgraded: 256 rows read / 256 returned; zero rows written by the SELECT |
| Rollback | Before/after state SHA-256 identical: `95eb8d3fb9f28af8c2d255ea2fda1d5fcaa7431170d32938a7feb7d9b15591ea` |
| Final → third-process state | Same 406 receipts, zero expired, watermark 1,007 and SHA-256 `5a30f4622343200af85611552ddc3e62a489a8d6a73305e333ffedf32be37a99` |
| Lifecycle cleanup | Three distinct process groups/constructor identities; each stopped, loopback port closed, no surviving proof processes; owned leases explicitly released |

**Important EXPLAIN limitation:** the warm legacy snapshot reused an EXPLAIN statement prepared before `DROP INDEX` and still displayed the absent index. That stale row is retained below and **is not baseline-plan evidence**. `sqlite_master` and `PRAGMA index_info` showed the index absent. The restarted process prepared a fresh indexed plan. The counters above are native workerd `SqlStorageCursor` counters for the **SELECT subquery**, not DELETE counters, returned-row approximations, CPU measurements, or Cloudflare billing claims.

**Provider and safety:** the repository [configuration selects AWS](https://github.com/openclaw/clawsweeper/blob/a5fdc6606095eeadef03b15191043e95d7b68c85/.crabbox.yaml#L1-L3), and its [provider contract preserves that selection](https://github.com/openclaw/clawsweeper/blob/a5fdc6606095eeadef03b15191043e95d7b68c85/.agents/skills/crabbox/SKILL.md#L8-L20). No provider override was used. This is AWS-hosted local workerd, **not** Docker, local-container, Testbox, or deployed Cloudflare. The Windows-specific container wording does not describe this Mac/Linux execution. `--fresh-pr` verified the exact head, `--no-hydrate` and `CRABBOX_ENV_ALLOW=CI` avoided credentials, IMDSv2's IAM credential endpoint returned 404 before repository execution, and the bootstrap discarded inherited environment. Wrangler was local-only on loopback with isolated persistence, no account/routes/production bindings or secrets, and GitHub pointed at loopback port 9. Bay's observer contract is unchanged.

The first proof-only attempt failed before workerd startup because its runtime-version metadata lookup used the wrong package location; the corrected bootstrap then passed. A coordinator heartbeat timeout did not interrupt the successful run. Both sequential AWS leases were explicitly released after artifact capture; the successful run had already stopped all proof process groups. No production load test, deployment, or real webhook authentication is claimed. The existing 100k Node SQLite performance experiment remains complementary.

### Reproduction artifact

Save the exact self-contained bootstrap below as `/tmp/clawsweeper-expiry-do-proof/bootstrap.sh`. SHA-256: `21fe68d4aa0b0cd681a08a31dc3cdcc9418a2916472feb1acb6ad62360c83560`. The portable invocation below uses the already-verified installed Crabbox CLI from a ClawSweeper checkout; the recorded run used the repository-documented trusted wrapper. Preserve the configured AWS provider. The portal may require operator access; the script and selected observed trace are included here as durable public evidence.

```bash
env -u CRABBOX_AWS_INSTANCE_PROFILE -u CRABBOX_TAILSCALE -u CRABBOX_TAILSCALE_AUTH_KEY -u CRABBOX_TAILSCALE_AUTH_KEY_ENV -u CRABBOX_TAILSCALE_EXIT_NODE -u CRABBOX_TAILSCALE_EXIT_NODE_ALLOW_LAN_ACCESS -u CRABBOX_TAILSCALE_HOSTNAME_TEMPLATE -u CRABBOX_TAILSCALE_TAGS CRABBOX_ENV_ALLOW=CI CI=1 crabbox run --fresh-pr openclaw/clawsweeper#1255 --no-hydrate --network public --tailscale=false --tailscale-exit-node= --tailscale-exit-node-allow-lan-access=false --script /tmp/clawsweeper-expiry-do-proof/bootstrap.sh --stop-after always --ttl 40m --idle-timeout 15m --timing-json --label pr1255-real-do-upgrade-proof
```

<details><summary>Exact executed bootstrap</summary>

```bash
#!/usr/bin/env bash
set -euo pipefail
# Trusted, proof-only bootstrap. No production credentials, routes or deployment.
ROOT=/tmp/clawsweeper-expiry-do-proof
if [ "${1:-}" != sanitized ]; then
  mkdir -p "$ROOT"
  TASK=$(mktemp -d "$ROOT/runtime.XXXXXX")
  mkdir -p "$TASK/home" "$TASK/tmp"
  exec env -i PATH="$PATH" HOME="$TASK/home" TMPDIR="$TASK/tmp" CI=1 \
    COREPACK_ENABLE_DOWNLOAD_PROMPT=0 COREPACK_ENABLE_PROJECT_SPEC=0 \
    WRANGLER_SEND_METRICS=false WRANGLER_LOG_PATH="$TASK/wrangler-log" \
    bash "$0" sanitized "$TASK" "$PWD"
fi
TASK=$2
REPO=$3
EXPECTED=a5fdc6606095eeadef03b15191043e95d7b68c85
test "$(git -C "$REPO" rev-parse HEAD)" = "$EXPECTED"
test -z "$(git -C "$REPO" status --porcelain --untracked-files=no)"
node -e 'if (+process.versions.node.split(".")[0] < 24) throw Error("Node >=24 required")'
command -v corepack >/dev/null
# Fail closed if this ephemeral AWS instance can obtain any IAM role credentials.
IMDS_TOKEN=$(curl --noproxy '*' -fsS --max-time 5 -X PUT \
  -H 'X-aws-ec2-metadata-token-ttl-seconds: 60' http://169.254.169.254/latest/api/token)
IAM_CODE=$(curl --noproxy '*' -sS --max-time 5 -o /dev/null -w '%{http_code}' \
  -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" \
  http://169.254.169.254/latest/meta-data/iam/security-credentials/)
unset IMDS_TOKEN
test "$IAM_CODE" = 404
printf 'SAFETY IMDSv2_IAM_HTTP=404 isolated_HOME=true forwarded_credentials=none\n'
sha256sum "$0" "$REPO/dashboard/exact-review-queue.ts" \
  "$REPO/dashboard/github-webhook-read-model.ts" "$REPO/src/stable-json.ts"
printf 'SOURCE_HEAD=%s NODE=%s\n' "$EXPECTED" "$(node --version)"
cd "$TASK"
printf '{"private":true,"packageManager":"pnpm@11.10.0"}\n' > package.json
corepack pnpm@11.10.0 add --ignore-scripts --save-exact wrangler@4.107.0 > install.log 2>&1
node node_modules/wrangler/bin/wrangler.js dev --help > wrangler-dev-help.txt
for option in --local --ip --port --persist-to --inspector-port; do
  grep -q -- "$option" wrangler-dev-help.txt
done
cat > fixture.ts <<'WORKER'
import { ExactReviewQueue } from '__REPO__/dashboard/exact-review-queue.ts';
const NOW = Date.parse('2026-08-26T12:00:00.000Z');
const CUT = NOW - 30 * 86400000;
const P = 'github_webhook_read_model_';
const D = P + 'deliveries_v1';
const IDX = P + 'deliveries_received_at_v1';
const assert = (ok, label) => { if (!ok) throw Error(label); };
async function hash(value) {
  return [...new Uint8Array(await crypto.subtle.digest('SHA-256',
    new TextEncoder().encode(JSON.stringify(value))))].map(x => x.toString(16).padStart(2, '0')).join('');
}
export class ExpiryProof extends ExactReviewQueue {
  instance = crypto.randomUUID();
  async fetch(request) {
    // An ordinary production fetch runs ensureReady/initializeStorage through its
    // real blockConcurrencyWhile barrier. This unknown route has no queue work.
    const initialized = await super.fetch(new Request('http://fixture.invalid/__expiry_init__'));
    assert(initialized.status === 404, 'production initialization route');
    const sql = this.storage.sql;
    const rows = (q, ...args) => [...sql.exec(q, ...args)];
    const count = () => rows(`SELECT count(*) n FROM ${D}`)[0].n;
    const expired = () => rows(`SELECT count(*) n FROM ${D} WHERE received_at < ?`, CUT)[0].n;
    const watermark = () => rows(`SELECT watermark FROM ${P}meta_v1`)[0].watermark;
    const state = () => Object.fromEntries(rows(
      "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'github_webhook_read_model_%' ORDER BY name"
    ).map(({name}) => [name, rows(`SELECT * FROM ${name} ORDER BY rowid`)]));
    const snapshot = async () => {
      const data = state();
      const select = `SELECT delivery_id FROM ${D} WHERE received_at < ? ORDER BY received_at ASC LIMIT 256`;
      let plan;
      try { plan = rows('EXPLAIN QUERY PLAN ' + select, CUT); }
      catch (error) { plan = {unavailable: String(error)}; }
      const cursor = sql.exec(select, CUT);
      const selected = [...cursor];
      const tableHashes = {};
      for (const [name, value] of Object.entries(data)) tableHashes[name] = {rows: value.length, sha256: await hash(value)};
      return {doId: this.state.id.toString(), instance: this.instance,
        storageType: sql.constructor.name, count: count(), expired: expired(), watermark: watermark(),
        stateHash: await hash(data), tables: tableHashes,
        index: rows('SELECT sql FROM sqlite_master WHERE type=\'index\' AND name=?', IDX),
        indexColumns: rows(`PRAGMA index_info('${IDX}')`),
        plan, selector: {returnedRows: selected.length,
          rowsRead: cursor.rowsRead ?? null, rowsWritten: cursor.rowsWritten ?? null},
        controls: rows(`SELECT delivery_id,received_at,watermark FROM ${D} WHERE delivery_id IN ('r600','r601','r999') ORDER BY delivery_id`)};
    };
    const store = this.githubWebhookReadModelStore;
    const delivery = (id, number = 2000) => ({version: 1, deliveryId: id,
      event: 'issues', action: 'opened', receivedAt: new Date(NOW).toISOString(),
      eventClasses: ['issues'], objects: [{kind: 'item', repository: 'synthetic/expiry',
        number, itemKind: 'issue', sourceUpdatedAt: new Date(NOW).toISOString(),
        snapshot: {number, title: 'Synthetic expiry proof'}}]});
    const action = new URL(request.url).pathname;
    let result;
    if (action === '/seed') {
      assert(count() === 0, 'fresh isolated fixture required');
      this.storage.transactionSync(() => {
        sql.exec(`DROP INDEX ${IDX}`);
        for (let i = 0; i < 1000; i++) {
          const at = i < 600 ? CUT - 600 + i : i === 600 ? CUT : i === 601 ? CUT + 1 : NOW;
          sql.exec(`INSERT INTO ${D} VALUES (?, 'issues', 'opened', ?, ?)`, 'r' + i, at, i + 1);
        }
        sql.exec(`UPDATE ${P}meta_v1 SET watermark=1000,created_at=?,updated_at=? WHERE singleton_id=1`, CUT - 600, NOW);
        sql.exec(`INSERT INTO ${P}classes_v1 VALUES ('issues',1000,?,?,1000)`, CUT - 600, NOW);
        for (const n of [10, 11]) sql.exec(`INSERT INTO ${P}items_v1 VALUES ('synthetic/expiry',?,'issue',?,?,?, ?,?)`,
          n, NOW, JSON.stringify({number: n, title: 'Preserve me'}), 'r' + (n - 1), n, NOW);
      });
      result = await snapshot();
      assert(result.count === 1000 && result.expired === 600 && result.index.length === 0, 'legacy baseline');
    } else if (action === '/snapshot') result = await snapshot();
    else if (action === '/exercise') {
      const before = await snapshot();
      assert(before.count === 1000 && before.expired === 600, 'exercise baseline');
      const retained = store.ingest(delivery('r999'), NOW);
      assert(retained.deduped && retained.watermark === 1000 && expired() === 600, 'dedupe must not prune');
      const batches = [];
      for (let i = 0; i < 4; i++) {
        const n = count(), e = expired();
        const accepted = store.ingest(delivery('new' + i, 2000 + i), NOW);
        batches.push({deleted: n + 1 - count(), expiredBefore: e, expiredAfter: expired(), ...accepted});
        assert(!accepted.deduped && accepted.watermark === 1001 + i, 'monotonic batch watermark');
      }
      assert(JSON.stringify(batches.map(x => x.deleted)) === '[256,256,88,0]', 'bounded receipt deletion');
      const duplicate = store.ingest(delivery('r999'), NOW);
      assert(duplicate.deduped && duplicate.watermark === 1000 && watermark() === 1004, 'original watermark');
      const replay = store.ingest(delivery('r0'), NOW);
      assert(!replay.deduped && replay.watermark === 1005, 'pruned GUID accepted');
      assert(rows(`SELECT * FROM ${D} WHERE delivery_id='r600'`)[0].received_at === CUT, 'strict cutoff');
      assert(rows(`SELECT * FROM ${D} WHERE delivery_id='r601'`)[0].received_at === CUT + 1, 'cutoff plus one');
      // Add one backdated receipt without pruning it, using the production
      // store's explicit now parameter. The fixed clock affects only fixture calls.
      const old = delivery('rollback-expired', 3000);
      old.receivedAt = new Date(CUT - 1).toISOString();
      assert(store.ingest(old, CUT - 1).watermark === 1006 && expired() === 1, 'rollback fixture');
      const rollbackBefore = await snapshot();
      const originalPrune = store.pruneSync;
      let observedExpiredAfterPrune = null, injected = false;
      store.pruneSync = function(now) {
        originalPrune.call(this, now);
        observedExpiredAfterPrune = expired();
        throw Error('fixture_failure_after_real_prune');
      };
      try { store.ingest(delivery('must-rollback', 4000), NOW); }
      catch (error) { assert(error.message === 'fixture_failure_after_real_prune', 'expected injected failure'); injected = true; }
      finally { store.pruneSync = originalPrune; }
      const rollbackAfter = await snapshot();
      assert(injected && observedExpiredAfterPrune === 0 && rollbackAfter.expired === 1, 'real pruning rolled back');
      assert(rollbackBefore.stateHash === rollbackAfter.stateHash, 'receipt/item/class/meta rollback');
      const finalRetry = store.ingest(delivery('must-rollback', 4000), NOW);
      assert(!finalRetry.deduped && finalRetry.watermark === 1007 && expired() === 0, 'rollback retry');
      const after = await snapshot();
      result = {retained, batches, duplicate, replay,
        rollback: {beforeHash: rollbackBefore.stateHash, afterHash: rollbackAfter.stateHash,
          observedExpiredAfterPrune, expiredAfterRollback: rollbackAfter.expired,
          watermarkAfterRollback: rollbackAfter.watermark, retry: finalRetry}, after};
    } else return new Response('fixture route not found', {status:404});
    return Response.json(result);
  }
}
export default {fetch(request, env) {
  return env.PROOF.get(env.PROOF.idFromName('expiry-upgrade-v1')).fetch(request);
}};
WORKER
node --input-type=module - "$REPO" <<'REPLACE'
import {readFileSync,writeFileSync} from 'node:fs';
writeFileSync('fixture.ts', readFileSync('fixture.ts','utf8').replace('__REPO__',process.argv[2]));
REPLACE
cat > wrangler.json <<'CONFIG'
{"name":"expiry-do-proof","main":"fixture.ts","compatibility_date":"2026-05-11","workers_dev":false,"send_metrics":false,"durable_objects":{"bindings":[{"name":"PROOF","class_name":"ExpiryProof"}]},"migrations":[{"tag":"v1","new_sqlite_classes":["ExpiryProof"]}],"vars":{"GITHUB_API_URL":"http://127.0.0.1:9","TARGET_REPOS":"synthetic/expiry","PUBLIC_BAY_REPOS":""}}
CONFIG
cat > run.mjs <<'DRIVER'
import assert from 'node:assert/strict';
import {spawn,execFileSync} from 'node:child_process';
import {openSync,writeFileSync,readFileSync,readdirSync} from 'node:fs';
import {createHash} from 'node:crypto';
import path from 'node:path';
const trace = [], children = [];
const emit = (phase, detail) => {const row={phase,...detail}; trace.push(row); console.log(JSON.stringify(row));};
const sha = file => createHash('sha256').update(readFileSync(file)).digest('hex');
const wait = ms => new Promise(resolve=>setTimeout(resolve,ms));
const wrangler = path.resolve('node_modules/wrangler/bin/wrangler.js');
const url = 'http://127.0.0.1:18787';
let current;
for (const signal of ['SIGINT','SIGTERM']) process.once(signal, async () => {
  try {await stop(signal);writeFileSync('trace.json',JSON.stringify(trace,null,2)+'\n');}
  finally {process.exit(128);}
});
function ownedPids(group) {
  return execFileSync('ps',['-eo','pid,pgid,stat,comm'],{encoding:'utf8'}).trim().split('\n').slice(1)
    .map(s=>s.trim().split(/\s+/)).filter(a=>+a[1]===group).map(a=>({pid:+a[0],pgid:+a[1],state:a[2],command:a[3]}));
}
async function api(route) {
  const response=await fetch(url+route,{method:'POST',signal:AbortSignal.timeout(15000)});
  const text=await response.text(); assert.equal(response.status,200,text.slice(0,2000)); return JSON.parse(text);
}
async function start(sequence) {
  const fd=openSync(`wrangler-${sequence}.log`,'w');
  const child=spawn(process.execPath,[wrangler,'dev','--local','--ip','127.0.0.1','--port','18787',
    '--inspector-port','18788','--persist-to',path.resolve('persistence'),'--config',path.resolve('wrangler.json')],
    {stdio:['ignore',fd,fd],detached:true});
  current=child; children.push(child);
  child.exited=new Promise(resolve=>child.once('exit',(code,signal)=>resolve({code,signal})));
  let ready;
  for(let i=0;i<120;i++) {
    if(child.exitCode!==null) throw Error(`Wrangler exited: ${readFileSync(`wrangler-${sequence}.log`,'utf8')}`);
    try {ready=await api('/snapshot');break;} catch(error) {if(i===119) throw error;await wait(500);}
  }
  const pids=ownedPids(child.pid);
  assert(pids.some(p=>p.command.includes('workerd')),'real workerd process required');
  emit('process_start',{sequence,group:child.pid,pids,doId:ready.doId,instance:ready.instance});
  return ready;
}
async function stop(sequence) {
  if(!current)return;
  const child=current;current=null;
  const before=ownedPids(child.pid);
  try{process.kill(-child.pid,'SIGTERM');}catch(e){if(e.code!=='ESRCH')throw e;}
  let exit=await Promise.race([child.exited,wait(8000).then(()=>null)]);
  if(!exit){try{process.kill(-child.pid,'SIGKILL');}catch(e){if(e.code!=='ESRCH')throw e;}exit=await child.exited;}
  for(let i=0;i<50 && ownedPids(child.pid).some(p=>!p.state.startsWith('Z'));i++) await wait(100);
  const remaining=ownedPids(child.pid).filter(p=>!p.state.startsWith('Z'));
  assert.equal(remaining.length,0,'owned process group stopped');
  let accepting=false;try{await fetch(url,{signal:AbortSignal.timeout(1000)});accepting=true;}catch{}
  assert.equal(accepting,false,'loopback server stopped');
  emit('process_stop',{sequence,group:child.pid,before,exit,remaining,loopbackClosed:true});
}
function persistedFiles(dir) {
  return readdirSync(dir,{withFileTypes:true}).flatMap(e=>e.isDirectory()?persistedFiles(path.join(dir,e.name)):
    [{path:path.join(dir,e.name),sha256:sha(path.join(dir,e.name))}]);
}
try {
  const pkg=JSON.parse(readFileSync('node_modules/wrangler/package.json'));
  const workerdPackages=readdirSync('node_modules/.pnpm').filter(name=>name.startsWith('workerd@'));
  assert.equal(workerdPackages.length,1,'one pinned workerd engine');
  const workerdPkg=JSON.parse(readFileSync(`node_modules/.pnpm/${workerdPackages[0]}/node_modules/workerd/package.json`));
  const pnpm=execFileSync('corepack',['pnpm@11.10.0','--version'],{encoding:'utf8'}).trim();
  emit('runtime',{node:process.version,pnpm,wrangler:pkg.version,workerd:workerdPkg.version,
    fixtureSha256:sha('fixture.ts'),configSha256:sha('wrangler.json'),lockSha256:sha('pnpm-lock.yaml'),
    localOnly:true,fixtureNow:'2026-08-26T12:00:00.000Z',cutoff:'2026-07-27T12:00:00.000Z'});
  assert.equal(pkg.version,'4.107.0');
  await start(1);
  const baseline=await api('/seed'); emit('legacy_baseline',baseline);
  await stop(1); emit('persisted_legacy',{files:persistedFiles('persistence')});
  const upgraded=await start(2); emit('upgraded',upgraded);
  assert.equal(upgraded.doId,baseline.doId);assert.notEqual(upgraded.instance,baseline.instance);
  assert.equal(upgraded.stateHash,baseline.stateHash);assert.deepEqual(upgraded.tables,baseline.tables);
  assert.equal(upgraded.index.length,1);assert.deepEqual(upgraded.indexColumns.map(x=>x.name),['received_at']);
  if(Array.isArray(upgraded.plan)) {
    assert(upgraded.plan.some(x=>x.detail.includes('deliveries_received_at_v1')));
    assert(!upgraded.plan.some(x=>x.detail.includes('TEMP B-TREE')));
  }
  const exercise=await api('/exercise');emit('store_behavior',exercise);
  await stop(2);emit('persisted_after_behavior',{files:persistedFiles('persistence')});
  const reopened=await start(3);emit('idempotent_reopen',reopened);
  assert.equal(reopened.doId,upgraded.doId);assert.notEqual(reopened.instance,upgraded.instance);
  assert.equal(reopened.stateHash,exercise.after.stateHash);assert.deepEqual(reopened.index,upgraded.index);
  assert.deepEqual(reopened.indexColumns,upgraded.indexColumns);
  emit('assertions',{passed:true,legacyDataPreserved:true,realSqlStorage:true,
    boundedDeletes:[256,256,88,0],strictCutoff:true,dedupeOriginalWatermark:true,
    prunedGuidReaccepted:true,transactionRollback:true,idempotentRestart:true});
} finally {
  await stop('final');
  const remaining=children.flatMap(c=>ownedPids(c.pid).filter(p=>!p.state.startsWith('Z')));
  emit('process_cleanup',{ownedGroups:children.map(c=>c.pid),remaining});
  writeFileSync('trace.json',JSON.stringify(trace,null,2)+'\n');
  assert.equal(remaining.length,0);
}
DRIVER
node run.mjs
test "$(git -C "$REPO" rev-parse HEAD)" = "$EXPECTED"
test -z "$(git -C "$REPO" status --porcelain --untracked-files=no)"
printf 'FINAL source_head_unchanged=true tracked_source_clean=true\n'
printf 'ARTIFACT_ROOT=%s\n' "$TASK"
tar -czf "$ROOT/artifacts.tar.gz" fixture.ts wrangler.json run.mjs trace.json \
  pnpm-lock.yaml wrangler-dev-help.txt install.log wrangler-1.log wrangler-2.log wrangler-3.log
```

</details>

<details><summary>Selected observed workerd trace (including the known-stale legacy EXPLAIN)</summary>

```jsonl
{"phase":"runtime","node":"v24.18.1","pnpm":"11.10.0","wrangler":"4.107.0","workerd":"1.20260701.1","fixtureSha256":"269bbd77ba1fc637be0bd90855af593b835d48d25a9a8d963ac44b54f5f836c6","configSha256":"3b646b942b40bd01c894f25b34259bb0b34e55c398a72dde24f7845d9ff2ba48","lockSha256":"a86620583a7afb150d55345020a7cb1107a8610c8f4b69c0ace8c61184a7bcc4","localOnly":true,"fixtureNow":"2026-08-26T12:00:00.000Z","cutoff":"2026-07-27T12:00:00.000Z"}
{"phase":"process_start","sequence":1,"group":3532,"doId":"d0ab742d0ec7909873c0dda1fe7f0fbc969df5ab2b73952485f08936556a4252","instance":"c5abe40e-008a-4c7a-92fd-ea6ee11f9916"}
{"phase":"legacy_baseline","doId":"d0ab742d0ec7909873c0dda1fe7f0fbc969df5ab2b73952485f08936556a4252","instance":"c5abe40e-008a-4c7a-92fd-ea6ee11f9916","storageType":"SqlStorage","count":1000,"expired":600,"watermark":1000,"stateHash":"b3022b9990f0e5e11828220fa06170de8e05056eea00b1aac4074911198cbfa0","index":[],"indexColumns":[],"plan":[{"id":5,"parent":0,"notused":203,"detail":"SEARCH github_webhook_read_model_deliveries_v1 USING INDEX github_webhook_read_model_deliveries_received_at_v1 (received_at<?)"}],"selector":{"returnedRows":256,"rowsRead":1600,"rowsWritten":0},"controls":[{"delivery_id":"r600","received_at":1785153600000,"watermark":601},{"delivery_id":"r601","received_at":1785153600001,"watermark":602},{"delivery_id":"r999","received_at":1787745600000,"watermark":1000}],"explainKnownStaleNotUsedAsBaselineProof":true}
{"phase":"process_stop","sequence":1,"group":3532,"exit":{"code":143,"signal":null},"remaining":[],"loopbackClosed":true}
{"phase":"process_start","sequence":2,"group":3692,"doId":"d0ab742d0ec7909873c0dda1fe7f0fbc969df5ab2b73952485f08936556a4252","instance":"1af6de06-02aa-450e-b120-14f9171ab3dd"}
{"phase":"upgraded","doId":"d0ab742d0ec7909873c0dda1fe7f0fbc969df5ab2b73952485f08936556a4252","instance":"1af6de06-02aa-450e-b120-14f9171ab3dd","storageType":"SqlStorage","count":1000,"expired":600,"watermark":1000,"stateHash":"b3022b9990f0e5e11828220fa06170de8e05056eea00b1aac4074911198cbfa0","index":[{"sql":"CREATE INDEX github_webhook_read_model_deliveries_received_at_v1\n         ON github_webhook_read_model_deliveries_v1 (received_at)"}],"indexColumns":[{"seqno":0,"cid":3,"name":"received_at"}],"plan":[{"id":5,"parent":0,"notused":203,"detail":"SEARCH github_webhook_read_model_deliveries_v1 USING INDEX github_webhook_read_model_deliveries_received_at_v1 (received_at<?)"}],"selector":{"returnedRows":256,"rowsRead":256,"rowsWritten":0},"controls":[{"delivery_id":"r600","received_at":1785153600000,"watermark":601},{"delivery_id":"r601","received_at":1785153600001,"watermark":602},{"delivery_id":"r999","received_at":1787745600000,"watermark":1000}]}
{"phase":"store_behavior","retained":{"accepted":true,"deduped":true,"watermark":1000},"batches":[{"deleted":256,"expiredBefore":600,"expiredAfter":344,"accepted":true,"deduped":false,"watermark":1001},{"deleted":256,"expiredBefore":344,"expiredAfter":88,"accepted":true,"deduped":false,"watermark":1002},{"deleted":88,"expiredBefore":88,"expiredAfter":0,"accepted":true,"deduped":false,"watermark":1003},{"deleted":0,"expiredBefore":0,"expiredAfter":0,"accepted":true,"deduped":false,"watermark":1004}],"duplicate":{"accepted":true,"deduped":true,"watermark":1000},"replay":{"accepted":true,"deduped":false,"watermark":1005},"rollback":{"beforeHash":"95eb8d3fb9f28af8c2d255ea2fda1d5fcaa7431170d32938a7feb7d9b15591ea","afterHash":"95eb8d3fb9f28af8c2d255ea2fda1d5fcaa7431170d32938a7feb7d9b15591ea","observedExpiredAfterPrune":0,"expiredAfterRollback":1,"watermarkAfterRollback":1006,"retry":{"accepted":true,"deduped":false,"watermark":1007}},"after":{"count":406,"expired":0,"watermark":1007,"stateHash":"5a30f4622343200af85611552ddc3e62a489a8d6a73305e333ffedf32be37a99"}}
{"phase":"process_stop","sequence":2,"group":3692,"exit":{"code":143,"signal":null},"remaining":[],"loopbackClosed":true}
{"phase":"process_start","sequence":3,"group":3844,"doId":"d0ab742d0ec7909873c0dda1fe7f0fbc969df5ab2b73952485f08936556a4252","instance":"3609ce47-9ba1-45cf-80ef-4e5b9a0a155a"}
{"phase":"idempotent_reopen","doId":"d0ab742d0ec7909873c0dda1fe7f0fbc969df5ab2b73952485f08936556a4252","instance":"3609ce47-9ba1-45cf-80ef-4e5b9a0a155a","storageType":"SqlStorage","count":406,"expired":0,"watermark":1007,"stateHash":"5a30f4622343200af85611552ddc3e62a489a8d6a73305e333ffedf32be37a99","index":[{"sql":"CREATE INDEX github_webhook_read_model_deliveries_received_at_v1\n         ON github_webhook_read_model_deliveries_v1 (received_at)"}],"indexColumns":[{"seqno":0,"cid":3,"name":"received_at"}],"plan":[{"id":5,"parent":0,"notused":203,"detail":"SEARCH github_webhook_read_model_deliveries_v1 USING INDEX github_webhook_read_model_deliveries_received_at_v1 (received_at<?)"}],"selector":{"returnedRows":0,"rowsRead":1,"rowsWritten":0},"controls":[{"delivery_id":"r600","received_at":1785153600000,"watermark":601},{"delivery_id":"r601","received_at":1785153600001,"watermark":602},{"delivery_id":"r999","received_at":1787745600000,"watermark":1000}]}
{"phase":"assertions","passed":true,"legacyDataPreserved":true,"realSqlStorage":true,"boundedDeletes":[256,256,88,0],"strictCutoff":true,"dedupeOriginalWatermark":true,"prunedGuidReaccepted":true,"transactionRollback":true,"idempotentRestart":true}
{"phase":"process_stop","sequence":"final","group":3844,"exit":{"code":143,"signal":null},"remaining":[],"loopbackClosed":true}
{"phase":"process_cleanup","ownedGroups":[3532,3692,3844],"remaining":[]}
```

</details>

## Finding Disposition — changelog scope

**Rejected: “Remove the release-owned changelog entry.”** The cited rule concerns a different target repository. This is `openclaw/clawsweeper`. [AGENTS.md](https://github.com/openclaw/clawsweeper/blob/a5fdc6606095eeadef03b15191043e95d7b68c85/AGENTS.md#L50-L52) says **“OpenClaw `CHANGELOG.md` is release-owned.”** [CONTRIBUTING.md](https://github.com/openclaw/clawsweeper/blob/a5fdc6606095eeadef03b15191043e95d7b68c85/CONTRIBUTING.md#L16-L19) explicitly scopes the restriction to **“an `openclaw/openclaw` target PR”** and separately directs ClawSweeper PRs to their own release-note policy. The maintainer-authored ClawSweeper entry intentionally remains; it neither edits OpenClaw's changelog nor publishes a release. The same scope error was resolved in the fresh review of https://github.com/openclaw/clawsweeper/pull/1254.

The objective DO-runtime proof request is addressed above. No production-code finding remains accepted or unresolved. Please reassess the unchanged head against this updated proof and policy disposition; no source, test, retention, timeout, or safety gate was changed to satisfy the review.
