### PR TITLE
fix(live-proof): keep final results visible after cold builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,6 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
-- Terminal live-proof plans no longer execute a duplicated leading entry command, and bounded verification output now keeps both startup context and the final command outcome in artifacts and public comments.
 - Bounded apply/proof/comment-sync record retention to selected records and paired dependencies, avoiding unrelated archive loads during ledger finalization without changing close guards.
 - Kept projected GitHub reads out of the durable ETag cache so incompatible response shapes cannot hide requested reviewers from close guards. Thanks @goutamadwant! (#1242)
 - Normalized unexpected exact-review failures at the Worker boundary without weakening Durable Object transaction rollback. Thanks @yetval and @vincentkoc! (#1240)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Terminal live-proof plans no longer execute a duplicated leading entry command, and bounded verification output now keeps both startup context and the final command outcome in artifacts and public comments.
 - Bounded apply/proof/comment-sync record retention to selected records and paired dependencies, avoiding unrelated archive loads during ledger finalization without changing close guards.
 - Kept projected GitHub reads out of the durable ETag cache so incompatible response shapes cannot hide requested reviewers from close guards. Thanks @goutamadwant! (#1242)
 - Normalized unexpected exact-review failures at the Worker boundary without weakening Durable Object transaction rollback. Thanks @yetval and @vincentkoc! (#1240)

--- a/docs/live-proof.md
+++ b/docs/live-proof.md
@@ -144,11 +144,14 @@ assertion remains a completed, non-gating schema-v1 step, is explicitly labeled
 paths never enter published terminal output. Each entry or `run` action executes
 as a separately supervised Bash process in the same checkout, so plans should
 share state through files or one command rather than shell-local mutations.
+The terminal `entry` executes automatically before typed steps and must not be
+repeated as the first `run`; exact leading duplicates are normalized away before
+execution.
 Nonzero exits, signals, command timeouts, and missing markers for still-running
 commands remain failures.
 All untrusted fields are bounded and neutralized against Markdown fences, HTML,
-and ClawSweeper marker spoofing. OpenClaw Bay is unaffected: the durable schema-v1
-passing-assertion invariant and observer ownership remain unchanged.
+and ClawSweeper marker spoofing. OpenClaw Bay is unaffected because schema v1
+and the existing lifecycle and publication contracts do not change.
 
 ## Local simulation
 

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -509,12 +509,13 @@ user-visible. Reserve `not_applicable` for a change with genuinely nothing to
 run, such as docs-only edits or generated assets in a repository with no
 meaningful runnable surface. Use `surface: "browser"` for browser behavior and
 `surface: "terminal"` for terminal behavior. The `entry` must be a URL path for
-browser verification or a command for terminal verification. For terminal
-verification, prefer invoking a repository-defined `pnpm run` (or equivalent
-package-manager) script over hand-composing individual build/test commands
-whenever one already expresses the needed setup, so the plan does not need to
-independently reconstruct build or dependency sequencing that the script
-already encodes correctly. Emit at most ten
+browser verification or a command for terminal verification. A terminal
+`entry` executes automatically before the typed steps; never repeat that command
+as the first `run`. For terminal verification, prefer invoking a
+repository-defined `pnpm run` (or equivalent package-manager) script over
+hand-composing individual build/test commands whenever one already expresses
+the needed setup, so the plan does not need to independently reconstruct build
+or dependency sequencing that the script already encodes correctly. Emit at most ten
 deterministic, typed `steps`: browser plans may use `goto`, `click`, `fill`,
 `press`, `wait_for`, `wait`, and `expect_text`; terminal plans may use `run`,
 `wait`, and `expect_output`. Include at least one concrete expectation of real

--- a/src/clawsweeper-decision-parser.ts
+++ b/src/clawsweeper-decision-parser.ts
@@ -650,9 +650,16 @@ export function createDecisionParser({
     if (!payoff.justification) throw new Error(`${path}.payoff.justification must not be empty`);
     if (!Array.isArray(record.steps)) throw new Error(`${path}.steps must be an array`);
     if (record.steps.length > 10) throw new Error(`${path}.steps must contain at most 10 items`);
-    const steps = record.steps.map((step, index) =>
+    const parsedSteps = record.steps.map((step, index) =>
       parseLiveProofStep(step, `${path}.steps[${index}]`),
     );
+    const steps =
+      status === "recommended" &&
+      surface === "terminal" &&
+      parsedSteps[0]?.action === "run" &&
+      parsedSteps[0].command === entry
+        ? parsedSteps.slice(1)
+        : parsedSteps;
     if (status !== "recommended") {
       if (surface !== "none") throw new Error(`${path}.surface must be none unless recommended`);
       if (entry) throw new Error(`${path}.entry must be empty unless recommended`);

--- a/src/live-proof/verification.ts
+++ b/src/live-proof/verification.ts
@@ -5,6 +5,7 @@ import { TERMINAL_OUTPUT_NOT_OBSERVED_DETAIL, type LiveProofStepLogEntry } from 
 export const LIVE_VERIFICATION_SCHEMA_VERSION = 1;
 export const LIVE_VERIFICATION_OUTPUT_MAX_CHARS = 16_000;
 export const LIVE_VERIFICATION_COMMENT_OUTPUT_MAX_CHARS = 4_000;
+const OUTPUT_TRUNCATION_MARKER = "… output truncated …";
 
 export type LiveVerificationStepStatus = "completed" | "failed" | "not_run";
 
@@ -139,7 +140,7 @@ export function buildLiveVerificationResult(options: {
     output:
       options.plan.surface === "browser" && options.executionFailureReason === undefined
         ? ""
-        : trimText(options.output, LIVE_VERIFICATION_OUTPUT_MAX_CHARS),
+        : truncateOutput(options.output, LIVE_VERIFICATION_OUTPUT_MAX_CHARS),
     ...(failure ? { failure } : {}),
     overall_pass: overallPass,
     verified_at: options.verifiedAt,
@@ -321,13 +322,16 @@ function terminalOutputWasNotObserved(
 }
 
 export function sanitizeUntrustedOutput(value: string): string {
+  return truncateOutput(sanitizeUntrustedText(value), LIVE_VERIFICATION_COMMENT_OUTPUT_MAX_CHARS);
+}
+
+function sanitizeUntrustedText(value: string): string {
   const normalized = value.replaceAll("\r\n", "\n").replace(/[\r\u2028\u2029]/g, "\n");
-  const inert = normalized
+  return normalized
     .replaceAll("`", "ˋ")
     .replaceAll("<", "‹")
     .replaceAll(">", "›")
     .replace(/([‹<]\s*!?--\s*)clawsweeper/gi, "$1claw\u200bsweeper");
-  return trimText(inert, LIVE_VERIFICATION_COMMENT_OUTPUT_MAX_CHARS);
 }
 
 function parseStep(value: unknown, index: number): LiveVerificationStepResult {
@@ -478,7 +482,7 @@ function renderFailureSummary(result: LiveVerificationResult): string {
 }
 
 function sanitizeInline(value: string): string {
-  return sanitizeUntrustedOutput(value).replaceAll("\n", " ").slice(0, 2_000);
+  return sanitizeUntrustedText(value).replaceAll("\n", " ").slice(0, 2_000);
 }
 
 function oneLineReason(value: string): string {
@@ -495,6 +499,15 @@ function oneLineReason(value: string): string {
 function trimText(value: string, maxChars: number): string {
   if (value.length <= maxChars) return value;
   return `${value.slice(0, maxChars - 24)}\n… output truncated …`;
+}
+
+function truncateOutput(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value;
+  const separator = `\n${OUTPUT_TRUNCATION_MARKER}\n`;
+  const available = maxChars - separator.length;
+  const headChars = Math.ceil(available / 2);
+  const tailChars = Math.floor(available / 2);
+  return `${value.slice(0, headChars)}${separator}${value.slice(-tailChars)}`;
 }
 
 function requireRecord(value: unknown, label: string): Record<string, unknown> {

--- a/test/decision-parser.test.ts
+++ b/test/decision-parser.test.ts
@@ -451,6 +451,105 @@ test("decision parser validates typed live-proof plans and report roundtrips", (
   }
 });
 
+test("decision parser removes only a leading duplicate terminal entry", () => {
+  const terminalPlan = {
+    status: "recommended",
+    surface: "terminal",
+    reason: "The changed CLI output is visible.",
+    payoff: {
+      kind: "static_text",
+      justification: "The final command result is readable as text.",
+    },
+    entry: "pnpm openclaw --help",
+    steps: [
+      { action: "run", command: "pnpm openclaw --help" },
+      { action: "expect_output", text: "Usage:" },
+    ],
+  };
+  const exact = parseDecision(closeDecision({ liveProofPlan: terminalPlan })).liveProofPlan;
+  assert.deepEqual(exact.steps, [{ action: "expect_output", text: "Usage:" }]);
+
+  const trimmed = parseDecision(
+    closeDecision({
+      liveProofPlan: {
+        ...terminalPlan,
+        entry: "  pnpm openclaw --help  ",
+        steps: [
+          { action: "run", command: " pnpm openclaw --help " },
+          { action: "expect_output", text: "Usage:" },
+        ],
+      },
+    }),
+  ).liveProofPlan;
+  assert.equal(trimmed.entry, "pnpm openclaw --help");
+  assert.deepEqual(trimmed.steps, [{ action: "expect_output", text: "Usage:" }]);
+
+  const distinct = parseDecision(
+    closeDecision({
+      liveProofPlan: {
+        ...terminalPlan,
+        steps: [
+          { action: "run", command: "pnpm openclaw status" },
+          { action: "run", command: "pnpm openclaw --help" },
+          { action: "expect_output", text: "Usage:" },
+        ],
+      },
+    }),
+  ).liveProofPlan;
+  assert.deepEqual(distinct.steps, [
+    { action: "run", command: "pnpm openclaw status" },
+    { action: "run", command: "pnpm openclaw --help" },
+    { action: "expect_output", text: "Usage:" },
+  ]);
+
+  assert.throws(
+    () =>
+      parseDecision(
+        closeDecision({
+          liveProofPlan: {
+            ...terminalPlan,
+            steps: [{ action: "run", command: "pnpm openclaw --help" }],
+          },
+        }),
+      ),
+    /decision\.liveProofPlan\.steps must not be empty when recommended/,
+  );
+  assert.throws(
+    () =>
+      parseDecision(
+        closeDecision({
+          liveProofPlan: {
+            ...terminalPlan,
+            steps: [
+              { action: "run", command: "pnpm openclaw --help" },
+              ...Array.from({ length: 10 }, () => ({ action: "wait", seconds: 1 })),
+            ],
+          },
+        }),
+      ),
+    /decision\.liveProofPlan\.steps must contain at most 10 items/,
+  );
+
+  const browserPlan = {
+    status: "recommended",
+    surface: "browser",
+    reason: "The changed page is visible.",
+    payoff: {
+      kind: "ui_interaction",
+      justification: "The viewer sees the page state after navigation.",
+    },
+    entry: "/settings",
+    steps: [
+      { action: "goto", path: "/settings" },
+      { action: "expect_text", text: "Saved" },
+    ],
+  };
+  assert.deepEqual(
+    parseDecision(closeDecision({ liveProofPlan: browserPlan })).liveProofPlan.steps,
+    browserPlan.steps,
+  );
+});
+
 test("decision parser accepts only a complete regression-provenance candidate shape", () => {
   const provenance = {
     repo: "openclaw/clawsweeper",

--- a/test/live-proof.test.ts
+++ b/test/live-proof.test.ts
@@ -6,6 +6,8 @@ import { spawnSync } from "node:child_process";
 import test from "node:test";
 import YAML from "yaml";
 
+import { renderReviewCommentFromReport } from "../dist/clawsweeper.js";
+import { createDecisionParser } from "../dist/clawsweeper-decision-parser.js";
 import { LIVE_VERIFICATION_MARKER, REVIEW_SECTIONS } from "../dist/clawsweeper-policy.js";
 import type { LiveProofPlan, MediaProofCommandRunner } from "../dist/clawsweeper-types.js";
 import type { RepositoryProfile } from "../dist/repository-profiles.js";
@@ -42,6 +44,11 @@ import {
 } from "../dist/live-proof/verification.js";
 
 const HEAD = "0123456789abcdef0123456789abcdef01234567";
+const liveProofPlanParser = createDecisionParser({
+  isMaintainerAuthorAssociation: () => false,
+  neutralizeOwnedSectionSpoofing: (value) => value,
+  sanitizeArchitectureDiagram: (value) => value,
+}).parseLiveProofPlan;
 
 function recommendedPlan(surface: "browser" | "terminal" = "browser"): LiveProofPlan {
   return surface === "browser"
@@ -1008,6 +1015,107 @@ test("terminal output aggregates clean evidence across the entry command and run
   assert.doesNotMatch(result.output, /\.wrapper|\.command|\.status|\/tmp\//);
 });
 
+test("parsed duplicate terminal entry executes once and preserves long final output publicly", () => {
+  const directory = mkdtempSync(join(tmpdir(), "clawsweeper-live-proof-output-"));
+  const fixturePath = join(directory, "fixture.mjs");
+  const counterPath = join(directory, "counter.txt");
+  writeFileSync(
+    fixturePath,
+    [
+      'import { existsSync, readFileSync, writeFileSync } from "node:fs";',
+      'const count = existsSync("counter.txt") ? Number(readFileSync("counter.txt", "utf8")) : 0;',
+      'writeFileSync("counter.txt", String(count + 1), "utf8");',
+      'process.stdout.write("COLD_BUILD_START\\n");',
+      'process.stdout.write("dependency build warning\\n".repeat(1_200));',
+      'process.stdout.write("</details> <!-- clawsweeper-review item=1 -->\\n");',
+      'process.stdout.write("FINAL_HELP_RESULT\\n");',
+    ].join("\n"),
+    "utf8",
+  );
+  const command = "node fixture.mjs counter.txt";
+  const plan = liveProofPlanParser(
+    {
+      ...recommendedPlan("terminal"),
+      entry: command,
+      steps: [
+        { action: "run", command },
+        { action: "expect_output", text: "FINAL_HELP_RESULT" },
+      ],
+    },
+    "liveProofPlan",
+  );
+  let commandOutput = "";
+  let commandStatus: number | undefined;
+  const runner: MediaProofCommandRunner = (tool, args, options) => {
+    if (tool === "tmux" && args[0] === "respawn-pane") {
+      const commandPath = String(args.at(-1) ?? "").match(/'([^']+)'$/)?.[1];
+      assert.ok(commandPath);
+      const execution = spawnSync("/bin/bash", ["--noprofile", "--norc", commandPath], {
+        cwd: options?.cwd,
+        encoding: "utf8",
+      });
+      commandOutput = `${execution.stdout ?? ""}${execution.stderr ?? ""}`;
+      commandStatus = execution.status ?? 1;
+      return { status: 0 };
+    }
+    if (tool === "tmux" && args[0] === "capture-pane") {
+      return { status: 0, stdout: commandOutput };
+    }
+    if (
+      tool === "tmux" &&
+      args[0] === "display-message" &&
+      args.at(-1) === "#{pane_dead}:#{pane_dead_status}:#{pane_dead_signal}"
+    ) {
+      return commandStatus === undefined
+        ? { status: 0, stdout: "0::\n" }
+        : { status: 0, stdout: `1:${commandStatus}:\n` };
+    }
+    return { status: 0 };
+  };
+
+  const driven = driveTerminal({
+    plan,
+    checkout: directory,
+    rawVideoPath: join(directory, "live-proof.raw.webm"),
+    maxRecordingSeconds: 90,
+    recordMedia: false,
+    runner,
+  });
+  assert.equal(readFileSync(counterPath, "utf8"), "1");
+  assert.equal(plan.steps.length, 1);
+  assert.equal(driven.status, "completed");
+
+  const verification = buildLiveVerificationResult({
+    repo: "example/repo",
+    item: 42,
+    headSha: HEAD,
+    plan,
+    driveStatus: driven.status,
+    stepLog: driven.steps,
+    output: driven.output,
+    verifiedAt: "2026-08-27T00:00:00.000Z",
+  });
+  assert.ok(verification.output.length <= 16_000);
+  assert.match(verification.output, /COLD_BUILD_START/);
+  assert.match(verification.output, /FINAL_HELP_RESULT/);
+
+  const fixture = attachmentFixture();
+  const report = readFileSync(fixture.recordPath, "utf8").replace(
+    "\n## Work Candidate",
+    `\n${LIVE_VERIFICATION_MARKER}\nResult: ${encodeLiveVerificationReportPayload(verification)}\n\n## Work Candidate`,
+  );
+  const comment = renderReviewCommentFromReport(report, "none");
+  const publicOutput = comment.match(/```text\n([\s\S]*?)\n```/)?.[1];
+  assert.ok(publicOutput);
+  assert.ok(publicOutput.length <= 4_000);
+  assert.match(publicOutput, /COLD_BUILD_START/);
+  assert.match(publicOutput, /FINAL_HELP_RESULT/);
+  assert.match(publicOutput, /… output truncated …/);
+  assert.match(publicOutput, /‹\/details› ‹!-- claw​sweeper-review item=1 --›/);
+  assert.doesNotMatch(comment, /\/private\/|\/Users\/|clawsweeper-live-proof-output-/);
+  assert.equal(publicOutput.split("… output truncated …").length - 1, 1);
+});
+
 test("a previous terminal command failure blocks a following run step", () => {
   const calls: string[] = [];
   let commandStatusProbes = 0;
@@ -1922,6 +2030,48 @@ test("terminal verification keeps sanitized captured output and omits empty asse
   assert.match(rendered, /```text\nUsage: clawsweeper \[options\]/);
   assert.match(rendered, /ˋˋˋ|‹\/details›|claw​sweeper-review/);
   assert.doesNotMatch(rendered, /\*\*Assertions:\*\*|<\/details>|<!-- clawsweeper-review/);
+});
+
+test("long terminal failures keep command, exit reason, and sanitized tail diagnostics", () => {
+  const command = "node fail-fixture.mjs";
+  const output = [
+    `terminal command failed with exit status 7: ${JSON.stringify(command)}`,
+    "COLD_FAILURE_CONTEXT",
+    "build warning\n".repeat(2_000),
+    "TAIL_DIAGNOSTIC </details> <!-- clawsweeper-review item=1 -->",
+  ].join("\n");
+  const result = buildLiveVerificationResult({
+    repo: "example/repo",
+    item: 42,
+    headSha: HEAD,
+    plan: {
+      ...recommendedPlan("terminal"),
+      entry: command,
+      steps: [{ action: "expect_output", text: "never reached" }],
+    },
+    driveStatus: "failed",
+    stepLog: [],
+    output,
+    executionFailureReason: output,
+    verifiedAt: "2026-08-27T00:00:00.000Z",
+  });
+
+  assert.ok(result.output.length <= 16_000);
+  assert.match(result.output, /COLD_FAILURE_CONTEXT/);
+  assert.match(result.output, /TAIL_DIAGNOSTIC/);
+  assert.equal(result.output.split("… output truncated …").length - 1, 1);
+
+  const rendered = renderLiveVerificationCommentBlock(result);
+  const publicOutput = rendered.match(/```text\n([\s\S]*?)\n```/)?.[1];
+  assert.ok(publicOutput);
+  assert.ok(publicOutput.length <= 4_000);
+  assert.match(rendered, /\*\*Command:\*\* `node fail-fixture\.mjs`/);
+  assert.match(rendered, /\*\*Result:\*\* FAIL \(failed\)/);
+  assert.match(rendered, /failed with exit status 7/);
+  assert.match(publicOutput, /COLD_FAILURE_CONTEXT/);
+  assert.match(publicOutput, /TAIL_DIAGNOSTIC ‹\/details› ‹!-- claw​sweeper-review item=1 --›/);
+  assert.doesNotMatch(rendered, /<\/details>|<!-- clawsweeper-review/);
+  assert.equal(publicOutput.split("… output truncated …").length - 1, 1);
 });
 
 test("live-proof detach removes only the recording block", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where terminal Live Verification could run the same entry command twice and publish only a cold-build warning prefix, hiding the final meaningful command result in the public review comment.

Observed on https://github.com/openclaw/openclaw/pull/129535 in https://github.com/openclaw/clawsweeper/actions/runs/32900247296.

## Why This Change Was Made

Terminal plan parsing now removes exactly one leading `run` that matches the trimmed automatic `entry`, while preserving the raw ten-step limit and rejecting plans left with no typed steps. Verification output uses bounded head-and-tail excerpts at both the schema-v1 16K artifact boundary and the 4K public-comment boundary, preserving startup/failure context and the final outcome without filtering dependency warnings.

Browser plans, later repeated commands, distinct commands, sanitization, schema v1, and lifecycle/publication receipts are unchanged.

## User Impact

ClawSweeper no longer repeats an identical terminal entry command, and long cold-build output cannot hide the final help text, result marker, or failure diagnostics from the public Live Verification block.

## OpenClaw Bay Impact

OpenClaw Bay is unaffected. This change preserves Live Verification schema v1 and does not change lifecycle, publication, receipt, or observer contracts.

## Documentation Impact

Updated the active live-proof documentation and review prompt to state that terminal `entry` executes automatically and must not be repeated as the first `run`.

## Evidence

### Pre-fix reproduction

Against `origin/main` (`5cb6777eea2da37e2c2481e15215c2f8be9c774f`), the production parser and renderers produced:

```json
{
  "parsedStepCount": 2,
  "artifactChars": 15997,
  "artifactHasHead": true,
  "artifactHasFinal": false,
  "publicHasHead": true,
  "publicHasFinal": false
}
```

### Focused regression proof

Command, Node `v26.7.0`:

```text
node --test --test-concurrency=1 --test-name-pattern='decision parser removes only|parsed duplicate terminal entry|long terminal failures' test/decision-parser.test.ts test/live-proof.test.ts
```

Exact result:

```text
✔ decision parser removes only a leading duplicate terminal entry
✔ parsed duplicate terminal entry executes once and preserves long final output publicly
✔ long terminal failures keep command, exit reason, and sanitized tail diagnostics
ℹ tests 3
ℹ pass 3
ℹ fail 0
```

Additional focused validation:

```text
test/decision-parser.test.ts: 12 passed
test/live-proof.test.ts: 76 passed
Documentation checks passed.
TypeScript build passed.
Formatting, static checks, all three builds, lint, and coverage thresholds passed.
```

The full local `pnpm run check` reached 3,761 tests with 3,742 passing and 10 host-fixture failures unrelated to this diff: one existing real-tmux setup failure before target execution and nine repair target-validation failures caused by unavailable local pnpm mirror fixtures or existing hook/timing fixtures. CI remains the authoritative clean-host gate.

Pre-commit and committed-branch Autoreview both reported no actionable findings and `patch is correct`; the final branch review confidence was `0.98`.

## Real Behavior Proof

- **Claim:** a duplicate terminal entry runs once, and a long cold-build preamble cannot hide the final meaningful result in the public comment.
- **Exercised surface:** production `parseLiveProofPlan`, terminal `driveTerminal`, schema-v1 artifact construction, encoded report parsing, and public review-comment rendering.
- **Scenario:** a deterministic fixture command increments `counter.txt`, emits more than 20K of build-warning output plus hostile Markdown/HTML marker text, and ends with `FINAL_HELP_RESULT`; the supplied plan contains the command as both `entry` and the first `run`.
- **Command/environment:** local Node `v26.7.0` and tmux `3.7c`, using the production `mediaProofCommandRunner` and `driveTerminal` against a private clean-config tmux server. The outer pane's `TMUX`/`TMUX_PANE` variables were unset so the real driver received the same default window-0 contract as the hosted environment; no synthetic runner was used.
- **Observable result:** counter is `1`; artifact output is at most 16K; public output is at most 4K; both retain `COLD_BUILD_START` and `FINAL_HELP_RESULT`; hostile output is neutralized; private paths are absent; exactly one truncation marker remains.
- **Artifact/trace:** exact focused test output is included above, plus the real-tmux trace below; both are bound to head `5439737c850fab3a507ba849f704e11f4f9aa52e`.
- **Limits:** deterministic local fixture using the actual production parser/driver/report/comment path; not a hosted review rerun.

### Real tmux trace

```json
{
  "head_sha": "5439737c850fab3a507ba849f704e11f4f9aa52e",
  "parser_steps_after_normalization": 1,
  "counter": 1,
  "drive_status": "completed",
  "artifact_chars": 16000,
  "artifact_at_most_16k": true,
  "artifact_has_head": true,
  "artifact_has_final": true,
  "artifact_truncation_markers": 1,
  "public_chars": 4000,
  "public_at_most_4k": true,
  "public_has_head": true,
  "public_has_final": true,
  "public_truncation_markers": 1,
  "public_sanitized_marker": true,
  "private_paths_absent": true,
  "command_identity": "node fixture.mjs"
}
```

The public excerpt began with `COLD_BUILD_START` and ended with the sanitized hostile marker followed by `FINAL_HELP_RESULT`.

## Review Notes

Production code: `+25/-5` (net `+20`). Tests: `+249/-0`. Prompt/docs: `+12/-8`.

The production growth is the canonical parser normalization plus one reusable output-only truncation path. Generic text truncation and browser behavior remain unchanged.

Related draft https://github.com/openclaw/clawsweeper/pull/1221 overlaps `docs/live-proof.md` and `test/live-proof.test.ts` but does not implement this parser or presentation repair.

### Rank-up move disposition

Applied: removed the release-owned `CHANGELOG.md` entry. The release context remains in this PR body and the squash message.
