### PR TITLE
fix: pinned-base tests fail without a cached pnpm runtime

### DIFF
--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -2088,7 +2088,15 @@ test("pinned-base validation reproduction proves the same base failure", () => {
   fs.mkdirSync(path.join(cwd, "src"));
   fs.writeFileSync(
     path.join(cwd, "check.js"),
-    "console.error('src/base.ts:1: lint failed'); process.exit(1);\n",
+    [
+      "const fs = require('node:fs');",
+      "const { execFileSync } = require('node:child_process');",
+      "const profile = Object.fromEntries(['HOME', 'XDG_CACHE_HOME', 'COREPACK_HOME'].map(key => [key, process.env[key]]));",
+      "for (const directory of Object.values(profile)) if (!fs.statSync(directory).isDirectory()) throw new Error('missing validation profile');",
+      "console.log('pinned-base-profile:' + JSON.stringify({ ...profile, cwd: process.cwd(), head: execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim(), pnpmOffline: process.env.PNPM_CONFIG_OFFLINE, npmOffline: process.env.npm_config_offline }));",
+      "console.error('src/base.ts:1: lint failed'); process.exit(1);",
+      "",
+    ].join("\n"),
   );
   fs.writeFileSync(path.join(cwd, "src/base.ts"), "export const base = true;\n");
   fs.writeFileSync(path.join(cwd, "src/repair.ts"), "export const value = 1;\n");
@@ -2099,13 +2107,32 @@ test("pinned-base validation reproduction proves the same base failure", () => {
   git(cwd, "add", "src/repair.ts");
   git(cwd, "commit", "-m", "repair change");
 
-  const baseError = reproduceValidationFailureAtPinnedBase({
-    commands: ["pnpm check:changed"],
-    targetDir: cwd,
-    options: validationOptions("openclaw/openclaw", { pinnedBaseRef }),
-  });
+  const profiles = withPinnedBasePnpm(() =>
+    Array.from({ length: 2 }, () => {
+      const baseError = reproduceValidationFailureAtPinnedBase({
+        commands: ["pnpm check:changed"],
+        targetDir: cwd,
+        options: validationOptions("openclaw/openclaw", { pinnedBaseRef }),
+      });
 
-  assert.match(String(baseError), /src\/base\.ts:1: lint failed/);
+      assert.match(String(baseError), /src\/base\.ts:1: lint failed/);
+      const observation = /pinned-base-profile:(\{[^\r\n]*?\})/.exec(String(baseError));
+      assert.ok(observation, "check.js must report its validation environment");
+      return JSON.parse(observation[1]);
+    }),
+  );
+  for (const profile of profiles) {
+    assert.equal(profile.head, pinnedBaseRef);
+    assert.notEqual(profile.cwd, fs.realpathSync(cwd));
+    assert.equal(profile.pnpmOffline, "true");
+    assert.equal(profile.npmOffline, "true");
+    assert.equal(fs.existsSync(profile.cwd), false, "pinned checkout must be removed");
+    for (const key of ["HOME", "XDG_CACHE_HOME", "COREPACK_HOME"]) {
+      assert.notEqual(profile[key], process.env[key]);
+      assert.notEqual(profiles[0][key], profiles[1][key], "reproductions need separate profiles");
+      assert.equal(fs.existsSync(profile[key]), false, "validation profile must be removed");
+    }
+  }
 });
 
 test("pinned-base reproduction avoids fetching unrelated missing partial-clone history", () => {
@@ -2154,11 +2181,13 @@ test("pinned-base reproduction avoids fetching unrelated missing partial-clone h
   assert.match(missingObjects, new RegExp(`^\\?${omittedHistoricalBlob}$`, "m"));
   git(target, "remote", "set-url", "origin", "https://invalid.invalid/offline.git");
 
-  const baseError = reproduceValidationFailureAtPinnedBase({
-    commands: ["pnpm check:changed"],
-    targetDir: target,
-    options: validationOptions("openclaw/openclaw", { pinnedBaseRef }),
-  });
+  const baseError = withPinnedBasePnpm(() =>
+    reproduceValidationFailureAtPinnedBase({
+      commands: ["pnpm check:changed"],
+      targetDir: target,
+      options: validationOptions("openclaw/openclaw", { pinnedBaseRef }),
+    }),
+  );
 
   assert.match(String(baseError), /src\/base\.ts:1: lint failed/);
   assert.match(
@@ -2197,11 +2226,13 @@ test("pinned-base reproduction preserves the source comparison branch for change
   git(cwd, "update-ref", "refs/remotes/origin/main", pinnedBaseRef);
   assert.notEqual(sourceMainSha, pinnedBaseRef);
 
-  const baseError = reproduceValidationFailureAtPinnedBase({
-    commands: ["pnpm check:changed"],
-    targetDir: cwd,
-    options: validationOptions("openclaw/openclaw", { pinnedBaseRef }),
-  });
+  const baseError = withPinnedBasePnpm(() =>
+    reproduceValidationFailureAtPinnedBase({
+      commands: ["pnpm check:changed"],
+      targetDir: cwd,
+      options: validationOptions("openclaw/openclaw", { pinnedBaseRef }),
+    }),
+  );
 
   assert.match(String(baseError), /src\/base\.ts:1: lint failed/);
 });
@@ -2248,14 +2279,16 @@ test("pinned-base reproduction hydrates blobs required by the older pinned snaps
     new RegExp(`^\\?${requiredBlob}$`, "m"),
   );
 
-  const baseError = reproduceValidationFailureAtPinnedBase({
-    commands: ["pnpm check:changed"],
-    targetDir: target,
-    options: validationOptions("openclaw/openclaw", {
-      pinnedBaseRef,
-      pinnedBaseRemoteUrl: pathToFileURL(remote).href,
+  const baseError = withPinnedBasePnpm(() =>
+    reproduceValidationFailureAtPinnedBase({
+      commands: ["pnpm check:changed"],
+      targetDir: target,
+      options: validationOptions("openclaw/openclaw", {
+        pinnedBaseRef,
+        pinnedBaseRemoteUrl: pathToFileURL(remote).href,
+      }),
     }),
-  });
+  );
 
   assert.match(String(baseError), /src\/base\.ts:1: lint failed/);
 });
@@ -2277,11 +2310,13 @@ test("pinned-base reproduction preserves the source SHA-256 object format", () =
   const pinnedBaseRef = git(cwd, "rev-parse", "HEAD");
   assert.equal(pinnedBaseRef.length, 64);
 
-  const baseError = reproduceValidationFailureAtPinnedBase({
-    commands: ["pnpm check:changed"],
-    targetDir: cwd,
-    options: validationOptions("openclaw/openclaw", { pinnedBaseRef }),
-  });
+  const baseError = withPinnedBasePnpm(() =>
+    reproduceValidationFailureAtPinnedBase({
+      commands: ["pnpm check:changed"],
+      targetDir: cwd,
+      options: validationOptions("openclaw/openclaw", { pinnedBaseRef }),
+    }),
+  );
 
   assert.match(String(baseError), /src\/base\.ts:1: lint failed/);
 });
@@ -2326,11 +2361,13 @@ test("pinned-base reproduction does not inherit target-controlled checkout hooks
   });
   git(cwd, "config", "core.hooksPath", hooks);
 
-  const baseError = reproduceValidationFailureAtPinnedBase({
-    commands: ["pnpm check:changed"],
-    targetDir: cwd,
-    options: validationOptions("openclaw/openclaw", { pinnedBaseRef }),
-  });
+  const baseError = withPinnedBasePnpm(() =>
+    reproduceValidationFailureAtPinnedBase({
+      commands: ["pnpm check:changed"],
+      targetDir: cwd,
+      options: validationOptions("openclaw/openclaw", { pinnedBaseRef }),
+    }),
+  );
 
   assert.match(String(baseError), /src\/base\.ts:1: lint failed/);
   assert.equal(fs.existsSync(marker), false);
@@ -8847,6 +8884,34 @@ function linuxValidationContainmentAvailable() {
     { stdio: "ignore" },
   );
   return probe.status === 0;
+}
+
+function withPinnedBasePnpm(callback) {
+  // Dependency-free pinned-base fixtures skip setup and must not resolve host pnpm.
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-pinned-base-pnpm-"));
+  const pnpmPath = path.join(binDir, "pnpm.cjs");
+  fs.writeFileSync(
+    pnpmPath,
+    `const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const { spawnSync } = require("node:child_process");
+const args = process.argv.slice(2).filter(arg => ![
+  "--config.verify-deps-before-run=false",
+  "--config.enable-pre-post-scripts=false",
+].includes(arg));
+assert.deepEqual(args, ["check:changed"]);
+assert.equal(JSON.parse(fs.readFileSync("package.json", "utf8")).scripts["check:changed"], "node check.js");
+const child = spawnSync(process.execPath, ["check.js"], { stdio: "inherit" });
+if (child.error) throw child.error;
+if (child.signal) process.kill(process.pid, child.signal);
+else process.exit(child.status ?? 1);
+`,
+  );
+  try {
+    return withMockCommand("pnpm", pnpmPath, callback);
+  } finally {
+    fs.rmSync(binDir, { recursive: true, force: true });
+  }
 }
 
 function withMockCommand(command, scriptPath, callback) {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where six pinned-base validation tests fail on pnpm distribution resolution instead of reaching their intended `check.js` assertions when the host does not have the fixture's pinned pnpm version in the disposable offline cache. The failure was independently reproduced on unchanged baseline `5cb6777eea2da37e2c2481e15215c2f8be9c774f`.

## Why This Change Was Made

These dependency-free fixtures deliberately use `installTargetDeps: false`, so the fixtures own supplying their executable. A scoped adapter uses the existing `withMockCommand` / `mockCommandBinEnv` boundary to run the actual fixture `check.js` in the real validator's working directory and environment. It rejects unexpected invocations and forwards the child's output and exit status; it does not manufacture the expected lint diagnostic or mock reproduction/classification.

The pnpm pin, existing assertions, production preparation, disposable profiles, and offline containment remain unchanged. The first existing case additionally checks the pinned HEAD, independent checkout, offline flags, fresh HOME/cache/Corepack directories across two reproductions, and cleanup. Production LOC: +0/-0. Tests: +99/-34 in one file.

## User Impact

Developers can run the pinned-base reproduction tests without depending on their installed pnpm version or a pre-warmed distribution cache. There is no production behavior or public API change.

## OpenClaw Bay Impact

None. This changes only local test-fixture execution, not review publication, queues, telemetry, dashboards, or data contracts.

## Documentation Impact

Reviewed `AGENTS.md`, `CONTRIBUTING.md`, and `docs/repair/README.md`. Their preparation and containment contracts remain accurate; no documentation or changelog change is needed for this test-only repair.

## Evidence

The original six cases failed before this repair and pass afterward. The full adjacent pinned-base group passes on the committed head with external networking denied. The changed file passes formatting, lint, and `git diff --check`; fresh isolated Codex reviews before commit and on the committed branch against `origin/main` both reported no accepted/actionable findings in their default P0 scope.

The local full `pnpm run check` was also attempted and is **not green**: 3,703 passed, 46 failed, 9 skipped. Forty-two failures match the separately reproduced inherited Git-pruning defect; two other fixtures still try to resolve host pnpm; one live-proof test cannot access the host tmux socket under the stricter outer sandbox; and one setup-deadline test times out at an earlier Git identity inspection. Those failures are not hidden, skipped, or folded into this patch. Exact-head hosted CI remains a landing gate.

## Real Behavior Proof

**Revision:** `f8536584ad1bc26f50f5d81a08cafd669ad10f49` (same reviewed test patch; relevant validation files are unchanged on current base `ff813ac2fa76d853d8a9129e6763d09624cafe72`).

**Claim and exercised surface:** the six affected fixtures now execute their real `check.js` through `reproduceValidationFailureAtPinnedBase` and the production contained command runner, without resolving an external pnpm distribution. Real local Git repositories exercise partial clones, historical blob hydration, comparison refs, SHA-256 object format, checkout-hook rejection, and adjacent fail-closed cases.

**Environment:** macOS, Node 24.19.0, repository pnpm 11.10.0. Dependencies were prepared offline with zero downloads. The focused proof adds an outer macOS sandbox denying non-loopback networking and restricts Git transports to local files; production isolation is not relaxed.

Build command:

```bash
env PNPM_CONFIG_OFFLINE=true npm_config_offline=true COREPACK_ENABLE_NETWORK=0 pnpm run build:all
```

Focused proof command:

```bash
/usr/bin/sandbox-exec -p '(version 1) (allow default) (deny network*) (allow network-bind (local ip "localhost:*")) (allow network-inbound (local ip "localhost:*")) (allow network-outbound (remote ip "localhost:*"))' /usr/bin/env PNPM_CONFIG_OFFLINE=true npm_config_offline=true COREPACK_ENABLE_NETWORK=0 GIT_ALLOW_PROTOCOL=file node --test --test-reporter=tap '--test-name-pattern=^pinned-base ' test/repair/target-validation.test.ts
```

**Observed result and trace:** before the repair, all six selected cases stopped at `Failed to resolve @pnpm/exe@10.33.0 in package mirror …`, before `src/base.ts:1: lint failed`. After the repair, the actual scripts emit that lint diagnostic, and the existing partial-clone/ref/object-format/hook assertions succeed. The first case also emits a `pinned-base-profile` observation from inside `check.js`; assertions verify the pinned HEAD, separate disposable cwd and profiles, both offline flags, and removal after each run. The adjacent group, including its independent-runtime and fail-closed cases, finishes:

```text
1..11
# tests 11
# pass 11
# fail 0
# cancelled 0
# skipped 0
```

**Limits:** this is executable fixture/reproduction proof, not integration proof for downloading or installing the external pnpm distribution. No production runtime changed. macOS proof does not establish Linux namespace availability; the existing platform-specific containment tests retain their platform limits. The separate local full-gate failures above remain disclosed.
