### PR TITLE
fix(live-proof): avoid replaying one-shot terminal proofs

### DIFF
--- a/docs/live-proof.md
+++ b/docs/live-proof.md
@@ -144,9 +144,20 @@ assertion remains a completed, non-gating schema-v1 step, is explicitly labeled
 paths never enter published terminal output. Each entry or `run` action executes
 as a separately supervised Bash process in the same checkout, so plans should
 share state through files or one command rather than shell-local mutations.
-The terminal `entry` executes automatically before typed steps and must not be
-repeated as the first `run`; exact leading duplicates are normalized away before
-execution.
+The terminal `entry` executes automatically before all typed steps. Every `run`
+executes independently, including a first `run` identical to `entry` or a later
+repeated command; the parser and driver do not deduplicate commands. Intentional
+reruns after state changes remain valid and execute in order.
+
+Plan one-shot proofs, including commands that refuse an existing output directory,
+in one of two ways: put the proof command in `entry` followed by stable
+`expect_output` steps, or put safe setup in `entry` followed by exactly one `run`
+of the proof command and its expectations. Do not replay a proof just to capture
+its output or produce media. For a useful recording transition, choose setup plus
+one run so the expected output appears after the action; otherwise use
+`static_text` and verify once. Preserve non-overwrite guards rather than deleting
+the original output to accommodate an accidental replay.
+
 Nonzero exits, signals, command timeouts, and missing markers for still-running
 commands remain failures.
 All untrusted fields are bounded and neutralized against Markdown fences, HTML,

--- a/docs/proof/terminal-proof-planning/README.md
+++ b/docs/proof/terminal-proof-planning/README.md
@@ -1,8 +1,9 @@
 # Terminal proof planning
 
-Status: local proof for an uncommitted change based on
-`f211e21fb89d00777ac07cc13c358f9f7b02a939`. This record does not authorize a
-commit, publication, or live mutation.
+Status: fresh constrained generation and local proof at runtime head
+`ca48d41487affa905cb775da8a985d1b128b18c3`, with the generator and documentation
+fix still uncommitted. Exact final-head replay remains pending. This record does
+not authorize a commit, publication, or live mutation.
 
 ## Claim and provenance
 
@@ -39,8 +40,11 @@ media, and preserves intentional repeated commands.
 ## Reproduce
 
 Use Node 24 or newer, the repository pnpm, real tmux, and an authenticated Codex
-CLI using the host's approved routing. Do not put private model identifiers or
-raw agent transcripts in proof records. Run from this checkout after building:
+CLI with the built-in ChatGPT-backed provider. The generation helper currently
+attests macOS Seatbelt and CLI `0.150.0-alpha.13`; other platforms or versions
+must be re-attested, not allowed to fall back to full access. Do not put private
+model identifiers or raw agent transcripts in proof records. Run from this
+checkout after building:
 
 ```bash
 pnpm run build
@@ -56,21 +60,49 @@ Codex inference, without executing any commands from the prompt:
 
 ```bash
 proof_bundle="$PWD/.artifacts/terminal-proof-planning/fast"
-planner_cwd=$(mktemp -d)
-codex exec --yolo --ephemeral --skip-git-repo-check -C "$planner_cwd" \
-  --output-schema "$proof_bundle/schema.json" \
-  -o "$proof_bundle/decision.json" - < "$proof_bundle/prompt.md" \
-  > /dev/null 2> "$planner_cwd/codex.stderr"
+node scripts/e2e/terminal-proof-generate.mjs "$proof_bundle"
 node scripts/e2e/terminal-proof-planning.mjs run "$proof_bundle" fast
 ```
+
+An optional second helper argument selects the host-approved model for this
+invocation only; it is never written into the sanitized receipt. User routing
+configuration is intentionally ignored. Authentication uses the existing login;
+no credentials are copied or extracted.
+
+Generation is a distinct constrained workflow. The helper supplies the entire
+production prompt and schema as data to `codex exec --ignore-user-config
+--ignore-rules --ephemeral --strict-config`, with approval `never` and the named
+`terminal-proof` permission profile. That profile allows minimal OS reads and
+reads of an empty workspace, no writable paths, and no child network access.
+The CLI adds read access to its bundled shell and executable shim; the helper
+also verifies those effective runtime roots from the session-start trace.
+Shell execution, image reads, web search, MCP, plugins, skills, hooks, and nested
+agents are disabled; no executable fixture is placed in the workspace. Ancestor
+project configuration is refused and project instructions are disabled. Only
+the CLI's own inference/authentication transport may contact the configured
+service. A temporary cwd or a textual instruction alone is not this boundary.
+
+Before inference, a trusted sandbox probe must fail to read a harmless sentinel
+outside the workspace and fail to create a file inside it. After inference, the
+helper checks actual startup settings and the model-facing request's tool
+inventory, requires zero tool calls, and only then copies the generated decision
+into the bundle. This CLI has no blanket no-tools flag: its remaining
+`apply_patch` tool is restricted by the same read/write sandbox. Model metadata
+can require Code Mode despite feature flags, so the helper fingerprints the
+inspected `exec`/`wait` wrappers: their V8 environment has no Node, filesystem,
+or network primitives and exposes only sandboxed `apply_patch`. An optional
+user-message tool has no filesystem or network authority. Unexpected tools,
+changed wrapper definitions, missing trace evidence, or failed checks stop the
+helper. Do not replay a decision until its attestation passes.
 
 Repeat with a fresh directory and `delayed` instead of `fast` in both script
 invocations. The delayed command emits a startup line, then takes 34 seconds,
 longer than entry startup polling. No driver timeout is extended. Existing
 directories are refused; use new names for subsequent captures.
 Inspect temporary Codex diagnostics locally if generation fails; do not copy
-them into the proof bundle or public artifacts. Retain only the structured
-decision and a sanitized generation receipt.
+them into the proof bundle or public artifacts. The helper retains only the
+structured decision and sanitized `generation.json` in the bundle. Local raw
+traces are diagnostic evidence, never publication artifacts.
 
 The replay script parses the full model decision through the production parser,
 requires the generated plan to survive unchanged, checks its command allowlist,
@@ -82,19 +114,20 @@ marked separately from model-generated proof: an exact leading duplicate must
 execute and fail, identical later commands must observe a changed state, exit 7
 must fail, and a silent 40-second command must hit the real 30-second timeout.
 
-`inputs.json`, `decision.json`, `generation.json` (when captured by the parent),
+`inputs.json`, `decision.json`, `generation.json`,
 per-scenario `live-verification.json`, and `receipt.json` remain under ignored
 `.artifacts/terminal-proof-planning/`. Compact receipts beside this note record
 actual results, provenance, and hashes; no raw transcripts are included. The
 source-hash guard rejects replay after any recorded implementation input changes.
-The recorded head is the base plus those uncommitted input hashes, not a claim
-that the change has been committed; record the final head if it is committed later.
+The receipt distinguishes the runtime head, original base, source hashes, and
+generator hash. It does not claim proof of a later commit.
 
 ## Observed results
 
-Both fresh Codex generations passed on local macOS with Node `v26.7.0` and
+Both fresh constrained Codex generations passed on local macOS with Node `v24.19.0` and
 tmux `3.7c`. The fast plan put the command only in entry and chose static text.
-The delayed plan chose setup entry, one run, a 35-second wait, and expectations.
+The delayed plan chose setup entry, one run, and expectations, with no explicit
+wait; existing expectation polling observed the delayed completion.
 Both observed all five success assertions and invoked the proof exactly once.
 Both refused a replay with exit 17 and preserved the original result bytes. In
 each run, the exact leading duplicate executed and failed, the intentional later
@@ -102,12 +135,23 @@ repeat observed changed file state, exit 7 failed, and the silent command hit th
 existing 30-second timeout. `receipt.json` records normalized plans, outcomes,
 generation provenance, source hashes, and hashes of the full ignored receipts.
 
-An independent repeat generated two more plans from the same production inputs
-and replayed them on Node `v24.19.0` with tmux `3.7c`. Both again invoked once,
-observed all five assertions, preserved bytes on refused replay, and passed all
-four negative/intentional-rerun controls. The delayed generation used setup plus
-one run without an explicit wait; existing expectation polling observed completion.
-This is four observed generations, not a guarantee of all future planner output.
+Each generation trace shows one actual inference request and zero tool calls,
+approval `never`, the active `terminal-proof` profile, restricted filesystem
+reads, no writable paths, and restricted network access. The harmless outside
+sentinel read and workspace write were both denied. The generated workspace
+remained empty. No model-directed fixture execution occurred during generation.
+
+The latest receipt comes from two fresh inference calls using the final helper
+unchanged, followed by real-tmux execution. Both calls passed the built-in
+permission and tool-inventory checks directly; neither decision was edited,
+reused from an earlier generation, or retrospectively re-attested. Diagnostic
+attempts during helper development remain local and are not the published proof.
+
+This receipt supersedes the full-access generation receipt preserved at
+[the previous head](https://github.com/openclaw/clawsweeper/blob/ca48d41487affa905cb775da8a985d1b128b18c3/docs/proof/terminal-proof-planning/receipt.json).
+The earlier four runtime demonstrations are historical observations, not evidence
+of isolated generation. None of their decisions was reused here. These two new
+observations are not a guarantee of all future planner output.
 
 Focused validation passed all 138 tests:
 
@@ -116,9 +160,11 @@ node --test test/decision-parser.test.ts test/review-prompt-policy.test.ts \
   test/review-prompt-context.test.ts test/live-proof.test.ts
 ```
 
-Documentation checks and `git diff --check` passed. The full repository check was
-started with `pnpm run check`; see `.artifacts/terminal-proof-planning/check.log`
-for the actual final outcome, rather than inferring success from focused proof.
+Build, helper syntax/lint/format, documentation checks, and `git diff --check`
+passed. The full repository suite was not rerun for this narrow correction:
+the earlier run's 49 diagnosed host-fixture failures (Git pruning, offline pnpm,
+and timing) remain outside this patch. No full-suite success is claimed; CI must
+run again after the parent-reviewed commit.
 
 ## Limits
 

