### PR TITLE
fix(dashboard): hide exact-review server details

### DIFF
--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -28,7 +28,6 @@ import {
   githubAppJsonAsPlainError as githubAppJson,
   signGithubAppJwt,
 } from "./github-api.ts";
-import { sanitizedServerError } from "./error-safety.ts";
 import {
   HEALTH_HISTORY_RETENTION_DAYS,
   HEALTH_HISTORY_SAMPLE_MS,
@@ -4437,10 +4436,12 @@ async function exactReviewQueueRequest(env, path, request?: Request) {
       JSON.parse(responseBody);
       return response;
     } catch {
-      return json({ error: sanitizedServerError(responseBody) }, response.status);
+      console.error("exact_review_queue_malformed_server_response");
+      return json({ error: "exact_review_queue_unavailable" }, response.status);
     }
-  } catch (error) {
-    return json({ error: sanitizedServerError(error) }, 500);
+  } catch {
+    console.error("exact_review_queue_request_failed");
+    return json({ error: "exact_review_queue_unavailable" }, 500);
   }
 }
 

--- a/docs/proof/exact-review-do-json-errors/README.md
+++ b/docs/proof/exact-review-do-json-errors/README.md
@@ -1,4 +1,4 @@
-# Exact-review Worker sanitized JSON error proof
+# Exact-review Worker safe JSON error proof
 
 This proof starts the actual local Wrangler Worker and its ExactReviewQueue
 Durable Object, then drives the signed internal
@@ -6,25 +6,23 @@ Durable Object, then drives the signed internal
 Durable Object boundary. A proof-only entry module re-exports the production
 `ExactReviewQueue` with its real SQLite `storage.sql.exec` wrapped so one
 marked request fails the `SELECT item_key, item_json` state read with an
-error message carrying a planted GitHub token. The production route code,
-worker forwarding, HMAC verification, storage initialization, and every other
-request run unmodified.
+stack-bearing rejection string carrying a planted GitHub token and a synthetic
+internal file path. The production route code, worker forwarding, HMAC
+verification, storage initialization, and every other request run unmodified.
 
 The scenario sends three identical-shape signed requests: a baseline list
 (expect 200), the marked failing request, and a recovery list (expect 200).
 The script detects whether the checked-out tree contains the fix and asserts
 accordingly:
 
-- before (base tree): the injected Durable Object failure escapes the Worker,
-  and the client receives a non-JSON 500 with no sanitized error contract; in
-  the local dev runtime the error page also exposes the planted token to the
-  client.
+- before (base tree): the Worker returns the stack-bearing rejection text in
+  its JSON 500, including the synthetic internal file path.
 - after (fixed tree): the Durable Object still rejects so its transaction
-  remains fail closed, while the Worker converts that rejected stub call into
-  HTTP 500 with
+  remains fail closed, while the Worker returns HTTP 500 with
   `content-type: application/json` and body
-  `{"error":"injected sqlite read failure exposing GH_TOKEN=[REDACTED]"}`;
-  the planted token never reaches the client.
+  `{"error":"exact_review_queue_unavailable"}`. The planted token and internal
+  path never reach the client, and the Worker records the bounded
+  `exact_review_queue_request_failed` diagnostic event.
 
 Run from the repository root of the tree under test:
 
