### PR TITLE
fix: avoid persistence warnings for test fixtures

### DIFF
--- a/docs/pr-review-comments.md
+++ b/docs/pr-review-comments.md
@@ -107,6 +107,13 @@ review metrics, stored-data warnings, root-cause clusters, proof suggestions,
 merge-risk options, full review comments, labels, evidence, optional rank-up
 moves, the rank legend, workflow notes, and review history.
 
+For OpenClaw PRs, stored-data warnings flag possible persistence changes in
+production source or semantic documentation changes, not setup in test,
+fixture, or example source paths. Renames retain evidence from either production
+path. Missing, empty, or truncated patches on likely production persistence paths,
+and truncated file lists, still produce conservative unknown warnings. The
+warning requests review; it does not prove a persisted contract changed.
+
 Security defaults to `None.` when there are no concerns. Do not spend public
 space explaining why an uneventful security pass is uneventful.
 

--- a/src/clawsweeper-change-detection.ts
+++ b/src/clawsweeper-change-detection.ts
@@ -84,7 +84,10 @@ export function dataModelChangeFromContext(repo: string, context: ItemContext): 
     const path = typeof file.filename === "string" ? file.filename.trim() : "";
     const previousPath =
       typeof file.previous_filename === "string" ? file.previous_filename.trim() : "";
-    const candidates = [path, previousPath].filter(Boolean);
+    // Scope each rename side before unknown handling, retaining the semantic docs branch.
+    const candidates = [path, previousPath].filter(
+      (candidate) => isProductionSourcePath(candidate) || isDocsPath(candidate),
+    );
     const likelyPath = candidates.find(isLikelyOpenClawDataModelPath) ?? "";
     const patch = typeof file.patch === "string" ? file.patch : null;
     const lines = patch === null ? [] : changedPatchLines(patch);

--- a/test/fixtures/persistence-classifier-130585.json
+++ b/test/fixtures/persistence-classifier-130585.json
@@ -1,0 +1,18 @@
+{
+  "pullRequest": "https://github.com/openclaw/openclaw/pull/130585",
+  "headSha": "7415491d399e97288a1e5c58eea8273a0d3e12e0",
+  "pullFiles": [
+    {
+      "filename": "scripts/run-opengrep.sh",
+      "additions": 1,
+      "deletions": 3,
+      "patch": "@@ -45,10 +45,8 @@ if ! command -v opengrep >/dev/null 2>&1; then\n   cat >&2 <<'EOF'\n error: 'opengrep' not found on PATH.\n \n-Install with one of:\n+Install with:\n   curl -fsSL https://raw.githubusercontent.com/opengrep/opengrep/v1.27.1/install.sh | bash -s -- -v v1.27.1\n-  brew install opengrep/tap/opengrep\n-  pipx install opengrep\n \n (See https://opengrep.dev for other options.)\n EOF"
+    },
+    {
+      "filename": "test/scripts/run-opengrep.test.ts",
+      "additions": 31,
+      "deletions": 0,
+      "patch": "@@ -42,6 +42,37 @@ function installOpengrepStub(repo: string): { argsPath: string; binDir: string }\n }\n \n describe(\"run-opengrep.sh\", () => {\n+  it(\"fails before scanning with official installation advice when opengrep is missing\", () => {\n+    const repo = createTempDir(\"openclaw-run-opengrep-missing-\");\n+    copyRunOpengrepFiles(repo);\n+    writeFile(path.join(repo, \"security/opengrep/precise.yml\"), \"rules: []\\n\");\n+\n+    const binDir = path.join(repo, \"bin\");\n+    fs.mkdirSync(binDir);\n+    for (const command of [\"bash\", \"dirname\", \"cat\"]) {\n+      const executable = execFileSync(\"bash\", [\"-c\", 'command -v \"$1\"', \"_\", command], {\n+        encoding: \"utf8\",\n+      }).trim();\n+      fs.symlinkSync(executable, path.join(binDir, command));\n+    }\n+\n+    const result = spawnSync(\n+      \"bash\",\n+      [\"scripts/run-opengrep.sh\", \"--changed\", \"--sarif\", \"--error\"],\n+      { cwd: repo, env: { ...process.env, PATH: binDir }, encoding: \"utf8\" },\n+    );\n+\n+    expect(result.status).toBe(127);\n+    expect(result.stdout).toBe(\"\");\n+    expect(result.stderr).toContain(\"'opengrep' not found on PATH\");\n+    expect(result.stderr).toMatch(\n+      /curl -fsSL https:\\/\\/raw\\.githubusercontent\\.com\\/opengrep\\/opengrep\\/\\S+\\/install\\.sh \\| bash -s -- -v \\S+/,\n+    );\n+    expect(fs.existsSync(path.join(repo, \".opengrep-out\"))).toBe(false);\n+    expect(result.stderr).not.toContain(\"pipx\");\n+    expect(result.stderr).not.toContain(\"opengrep/tap/opengrep\");\n+  });\n+\n   it(\"validates the rulepack when only OpenGrep rulepack files changed\", () => {\n     const repo = createTempDir(\"openclaw-run-opengrep-\");\n     git(repo, \"init\", \"-q\");"
+    }
+  ]
+}