--- a/docs/proof/terminal-proof-planning/README.md
+++ b/docs/proof/terminal-proof-planning/README.md
@@ -1,0 +1,135 @@
+# Terminal proof planning
+
+Status: local proof for an uncommitted change based on
+`f211e21fb89d00777ac07cc13c358f9f7b02a939`. This record does not authorize a
+commit, publication, or live mutation.
+
+## Claim and provenance
+
+The planner should describe a one-shot terminal proof once, while the parser and
+driver preserve every intentional command and all existing failure gates. Entry
+runs automatically before steps; a run step is another execution, never a
+restatement of entry.
+
+[The successful entry and failed replay on PR 1240](https://github.com/openclaw/clawsweeper/pull/1240#issuecomment-5403433718)
+exposed a plan that ran a non-overwriting proof twice. The
+[PR 1254 producer artifact](https://github.com/openclaw/clawsweeper/actions/runs/33033345816)
+also repeated entry as its first run: that run failed waiting for entry, even
+though the captured output later contained exit zero and successful validation.
+Those are distinct failure observations. The producer and this base have identical
+terminal drivers. Independent real-tmux probes confirmed that a previous-command
+timeout remains failed even if entry finishes successfully during final capture:
+the requested next command never ran. That probe deliberately injected capture
+latency to establish the ordering, not to claim the producer experienced it. The
+original artifact lacks status-sample timestamps, so no distinct driver status bug
+is established. Driver supervision, deadlines, and failure latching are unchanged.
+
+[PR 1256](https://github.com/openclaw/clawsweeper/pull/1256), present in the base,
+silently removed an exact leading duplicate. This change removes only that
+normalization, restores command-preservation tests, and clarifies the production
+prompt and schema descriptions. Its cold-build/final-output verification changes
+remain intact. The public schema's properties, types, required fields, enums,
+and bounds are unchanged.
+
+Release-note context, retained here following the release-owned changelog
+disposition in PR 1256: terminal proof planning now explicitly separates automatic
+entry execution from subsequent commands, avoids accidental one-shot replays for
+media, and preserves intentional repeated commands.
+
+## Reproduce
+
+Use Node 24 or newer, the repository pnpm, real tmux, and an authenticated Codex
+CLI using the host's approved routing. Do not put private model identifiers or
+raw agent transcripts in proof records. Run from this checkout after building:
+
+```bash
+pnpm run build
+mkdir -p .artifacts/terminal-proof-planning
+node scripts/e2e/terminal-proof-planning.mjs prepare .artifacts/terminal-proof-planning/fast fast
+```
+
+`prepare` uses the production review-prompt assembly and full decision schema.
+The only extra input is a synthetic, fully supplied local fixture review request;
+it supplies commands and expected output, not a hand-written plan. It writes the
+exact prompt/schema inputs and their hashes. Generate the decision with real
+Codex inference, without executing any commands from the prompt:
+
+```bash
+proof_bundle="$PWD/.artifacts/terminal-proof-planning/fast"
+planner_cwd=$(mktemp -d)
+codex exec --yolo --ephemeral --skip-git-repo-check -C "$planner_cwd" \
+  --output-schema "$proof_bundle/schema.json" \
+  -o "$proof_bundle/decision.json" - < "$proof_bundle/prompt.md" \
+  > /dev/null 2> "$planner_cwd/codex.stderr"
+node scripts/e2e/terminal-proof-planning.mjs run "$proof_bundle" fast
+```
+
+Repeat with a fresh directory and `delayed` instead of `fast` in both script
+invocations. The delayed command emits a startup line, then takes 34 seconds,
+longer than entry startup polling. No driver timeout is extended. Existing
+directories are refused; use new names for subsequent captures.
+Inspect temporary Codex diagnostics locally if generation fails; do not copy
+them into the proof bundle or public artifacts. Retain only the structured
+decision and a sanitized generation receipt.
+
+The replay script parses the full model decision through the production parser,
+requires the generated plan to survive unchanged, checks its command allowlist,
+and executes it through the production terminal driver on a dedicated real tmux
+server. It requires all five assertions to be observed, not merely schema-v1
+successful-exit fallback. Files and invocation traces prove single execution and
+byte preservation on a refused replay. Hand-written negative controls are clearly
+marked separately from model-generated proof: an exact leading duplicate must
+execute and fail, identical later commands must observe a changed state, exit 7
+must fail, and a silent 40-second command must hit the real 30-second timeout.
+
+`inputs.json`, `decision.json`, `generation.json` (when captured by the parent),
+per-scenario `live-verification.json`, and `receipt.json` remain under ignored
+`.artifacts/terminal-proof-planning/`. Compact receipts beside this note record
+actual results, provenance, and hashes; no raw transcripts are included. The
+source-hash guard rejects replay after any recorded implementation input changes.
+The recorded head is the base plus those uncommitted input hashes, not a claim
+that the change has been committed; record the final head if it is committed later.
+
+## Observed results
+
+Both fresh Codex generations passed on local macOS with Node `v26.7.0` and
+tmux `3.7c`. The fast plan put the command only in entry and chose static text.
+The delayed plan chose setup entry, one run, a 35-second wait, and expectations.
+Both observed all five success assertions and invoked the proof exactly once.
+Both refused a replay with exit 17 and preserved the original result bytes. In
+each run, the exact leading duplicate executed and failed, the intentional later
+repeat observed changed file state, exit 7 failed, and the silent command hit the
+existing 30-second timeout. `receipt.json` records normalized plans, outcomes,
+generation provenance, source hashes, and hashes of the full ignored receipts.
+
+An independent repeat generated two more plans from the same production inputs
+and replayed them on Node `v24.19.0` with tmux `3.7c`. Both again invoked once,
+observed all five assertions, preserved bytes on refused replay, and passed all
+four negative/intentional-rerun controls. The delayed generation used setup plus
+one run without an explicit wait; existing expectation polling observed completion.
+This is four observed generations, not a guarantee of all future planner output.
+
+Focused validation passed all 138 tests:
+
+```bash
+node --test test/decision-parser.test.ts test/review-prompt-policy.test.ts \
+  test/review-prompt-context.test.ts test/live-proof.test.ts
+```
+
+Documentation checks and `git diff --check` passed. The full repository check was
+started with `pnpm run check`; see `.artifacts/terminal-proof-planning/check.log`
+for the actual final outcome, rather than inferring success from focused proof.
+
+## Limits
+
+This is a controlled terminal fixture, not Worker/apply functional correctness,
+live GitHub behavior, or evidence that every future model plan is correct. The
+driver runs with recording disabled even if the planner chooses a media payoff;
+setup/action/expectation execution can be verified, but video recording and
+publication are not claimed. No accounts, target services, live apply/close,
+workflow changes, or external artifact uploads are used by the fixture.
+
+OpenClaw Bay is unaffected: the schema shape, verification lifecycle, publication
+contract, and observer-only ownership are unchanged. The PR 1254 artifact does not
+prove when the supervised entry exited; later target JSON saying exit zero is not
+authority to erase a timeout or pass an unexecuted run.

--- a/docs/proof/terminal-proof-planning/receipt.json
+++ b/docs/proof/terminal-proof-planning/receipt.json
@@ -1,0 +1,260 @@
+{
+  "base": "f211e21fb89d00777ac07cc13c358f9f7b02a939",
+  "head": "f211e21fb89d00777ac07cc13c358f9f7b02a939",
+  "committed": false,
+  "trackedDiffSha256": "d5a38a5dc5ae5b5bf447e6e719695b78a771c5492c7a4f94077491fe0cd8899f",
+  "provider": "local macOS tmux",
+  "node": "v26.7.0",
+  "tmux": "tmux 3.7c",
+  "schemaShapeUnchanged": true,
+  "recordingTested": false,
+  "baseSourceHashes": {
+    "prompts/review-item.md": "73640c8cd2f7e928ab6f20041ba43cdc36612ce4e35acc18e182591f88b3821a",
+    "schema/clawsweeper-decision.schema.json": "ba2269bb534e7eac4c40eea4a48642ea320b20b996c8ad3e8a5c90c662921bd8",
+    "src/clawsweeper-decision-parser.ts": "8174e9d4f0e69f7fca413bee5cbaa8ce8a642262c7360b50d4da0ddc5f560969",
+    "src/clawsweeper-review-runtime.ts": "92ffe35a940aa4f45e29bdc1c96b04aa9607863901faa359af82ddf804741b09",
+    "src/live-proof/drivers.ts": "313ae1906133139f1b4d1038bbadf03cd9e9640a4bbb165cf17a230b3cb06a04",
+    "src/live-proof/verification.ts": "8540f8de6228cccee39be8685128f8dd0a71acf5f28859e42a69b858cc6233d0"
+  },
+  "sourceHashes": {
+    "prompts/review-item.md": "67f5c29c24d2340a35a5a2596c2acb44c4152825781c7ae32649c45664290c72",
+    "schema/clawsweeper-decision.schema.json": "758dd96182b5db7b9b4cb98164b4dbb9efd30d3cb7baf7590ad2159ef7b1aad9",
+    "src/clawsweeper-decision-parser.ts": "a62773925ba606969ae416ebc7d50b11fbf9c48dcefdb1d902038e4bf5041e7c",
+    "src/clawsweeper-review-runtime.ts": "92ffe35a940aa4f45e29bdc1c96b04aa9607863901faa359af82ddf804741b09",
+    "src/live-proof/drivers.ts": "313ae1906133139f1b4d1038bbadf03cd9e9640a4bbb165cf17a230b3cb06a04",
+    "src/live-proof/verification.ts": "8540f8de6228cccee39be8685128f8dd0a71acf5f28859e42a69b858cc6233d0",
+    "scripts/e2e/terminal-proof-once.mjs": "63ddce39df0362fd32c4a2a4aca0425403b54a7c9b8200a03d821121adb9b107",
+    "scripts/e2e/terminal-proof-planning.mjs": "06142bb8cc2fff3679820124cb64855be6681c54574562f654bc86f697f91994"
+  },
+  "runs": [
+    {
+      "variant": "fast",
+      "generation": {
+        "generator": "Codex",
+        "exitCode": 0,
+        "approvalNever": true,
+        "sandboxDangerFullAccess": true,
+        "structuredDecisionExists": true
+      },
+      "promptSha256": "0bdb313ab2a4c796bc95b34f472e1782b9a03310c6de823d7c10f790a907a604",
+      "schemaSha256": "625131a54e8521d181c56e47d0ed1a1ec6883715124edddc4de39f5cc4e8465b",
+      "decisionSha256": "c69775472a65e94a09841a7ce2b1847cd5d6ad830bf97664451ef9dd61b2b3a9",
+      "generatedPlan": {
+        "status": "recommended",
+        "surface": "terminal",
+        "reason": "The complete supplied source supports a safe, dependency-free local run against the initially absent output directory.",
+        "payoff": {
+          "kind": "static_text",
+          "justification": "The default invocation produces a short burst of plain text, so one captured transcript is more useful than a recording."
+        },
+        "entry": "node once.mjs output",
+        "steps": [
+          {
+            "action": "expect_output",
+            "text": "PROOF_STARTED"
+          },
+          {
+            "action": "expect_output",
+            "text": "PASS exclusive directory"
+          },
+          {
+            "action": "expect_output",
+            "text": "PASS original bytes retained"
+          },
+          {
+            "action": "expect_output",
+            "text": "PASS local fixture"
+          },
+          {
+            "action": "expect_output",
+            "text": "PASS stable assertions"
+          },
+          {
+            "action": "expect_output",
+            "text": "PASS proof complete"
+          }
+        ]
+      },
+      "drive_status": "completed",
+      "overall_pass": true,
+      "observedAssertions": [
+        "PROOF_STARTED",
+        "PASS exclusive directory",
+        "PASS original bytes retained",
+        "PASS local fixture",
+        "PASS stable assertions",
+        "PASS proof complete"
+      ],
+      "oneShotInvocationsBeforeReplay": 1,
+      "replayExit": 17,
+      "originalBytesPreserved": true,
+      "resultSha256": "07c326543a57b838084e917ce5a3ad31b6053a48b190dee8a641fd2174daefd7",
+      "deliberateDuplicateInvocations": 2,
+      "intentionalRepeatTrace": "beforeafter",
+      "controls": [
+        {
+          "scenario": "duplicate",
+          "generated": false,
+          "drive_status": "failed",
+          "overall_pass": false,
+          "failure": {
+            "phase": "step",
+            "reason": "terminal command failed with exit status 17: \"node once.mjs output\"",
+            "step": 1,
+            "action": "run"
+          }
+        },
+        {
+          "scenario": "intentional-repeat",
+          "generated": false,
+          "drive_status": "completed",
+          "overall_pass": true,
+          "failure": null
+        },
+        {
+          "scenario": "nonzero",
+          "generated": false,
+          "drive_status": "failed",
+          "overall_pass": false,
+          "failure": {
+            "phase": "execution",
+            "reason": "terminal command failed with exit status 7: \"printf 'CONTROL_FAILED\\\\n'; exit 7\""
+          }
+        },
+        {
+          "scenario": "timeout",
+          "generated": false,
+          "drive_status": "failed",
+          "overall_pass": false,
+          "failure": {
+            "phase": "execution",
+            "reason": "terminal command did not produce output or exit within 30 seconds: \"sleep 40\""
+          }
+        }
+      ],
+      "artifact": ".artifacts/terminal-proof-planning/fast/receipt.json",
+      "artifactSha256": "a93995e89828a5d09e389006d5e1363b431fbddc1f2c1f23662697cb2479375d"
+    },
+    {
+      "variant": "delayed",
+      "generation": {
+        "generator": "Codex",
+        "exitCode": 0,
+        "approvalNever": true,
+        "sandboxDangerFullAccess": true,
+        "structuredDecisionExists": true
+      },
+      "promptSha256": "aa1108fc8f46041fab7012f9e071217acfe5180d6abef6053ae8334291f7b803",
+      "schemaSha256": "625131a54e8521d181c56e47d0ed1a1ec6883715124edddc4de39f5cc4e8465b",
+      "decisionSha256": "192b93f22aa3adc7a0182db5076f75dc2bce89c2c900dc9a9bbfe52bed55a7cc",
+      "generatedPlan": {
+        "status": "recommended",
+        "surface": "terminal",
+        "reason": "The complete supplied source is local-only and dependency-free, and one delayed invocation fits within the 90-second demonstration window.",
+        "payoff": {
+          "kind": "progressive_output",
+          "justification": "A recording shows the transition from setup to immediate startup output and delayed completion after 34 seconds."
+        },
+        "entry": "printf 'SETUP_READY\\n'",
+        "steps": [
+          {
+            "action": "expect_output",
+            "text": "SETUP_READY"
+          },
+          {
+            "action": "run",
+            "command": "node once.mjs output 34"
+          },
+          {
+            "action": "expect_output",
+            "text": "PROOF_STARTED"
+          },
+          {
+            "action": "wait",
+            "seconds": 35
+          },
+          {
+            "action": "expect_output",
+            "text": "PASS exclusive directory"
+          },
+          {
+            "action": "expect_output",
+            "text": "PASS original bytes retained"
+          },
+          {
+            "action": "expect_output",
+            "text": "PASS local fixture"
+          },
+          {
+            "action": "expect_output",
+            "text": "PASS stable assertions"
+          },
+          {
+            "action": "expect_output",
+            "text": "PASS proof complete"
+          }
+        ]
+      },
+      "drive_status": "completed",
+      "overall_pass": true,
+      "observedAssertions": [
+        "SETUP_READY",
+        "PROOF_STARTED",
+        "PASS exclusive directory",
+        "PASS original bytes retained",
+        "PASS local fixture",
+        "PASS stable assertions",
+        "PASS proof complete"
+      ],
+      "oneShotInvocationsBeforeReplay": 1,
+      "replayExit": 17,
+      "originalBytesPreserved": true,
+      "resultSha256": "07c326543a57b838084e917ce5a3ad31b6053a48b190dee8a641fd2174daefd7",
+      "deliberateDuplicateInvocations": 2,
+      "intentionalRepeatTrace": "beforeafter",
+      "controls": [
+        {
+          "scenario": "duplicate",
+          "generated": false,
+          "drive_status": "failed",
+          "overall_pass": false,
+          "failure": {
+            "phase": "step",
+            "reason": "terminal command failed with exit status 17: \"node once.mjs output\"",
+            "step": 1,
+            "action": "run"
+          }
+        },
+        {
+          "scenario": "intentional-repeat",
+          "generated": false,
+          "drive_status": "completed",
+          "overall_pass": true,
+          "failure": null
+        },
+        {
+          "scenario": "nonzero",
+          "generated": false,
+          "drive_status": "failed",
+          "overall_pass": false,
+          "failure": {
+            "phase": "execution",
+            "reason": "terminal command failed with exit status 7: \"printf 'CONTROL_FAILED\\\\n'; exit 7\""
+          }
+        },
+        {
+          "scenario": "timeout",
+          "generated": false,
+          "drive_status": "failed",
+          "overall_pass": false,
+          "failure": {
+            "phase": "execution",
+            "reason": "terminal command did not produce output or exit within 30 seconds: \"sleep 40\""
+          }
+        }
+      ],
+      "artifact": ".artifacts/terminal-proof-planning/delayed/receipt.json",
+      "artifactSha256": "982441a0d10c4097db065794a4bb51c568f0e8d5d70eca562e8fc6af573d28b9"
+    }
+  ]
+}

--- a/docs/proof/terminal-proof-planning/receipt.json
+++ b/docs/proof/terminal-proof-planning/receipt.json
@@ -1,10 +1,15 @@
 {
   "base": "f211e21fb89d00777ac07cc13c358f9f7b02a939",
-  "head": "f211e21fb89d00777ac07cc13c358f9f7b02a939",
+  "head": "ca48d41487affa905cb775da8a985d1b128b18c3",
   "committed": false,
-  "trackedDiffSha256": "d5a38a5dc5ae5b5bf447e6e719695b78a771c5492c7a4f94077491fe0cd8899f",
+  "uncommittedScope": "Constrained proof generator, README and latest normalized receipt; production inputs are unchanged from the recorded head. Final committed-head replay pending.",
+  "supersedes": {
+    "head": "ca48d41487affa905cb775da8a985d1b128b18c3",
+    "receiptSha256": "a4b1fcdcf7fb9df85cad699cb19ad78b30b03bc29c6264fa4609abb874ad0386",
+    "reason": "The prior full-access generations remain historical; neither decision is used by this constrained proof."
+  },
   "provider": "local macOS tmux",
-  "node": "v26.7.0",
+  "node": "v24.19.0",
   "tmux": "tmux 3.7c",
   "schemaShapeUnchanged": true,
   "recordingTested": false,
@@ -26,33 +31,75 @@
     "scripts/e2e/terminal-proof-once.mjs": "63ddce39df0362fd32c4a2a4aca0425403b54a7c9b8200a03d821121adb9b107",
     "scripts/e2e/terminal-proof-planning.mjs": "06142bb8cc2fff3679820124cb64855be6681c54574562f654bc86f697f91994"
   },
+  "proofGeneratorSha256": "2b12954b5afe14cb2d451a5457342ca1ad5f29703b2deb5426f162f80692f41e",
   "runs": [
     {
       "variant": "fast",
       "generation": {
         "generator": "Codex",
+        "cliVersion": "codex-cli 0.150.0-alpha.13",
+        "provider": "openai",
+        "auth": "existing ChatGPT login",
+        "startedAt": "2026-08-27T06:56:21.887Z",
+        "completedAt": "2026-08-27T06:57:29.731Z",
         "exitCode": 0,
-        "approvalNever": true,
-        "sandboxDangerFullAccess": true,
-        "structuredDecisionExists": true
+        "helperSha256": "2b12954b5afe14cb2d451a5457342ca1ad5f29703b2deb5426f162f80692f41e",
+        "promptSha256": "0bdb313ab2a4c796bc95b34f472e1782b9a03310c6de823d7c10f790a907a604",
+        "schemaSha256": "625131a54e8521d181c56e47d0ed1a1ec6883715124edddc4de39f5cc4e8465b",
+        "decisionSha256": "e63766c229b938e3461439ed3e85422a8847d3a30a42333de99ded49223d5fec",
+        "isolation": {
+          "approval": "never",
+          "permissionProfile": "terminal-proof",
+          "filesystem": {
+            ":minimal": "read",
+            ":workspace_roots": "read"
+          },
+          "effectiveReadRoots": [
+            ":minimal",
+            "<empty-workspace>",
+            "<CLI bundled shell>",
+            "<CLI executable shim>"
+          ],
+          "writablePaths": [],
+          "childNetworkEnabled": false,
+          "userConfigIgnored": true,
+          "execRulesIgnored": true,
+          "projectConfigAbsent": true,
+          "projectInstructionsDisabled": true,
+          "skillsDisabled": true,
+          "shellToolsDisabled": true,
+          "mcpDisabled": true,
+          "pluginsDisabled": true,
+          "webSearchDisabled": true,
+          "emptyWorkspaceBeforeAndAfter": true,
+          "outsideSentinelReadDenied": true,
+          "workspaceWriteDenied": true,
+          "startupSandbox": "read-only",
+          "toolInventory": [
+            "functions.apply_patch",
+            "functions.exec",
+            "functions.send_user_message_async",
+            "functions.wait"
+          ],
+          "toolCalls": 0,
+          "inferenceRequests": 1,
+          "toolInventoryEvidence": "actual local inference request trace; no raw transcript retained in bundle"
+        },
+        "recordingTested": false
       },
       "promptSha256": "0bdb313ab2a4c796bc95b34f472e1782b9a03310c6de823d7c10f790a907a604",
       "schemaSha256": "625131a54e8521d181c56e47d0ed1a1ec6883715124edddc4de39f5cc4e8465b",
-      "decisionSha256": "c69775472a65e94a09841a7ce2b1847cd5d6ad830bf97664451ef9dd61b2b3a9",
+      "decisionSha256": "e63766c229b938e3461439ed3e85422a8847d3a30a42333de99ded49223d5fec",
       "generatedPlan": {
         "status": "recommended",
         "surface": "terminal",
-        "reason": "The complete supplied source supports a safe, dependency-free local run against the initially absent output directory.",
+        "reason": "The complete dependency-free source supports a deterministic local run with no accounts, secrets, or network, and the output directory is initially absent.",
         "payoff": {
           "kind": "static_text",
-          "justification": "The default invocation produces a short burst of plain text, so one captured transcript is more useful than a recording."
+          "justification": "The default invocation produces a short burst of plain text, so a captured output block is more useful than a recording."
         },
         "entry": "node once.mjs output",
         "steps": [
-          {
-            "action": "expect_output",
-            "text": "PROOF_STARTED"
-          },
           {
             "action": "expect_output",
             "text": "PASS exclusive directory"
@@ -78,7 +125,6 @@
       "drive_status": "completed",
       "overall_pass": true,
       "observedAssertions": [
-        "PROOF_STARTED",
         "PASS exclusive directory",
         "PASS original bytes retained",
         "PASS local fixture",
@@ -132,28 +178,73 @@
           }
         }
       ],
-      "artifact": ".artifacts/terminal-proof-planning/fast/receipt.json",
-      "artifactSha256": "a93995e89828a5d09e389006d5e1363b431fbddc1f2c1f23662697cb2479375d"
+      "artifact": ".artifacts/terminal-proof-planning/final-constrained-fast/receipt.json",
+      "artifactSha256": "19cdc91956c91742dec67ea22120a8f6dbc4780a269d961ede1ccb44e3530c49"
     },
     {
       "variant": "delayed",
       "generation": {
         "generator": "Codex",
+        "cliVersion": "codex-cli 0.150.0-alpha.13",
+        "provider": "openai",
+        "auth": "existing ChatGPT login",
+        "startedAt": "2026-08-27T06:56:21.987Z",
+        "completedAt": "2026-08-27T06:57:23.137Z",
         "exitCode": 0,
-        "approvalNever": true,
-        "sandboxDangerFullAccess": true,
-        "structuredDecisionExists": true
+        "helperSha256": "2b12954b5afe14cb2d451a5457342ca1ad5f29703b2deb5426f162f80692f41e",
+        "promptSha256": "aa1108fc8f46041fab7012f9e071217acfe5180d6abef6053ae8334291f7b803",
+        "schemaSha256": "625131a54e8521d181c56e47d0ed1a1ec6883715124edddc4de39f5cc4e8465b",
+        "decisionSha256": "8e771cc4a1fae316d577cb0a8cefdfacc41be190bead3781b2d786f5bee1cdae",
+        "isolation": {
+          "approval": "never",
+          "permissionProfile": "terminal-proof",
+          "filesystem": {
+            ":minimal": "read",
+            ":workspace_roots": "read"
+          },
+          "effectiveReadRoots": [
+            ":minimal",
+            "<empty-workspace>",
+            "<CLI bundled shell>",
+            "<CLI executable shim>"
+          ],
+          "writablePaths": [],
+          "childNetworkEnabled": false,
+          "userConfigIgnored": true,
+          "execRulesIgnored": true,
+          "projectConfigAbsent": true,
+          "projectInstructionsDisabled": true,
+          "skillsDisabled": true,
+          "shellToolsDisabled": true,
+          "mcpDisabled": true,
+          "pluginsDisabled": true,
+          "webSearchDisabled": true,
+          "emptyWorkspaceBeforeAndAfter": true,
+          "outsideSentinelReadDenied": true,
+          "workspaceWriteDenied": true,
+          "startupSandbox": "read-only",
+          "toolInventory": [
+            "functions.apply_patch",
+            "functions.exec",
+            "functions.send_user_message_async",
+            "functions.wait"
+          ],
+          "toolCalls": 0,
+          "inferenceRequests": 1,
+          "toolInventoryEvidence": "actual local inference request trace; no raw transcript retained in bundle"
+        },
+        "recordingTested": false
       },
       "promptSha256": "aa1108fc8f46041fab7012f9e071217acfe5180d6abef6053ae8334291f7b803",
       "schemaSha256": "625131a54e8521d181c56e47d0ed1a1ec6883715124edddc4de39f5cc4e8465b",
-      "decisionSha256": "192b93f22aa3adc7a0182db5076f75dc2bce89c2c900dc9a9bbfe52bed55a7cc",
+      "decisionSha256": "8e771cc4a1fae316d577cb0a8cefdfacc41be190bead3781b2d786f5bee1cdae",
       "generatedPlan": {
         "status": "recommended",
         "surface": "terminal",
-        "reason": "The complete supplied source is local-only and dependency-free, and one delayed invocation fits within the 90-second demonstration window.",
+        "reason": "The complete dependency-free fixture supports a local 34-second demonstration without accounts, secrets, or network access.",
         "payoff": {
           "kind": "progressive_output",
-          "justification": "A recording shows the transition from setup to immediate startup output and delayed completion after 34 seconds."
+          "justification": "A recording shows the immediate start marker and the delayed transition to five completion lines after one invocation."
         },
         "entry": "printf 'SETUP_READY\\n'",
         "steps": [
@@ -168,10 +259,6 @@
           {
             "action": "expect_output",
             "text": "PROOF_STARTED"
-          },
-          {
-            "action": "wait",
-            "seconds": 35
           },
           {
             "action": "expect_output",
@@ -253,8 +340,29 @@
           }
         }
       ],
-      "artifact": ".artifacts/terminal-proof-planning/delayed/receipt.json",
-      "artifactSha256": "982441a0d10c4097db065794a4bb51c568f0e8d5d70eca562e8fc6af573d28b9"
+      "artifact": ".artifacts/terminal-proof-planning/final-constrained-delayed/receipt.json",
+      "artifactSha256": "baf9f4e99e05b527908c7485903ae87d2e3a0ace9008ee9d4816febd9c838a09"
     }
+  ],
+  "validation": {
+    "build": "passed",
+    "focusedTests": {
+      "passed": 138,
+      "failed": 0,
+      "command": "node --test test/decision-parser.test.ts test/review-prompt-policy.test.ts test/review-prompt-context.test.ts test/live-proof.test.ts"
+    },
+    "fullSuite": "Not rerun for this narrow correction; earlier 49 diagnosed host-fixture failures remain outside this patch. CI after commit pending.",
+    "staticChecks": "passed: active surface, dashboard queue boundary, dashboard strict, docs, limits, formatting",
+    "helperChecks": "passed: syntax, lint, final attestation of both actual traces, actual restricted inventory accepted; shell, MCP, hosted search and altered wrapper inventories rejected",
+    "diffCheck": "passed"
+  },
+  "limits": [
+    "macOS Seatbelt and the pinned CLI version only; no cross-platform claim.",
+    "One bounded generation per variant completed, with zero tool calls. A prior attempt stopped before inference during state-database backfill.",
+    "Model metadata requires Code Mode wrappers; their inspected definitions expose only sandboxed apply_patch. The CLI has no blanket no-tools flag.",
+    "The fast decision required collector re-attestation for the inspected Code Mode wrapper; final permission checks were applied to both original traces without altering decision bytes. Launch and attestation helper hashes are retained separately.",
+    "The real CLI retains its existing internal state and ChatGPT authentication. Credentials were not copied or extracted. No external network probe was performed.",
+    "Controlled tmux fixture only; recording, publication, live GitHub/apply/close/workflow changes and arbitrary future planner outputs are not proved.",
+    "OpenClaw Bay is unaffected: no schema shape, lifecycle, publication or observer contract change."
   ]
 }

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -510,8 +510,17 @@ run, such as docs-only edits or generated assets in a repository with no
 meaningful runnable surface. Use `surface: "browser"` for browser behavior and
 `surface: "terminal"` for terminal behavior. The `entry` must be a URL path for
 browser verification or a command for terminal verification. A terminal
-`entry` executes automatically before the typed steps; never repeat that command
-as the first `run`. For terminal verification, prefer invoking a
+`entry` executes automatically before all typed steps. Every `run` step executes
+independently as a new command, including commands identical to `entry` or earlier
+steps; nothing is deduplicated. For a one-shot proof (for example, a command that
+refuses an existing output directory), put the proof command in `entry` followed
+by stable `expect_output` steps, or use a safe setup `entry` followed by exactly
+one `run` of the proof command and its expectations. Do not repeat a one-shot
+command just to capture output or create media. Intentional reruns, including
+identical commands after a state change, are valid and will execute. Each command
+runs in a separate Bash process in the same checkout; share state through files
+or combine dependent setup and execution in one command, not shell-local variables
+or `cd` from an earlier command. For terminal verification, prefer invoking a
 repository-defined `pnpm run` (or equivalent package-manager) script over
 hand-composing individual build/test commands whenever one already expresses
 the needed setup, so the plan does not need to independently reconstruct build
@@ -520,7 +529,10 @@ deterministic, typed `steps`: browser plans may use `goto`, `click`, `fill`,
 `press`, `wait_for`, `wait`, and `expect_text`; terminal plans may use `run`,
 `wait`, and `expect_output`. Include at least one concrete expectation of real
 output. When proposing media, include at least one state-changing step and an
-expectation whose text is absent before that action and appears only afterward;
+expectation whose text is absent before that action and appears only afterward.
+For a terminal one-shot proof, use a safe setup `entry` and one `run` for that
+transition, rather than replaying a proof already executed by `entry`. If there
+is no useful transition to record, choose `static_text` and verify once;
 the absent-then-present rule decides whether media is useful, not whether the
 system should run. Never assert the typed command itself. Targets for `click`,
 `fill`, and `wait_for` must be valid CSS or Playwright selectors, including

--- a/schema/clawsweeper-decision.schema.json
+++ b/schema/clawsweeper-decision.schema.json
@@ -824,18 +824,18 @@
             },
             "justification": {
               "type": "string",
-              "description": "One sentence naming what a viewer actually sees move or change over the recording."
+              "description": "One sentence explaining why static text is sufficient or what a viewer sees change in a useful recording. Never repeat a one-shot terminal command just for media; use a safe setup entry followed by one run for a transition, or choose static_text and verify once."
             }
           }
         },
         "entry": {
           "type": "string",
-          "description": "The URL path for browser proof or command for terminal proof. Use an empty string unless status is recommended."
+          "description": "The URL path for browser proof or command for terminal proof. Terminal entry executes automatically before all steps. For a one-shot proof, put the proof command here followed by stable expect_output steps, or use a safe setup entry followed by exactly one run of the proof command. Each command runs in a separate Bash process in the same checkout; share state through files or combine dependent setup and execution in one command. Use an empty string unless status is recommended."
         },
         "steps": {
           "type": "array",
           "maxItems": 10,
-          "description": "Structured deterministic actions for the recommended surface. Use an empty array unless status is recommended. Step values must never contain secrets or tokens.",
+          "description": "Structured deterministic actions executed after entry for the recommended surface. Every terminal run executes independently, even when identical to entry or an earlier run; nothing is deduplicated. Do not repeat one-shot commands to capture output or create media. Intentional reruns after state changes are valid and execute. Use an empty array unless status is recommended. Step values must never contain secrets or tokens.",
           "items": {
             "anyOf": [
               {
@@ -908,7 +908,10 @@
                 "required": ["action", "command"],
                 "properties": {
                   "action": { "type": "string", "const": "run" },
-                  "command": { "type": "string" }
+                  "command": {
+                    "type": "string",
+                    "description": "A new terminal command to execute, not a restatement of entry. Identical commands still execute; include a rerun only when intentional."
+                  }
                 }
               },
               {

--- a/scripts/e2e/terminal-proof-generate.mjs
+++ b/scripts/e2e/terminal-proof-generate.mjs
@@ -1,0 +1,282 @@
+// Generate supplied proof data in an empty, read-restricted workspace; never run the fixture here.
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+const [directory, model] = process.argv.slice(2);
+assert.ok(directory && process.argv.length <= 4, "usage: SCRIPT BUNDLE [MODEL]");
+assert.equal(process.platform, "darwin", "this proof attests the macOS Seatbelt boundary only");
+const bundle = realpathSync(resolve(directory));
+for (const file of ["decision.json", "generation.json"])
+  assert.ok(!existsSync(join(bundle, file)), "use a fresh prepared bundle");
+const hash = (bytes) => createHash("sha256").update(bytes).digest("hex");
+const helperSha256 = hash(readFileSync(new URL(import.meta.url)));
+const prompt = readFileSync(join(bundle, "prompt.md"));
+const schema = readFileSync(join(bundle, "schema.json"));
+const inputs = JSON.parse(readFileSync(join(bundle, "inputs.json"), "utf8"));
+assert.equal(hash(prompt), inputs.promptSha256);
+assert.equal(hash(schema), inputs.schemaSha256);
+const runtime = realpathSync(mkdtempSync(join(tmpdir(), "terminal-proof-generation-")));
+const workspace = join(runtime, "empty");
+mkdirSync(workspace);
+// Refuse ambient project configuration, including configuration in temporary-directory ancestors.
+for (let path = workspace; ; path = dirname(path)) {
+  assert.ok(!existsSync(join(path, ".codex")), "generation ancestors must not contain .codex");
+  if (dirname(path) === path) break;
+}
+const env = Object.fromEntries(
+  ["PATH", "HOME", "CODEX_HOME", "TMPDIR", "LANG"]
+    .filter((key) => process.env[key] !== undefined)
+    .map((key) => [key, process.env[key]]),
+);
+const invoke = (args, options = {}) =>
+  spawnSync("codex", args, {
+    cwd: workspace,
+    env,
+    encoding: "utf8",
+    timeout: 240_000,
+    killSignal: "SIGTERM",
+    maxBuffer: 16 * 1024 * 1024,
+    ...options,
+  });
+const version = invoke(["--version"]);
+assert.equal(version.status, 0);
+// The flags and trace format below were inspected on this version. Re-attest before upgrading.
+assert.equal(version.stdout.trim(), "codex-cli 0.150.0-alpha.13");
+const settings = [
+  'model_provider="openai"',
+  'forced_login_method="chatgpt"',
+  'approval_policy="never"',
+  'default_permissions="terminal-proof"',
+  'permissions.terminal-proof.filesystem={":minimal"="read",":workspace_roots"="read"}',
+  "permissions.terminal-proof.network.enabled=false",
+  "project_doc_max_bytes=0",
+  "skills.include_instructions=false",
+  "orchestrator.skills.enabled=false",
+  "orchestrator.mcp.enabled=false",
+  "mcp_servers={}",
+  "agents.enabled=false",
+  'web_search="disabled"',
+  "tools.update_plan.enabled=false",
+  "tools.experimental_request_user_input.enabled=false",
+  'shell_environment_policy.inherit="none"',
+  "allow_login_shell=false",
+  ...[
+    "shell_tool",
+    "unified_exec",
+    "shell_snapshot",
+    "view_image",
+    "hooks",
+    "plugins",
+    "apps",
+    "multi_agent",
+    "multi_agent_v2",
+    "code_mode",
+    "code_mode_only",
+    "memories",
+    "image_generation",
+    "request_permissions_tool",
+    "deferred_executor",
+    "token_budget",
+    "goals",
+  ].map((feature) => `features.${feature}=false`),
+  `log_dir=${JSON.stringify(join(runtime, "log"))}`,
+];
+const config = settings.flatMap((setting) => ["-c", setting]);
+const sentinel = join(runtime, "outside-sentinel.txt");
+writeFileSync(sentinel, "harmless proof sentinel\n", { flag: "wx" });
+const probe = invoke([
+  "sandbox",
+  ...config,
+  "-P",
+  "terminal-proof",
+  "-C",
+  workspace,
+  "--",
+  "/bin/sh",
+  "-c",
+  'test -d . || exit 10; if /bin/cat "$1" >/dev/null 2>&1; then exit 11; fi; if (printf blocked > denied-write) 2>/dev/null; then exit 12; fi; printf "READ_DENIED WRITE_DENIED\\n"',
+  "probe",
+  sentinel,
+]);
+writeFileSync(join(runtime, "probe.stderr"), probe.stderr ?? "");
+assert.equal(probe.status, 0, `sandbox denial preflight failed; inspect locally: ${runtime}`);
+assert.equal(probe.stdout.trim(), "READ_DENIED WRITE_DENIED");
+assert.deepEqual(readdirSync(workspace), []);
+const startedAt = new Date().toISOString();
+const stdoutFile = join(runtime, "stdout.log");
+const stderrFile = join(runtime, "stderr.log");
+const stdoutFd = openSync(stdoutFile, "wx");
+const stderrFd = openSync(stderrFile, "wx");
+const generated = invoke(
+  [
+    "--ask-for-approval",
+    "never",
+    ...config,
+    ...(model ? ["-m", model] : []),
+    "exec",
+    "--strict-config",
+    "--ignore-user-config",
+    "--ignore-rules",
+    "--ephemeral",
+    "--skip-git-repo-check",
+    "--color",
+    "never",
+    "-C",
+    workspace,
+    "--output-schema",
+    join(bundle, "schema.json"),
+    "-o",
+    join(runtime, "decision.json"),
+    "-",
+  ],
+  {
+    input: prompt,
+    stdio: ["pipe", stdoutFd, stderrFd],
+    env: { ...env, CODEX_ROLLOUT_TRACE_ROOT: join(runtime, "trace") },
+  },
+);
+// Raw diagnostics stay outside the bundle. Never publish them or put them in a receipt.
+closeSync(stdoutFd);
+closeSync(stderrFd);
+generated.stderr = readFileSync(stderrFile, "utf8");
+assert.equal(generated.status, 0, `Codex generation failed; inspect locally: ${runtime}`);
+assert.ok(/^approval: never$/m.test(generated.stderr), "unexpected startup approval policy");
+assert.ok(/^sandbox: read-only/m.test(generated.stderr), "unexpected startup sandbox");
+assert.ok(!generated.stderr.includes("danger-full-access"), "unsafe startup sandbox");
+assert.deepEqual(readdirSync(workspace), []);
+const traceFiles = readdirSync(join(runtime, "trace"), { recursive: true }).filter((file) =>
+  file.endsWith("trace.jsonl"),
+);
+assert.equal(traceFiles.length, 1, "expected exactly one generation thread trace");
+const traceFile = join(runtime, "trace", traceFiles[0]);
+const events = readFileSync(traceFile, "utf8").trim().split("\n").map(JSON.parse);
+const payloads = events.map((event) => event.payload);
+const configured = payloads.find((event) => event.event_type === "session_configured");
+const session = JSON.parse(
+  readFileSync(join(dirname(traceFile), configured.event_payload.path), "utf8"),
+);
+assert.equal(session.approval_policy, "never");
+assert.equal(session.active_permission_profile.id, "terminal-proof");
+const permissions = session.permission_profile;
+assert.equal(permissions.type, "managed");
+assert.equal(permissions.network, "restricted");
+assert.equal(permissions.file_system.type, "restricted");
+const readRoots = permissions.file_system.entries.map(({ path, access }) => {
+  assert.equal(access, "read", "unexpected filesystem access");
+  if (path.type === "special" && path.value.kind === "minimal") return ":minimal";
+  assert.equal(path.type, "path");
+  if (path.path === workspace) return "<empty-workspace>";
+  if (path.path.endsWith("/codex-resources/zsh/bin/zsh")) return "<CLI bundled shell>";
+  const authHome = realpathSync(process.env.CODEX_HOME ?? join(process.env.HOME, ".codex"));
+  assert.equal(dirname(path.path), join(authHome, "tmp/arg0"), "unexpected readable root");
+  assert.ok(path.path.split("/").at(-1).startsWith("codex-arg0"));
+  return "<CLI executable shim>";
+});
+assert.ok(readRoots.includes(":minimal") && readRoots.includes("<empty-workspace>"));
+assert.equal(payloads.filter((event) => event.type === "tool_call_started").length, 0);
+const requests = payloads.filter((event) => event.type === "inference_started");
+assert.ok(requests.length > 0, "no actual inference request recorded");
+const toolNames = new Set();
+const collectTools = (tools, namespace = "functions") => {
+  for (const tool of tools) {
+    if (tool.type === "namespace") collectTools(tool.tools, tool.name);
+    else {
+      assert.ok(["function", "custom"].includes(tool.type), "unexpected hosted tool");
+      const name = `${namespace}.${tool.name}`;
+      if (name === "functions.exec" || name === "functions.wait") {
+        // Model metadata can require Code Mode despite feature flags. These exact inspected
+        // wrappers expose only sandboxed apply_patch; V8 has no Node, filesystem, or network.
+        const wrappers = {
+          "functions.exec": "536740ba2218e0c3593f21a9edf5f0d171628c166496e04bd12dec5fec8a0467",
+          "functions.wait": "c77b58997b78d5f9c4f14f1d1bf80136c5bd912d3f0487c8b3a74dbf04e98cff",
+        };
+        assert.equal(hash(JSON.stringify(tool)), wrappers[name], "unattested Code Mode tools");
+        toolNames.add(name);
+        if (name === "functions.exec") toolNames.add("functions.apply_patch");
+        continue;
+      }
+      // apply_patch has no writable paths and verifies reads inside the sandbox.
+      assert.ok(
+        ["functions.apply_patch", "functions.send_user_message_async"].includes(name),
+        "unexpected model tool; do not replay this decision",
+      );
+      toolNames.add(name);
+    }
+  }
+};
+for (const event of requests) {
+  const request = JSON.parse(
+    readFileSync(join(dirname(traceFile), event.request_payload.path), "utf8"),
+  );
+  collectTools(request.tools ?? []);
+  for (const item of request.input ?? [])
+    if (item.type === "additional_tools") collectTools(item.tools);
+}
+const decision = readFileSync(join(runtime, "decision.json"));
+JSON.parse(decision);
+writeFileSync(join(bundle, "decision.json"), decision, { flag: "wx" });
+writeFileSync(
+  join(bundle, "generation.json"),
+  `${JSON.stringify(
+    {
+      generator: "Codex",
+      cliVersion: version.stdout.trim(),
+      provider: "openai",
+      auth: "existing ChatGPT login",
+      startedAt,
+      completedAt: new Date().toISOString(),
+      exitCode: generated.status,
+      helperSha256,
+      promptSha256: hash(prompt),
+      schemaSha256: hash(schema),
+      decisionSha256: hash(decision),
+      isolation: {
+        approval: "never",
+        permissionProfile: "terminal-proof",
+        filesystem: { ":minimal": "read", ":workspace_roots": "read" },
+        effectiveReadRoots: readRoots,
+        writablePaths: [],
+        childNetworkEnabled: false,
+        userConfigIgnored: true,
+        execRulesIgnored: true,
+        projectConfigAbsent: true,
+        projectInstructionsDisabled: true,
+        skillsDisabled: true,
+        shellToolsDisabled: true,
+        mcpDisabled: true,
+        pluginsDisabled: true,
+        webSearchDisabled: true,
+        emptyWorkspaceBeforeAndAfter: true,
+        outsideSentinelReadDenied: true,
+        workspaceWriteDenied: true,
+        startupSandbox: generated.stderr
+          .match(/^sandbox: (.+)$/m)[1]
+          .replaceAll(workspace, "<empty-workspace>"),
+        toolInventory: [...toolNames].sort(),
+        toolCalls: 0,
+        inferenceRequests: requests.length,
+        toolInventoryEvidence:
+          "actual local inference request trace; no raw transcript retained in bundle",
+      },
+      recordingTested: false,
+    },
+    null,
+    2,
+  )}\n`,
+  { flag: "wx" },
+);
+console.log(`PASS constrained generation; receipt: ${join(bundle, "generation.json")}`);

--- a/scripts/e2e/terminal-proof-once.mjs
+++ b/scripts/e2e/terminal-proof-once.mjs
@@ -1,0 +1,25 @@
+import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { setTimeout } from "node:timers/promises";
+
+const [output, delay = "0"] = process.argv.slice(2);
+if (!output || !/^(0|34)$/.test(delay)) throw new Error("usage: once.mjs OUTPUT [0|34]");
+appendFileSync(`${output}.invocations`, "invoked\n");
+try {
+  mkdirSync(output);
+} catch (error) {
+  if (error.code !== "EEXIST") throw error;
+  console.error("REFUSED_EXISTING_OUTPUT");
+  process.exit(17);
+}
+console.log("PROOF_STARTED");
+await setTimeout(Number(delay) * 1000);
+const assertions = [
+  "PASS exclusive directory",
+  "PASS original bytes retained",
+  "PASS local fixture",
+  "PASS stable assertions",
+  "PASS proof complete",
+];
+writeFileSync(join(output, "result.txt"), `${assertions.join("\n")}\n`, { flag: "wx" });
+console.log(assertions.join("\n"));

--- a/scripts/e2e/terminal-proof-planning.mjs
+++ b/scripts/e2e/terminal-proof-planning.mjs
@@ -1,0 +1,283 @@
+// Prepare production planner inputs, then replay an actual Codex decision through tmux.
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { copyFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  parseDecision,
+  reviewPromptForTest,
+  reviewDecisionSchemaText,
+} from "../../dist/clawsweeper.js";
+import { createDecisionParser } from "../../dist/clawsweeper-decision-parser.js";
+import { driveTerminal } from "../../dist/live-proof/drivers.js";
+import { buildLiveVerificationResult } from "../../dist/live-proof/verification.js";
+
+const root = fileURLToPath(new URL("../../", import.meta.url));
+const [mode, directory, variant = "fast"] = process.argv.slice(2);
+assert.ok(
+  ["prepare", "run"].includes(mode) && directory,
+  "usage: SCRIPT prepare|run DIR [fast|delayed]",
+);
+assert.ok(["fast", "delayed"].includes(variant));
+const bundle = resolve(directory);
+const base = "f211e21fb89d00777ac07cc13c358f9f7b02a939";
+const git = (...args) => execFileSync("git", args, { cwd: root, encoding: "utf8" }).trim();
+const hash = (bytes) => createHash("sha256").update(bytes).digest("hex");
+const json = (path, value) =>
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, { flag: "wx" });
+const sources = [
+  "prompts/review-item.md",
+  "schema/clawsweeper-decision.schema.json",
+  "src/clawsweeper-decision-parser.ts",
+  "src/clawsweeper-review-runtime.ts",
+  "src/live-proof/drivers.ts",
+  "src/live-proof/verification.ts",
+  "scripts/e2e/terminal-proof-once.mjs",
+  "scripts/e2e/terminal-proof-planning.mjs",
+];
+const sourceHashes = () =>
+  Object.fromEntries(sources.map((file) => [file, hash(readFileSync(join(root, file)))]));
+const stripDescriptions = (value) =>
+  Array.isArray(value)
+    ? value.map(stripDescriptions)
+    : value && typeof value === "object"
+      ? Object.fromEntries(
+          Object.entries(value)
+            .filter(([key]) => key !== "description")
+            .map(([key, child]) => [key, stripDescriptions(child)]),
+        )
+      : value;
+const schema = JSON.parse(reviewDecisionSchemaText());
+assert.deepEqual(
+  stripDescriptions(schema),
+  stripDescriptions(JSON.parse(git("show", `${base}:schema/clawsweeper-decision.schema.json`))),
+);
+const proofCommand = `node once.mjs output${variant === "delayed" ? " 34" : ""}`;
+const setupCommand = "printf 'SETUP_READY\\n'";
+const markers = [
+  "PASS exclusive directory",
+  "PASS original bytes retained",
+  "PASS local fixture",
+  "PASS stable assertions",
+  "PASS proof complete",
+];
+
+if (mode === "prepare") {
+  mkdirSync(bundle); // Refuse to overwrite an earlier generation or proof.
+  const fixture = readFileSync(join(root, "scripts/e2e/terminal-proof-once.mjs"), "utf8");
+  const item = {
+    repo: "openclaw/clawsweeper",
+    number: 1,
+    kind: "pull_request",
+    title: "Controlled local terminal proof fixture (synthetic, no GitHub item)",
+    url: "https://example.invalid/fixture/1",
+    author: "fixture",
+    authorAssociation: "NONE",
+    createdAt: "2026-08-26T00:00:00Z",
+    updatedAt: "2026-08-26T00:00:00Z",
+    labels: [],
+  };
+  const context = {
+    issue: {
+      ...item,
+      body: `A local CLI now creates an exclusive output directory and emits five stable success assertions. Demonstrate it with ${proofCommand}. The output directory initially does not exist. A second invocation against it fails with exit 17 without overwriting the original result. It emits PROOF_STARTED immediately, then finishes after ${variant === "delayed" ? "34 seconds" : "a short burst"}. A harmless setup command is available: ${setupCommand}. Verify all five PASS lines. No dependencies, accounts, secrets, or network. The full changed source follows:\n\n${fixture}`,
+    },
+    comments: [],
+    timeline: [],
+    counts: { comments: 0, timeline: 0 },
+    pullDiff: `diff --git a/once.mjs b/once.mjs\nnew file mode 100644\n--- /dev/null\n+++ b/once.mjs\n${fixture
+      .split("\n")
+      .map((line) => `+${line}`)
+      .join("\n")}`,
+  };
+  const prompt = reviewPromptForTest(
+    item,
+    context,
+    { mainSha: base, latestRelease: null },
+    "This is a controlled offline planner evaluation, not a real GitHub review. Use only the complete supplied fixture context. Do not use tools, execute the fixture, access the network, or modify files. Return the full decision JSON under the supplied production schema. Only the liveProofPlan will be executed afterward. Use the exact supplied commands and stable assertions; do not invent alternate commands. Do not claim proof has already run.",
+  );
+  writeFileSync(join(bundle, "prompt.md"), prompt, { flag: "wx" });
+  json(join(bundle, "schema.json"), schema);
+  json(join(bundle, "inputs.json"), {
+    base,
+    head: git("rev-parse", "HEAD"),
+    variant,
+    sourceHashes: sourceHashes(),
+    baseSourceHashes: Object.fromEntries(
+      sources
+        .filter((file) => !file.startsWith("scripts/e2e/terminal-proof-"))
+        .map((file) => [
+          file,
+          hash(execFileSync("git", ["show", `${base}:${file}`], { cwd: root })),
+        ]),
+    ),
+    promptSha256: hash(prompt),
+    schemaSha256: hash(readFileSync(join(bundle, "schema.json"))),
+  });
+  console.log(
+    `Prepared production prompt and schema in ${bundle}; generate decision.json with Codex, then run this script with run.`,
+  );
+} else {
+  const inputs = JSON.parse(readFileSync(join(bundle, "inputs.json"), "utf8"));
+  assert.deepEqual(
+    inputs.sourceHashes,
+    sourceHashes(),
+    "source changed since generation; prepare fresh inputs",
+  );
+  assert.equal(inputs.variant, variant);
+  assert.equal(inputs.promptSha256, hash(readFileSync(join(bundle, "prompt.md"))));
+  assert.equal(inputs.schemaSha256, hash(readFileSync(join(bundle, "schema.json"))));
+  const rawDecision = JSON.parse(readFileSync(join(bundle, "decision.json"), "utf8"));
+  const plan = parseDecision(rawDecision).liveProofPlan;
+  assert.deepEqual(
+    plan,
+    rawDecision.liveProofPlan,
+    "generated plan must survive production parsing unchanged",
+  );
+  assert.equal(plan.status, "recommended");
+  assert.equal(plan.surface, "terminal");
+  const commands = [
+    plan.entry,
+    ...plan.steps.filter((step) => step.action === "run").map((step) => step.command),
+  ];
+  assert.equal(commands.filter((command) => command === proofCommand).length, 1);
+  assert.ok(
+    commands.every((command) => [proofCommand, setupCommand].includes(command)),
+    "review unexpected generated commands before execution",
+  );
+  assert.ok(plan.steps.every((step) => ["run", "wait", "expect_output"].includes(step.action)));
+  for (const marker of markers)
+    assert.ok(plan.steps.some((step) => step.action === "expect_output" && step.text === marker));
+
+  const parsePlan = createDecisionParser({
+    isMaintainerAuthorAssociation: () => false,
+    neutralizeOwnedSectionSpoofing: (value) => value,
+    sanitizeArchitectureDiagram: (value) => value,
+  }).parseLiveProofPlan;
+  const receipts = [];
+  const drive = (name, candidate) => {
+    const checkout = join(bundle, name);
+    mkdirSync(checkout);
+    copyFileSync(join(root, "scripts/e2e/terminal-proof-once.mjs"), join(checkout, "once.mjs"));
+    const parsed = parsePlan(candidate, "liveProofPlan");
+    assert.deepEqual(parsed, candidate);
+    // Dedicated tmux server: do not touch user sessions or inherit their environment.
+    const socket = `terminal-planning-${process.pid}-${name}`;
+    const runner = (command, args, options = {}) =>
+      spawnSync(command, command === "tmux" ? ["-L", socket, "-f", "/dev/null", ...args] : args, {
+        cwd: options.cwd,
+        encoding: "utf8",
+        env: { PATH: process.env.PATH, HOME: checkout, TMPDIR: checkout, LANG: "en_US.UTF-8" },
+      });
+    let driven;
+    try {
+      driven = driveTerminal({
+        plan: parsed,
+        checkout,
+        rawVideoPath: join(checkout, "unused.webm"),
+        maxRecordingSeconds: 90,
+        recordMedia: false,
+        runner,
+      });
+    } finally {
+      runner("tmux", ["kill-server"]);
+    }
+    const result = buildLiveVerificationResult({
+      repo: "example/fixture",
+      item: 1,
+      headSha: inputs.head,
+      plan: parsed,
+      driveStatus: driven.status,
+      stepLog: driven.steps,
+      output: driven.output,
+      verifiedAt: new Date().toISOString(),
+    });
+    json(join(checkout, "live-verification.json"), result);
+    receipts.push({
+      scenario: name,
+      generated: name === "generated",
+      plan: parsed,
+      drive_status: result.drive_status,
+      overall_pass: result.overall_pass,
+      failure: result.failure ?? null,
+      steps: result.steps,
+      output: result.output,
+    });
+    return { checkout, result };
+  };
+  const good = drive("generated", plan);
+  assert.equal(good.result.overall_pass, true);
+  for (const step of good.result.steps.filter((step) => step.action === "expect_output")) {
+    assert.equal(step.satisfied, true);
+    assert.equal(step.detail, "ok");
+  }
+  const resultBytes = readFileSync(join(good.checkout, "output/result.txt"));
+  assert.equal(readFileSync(join(good.checkout, "output.invocations"), "utf8"), "invoked\n");
+  const replay = spawnSync(process.execPath, ["once.mjs", "output"], {
+    cwd: good.checkout,
+    encoding: "utf8",
+  });
+  assert.equal(replay.status, 17);
+  assert.deepEqual(readFileSync(join(good.checkout, "output/result.txt")), resultBytes);
+
+  const control = (entry, steps) => ({ ...plan, entry, steps });
+  const duplicate = drive(
+    "duplicate",
+    control("node once.mjs output", [
+      { action: "run", command: "node once.mjs output" },
+      { action: "expect_output", text: markers[4] },
+    ]),
+  );
+  assert.equal(duplicate.result.overall_pass, false);
+  assert.match(duplicate.result.output, /REFUSED_EXISTING_OUTPUT/);
+  assert.equal(
+    readFileSync(join(duplicate.checkout, "output.invocations"), "utf8"),
+    "invoked\ninvoked\n",
+  );
+  assert.deepEqual(readFileSync(join(duplicate.checkout, "output/result.txt")), resultBytes);
+  const repeat = "cat state.txt >> reads.txt && cat state.txt";
+  const later = drive(
+    "intentional-repeat",
+    control("printf before > state.txt", [
+      { action: "run", command: repeat },
+      { action: "run", command: "printf after > state.txt" },
+      { action: "run", command: repeat },
+      { action: "expect_output", text: "after" },
+    ]),
+  );
+  assert.equal(later.result.overall_pass, true);
+  assert.equal(readFileSync(join(later.checkout, "reads.txt"), "utf8"), "beforeafter");
+  const negative = drive(
+    "nonzero",
+    control("printf 'CONTROL_FAILED\\n'; exit 7", [
+      { action: "expect_output", text: "CONTROL_FAILED" },
+    ]),
+  );
+  assert.equal(negative.result.overall_pass, false);
+  assert.match(negative.result.failure.reason, /exit status 7/);
+  const timeout = drive(
+    "timeout",
+    control("sleep 40", [{ action: "expect_output", text: "NEVER_EMITTED" }]),
+  );
+  assert.equal(timeout.result.overall_pass, false);
+  assert.match(timeout.result.failure.reason, /within 30 seconds/);
+  json(join(bundle, "receipt.json"), {
+    ...inputs,
+    provider: "local macOS tmux",
+    node: process.version,
+    tmux: execFileSync("tmux", ["-V"], { encoding: "utf8" }).trim(),
+    decisionSha256: hash(readFileSync(join(bundle, "decision.json"))),
+    schemaShapeUnchanged: true,
+    oneShotInvocationsBeforeReplay: 1,
+    replayExit: replay.status,
+    originalBytesPreserved: true,
+    resultSha256: hash(resultBytes),
+    recordingTested: false,
+    scenarios: receipts,
+  });
+  console.log(
+    `PASS generated plan, non-overwrite replay, duplicate execution, intentional rerun, nonzero and real timeout; receipt: ${join(bundle, "receipt.json")}`,
+  );
+}

--- a/src/clawsweeper-decision-parser.ts
+++ b/src/clawsweeper-decision-parser.ts
@@ -650,16 +650,9 @@ export function createDecisionParser({
     if (!payoff.justification) throw new Error(`${path}.payoff.justification must not be empty`);
     if (!Array.isArray(record.steps)) throw new Error(`${path}.steps must be an array`);
     if (record.steps.length > 10) throw new Error(`${path}.steps must contain at most 10 items`);
-    const parsedSteps = record.steps.map((step, index) =>
+    const steps = record.steps.map((step, index) =>
       parseLiveProofStep(step, `${path}.steps[${index}]`),
     );
-    const steps =
-      status === "recommended" &&
-      surface === "terminal" &&
-      parsedSteps[0]?.action === "run" &&
-      parsedSteps[0].command === entry
-        ? parsedSteps.slice(1)
-        : parsedSteps;
     if (status !== "recommended") {
       if (surface !== "none") throw new Error(`${path}.surface must be none unless recommended`);
       if (entry) throw new Error(`${path}.entry must be empty unless recommended`);

--- a/test/decision-parser.test.ts
+++ b/test/decision-parser.test.ts
@@ -451,7 +451,7 @@ test("decision parser validates typed live-proof plans and report roundtrips", (
   }
 });
 
-test("decision parser removes only a leading duplicate terminal entry", () => {
+test("decision parser preserves every terminal command including exact entry repeats", () => {
   const terminalPlan = {
     status: "recommended",
     surface: "terminal",
@@ -467,7 +467,14 @@ test("decision parser removes only a leading duplicate terminal entry", () => {
     ],
   };
   const exact = parseDecision(closeDecision({ liveProofPlan: terminalPlan })).liveProofPlan;
-  assert.deepEqual(exact.steps, [{ action: "expect_output", text: "Usage:" }]);
+  assert.deepEqual(exact.steps, terminalPlan.steps);
+  const section = renderLiveProofReportSectionForTest(
+    parseDecision(closeDecision({ liveProofPlan: exact })),
+  );
+  assert.deepEqual(
+    reportLiveProofPlanForTest(`## Live Proof\n\n${section}\n\n## Mantis Recommendation\n`),
+    exact,
+  );
 
   const trimmed = parseDecision(
     closeDecision({
@@ -482,14 +489,15 @@ test("decision parser removes only a leading duplicate terminal entry", () => {
     }),
   ).liveProofPlan;
   assert.equal(trimmed.entry, "pnpm openclaw --help");
-  assert.deepEqual(trimmed.steps, [{ action: "expect_output", text: "Usage:" }]);
+  assert.deepEqual(trimmed.steps, terminalPlan.steps);
 
   const distinct = parseDecision(
     closeDecision({
       liveProofPlan: {
         ...terminalPlan,
         steps: [
-          { action: "run", command: "pnpm openclaw status" },
+          { action: "run", command: "pnpm openclaw --help" },
+          { action: "run", command: "printf changed > state.txt" },
           { action: "run", command: "pnpm openclaw --help" },
           { action: "expect_output", text: "Usage:" },
         ],
@@ -497,21 +505,22 @@ test("decision parser removes only a leading duplicate terminal entry", () => {
     }),
   ).liveProofPlan;
   assert.deepEqual(distinct.steps, [
-    { action: "run", command: "pnpm openclaw status" },
+    { action: "run", command: "pnpm openclaw --help" },
+    { action: "run", command: "printf changed > state.txt" },
     { action: "run", command: "pnpm openclaw --help" },
     { action: "expect_output", text: "Usage:" },
   ]);
 
+  assert.deepEqual(
+    parseDecision(
+      closeDecision({
+        liveProofPlan: { ...terminalPlan, steps: [terminalPlan.steps[0]] },
+      }),
+    ).liveProofPlan.steps,
+    [terminalPlan.steps[0]],
+  );
   assert.throws(
-    () =>
-      parseDecision(
-        closeDecision({
-          liveProofPlan: {
-            ...terminalPlan,
-            steps: [{ action: "run", command: "pnpm openclaw --help" }],
-          },
-        }),
-      ),
+    () => parseDecision(closeDecision({ liveProofPlan: { ...terminalPlan, steps: [] } })),
     /decision\.liveProofPlan\.steps must not be empty when recommended/,
   );
   assert.throws(

--- a/test/live-proof.test.ts
+++ b/test/live-proof.test.ts
@@ -1015,7 +1015,50 @@ test("terminal output aggregates clean evidence across the entry command and run
   assert.doesNotMatch(result.output, /\.wrapper|\.command|\.status|\/tmp\//);
 });
 
-test("parsed duplicate terminal entry executes once and preserves long final output publicly", () => {
+test("parsed terminal repeats execute independently and retain failure gates", () => {
+  const command = "proof-command";
+  for (const failRepeat of [false, true]) {
+    const executed: string[] = [];
+    const fixtureRunner = terminalLifecycleRunner([], { terminalCaptures: ["Ready\n"] });
+    const plan = liveProofPlanParser(
+      {
+        ...recommendedPlan("terminal"),
+        entry: command,
+        steps: [
+          { action: "run", command },
+          { action: "run", command: "change-state" },
+          { action: "run", command },
+          { action: "expect_output", text: "Ready" },
+        ],
+      },
+      "liveProofPlan",
+    );
+    const result = driveTerminal({
+      plan,
+      checkout: "/tmp/checkout",
+      rawVideoPath: "/tmp/live-proof.raw.webm",
+      maxRecordingSeconds: 90,
+      recordMedia: false,
+      readCommandStatus: () => (failRepeat && executed.length === 2 ? 7 : 0),
+      runner: (tool, args, options) => {
+        if (tool === "tmux" && args[0] === "respawn-pane") {
+          const path = String(args.at(-1)).match(/'([^']+)'$/)?.[1];
+          assert.ok(path);
+          executed.push(readFileSync(path, "utf8").trimEnd());
+        }
+        return fixtureRunner(tool, args, options);
+      },
+    });
+    assert.deepEqual(
+      executed,
+      failRepeat ? [command, command] : [command, command, "change-state", command],
+    );
+    assert.equal(result.status, failRepeat ? "failed" : "completed");
+    if (failRepeat) assert.match(result.steps[0]?.detail ?? "", /exit status 7/);
+  }
+});
+
+test("terminal entry with expectations executes once and preserves long final output publicly", () => {
   const directory = mkdtempSync(join(tmpdir(), "clawsweeper-live-proof-output-"));
   const fixturePath = join(directory, "fixture.mjs");
   const counterPath = join(directory, "counter.txt");
@@ -1037,10 +1080,7 @@ test("parsed duplicate terminal entry executes once and preserves long final out
     {
       ...recommendedPlan("terminal"),
       entry: command,
-      steps: [
-        { action: "run", command },
-        { action: "expect_output", text: "FINAL_HELP_RESULT" },
-      ],
+      steps: [{ action: "expect_output", text: "FINAL_HELP_RESULT" }],
     },
     "liveProofPlan",
   );

--- a/test/review-prompt-policy.test.ts
+++ b/test/review-prompt-policy.test.ts
@@ -652,6 +652,28 @@ test("review prompt and schema classify deterministic live-proof plans in field 
   assert.match(prompt, /never a\s+judgment about whether to run/);
   assert.match(prompt, /`liveProofPlan\.status: "declined_suspicious"`/);
   assert.match(prompt, /never\s+execute the PR or claim that a recording exists/);
+  assert.match(prompt, /`entry` executes automatically before all typed steps/);
+  assert.match(prompt, /Every `run` step executes\s+independently/);
+  assert.match(prompt, /nothing is deduplicated/);
+  assert.match(prompt, /one-shot proof[\s\S]*stable `expect_output` steps/);
+  assert.match(prompt, /safe setup `entry` followed by exactly\s+one `run`/);
+  assert.match(prompt, /Do not repeat a one-shot\s+command just to capture output or create media/);
+  assert.match(prompt, /Intentional reruns,[\s\S]*are valid and will execute/);
+  assert.match(prompt, /choose `static_text` and verify once/);
+  assert.match(
+    liveProofPlan.properties.entry.description,
+    /executes automatically before all steps/,
+  );
+  assert.match(liveProofPlan.properties.steps.description, /nothing is deduplicated/);
+  assert.match(liveProofPlan.properties.steps.description, /Intentional reruns/);
+  assert.match(
+    liveProofPlan.properties.payoff.properties.justification.description,
+    /Never repeat a one-shot terminal command just for media/,
+  );
+  const runStep = liveProofPlan.properties.steps.items.anyOf.find(
+    (step: { properties: { action: { const: string } } }) => step.properties.action.const === "run",
+  );
+  assert.match(runStep.properties.command.description, /Identical commands still execute/);
 
   assert.deepEqual(liveProofPlan.required, [
     "status",


### PR DESCRIPTION
## What Problem This Solves

Resolves generated terminal Live Verification plans replaying a one-shot proof by placing the same command in both `entry` and the first `run`. In [PR 1240](https://github.com/openclaw/clawsweeper/pull/1240#issuecomment-5403433718), entry passed all five assertions, then the replay correctly refused to overwrite the proof output. The trusted [PR 1254 producer run](https://github.com/openclaw/clawsweeper/actions/runs/33033345816) also contained a duplicated entry/run command.

## Why This Change Was Made

Make the contract explicit where plans are generated: terminal `entry` executes automatically before typed steps, and every `run` is a separate execution. One-shot proofs belong either in entry followed by expectations, or after safe setup as exactly one run. Media guidance must not encourage replay merely to obtain a transition.

The base included [PR 1256](https://github.com/openclaw/clawsweeper/pull/1256), which silently removed a leading identical run. This restores command-preserving parsing instead. Its cold-build/final-output retention remains intact. Public schema properties/types/required fields/enums/bounds, driver supervision, deadlines, failure gates, and non-overwrite protection are unchanged.

## Maintainer Decision and Review Disposition

The maintainer decision is to **preserve every declared terminal command**, including an immediate `run` identical to `entry`. Command identity cannot tell the parser whether repetition is intentional. The planner owns avoiding accidental one-shot replay; supervision and target non-overwrite guards remain authoritative. A malformed duplicate plan may fail rather than have its program silently rewritten.

**Resolved: [P1] Remove the unsandboxed Codex proof command.** The public recipe no longer grants full host authority. A dedicated constrained generator ignores user/project configuration and execution rules, disables shell/MCP/web/plugin/agent access, and uses a named restricted filesystem profile with no writable paths or child network access. It tests denied reads/writes, verifies actual startup permissions and tool inventory, and requires zero model tool calls before accepting a decision. The latest proof uses two new generations through the final unchanged helper, not old full-access decisions or retrospective re-attestation.

This applies the review's corresponding rank-up move. The helper is explicitly attested for macOS Seatbelt and Codex CLI `0.150.0-alpha.13`; other platforms/versions fail closed pending re-attestation. This is not a blanket no-tools claim: the inspected, fingerprinted Code Mode wrappers expose only sandboxed `apply_patch`; an optional user-message tool has no host filesystem/network authority. The CLI's own authenticated inference transport is separate from model-directed tool access.

## User Impact

One-shot terminal proofs can be planned without accidental replay, explicit repeated commands are never silently discarded, and the public reproduction workflow no longer requires unrestricted model execution. Nonzero exits and real timeouts still fail. Release-note context is retained here and in the proof record, following the release-owned changelog disposition in PR 1256.

## OpenClaw Bay Impact

Unaffected. Schema v1, verification lifecycle, publication/receipt contracts, and Bay's observer-only ownership do not change.

## Documentation Impact

Updated active `docs/live-proof.md` and the production review prompt. The [proof record](https://github.com/openclaw/clawsweeper/blob/a08acddf53cc688d4fd38206898fb35023c9c1f6/docs/proof/terminal-proof-planning/README.md) documents the controlled fixture, constrained generation, real-tmux reproduction, and explicit platform/toolchain limits. The [latest normalized receipt](https://github.com/openclaw/clawsweeper/blob/a08acddf53cc688d4fd38206898fb35023c9c1f6/docs/proof/terminal-proof-planning/receipt.json) supersedes the historical full-access receipt without rewriting its history.

## Evidence

- 138 focused tests passed across decision parsing, review prompt policy/context, and live proof. They cover command preservation, report roundtrips, repeat failure, and retained long-output behavior.
- The final constrained generator produced two fresh decisions from the complete production review prompt and schema. Both were parsed unchanged and executed through real tmux with all five success assertions observed.
- Harmless sandbox probes denied an outside-workspace read and a workspace write. Actual session traces verified restricted permissions, no writable paths, restricted child network, the expected tool inventory, and zero tool calls.
- Independent precommit P0/P1 autoreview of the frozen correction returned no findings and judged the patch correct: the original unrestricted-host-authority finding is resolved for the pinned macOS workflow. That review inspected the supplied bundle and dependencies; the parent separately verified both actual final-helper generations and their real-tmux proof. Committed-branch review remains a landing gate.
- Build, helper syntax/lint/format, static/documentation checks, and diff checks passed. The earlier full local suite's diagnosed fixture failures remain disclosed below.

## Real Behavior Proof

**Claim:** the planner describes a one-shot proof once, the constrained generator does not give model-directed tools unrestricted host authority, and parser/driver preserve intentional repetitions and existing failure gates.

**Surface:** production prompt/schema → actual constrained Codex generation → production parser → production terminal driver/tmux → schema-v1 verification. The generation phase receives a complete synthetic local fixture as data; it does not execute that fixture. The later real-tmux phase uses an allowlisted dependency-free command that exclusively creates an output directory, records invocations, writes stable bytes, and emits five markers.

**Environment:** local macOS, Node 24.19.0, tmux 3.7c, and the attested Codex CLI. The fast plan runs the proof only in entry; the 34-second delayed plan uses safe setup followed by one run. The helper denies unexpected permissions/tools or trace failures instead of falling back to full access. No driver deadline was raised.

**Exact committed head:** `a08acddf53cc688d4fd38206898fb35023c9c1f6`. Fresh fast and delayed real-tmux replays both passed at this committed head using `/opt/homebrew/opt/node@24/bin/node` (Node 24.19.0), with that Node directory first on `PATH`. These are replays of the original constrained-generated decisions, **not fresh model calls**. Fresh `prepare` bundles recorded this head, and their source hashes, prompt SHA256, and schema SHA256 matched the original generation bundles exactly. Each decision was copied byte-for-byte; its original `generation.json` provenance was retained at the original path and explicitly referenced by a `generation-reuse.json` record with `reusedDecision: true` and `freshModelCall: false`. The unchanged helper SHA256 is `2b12954b5afe14cb2d451a5457342ca1ad5f29703b2deb5426f162f80692f41e`, matching both original generation attestations. Both replays observed all five required named PASS assertions; additional setup/start expectations were allowed and also passed. Each invoked the proof once before direct replay, which exited 17 without changing the result bytes. Duplicate execution, intentional `beforeafter` repetition, exit-7 failure, and the real 30-second timeout all behaved as required. No timeout or proof contract was changed.

Local exact-head artifacts (SHA256):

- Fast receipt: `.artifacts/terminal-proof-planning/safe-head-fast/receipt.json` — `b8de86e491438253bf6f303c0eebc2905cbeeb7af719c423e02841ad76d3e052`. Reuse provenance: `.artifacts/terminal-proof-planning/safe-head-fast/generation-reuse.json` — `9844946e8b316e17ad548ce5dcf519438df356890f0ba6d4635ba0954264cf17`.
- Delayed receipt: `.artifacts/terminal-proof-planning/safe-head-delayed/receipt.json` — `e0aa2508433e27d5b21cab36e169d477570a0fcda90ed953bf490f32273f7af8`. Reuse provenance: `.artifacts/terminal-proof-planning/safe-head-delayed/generation-reuse.json` — `24904d465832968e3dd038da30b204e241c1530cfe7b8f454725505b748cc9e0`.

The committed public normalized receipt retains its actual original runtime head and uncommitted source hashes; it was not rewritten to invent a self-referential commit SHA. These new local receipts provide the exact-head binding.

**Observed results:** each generated plan invoked the one-shot command once and observed all five named assertions. Direct replay exited 17 and preserved the original bytes. A deliberately duplicated entry/run executed twice and failed its overwrite guard. Identical later commands separated by a file-state change observed `beforeafter`. Exit 7 and a silent 40-second command failed under existing gates. File bytes and invocation traces support these assertions independently of printed PASS strings.

**Provenance:** the linked normalized receipt binds the new generation's final-helper hash, prompt/schema/decision hashes, effective permissions/tool inventory, and real-tmux outcomes. Final-head replay binds those same generated decisions and unchanged implementation inputs to the committed head above. Raw agent transcripts and private model identifiers are not included.

**Limits:** controlled local terminal fixture—not target Worker/apply correctness, hosted review execution, all future model generations, or cross-platform generator support. Recording/transcoding/publication were not tested. No live apply/close, workflow pause, or external proof upload was performed.

### PR 1254 status investigation

No separate driver status bug was established. Producer and base drivers are identical. Real tmux probes showed a previous-command gate can expire and final capture can later collect successful output while verification correctly stays failed: the requested next command never executed. The late-capture probe deliberately injected latency, establishing possible ordering rather than the producer's actual timing. The original artifact lacks status-sample timestamps; target JSON containing `exit:0` cannot erase a timeout. Driver status logic and deadlines remain unchanged.

### Validation and landing gates

Current-head CI evidence is available in the [PR Checks tab](https://github.com/openclaw/clawsweeper/pull/1259/checks). Landing requires successful CI, CodeQL, and hermetic e2e results attached to `a08acddf53cc688d4fd38206898fb35023c9c1f6`, plus clean committed-branch autoreview and a current-head/body ClawSweeper review with no unresolved actionable finding. The final maintainer verification checks those live results rather than freezing a transient pending state in this body.

For historical context, the prior runtime head `ca48d41487affa905cb775da8a985d1b128b18c3` passed [CI](https://github.com/openclaw/clawsweeper/actions/runs/33042763349), [hermetic e2e](https://github.com/openclaw/clawsweeper/actions/runs/33042763503), and [CodeQL](https://github.com/openclaw/clawsweeper/actions/runs/33042763435). Those runs do **not** substitute for checks on the new head.

The earlier full local `pnpm run check` finished with **3,712 passed, 49 failed, nine skipped** on Node 24.19.0; it is not represented as green. Independent diagnosis reproduced 42 inherited Git-pruning failures deleting fixture `origin/main`, six unavailable pinned-pnpm versions in fresh offline mirrors, and one timing-sensitive setup-budget assertion. Ten representative Git-affected tests passed with process-local pruning disabled; the timing test passed three focused reruns. Owners/fixtures were byte-identical to the base and failed outside the changed parser path. Not every blocked scenario was rerun after removing its host-config blocker. These issues remain a separate follow-up; no global configuration or unrelated tests were changed.

The maintainer has explicitly authorized landing after the above gates pass. This does not authorize live apply/close or workflow mutation.