@@ -39,8 +37,6 @@ crabbox run \
   --artifact-glob '.artifacts/exact-review-do-json-errors/**'
 ```
 
-Limits: the before-mode HTML error page is the local dev runtime's rendering
-of the escaped exception; deployed workerd returns its generic internal-error
-response instead. The invariant proven is the Worker-facing failure contract:
-an escaped Durable Object rejection becomes a sanitized JSON 500 without
-changing the Durable Object transaction boundary.
+The invariant proven is the Worker-facing failure contract: a stack-bearing
+Durable Object rejection becomes a fixed JSON 500 without changing the Durable
+Object transaction boundary or losing the internal failure event.

--- a/docs/proof/exact-review-do-json-errors/run-proof.sh
+++ b/docs/proof/exact-review-do-json-errors/run-proof.sh
@@ -34,7 +34,7 @@ if [ -e "$output_dir" ]; then
 fi
 mkdir -p "$output_dir"
 
-if grep -q 'sanitizedServerError(responseBody)' dashboard/worker.ts; then
+if grep -q 'exact_review_queue_request_failed' dashboard/worker.ts; then
   proof_mode=after
 else
   proof_mode=before
@@ -61,7 +61,11 @@ import baseWorker, {
 } from "./worker.ts";
 
 const PROOF_FAILURE_MESSAGE =
-  "injected sqlite read failure exposing GH_TOKEN=ghp_examplesecrettoken0123456789abcd";
+  "injected sqlite read failure exposing private-marker-0123456789abcdef";
+const PROOF_FAILURE_STACK = [
+  `Error: ${PROOF_FAILURE_MESSAGE}`,
+  "at readQueue (file:///srv/clawsweeper-internal/exact-review-queue.ts:91:4)",
+].join("\n");
 
 function bindingProxy(target: any, overrides: Record<PropertyKey, unknown>) {
   return new Proxy(target, {
@@ -81,7 +85,7 @@ export class ExactReviewQueue extends BaseExactReviewQueue {
       exec: (query: string, ...args: unknown[]) => {
         if (armedPattern && armedPattern.test(String(query))) {
           armedPattern = null;
-          throw new Error(PROOF_FAILURE_MESSAGE);
+          throw PROOF_FAILURE_STACK;
         }
         return realStorage.sql.exec(query, ...args);
       },
@@ -138,7 +142,8 @@ const mode = process.env.EXACT_REVIEW_DO_PROOF_MODE === "before" ? "before" : "a
 const headSha = String(process.env.EXACT_REVIEW_DO_PROOF_HEAD || "unknown");
 if (!origin || !secret) throw new Error("proof origin and secret are required");
 
-const plantedToken = "ghp_examplesecrettoken0123456789abcd";
+const plantedMarker = "private-marker-0123456789abcdef";
+const stackMarker = "file:///srv/clawsweeper-internal/exact-review-queue.ts:91:4";
 const routePath = "/internal/exact-review/publications/list";
 const assertions = [];
 const transcript = [];
@@ -149,7 +154,7 @@ function assertProof(name, condition, details = {}) {
 }
 
 function redact(value) {
-  return String(value).split(plantedToken).join("ghp_[PLANTED_TOKEN_REDACTED]");
+  return String(value).split(plantedMarker).join("[PLANTED_MARKER_REDACTED]");
 }
 
 async function signedPost(label, value) {
@@ -197,19 +202,28 @@ const jsonContract =
   failing.contentType.includes("application/json") &&
   parsedFailing !== null &&
   typeof parsedFailing.error === "string";
-const tokenLeaked = failing.text.includes(plantedToken);
+const markerLeaked = failing.text.includes(plantedMarker);
+const stackLeaked = failing.text.includes(stackMarker);
 
 assertProof("failure_status_500", failing.status === 500, { http_status: failing.status });
 if (mode === "before") {
-  assertProof("broken_failure_contract_on_base", !jsonContract || tokenLeaked, {
+  assertProof("stack_exposed_on_base", stackLeaked, {
     json_contract: jsonContract,
-    token_leaked: tokenLeaked,
+    marker_leaked: markerLeaked,
+    stack_leaked: stackLeaked,
   });
 } else {
-  assertProof("worker_sanitized_json_contract", jsonContract, {
+  assertProof("worker_safe_json_contract", jsonContract, {
     content_type: failing.contentType,
   });
-  assertProof("planted_token_redacted", !tokenLeaked && failing.text.includes("[REDACTED"), {
+  assertProof(
+    "fixed_public_error",
+    parsedFailing.error === "exact_review_queue_unavailable",
+    {
+      response_body: redact(failing.text).slice(0, 300),
+    },
+  );
+  assertProof("internal_details_not_exposed", !markerLeaked && !stackLeaked, {
     response_body: redact(failing.text).slice(0, 300),
   });
 }
@@ -218,13 +232,14 @@ const summary = {
   mode,
   head_sha: headSha,
   route: routePath,
-  planted_token: "ghp_[PLANTED_TOKEN_REDACTED]",
+  planted_marker: "[PLANTED_MARKER_REDACTED]",
   failure_response: {
     status: failing.status,
     content_type: failing.contentType,
     body: redact(failing.text).slice(0, 2000),
     json_contract: jsonContract,
-    token_leaked: tokenLeaked,
+    marker_leaked: markerLeaked,
+    stack_leaked: stackLeaked,
   },
   assertions,
 };
@@ -282,3 +297,5 @@ EXACT_REVIEW_DO_PROOF_ORIGIN="http://127.0.0.1:${port}" \
   node "$driver"
 
 test -s "$output_dir/proof-summary.json"
+grep -q 'exact_review_queue_request_failed' "$wrangler_log"
+printf '%s\n' 'exact_review_queue_request_failed' >"$output_dir/internal-diagnostics.txt"

--- a/test/dashboard-worker-durable-object-error.test.ts
+++ b/test/dashboard-worker-durable-object-error.test.ts
@@ -46,40 +46,73 @@ test("exact-review Durable Object rejects storage failures directly", async () =
   assert.equal((await queue.fetch(publicationsListRequest(100))).status, 200);
 });
 
-test("exact-review Worker sanitizes rejected Durable Object calls", async () => {
-  const storage = new MemoryDurableStorage();
-  const queue = newQueue(storage);
-  assert.equal((await queue.fetch(publicationsListRequest(100))).status, 200);
-
-  storage.failNextSql(
-    /SELECT item_key, item_json/,
-    new Error(
-      "injected sqlite read failure exposing GH_TOKEN=ghp_examplesecrettoken0123456789abcd",
-    ),
-  );
+test("exact-review Worker projects rejected Durable Object calls to a fixed public error", async () => {
+  const internalStack = [
+    "Error: database pool internals",
+    "at readQueue (file:///srv/clawsweeper-private/exact-review-queue.ts:91:4)",
+  ].join("\n");
   const secret = "test-webhook-secret";
   const requestBody = JSON.stringify({ limit: 100 });
-  const response = await worker.fetch(signedPublicationsListRequest(requestBody, secret), {
-    CLAWSWEEPER_WEBHOOK_SECRET: secret,
-    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
-  });
+  const originalError = console.error;
+  const errors: unknown[][] = [];
+  console.error = (...values: unknown[]) => errors.push(values);
+  try {
+    const response = await worker.fetch(signedPublicationsListRequest(requestBody, secret), {
+      CLAWSWEEPER_WEBHOOK_SECRET: secret,
+      EXACT_REVIEW_QUEUE: new MemoryDurableNamespace({
+        async fetch() {
+          throw internalStack;
+        },
+      }),
+    });
 
-  assert.equal(response.status, 500);
-  assert.equal(response.headers.get("content-type"), "application/json; charset=utf-8");
-  const responseBody = (await response.json()) as { error?: unknown };
-  assert.equal(typeof responseBody.error, "string");
-  assert.equal(JSON.stringify(responseBody).includes("ghp_examplesecrettoken"), false);
+    assert.equal(response.status, 500);
+    assert.equal(response.headers.get("content-type"), "application/json; charset=utf-8");
+    assert.deepEqual(await response.json(), { error: "exact_review_queue_unavailable" });
+    assert.deepEqual(errors, [["exact_review_queue_request_failed"]]);
+  } finally {
+    console.error = originalError;
+  }
 });
 
-test("exact-review Worker normalizes malformed Durable Object 5xx responses", async () => {
-  const plantedToken = "ghp_examplesecrettoken0123456789abcd";
+test("exact-review Worker projects malformed Durable Object 5xx responses to a fixed public error", async () => {
+  const plantedMarker = "private-marker-0123456789abcdef";
   const secret = "test-webhook-secret";
   const body = JSON.stringify({ limit: 100 });
+  const originalError = console.error;
+  const errors: unknown[][] = [];
+  console.error = (...values: unknown[]) => errors.push(values);
+  try {
+    const response = await worker.fetch(signedPublicationsListRequest(body, secret), {
+      CLAWSWEEPER_WEBHOOK_SECRET: secret,
+      EXACT_REVIEW_QUEUE: new MemoryDurableNamespace({
+        async fetch() {
+          return new Response(`upstream failure marker=${plantedMarker}`, {
+            status: 503,
+            headers: { "content-type": "application/json" },
+          });
+        },
+      }),
+    });
+
+    assert.equal(response.status, 503);
+    assert.equal(response.headers.get("content-type"), "application/json; charset=utf-8");
+    assert.deepEqual(await response.json(), { error: "exact_review_queue_unavailable" });
+    assert.deepEqual(errors, [["exact_review_queue_malformed_server_response"]]);
+  } finally {
+    console.error = originalError;
+  }
+});
+
+test("exact-review Worker preserves structured Durable Object 5xx responses", async () => {
+  const secret = "test-webhook-secret";
+  const body = JSON.stringify({ limit: 100 });
+  const responseBody = { error: "lease_decision_unavailable", retryable: true };
   const response = await worker.fetch(signedPublicationsListRequest(body, secret), {
     CLAWSWEEPER_WEBHOOK_SECRET: secret,
     EXACT_REVIEW_QUEUE: new MemoryDurableNamespace({
       async fetch() {
-        return new Response(`upstream failure GH_TOKEN=${plantedToken}`, {
+        return new Response(JSON.stringify(responseBody), {
           status: 503,
           headers: { "content-type": "application/json" },
         });
@@ -88,11 +121,8 @@ test("exact-review Worker normalizes malformed Durable Object 5xx responses", as
   });
 
   assert.equal(response.status, 503);
-  assert.equal(response.headers.get("content-type"), "application/json; charset=utf-8");
-  const responseBody = (await response.json()) as { error?: unknown };
-  assert.equal(typeof responseBody.error, "string");
-  assert.equal(JSON.stringify(responseBody).includes(plantedToken), false);
-  assert.match(String(responseBody.error), /\[REDACTED\]/);
+  assert.equal(response.headers.get("content-type"), "application/json");
+  assert.deepEqual(await response.json(), responseBody);
 });
 
 test("exact-review Worker preserves intentional non-JSON 4xx responses", async () => {

--- a/test/record-export-bounds.test.ts
+++ b/test/record-export-bounds.test.ts
@@ -455,54 +455,58 @@ test("signed record export returns one oversized serialized record and advances"
   assert.equal(second.nextCursor, null);
 });
 
-test("signed record export returns sanitized 500 for missing and invalid logical byte metadata", async () => {
-  const missingHarness = await exportHarness();
-  const missing = fixtureRecord({
-    source: "canonical",
-    section: "items",
-    id: "1",
-    content: "missing-metadata",
-    storeRevision: 1,
-  });
-  seedFixtureRecord(missingHarness.storage, missing);
-  missingHarness.storage.sql.exec(
-    `DELETE FROM ${EXACT_REVIEW_CANONICAL_RECORD_TABLE}
+test("signed record export hides missing and invalid logical byte metadata", async () => {
+  const originalError = console.error;
+  const errors: unknown[][] = [];
+  console.error = (...values: unknown[]) => errors.push(values);
+  try {
+    const missingHarness = await exportHarness();
+    const missing = fixtureRecord({
+      source: "canonical",
+      section: "items",
+      id: "1",
+      content: "missing-metadata",
+      storeRevision: 1,
+    });
+    seedFixtureRecord(missingHarness.storage, missing);
+    missingHarness.storage.sql.exec(
+      `DELETE FROM ${EXACT_REVIEW_CANONICAL_RECORD_TABLE}
       WHERE repo_slug = ? AND section = ? AND item_id = ?`,
-    REPO_SLUG,
-    missing.section,
-    Number(missing.id),
-  );
-  const missingResponse = await exportResponse(missingHarness.env, 0);
-  assert.equal(missingResponse.status, 500);
-  assert.equal(missingResponse.headers.get("content-type"), "application/json; charset=utf-8");
-  const missingBody = (await missingResponse.json()) as { error?: unknown };
-  assert.equal(typeof missingBody.error, "string");
-  assert.match(String(missingBody.error), /invalid record export byte metadata.*items\/1/);
+      REPO_SLUG,
+      missing.section,
+      Number(missing.id),
+    );
+    const missingResponse = await exportResponse(missingHarness.env, 0);
+    assert.equal(missingResponse.status, 500);
+    assert.equal(missingResponse.headers.get("content-type"), "application/json; charset=utf-8");
+    assert.deepEqual(await missingResponse.json(), { error: "exact_review_queue_unavailable" });
 
-  const invalidHarness = await exportHarness();
-  const invalid = fixtureRecord({
-    source: "backfill",
-    section: "commits",
-    id: "b".repeat(40),
-    content: "invalid-metadata",
-    storeRevision: 1,
-  });
-  seedFixtureRecord(invalidHarness.storage, invalid);
-  invalidHarness.storage.sql.exec(
-    `UPDATE ${EXACT_REVIEW_RECORD_BACKFILL_TABLE}
+    const invalidHarness = await exportHarness();
+    const invalid = fixtureRecord({
+      source: "backfill",
+      section: "commits",
+      id: "b".repeat(40),
+      content: "invalid-metadata",
+      storeRevision: 1,
+    });
+    seedFixtureRecord(invalidHarness.storage, invalid);
+    invalidHarness.storage.sql.exec(
+      `UPDATE ${EXACT_REVIEW_RECORD_BACKFILL_TABLE}
         SET byte_length = 9007199254740992
       WHERE repo_slug = ? AND section = ? AND record_id = ?`,
-    REPO_SLUG,
-    invalid.section,
-    invalid.id,
-  );
-  const invalidResponse = await exportResponse(invalidHarness.env, 0);
-  assert.equal(invalidResponse.status, 500);
-  assert.equal(invalidResponse.headers.get("content-type"), "application/json; charset=utf-8");
-  const invalidBody = (await invalidResponse.json()) as { error?: unknown };
-  assert.equal(typeof invalidBody.error, "string");
-  assert.match(
-    String(invalidBody.error),
-    new RegExp(`invalid record export byte metadata.*commits/${invalid.id}`),
-  );
+      REPO_SLUG,
+      invalid.section,
+      invalid.id,
+    );
+    const invalidResponse = await exportResponse(invalidHarness.env, 0);
+    assert.equal(invalidResponse.status, 500);
+    assert.equal(invalidResponse.headers.get("content-type"), "application/json; charset=utf-8");
+    assert.deepEqual(await invalidResponse.json(), { error: "exact_review_queue_unavailable" });
+    assert.deepEqual(errors, [
+      ["exact_review_queue_request_failed"],
+      ["exact_review_queue_request_failed"],
+    ]);
+  } finally {
+    console.error = originalError;
+  }
 });


### PR DESCRIPTION
Related: https://github.com/openclaw/clawsweeper/security/code-scanning/98

## What Problem This Solves

Fixes an issue where signed exact-review Worker requests could receive
stack-bearing or otherwise internal Durable Object error data when a queue
operation failed or returned a malformed server response.

## Why This Change Was Made

The Worker now owns the externally reachable error projection: unexpected
failures return the fixed, bounded `exact_review_queue_unavailable` code while
the server records a bounded diagnostic category. Intentional non-JSON 4xx
responses and valid structured JSON 5xx responses retain their existing status,
headers, and body shape.

This does not change the generic JSON response helper or the Durable Object
transaction boundary.

## User Impact

Callers of signed exact-review internal routes no longer receive stack traces,
server paths, or internal failure text. Existing structured queue errors remain
machine-readable and unchanged.

## OpenClaw Bay Impact

None. The change is limited to signed `/internal` exact-review forwarding
failures and does not alter Bay data contracts, projections, or navigation.

## Documentation Impact

Updated the active exact-review Worker error proof and executable harness to
cover the fixed public response, retained internal diagnostic category, baseline
success, and post-failure recovery. The source of truth remains
`dashboard/worker.ts`; rerun the proof when that boundary or route changes.

## Evidence

- Pre-fix reproduction on `a22ff989bdf474dbe9c917f34199c7fea45c27c1`:
  a signed request to `/internal/exact-review/publications/list` returned a
  stack-bearing rejection with a synthetic internal path.
- Current head: `40d770463241a3cfca5ddd7ef3becc6f7e42676c`.
- Focused tests: 9 passed, 0 failed across the Worker/DO boundary and record
  export sibling path.
- Sol/high autoreview: clean, 0.98 patch-correct confidence.
- Independent high-reasoning test audit: clean on observable behavior,
  pre-fix regression, non-duplicate coverage, and no test-only production seam.
- Repo-native committed-range review: `nothing_found`, high confidence, exact
  range `a22ff989..40d77046`.
- Production LOC: +5/-4 (net +1). Tests: +108/-74. Proof/docs: +42/-29.
- `git diff --check`, focused formatting/lint/type checks, and all three builds
  passed.
- The full Linux `pnpm run check` passed static checks, builds, lint, changed
  coverage, and the coverage suite except one raw-sync infrastructure failure:
  `apply-drift-refresh` requires `.git`. That exact test passed after adding
  verification-only Git metadata. Hosted CI remains the canonical full gate.

## Real Behavior Proof

- **Claim:** a stack-bearing queue rejection never crosses the signed Worker
  response boundary, while a bounded internal failure event remains available.
- **Surface:** real local Wrangler Worker, HMAC-authenticated
  `/internal/exact-review/publications/list`, and the real ExactReviewQueue
  Durable Object with SQLite storage.
- **Scenario:** baseline list succeeds; one marked SQL read rejects with a
  synthetic stack and private marker; the Worker returns a fixed JSON 500; a
  recovery list succeeds.
- **Environment:** AWS Crabbox Linux on exact head
  `40d770463241a3cfca5ddd7ef3becc6f7e42676c`; run `run_e35fd7055126`, lease
  `cbx_251420c016b5`, auto-released.
- **Observed:** 9/9 focused tests passed; all six HTTP assertions passed:
  baseline 200, recovery 200, failure 500, JSON content type, fixed public
  error, and no internal marker or stack path in the response.
- **Artifact:** Crabbox collected
  `.artifacts/exact-review-do-json-errors/proof-summary.json` plus the redacted
  transcript and internal diagnostic category.
- **Limits:** local Cloudflare runtime and synthetic storage failure; no
  production request or production data was used.