--- a/test/pr-surface-policy.test.ts
+++ b/test/pr-surface-policy.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import {
@@ -239,7 +240,99 @@ test("config surface detector fails closed for truncated pull files", () => {
   });
 });
 
-test("data model detector finds persistent schema and embedding metadata changes", () => {
+test("tooling diagnostic and subprocess regression do not produce a stored-data warning", () => {
+  const fixture = JSON.parse(
+    readFileSync(new URL("./fixtures/persistence-classifier-130585.json", import.meta.url), "utf8"),
+  );
+  const detection = dataModelChangeFromPullFilesForTest({ pullFiles: fixture.pullFiles });
+
+  assert.deepEqual(detection, { change: false, surfaces: [] });
+
+  const comment = renderReviewCommentFromReport(
+    `${reportFrontMatter({
+      repository: "openclaw/openclaw",
+      type: "pull_request",
+      number: "130585",
+      url: fixture.pullRequest,
+      decision: "keep_open",
+      close_reason: "none",
+      work_candidate: "none",
+      pull_head_sha: fixture.headSha,
+      data_model_change: String(detection.change),
+      data_model_surfaces: JSON.stringify(detection.surfaces),
+    })}
+
+## Summary
+
+Corrects missing-tool installation guidance and adds a subprocess regression.
+`,
+    "none",
+  );
+
+  assert.doesNotMatch(comment, /Persistent data-model change detected|### Stored data model/);
+});
+
+for (const { name, file, surfaces, pullFilesTruncated } of [
+  {
+    name: "colocated test serialization",
+    file: { filename: "src/cache/store.test.ts", patch: '@@\n+writeFile("fixture.json", "{}");' },
+    surfaces: [],
+  },
+  {
+    name: "test setup with a missing patch",
+    file: { filename: "src/cache/__tests__/setup.ts" },
+    surfaces: [],
+  },
+  {
+    name: "fixture with a truncated patch",
+    file: {
+      filename: "fixtures/schema.sql",
+      patch: "@@\n+CREATE TABLE example (id TEXT);\n\n[truncated 90 chars]",
+    },
+    surfaces: [],
+  },
+  {
+    name: "example storage setup",
+    file: { filename: "examples/storage.ts", patch: '@@\n+await state.storage.put("key", value);' },
+    surfaces: [],
+  },
+  {
+    name: "test to production rename with a missing patch",
+    file: { filename: "src/state.ts", previous_filename: "fixtures/state.ts" },
+    surfaces: ["unknown-data-model-change: src/state.ts"],
+  },
+  {
+    name: "production to test rename with serialization removed",
+    file: {
+      filename: "tests/runtime/io.ts",
+      previous_filename: "src/runtime/io.ts",
+      patch: "@@\n-await writeFile(target, JSON.stringify(value));",
+    },
+    surfaces: ["serialized state: src/runtime/io.ts"],
+  },
+  {
+    name: "production to fixture rename with a missing patch",
+    file: { filename: "fixtures/state.ts", previous_filename: "src/state.ts" },
+    surfaces: ["unknown-data-model-change: src/state.ts"],
+  },
+  {
+    name: "truncated file list containing only test setup",
+    file: { filename: "test/setup.ts", patch: '@@\n+writeFile("fixture.json", "{}");' },
+    pullFilesTruncated: true,
+    surfaces: ["unknown-truncated-pull-files"],
+  },
+]) {
+  test(`data model detector scopes ${name}`, () => {
+    const detection = dataModelChangeFromPullFilesForTest({
+      pullFiles: [file],
+      pullFilesTruncated,
+    });
+
+    assert.deepEqual(detection, { change: surfaces.length > 0, surfaces });
+  });
+}
+
+test("data model detector finds production persistence and semantic docs changes in mixed diffs", () => {
   const detection = dataModelChangeFromPullFilesForTest({
     pullFiles: [
       {
@@ -259,6 +352,22 @@ test("data model detector finds persistent schema and embedding metadata changes
         filename: "packages/database/migrations/019_backfill_sessions.sql",
         patch: "@@\n+UPDATE sessions SET last_model = 'unknown' WHERE last_model IS NULL;",
       },
+      {
+        filename: "src/runtime/io.ts",
+        patch: "@@\n+await writeFile(target, JSON.stringify(value));",
+      },
+      {
+        filename: "src/workers/store.ts",
+        patch: '@@\n+await state.storage.put("revision", revision);',
+      },
+      {
+        filename: "docs/storage.md",
+        patch: "@@\n+The serialized format now includes a revision field.",
+      },
+      {
+        filename: "src/memory/vector-store.test.ts",
+        patch: '@@\n+writeFile("fixture.json", JSON.stringify(value));',
+      },
     ],
   });
 
@@ -266,8 +375,11 @@ test("data model detector finds persistent schema and embedding metadata changes
     change: true,
     surfaces: [
       "database schema: packages/database/migrations/018_sessions.sql",
+      "durable storage schema: src/workers/store.ts",
       "migration/backfill/repair: packages/database/migrations/019_backfill_sessions.sql",
       "migration/backfill/repair: src/doctor/backfill.ts",
+      "serialized state: docs/storage.md",
+      "serialized state: src/runtime/io.ts",
       "vector/embedding metadata: src/memory/vector-store.ts",
     ],
   });


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Maintainers can edit this same-repository branch.

</details>

Related: https://github.com/openclaw/openclaw/pull/130585 — diagnostic-only OpenGrep repair, already merged and unchanged by this PR.

## What Problem This Solves

Fixes an issue where maintainers reviewing test-only setup would receive a persistent-data-model warning and a migration-proof requirement even though no runtime persistence contract changed.

The [review of the OpenGrep diagnostic repair](https://github.com/openclaw/openclaw/pull/130585#issuecomment-5433465381) classified `test/scripts/run-opengrep.test.ts` as serialized state. That real two-file patch changes only missing-tool installation guidance (+1/-3) and adds a subprocess regression (+31/-0). The [maintainer disposition](https://github.com/openclaw/openclaw/pull/130585#issuecomment-5433518056) identifies the warning as inapplicable.

## Why This Change Was Made

The generic persistence detector matched the test fixture's `writeFile(...)` call without first excluding test/support paths. The producer now reuses the existing SQLite classifier's production-path predicate before both semantic detection and missing/truncated-patch handling, while preserving semantic documentation checks.

Current and previous filenames are filtered independently: moving production persistence code into a test or fixture path still retains the original production-side evidence. This changes the classification owner, not the renderer or upgrade-proof gate. It introduces no new regex family, dependency, config, schema, migration, or test-only production seam.

## User Impact

Test, fixture, and example setup no longer creates a persistence warning merely by writing temporary data. Actual production serialization, schemas, migrations/backfills, cache/vector/durable storage, semantic documentation changes, and conservative incomplete-evidence warnings retain their existing behavior.

The already-landed OpenGrep fix is not modified. The original review's separate terminal-completion discrepancy is not changed or labeled a proven reporter defect here.

## OpenClaw Bay Impact

No Bay changes are needed. Publication fields, queue/lifecycle behavior, and observer API contracts are unchanged; future review records carry corrected values in the existing data-model fields.

## Documentation Impact

Updated the active implementation reference `docs/pr-review-comments.md` to explain production/test scope, rename handling, conservative unknown warnings, and the distinction between a review signal and proof of a changed persistence contract. Its owning source remains `src/clawsweeper-change-detection.ts` and the report renderer; review this paragraph when those detection or rendering contracts change.

## Evidence

- Frozen the exact GitHub file patches from OpenClaw head `7415491d399e97288a1e5c58eea8273a0d3e12e0`, and verified them against the head-parent diff. The permanent fixture retains both complete patches and their additions/deletions.
- Reproduced the exact false-positive surface with the original reviewer source `a2641b27c403012451cf307d03fb699933fef6a5` and the current-main baseline. The production renderer emitted the original warning sentence.
- Regression red proof before the source edit: 25 tests passed and 9 failed for the intended test-scope classifications. Green proof afterward: `node --test test/pr-surface-policy.test.ts` passed all 34 tests.
- Coverage protects the real diff, colocated tests, missing/truncated test-support patches, mixed production/test diffs, both rename directions, removed serialization, semantic docs, and truncated file-list uncertainty. Existing config, SQLite, production persistence, and upgrade-proof tests remain green.
- `pnpm run build:all`, formatting, docs checks, all lint lanes, and focused coverage passed. Fresh isolated Codex reviews before commit and on the rebased committed branch both returned no findings (P0 scope; patch is correct). On the committed head, all three builds, formatting and docs checks, all 34 focused tests, and the production classifier/renderer replay passed again.
- The initial local `pnpm run check` ran 3,767 tests: 3,710 passed, 48 failed, and 9 skipped. The failures were independently reproduced from an extracted, rebuilt unchanged baseline and are separate from this patch: 42 failures from abbreviated fetch refspecs pruning `origin/main` with `fetch.prune=true`, and 6 from an unprepared pinned pnpm runtime in a fresh offline validation profile. These have separate active repairs; this PR does not disable pruning, enable network access in containment, or weaken their assertions. Current-main hosted CI is green; exact-head hosted CI must also be green before merge.
- Production LOC: +4/-1 (net +3); tests/fixture: +131/-1 (net +130); docs: +7/-0. The production growth applies an existing ownership predicate rather than adding another classifier policy.

## Real Behavior Proof

**Verified ClawSweeper head:** `b45a0380ccfe72d9dd9091c6bada26bea9871cf5`, rebased onto `f211e21fb89d00777ac07cc13c358f9f7b02a939`. All four task-file blobs are unchanged from the accepted precommit patch.

**Claim:** The actual reviewed two-file diagnostic/test diff must not produce a persistent-data-model warning, while real production persistence and incomplete-evidence signals remain intact.

**Exercised surface:** Captured GitHub `pullFiles` payload → compiled production `dataModelChangeFromContext` → report frontmatter → production `renderReviewCommentFromReport`. No publisher, apply, repair, or GitHub mutation path is used.

**Scenario and environment:** Exact OpenClaw PR 130585 head above; isolated ClawSweeper checkout on macOS, repository-pinned pnpm 11.10.0. Initial proof ran on Node 24.19.0; the committed-head rebuild, 34 focused tests, and production replay passed on Node 26.7.0. This is a controlled replay of real review input, not a mocked classifier or a claim of deployed/live model review.

**Commands:** `pnpm run build:all`; direct Node invocation of the compiled classifier and comment renderer using `test/fixtures/persistence-classifier-130585.json`; `node --test test/pr-surface-policy.test.ts`.

The classifier portion is independently reproducible from the checked-in real payload after building:

```bash
node --input-type=module <<'JS'
import fs from 'node:fs';
import { dataModelChangeFromContext } from './dist/clawsweeper-change-detection.js';
const { pullFiles } = JSON.parse(fs.readFileSync('test/fixtures/persistence-classifier-130585.json', 'utf8'));
console.log(dataModelChangeFromContext('openclaw/openclaw', {
  issue: {}, comments: [], timeline: [], pullFiles,
  counts: { comments: 0, timeline: 0, pullFilesTruncated: false },
}));
JS
```

**Observed before:**

```json
{"change":true,"surfaces":["serialized state: test/scripts/run-opengrep.test.ts"]}
```

The rendered comment contained: `Persistent data-model change detected: serialized state: test/scripts/run-opengrep.test.ts. Confirm migration or upgrade compatibility proof before merge.`

**Observed after:**

```json
{"change":false,"surfaces":[]}
```

The rendered comment has no stored-data warning. Companion production and rename scenarios retain their expected warnings.

**Limits:** No deployment is part of this PR. The original terminal-proof artifact records a completion-observation timeout and both output assertions as `not_run`; its passing test summary does not prove outer-process exit. Missing original pane/PID/exit telemetry prevents assigning that separate discrepancy to the reporter or wrapper, so neither is changed here.
