### PR TITLE
fix(live-proof): publish authoritative terminal results

### DIFF
--- a/docs/live-proof.md
+++ b/docs/live-proof.md
@@ -184,18 +184,26 @@ must remain live through a three-second stability hold before publication.
 Every earlier command must exit zero. The supervisor exits with the command's
 status, and tmux's pane lifecycle records whether that supervisor is still
 running or how it exited. Each proof uses a private tmux socket directory. The
-original pane wrapper launches the target asynchronously with job control
-disabled and stdio bound to its controlling terminal, then publishes its pane
-PID with a fresh nonce. After capture and the final viewport are sealed, the
-controller releases that exact tuple. The wrapper schedules a cleanup job
-through its private tmux server; that job TERM-sweeps and repeatedly applies
-terminal-scoped KILL until the terminal has no processes left. Cleanup succeeds
-only when the exact pane is dead and a matching atomic success receipt exists.
-A Darwin cleanup uses `killall -t`; other platforms use `pgrep`/`pkill` with an
-explicit all-process pattern.
-A stale tuple, pane replacement, cleanup command error, surviving process, or
-timeout fails the proof visibly. Target commands do not inherit `TMUX`,
-`TMUX_PANE`, or `TMUX_TMPDIR`.
+controller binds the exact pane PID and controlling terminal before opening the
+start gate. The pane process validates that tuple and opens a private lease file
+descriptor inherited by the held target and its descendants. Before opening a
+second execution gate, the controller starts a cleanup watchdog outside the pane
+process tree through the private tmux server and requires an exact atomic armed
+receipt bound to the pane PID, terminal, nonce, and lease inode.
+
+After capture and the final viewport are sealed, controller cleanup requests the
+already-armed watchdog. Pane death triggers the same watchdog independently. It
+TERM-sweeps, then repeatedly KILL-sweeps the union of processes on the bound
+terminal and processes still holding the lease until two consecutive scans are
+empty. Darwin finds lease holders with the stock `lsof`; Linux inspects `/proc`
+file descriptors. Cleanup succeeds only when an exact zero-survivor receipt
+matches the bound identity and the original pane is dead. Missing, malformed,
+stale, replaced, surviving-process, or timeout evidence fails visibly. Target
+commands do not inherit `TMUX`, `TMUX_PANE`, or `TMUX_TMPDIR`.
+
+The lease is lifecycle cleanup, not hostile same-UID isolation. A target that
+deliberately closes inherited descriptors or attacks same-user controller
+processes requires container, VM, namespace, or separate-user containment.
 All untrusted fields are bounded and neutralized against Markdown fences, HTML,
 and ClawSweeper marker spoofing. OpenClaw Bay is unaffected because schema v1
 and the existing lifecycle and publication contracts do not change.

--- a/docs/live-proof.md
+++ b/docs/live-proof.md
@@ -186,20 +186,23 @@ status, and tmux's pane lifecycle records whether that supervisor is still
 running or how it exited. Each proof uses a private tmux socket directory. The
 controller binds the exact pane PID and controlling terminal before opening the
 start gate. The pane process validates that tuple and opens a private lease file
-descriptor inherited by the held target and its descendants. Before opening a
-second execution gate, the controller starts a cleanup watchdog outside the pane
-process tree through the private tmux server and requires an exact atomic armed
-receipt bound to the pane PID, terminal, nonce, and lease inode.
+on reserved descriptor 9, inherited by the held target and its descendants.
+Before opening a second execution gate, the controller starts a cleanup watchdog
+outside the pane process tree through the private tmux server and requires an
+exact atomic armed receipt bound to the pane PID, terminal, nonce, and lease
+inode.
 
 After capture and the final viewport are sealed, controller cleanup requests the
 already-armed watchdog. Pane death triggers the same watchdog independently. It
-TERM-sweeps, then repeatedly KILL-sweeps the union of processes on the bound
-terminal and processes still holding the lease until two consecutive scans are
-empty. Darwin finds lease holders with the stock `lsof`; Linux inspects `/proc`
-file descriptors. Cleanup succeeds only when an exact zero-survivor receipt
-matches the bound identity and the original pane is dead. Missing, malformed,
-stale, replaced, surviving-process, or timeout evidence fails visibly. Target
-commands do not inherit `TMUX`, `TMUX_PANE`, or `TMUX_TMPDIR`.
+TERM-sweeps, then repeatedly KILL-sweeps processes still holding the lease plus
+bound-terminal members only while the original pane still owns both its lease
+and bound terminal. Lease-holder discovery remains active after pane death.
+Darwin finds lease holders with the stock `lsof`; Linux inspects `/proc` for
+reserved inherited descriptor 9. Cleanup succeeds only when an exact
+zero-survivor receipt matches the bound identity and the original pane is dead.
+Missing, malformed, stale, replaced, surviving-process, or timeout evidence
+fails visibly. Target commands do not inherit `TMUX`, `TMUX_PANE`, or
+`TMUX_TMPDIR`.
 
 The lease is lifecycle cleanup, not hostile same-UID isolation. A target that
 deliberately closes inherited descriptors or attacks same-user controller

--- a/docs/live-proof.md
+++ b/docs/live-proof.md
@@ -183,7 +183,9 @@ live after satisfying an output expectation. Non-recorded long-running proofs
 must remain live through a three-second stability hold before publication.
 Every earlier command must exit zero. The supervisor exits with the command's
 status, and tmux's pane lifecycle records whether that supervisor is still
-running or how it exited.
+running or how it exited. Cleanup asks tmux to tear down the exact owned pane;
+the pane PID is only an identity check and is never treated as a portable
+process-group ID.
 All untrusted fields are bounded and neutralized against Markdown fences, HTML,
 and ClawSweeper marker spoofing. OpenClaw Bay is unaffected because schema v1
 and the existing lifecycle and publication contracts do not change.

--- a/docs/live-proof.md
+++ b/docs/live-proof.md
@@ -183,9 +183,10 @@ live after satisfying an output expectation. Non-recorded long-running proofs
 must remain live through a three-second stability hold before publication.
 Every earlier command must exit zero. The supervisor exits with the command's
 status, and tmux's pane lifecycle records whether that supervisor is still
-running or how it exited. Cleanup asks tmux to tear down the exact owned pane;
-the pane PID is only an identity check and is never treated as a portable
-process-group ID.
+running or how it exited. Before the target starts, Bash job control creates and
+records a dedicated foreground process group while preserving controlling-
+terminal behavior. Cleanup signals only that trusted group; the pane PID remains
+an identity check and is never treated as a process-group ID.
 All untrusted fields are bounded and neutralized against Markdown fences, HTML,
 and ClawSweeper marker spoofing. OpenClaw Bay is unaffected because schema v1
 and the existing lifecycle and publication contracts do not change.

--- a/docs/live-proof.md
+++ b/docs/live-proof.md
@@ -183,10 +183,19 @@ live after satisfying an output expectation. Non-recorded long-running proofs
 must remain live through a three-second stability hold before publication.
 Every earlier command must exit zero. The supervisor exits with the command's
 status, and tmux's pane lifecycle records whether that supervisor is still
-running or how it exited. Before the target starts, Bash job control creates and
-records a dedicated foreground process group while preserving controlling-
-terminal behavior. Cleanup signals only that trusted group; the pane PID remains
-an identity check and is never treated as a process-group ID.
+running or how it exited. Each proof uses a private tmux socket directory. The
+original pane wrapper launches the target asynchronously with job control
+disabled and stdio bound to its controlling terminal, then publishes its pane
+PID with a fresh nonce. After capture and the final viewport are sealed, the
+controller releases that exact tuple. The wrapper schedules a cleanup job
+through its private tmux server; that job TERM-sweeps and repeatedly applies
+terminal-scoped KILL until the terminal has no processes left. Cleanup succeeds
+only when the exact pane is dead and a matching atomic success receipt exists.
+A Darwin cleanup uses `killall -t`; other platforms use `pgrep`/`pkill` with an
+explicit all-process pattern.
+A stale tuple, pane replacement, cleanup command error, surviving process, or
+timeout fails the proof visibly. Target commands do not inherit `TMUX`,
+`TMUX_PANE`, or `TMUX_TMPDIR`.
 All untrusted fields are bounded and neutralized against Markdown fences, HTML,
 and ClawSweeper marker spoofing. OpenClaw Bay is unaffected because schema v1
 and the existing lifecycle and publication contracts do not change.

--- a/docs/live-proof.md
+++ b/docs/live-proof.md
@@ -149,13 +149,18 @@ existing comment-sync path upserts the marker-backed review comment.
 
 Browser comments contain sanitized per-step outcomes and a one-line failing-step
 reason, never page text. Terminal comments retain capped output and list
-assertions only when present. A terminal command with a confirmed successful exit
-still passes when its expected marker is absent from the captured pane; the
-assertion remains a completed, non-gating schema-v1 step, is explicitly labeled
-`NOT OBSERVED`, and cannot qualify a recording. Private command files and runner
-paths never enter published terminal output. Each entry or `run` action executes
-as a separately supervised Bash process in the same checkout, so plans should
-share state through files or one command rather than shell-local mutations.
+assertions only when present. Each command runs in a real PTY, and terminal
+assertions inspect tmux-rendered history observed by the controller. Capture
+keeps a rolling 1 MiB diagnostic tail, but that target-writable artifact is not
+assertion authority. Once the controller observes an assertion, later history
+eviction does not erase that fact. Sealing proves the capture helper consumed the
+stream before completion. Successful runs publish the final visible 50-row
+terminal viewport, and long-running proofs publish their current viewport.
+Failed runs publish each command's bounded combined diagnostics under one label.
+Private supervisor files and runner paths never enter published terminal output.
+Each entry or `run` action executes as a separately supervised Bash process in
+the same checkout, so plans should share state through files or one command
+rather than shell-local mutations.
 The terminal `entry` executes automatically before all typed steps. Every `run`
 executes independently, including a first `run` identical to `entry` or a later
 repeated command; the parser and driver do not deduplicate commands. Intentional
@@ -171,7 +176,14 @@ one run so the expected output appears after the action; otherwise use
 the original output to accommodate an accidental replay.
 
 Nonzero exits, signals, command timeouts, and missing markers for still-running
-commands remain failures.
+commands remain failures. Terminal plans declare `terminalCompletion:
+exit_zero` when the final command must finish successfully, or
+`terminalCompletion: ready_while_running` when the final command must remain
+live after satisfying an output expectation. Non-recorded long-running proofs
+must remain live through a three-second stability hold before publication.
+Every earlier command must exit zero. The supervisor exits with the command's
+status, and tmux's pane lifecycle records whether that supervisor is still
+running or how it exited.
 All untrusted fields are bounded and neutralized against Markdown fences, HTML,
 and ClawSweeper marker spoofing. OpenClaw Bay is unaffected because schema v1
 and the existing lifecycle and publication contracts do not change.

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -533,7 +533,13 @@ user-visible. Reserve `not_applicable` for a change with genuinely nothing to
 run, such as docs-only edits or generated assets in a repository with no
 meaningful runnable surface. Use `surface: "browser"` for browser behavior and
 `surface: "terminal"` for terminal behavior. The `entry` must be a URL path for
-browser verification or a command for terminal verification. A terminal
+browser verification or a command for terminal verification. Set
+`terminalCompletion: "exit_zero"` when the final terminal command must finish
+successfully. Use `terminalCompletion: "ready_while_running"` only for a final
+server, watcher, or TUI command that must still be running after a stable
+`expect_output` marker appears. Every terminal command before the final command
+must exit zero. Browser and non-runnable plans use
+`terminalCompletion: "not_applicable"`. A terminal
 `entry` executes automatically before all typed steps. Every `run` step executes
 independently as a new command, including commands identical to `entry` or earlier
 steps; nothing is deduplicated. For a one-shot proof (for example, a command that
@@ -599,8 +605,8 @@ are disabled and the target child receives a sanitized environment. If unsure,
 use `declined_suspicious`, not `not_applicable`. For `not_applicable` and
 `declined_suspicious`, use `surface: "none"`, an empty `entry`, and an empty
 `steps` array. Use the same safe empty shape for issues, with
-`payoff.kind: "static_text"` and a concise explanation that no recording payoff
-was assessed.
+`payoff.kind: "static_text"`, `terminalCompletion: "not_applicable"`, and a
+concise explanation that no recording payoff was assessed.
 
 For PRs, also emit Codex `/review`-style findings in `reviewFindings`.
 Review the diff as another engineer's proposed patch and list every discrete,

--- a/schema/clawsweeper-decision.schema.json
+++ b/schema/clawsweeper-decision.schema.json
@@ -792,7 +792,7 @@
       "type": "object",
       "additionalProperties": false,
       "description": "For PRs, recommend a deterministic live proof only when a user-visible browser or terminal behavior can be demonstrated from the PR head in 90 seconds or less without external accounts, credentials, secrets, or third-party services. ClawSweeper executes recommended plans unsandboxed on a machine that holds credentials, so declined_suspicious is the safety control. Use it whenever the diff or installed dependencies, including new or bumped dependencies that cannot be inspected, could plausibly exfiltrate, read credential stores, transmit data to unexpected hosts, or display sensitive data. If unsure, use declined_suspicious.",
-      "required": ["status", "surface", "reason", "payoff", "entry", "steps"],
+      "required": ["status", "surface", "terminalCompletion", "reason", "payoff", "entry", "steps"],
       "properties": {
         "status": {
           "type": "string",
@@ -802,6 +802,11 @@
           "type": "string",
           "enum": ["browser", "terminal", "none"],
           "description": "Use browser or terminal only when status is recommended; otherwise use none."
+        },
+        "terminalCompletion": {
+          "type": "string",
+          "enum": ["exit_zero", "ready_while_running", "not_applicable"],
+          "description": "For terminal proof, use exit_zero when the final command must finish successfully or ready_while_running when the final command is a server or TUI that must remain live after its expected output appears. All earlier terminal commands must exit zero. Use not_applicable for browser, declined, and non-applicable plans."
         },
         "reason": {
           "type": "string",

--- a/src/clawsweeper-decision-parser.ts
+++ b/src/clawsweeper-decision-parser.ts
@@ -20,6 +20,7 @@ import {
   LIVE_PROOF_PAYOFF_SCHEMA_KEYS,
   LIVE_PROOF_STEP_SCHEMA_KEYS,
   LIVE_PROOF_SURFACES,
+  LIVE_PROOF_TERMINAL_COMPLETIONS,
   MANTIS_RECOMMENDATION_SCENARIOS,
   MANTIS_RECOMMENDATION_SCHEMA_KEYS,
   MANTIS_RECOMMENDATION_STATUSES,
@@ -634,6 +635,11 @@ export function createDecisionParser({
     rejectUnexpectedKeys(record, LIVE_PROOF_PLAN_SCHEMA_KEYS, path);
     const status = requireEnum(record.status, LIVE_PROOF_PLAN_STATUSES, `${path}.status`);
     const surface = requireEnum(record.surface, LIVE_PROOF_SURFACES, `${path}.surface`);
+    const terminalCompletion = requireEnum(
+      record.terminalCompletion,
+      LIVE_PROOF_TERMINAL_COMPLETIONS,
+      `${path}.terminalCompletion`,
+    );
     const reason = neutralizeOwnedSectionSpoofing(
       requireSingleLineString(record.reason, `${path}.reason`),
     ).trim();
@@ -655,11 +661,20 @@ export function createDecisionParser({
     );
     if (status !== "recommended") {
       if (surface !== "none") throw new Error(`${path}.surface must be none unless recommended`);
+      if (terminalCompletion !== "not_applicable") {
+        throw new Error(`${path}.terminalCompletion must be not_applicable unless recommended`);
+      }
       if (entry) throw new Error(`${path}.entry must be empty unless recommended`);
       if (steps.length) throw new Error(`${path}.steps must be empty unless recommended`);
-      return { status, surface, reason, payoff, entry, steps };
+      return { status, surface, terminalCompletion, reason, payoff, entry, steps };
     }
     if (surface === "none") throw new Error(`${path}.surface must identify a recommended surface`);
+    if (surface === "terminal" && terminalCompletion === "not_applicable") {
+      throw new Error(`${path}.terminalCompletion must identify terminal completion behavior`);
+    }
+    if (surface !== "terminal" && terminalCompletion !== "not_applicable") {
+      throw new Error(`${path}.terminalCompletion is only allowed for terminal proof`);
+    }
     if (!entry) throw new Error(`${path}.entry must not be empty when recommended`);
     if (!steps.length) throw new Error(`${path}.steps must not be empty when recommended`);
     if (surface === "browser" && !entry.startsWith("/")) {
@@ -672,7 +687,18 @@ export function createDecisionParser({
     if (steps.some((step) => !allowedActions.has(step.action))) {
       throw new Error(`${path}.steps contain an action that does not match ${surface} proof`);
     }
-    return { status, surface, reason, payoff, entry, steps };
+    if (terminalCompletion === "ready_while_running") {
+      const finalRunIndex = steps.reduce(
+        (lastIndex, step, index) => (step.action === "run" ? index : lastIndex),
+        -1,
+      );
+      if (!steps.slice(finalRunIndex + 1).some((step) => step.action === "expect_output")) {
+        throw new Error(
+          `${path}.steps must expect output after the final run for ready_while_running terminal proof`,
+        );
+      }
+    }
+    return { status, surface, terminalCompletion, reason, payoff, entry, steps };
   }
 
   function parseMantisRecommendation(value: unknown, path: string): MantisRecommendation {

--- a/src/clawsweeper-policy.ts
+++ b/src/clawsweeper-policy.ts
@@ -16,6 +16,7 @@ import type {
   LiveProofPlanStatus,
   LiveProofPayoffKind,
   LiveProofSurface,
+  LiveProofTerminalCompletion,
   MantisRecommendationScenario,
   MantisRecommendationStatus,
   MaturityLabelName,
@@ -663,6 +664,11 @@ export const LIVE_PROOF_PLAN_STATUSES = new Set<LiveProofPlanStatus>([
   "declined_suspicious",
 ]);
 export const LIVE_PROOF_SURFACES = new Set<LiveProofSurface>(["browser", "terminal", "none"]);
+export const LIVE_PROOF_TERMINAL_COMPLETIONS = new Set<LiveProofTerminalCompletion>([
+  "exit_zero",
+  "ready_while_running",
+  "not_applicable",
+]);
 export const LIVE_PROOF_PAYOFF_KINDS = new Set<LiveProofPayoffKind>([
   "progressive_output",
   "ui_interaction",
@@ -810,6 +816,7 @@ export const TELEGRAM_VISIBLE_PROOF_SCHEMA_KEYS = new Set(["status", "summary"])
 export const LIVE_PROOF_PLAN_SCHEMA_KEYS = new Set([
   "status",
   "surface",
+  "terminalCompletion",
   "reason",
   "payoff",
   "entry",

--- a/src/clawsweeper-report-document.ts
+++ b/src/clawsweeper-report-document.ts
@@ -295,6 +295,8 @@ export function createReportDocumentRendering(
       "",
       `Surface: ${decision.liveProofPlan.surface}`,
       "",
+      `Terminal completion: ${decision.liveProofPlan.terminalCompletion}`,
+      "",
       `Reason: ${sentence(decision.liveProofPlan.reason)}`,
       "",
       `Payoff: ${decision.liveProofPlan.payoff.kind}`,

--- a/src/clawsweeper-report-parser.ts
+++ b/src/clawsweeper-report-parser.ts
@@ -130,11 +130,17 @@ const parseRecordedLiveProofPlan = createDecisionParser({
 export function reportLiveProofPlan(markdown: string): LiveProofPlan {
   const section = reportSectionValue(markdown, LIVE_PROOF_SECTION_HEADING);
   const rawSteps = reportSectionList(section, "Steps");
+  const status = reportSectionLineValue(section, "Status");
+  const surface = reportSectionLineValue(section, "Surface");
+  const terminalCompletion =
+    reportSectionLineValue(section, "Terminal completion") ??
+    (status !== "recommended" || surface !== "terminal" ? "not_applicable" : undefined);
   try {
     return parseRecordedLiveProofPlan(
       {
-        status: reportSectionLineValue(section, "Status"),
-        surface: reportSectionLineValue(section, "Surface"),
+        status,
+        surface,
+        terminalCompletion,
         reason: reportSectionLineValue(section, "Reason"),
         payoff: {
           kind: reportSectionLineValue(section, "Payoff"),
@@ -149,10 +155,13 @@ export function reportLiveProofPlan(markdown: string): LiveProofPlan {
     return {
       status: "not_applicable",
       surface: "none",
-      reason: "No live-proof plan was recorded in this report.",
+      terminalCompletion: "not_applicable",
+      invalid: true,
+      reason:
+        "The live-proof plan is missing or invalid; regenerate the review report before execution.",
       payoff: {
         kind: "static_text",
-        justification: "No recording payoff was recorded in this report.",
+        justification: "Invalid report plans are non-runnable and fail closed.",
       },
       entry: "",
       steps: [],

--- a/src/clawsweeper-review-runtime.ts
+++ b/src/clawsweeper-review-runtime.ts
@@ -781,6 +781,7 @@ ${extra}
       liveProofPlan: {
         status: "not_applicable",
         surface: "none",
+        terminalCompletion: "not_applicable",
         reason: "Live proof was not assessed because the Codex review failed.",
         payoff: {
           kind: "static_text",

--- a/src/clawsweeper-types.ts
+++ b/src/clawsweeper-types.ts
@@ -128,6 +128,7 @@ export type FeatureShowcaseStatus = "showcase" | "none";
 export type TelegramVisibleProofStatus = "needed" | "not_needed";
 export type LiveProofPlanStatus = "recommended" | "not_applicable" | "declined_suspicious";
 export type LiveProofSurface = "browser" | "terminal" | "none";
+export type LiveProofTerminalCompletion = "exit_zero" | "ready_while_running" | "not_applicable";
 export type LiveProofPayoffKind =
   | "progressive_output"
   | "ui_interaction"
@@ -414,6 +415,8 @@ export interface TelegramVisibleProof {
 export interface LiveProofPlan {
   status: LiveProofPlanStatus;
   surface: LiveProofSurface;
+  terminalCompletion: LiveProofTerminalCompletion;
+  invalid?: true;
   reason: string;
   payoff: {
     kind: LiveProofPayoffKind;

--- a/src/live-proof/drivers.ts
+++ b/src/live-proof/drivers.ts
@@ -10,6 +10,7 @@ import {
   readSync,
   renameSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { constants as osConstants } from "node:os";
@@ -403,6 +404,9 @@ interface TerminalOutputWindow {
   expectations: readonly string[];
   observedExpectations: Set<string>;
   panePid?: number;
+  paneTty?: string;
+  leaseIdentity: string;
+  cleanupArmedReceipt?: string;
   nonce: string;
   frozenExit?: Extract<TerminalPaneState, { status: "exited" }>;
   finalizedExitStatus?: number;
@@ -421,10 +425,9 @@ interface TerminalCommandFiles {
   cleanupScript: string;
   cleanupResult: string;
   cleanupResultTemporary: string;
+  lease: string;
   status: string;
   statusTemporary: string;
-  release: string;
-  releaseTemporary: string;
   start: string;
   startTemporary: string;
   ready: string;
@@ -450,8 +453,8 @@ class TerminalCommandExecutionError extends Error {
 }
 
 type TerminalPaneState =
-  | { status: "running"; pid: number }
-  | { status: "exited"; pid: number; exitStatus: number };
+  | { status: "running"; pid: number; tty: string }
+  | { status: "exited"; pid: number; tty: string; exitStatus: number };
 
 function generateTerminalCaptureScript(): string {
   return `import {
@@ -523,48 +526,86 @@ process.stdin.resume();
 function generateTerminalCleanupScript(): string {
   return `#!/bin/bash
 set +m
-
-tty_name=$1
+tty_path=$1
 pane_pid=$2
 nonce=$3
-result_temporary=$4
-result=$5
-
-finish() {
-  builtin printf "%s %s %s\\n" "$pane_pid" "$nonce" "$1" >"$result_temporary"
-  mv -f -- "$result_temporary" "$result"
-  exit "$2"
-}
-
+lease_path=$4
+lease_identity=$5
+request=$6
+result_temporary=$7
+result=$8
+scan_file="$result_temporary.scan.$$"
+receipt() { builtin printf "%s\\n" "$1" >"$result_temporary" && mv -f -- "$result_temporary" "$result" || exit 125; }
+finish() { receipt "v1|done|$nonce|$pane_pid|$tty_path|$lease_identity|$1|$2|$3"; /bin/rm -f -- "$scan_file"; exit "$4"; }
+case "$tty_path" in /dev/*) tty_name=\${tty_path#/dev/} ;; *) finish startup error:tty 0 125 ;; esac
+case "$pane_pid" in ""|*[!0-9]*) finish startup error:pane-pid 0 125 ;; esac
+case "$lease_identity" in *[!0-9:]*|:*|*:|*:*:*|"") finish startup error:lease-identity 0 125 ;; *:*) ;; *) finish startup error:lease-identity 0 125 ;; esac
 if [ "$(/usr/bin/uname -s)" = Darwin ]; then
-  term_tty() { /usr/bin/killall -q -TERM -t "$tty_name" 2>/dev/null; }
-  probe_tty() { /usr/bin/killall -0 -t "$tty_name" >/dev/null 2>&1; }
-  kill_tty() { /usr/bin/killall -q -KILL -t "$tty_name" 2>/dev/null; }
+  lease_identity_now() { /usr/bin/stat -f '%d:%i' -- "$lease_path" 2>/dev/null; }
+  lease_pids() { /usr/sbin/lsof -t -- "$lease_path" 2>/dev/null; status=$?; [ "$status" -le 1 ]; }
+  holds_lease() { /usr/sbin/lsof -t -a -p "$1" -- "$lease_path" 2>/dev/null | /usr/bin/grep -qx "$1"; }
 else
-  term_tty() { /usr/bin/pkill -TERM -t "$tty_name" -f '.*' 2>/dev/null; }
-  probe_tty() { /usr/bin/pgrep -t "$tty_name" -f '.*' >/dev/null 2>&1; }
-  kill_tty() { /usr/bin/pkill -KILL -t "$tty_name" -f '.*' 2>/dev/null; }
+  lease_identity_now() { /usr/bin/stat -Lc '%d:%i' -- "$lease_path" 2>/dev/null; }
+  holds_lease() {
+    for descriptor in /proc/"$1"/fd/*; do
+      [ -e "$descriptor" ] || continue
+      [ "$(/usr/bin/stat -Lc '%d:%i' -- "$descriptor" 2>/dev/null)" = "$lease_identity" ] && return 0
+    done
+    return 1
+  }
+  lease_pids() { for process_path in /proc/[0-9]*; do holder_pid=\${process_path#/proc/}; holds_lease "$holder_pid" && builtin printf "%s\\n" "$holder_pid"; done; return 0; }
 fi
-
+tty_pids() { /bin/ps -axo pid=,tty= | /usr/bin/awk -v tty="$tty_name" '$2 == tty { print $1 }'; }
+on_bound_tty() { [ "$(/bin/ps -o tty= -p "$1" 2>/dev/null | /usr/bin/tr -d '[:space:]')" = "$tty_name" ]; }
+scan_bound_processes() {
+  : >"$scan_file"
+  lease_pids >>"$scan_file" || return $?
+  tty_pids >>"$scan_file" || return $?
+  /usr/bin/sort -n -u -o "$scan_file" "$scan_file"
+}
+signal_bound_processes() {
+  while IFS= read -r candidate; do
+    case "$candidate" in ""|*[!0-9]*) continue ;; esac
+    holds_lease "$candidate" || on_bound_tty "$candidate" || continue
+    /bin/kill "-$1" "$candidate" 2>/dev/null || [ "$?" -eq 1 ] || return $?
+  done <"$scan_file"
+}
+[ "$(lease_identity_now)" = "$lease_identity" ] || finish startup error:lease-identity 0 125
+holds_lease "$pane_pid" && on_bound_tty "$pane_pid" || finish startup error:pane-identity 0 125
+receipt "v1|armed|$nonce|$pane_pid|$tty_path|$lease_identity|$$"
+trigger=
+while [ -z "$trigger" ]; do
+  if [ -e "$request" ]; then
+    IFS= read -r cleanup_request <"$request" || finish controller error:request 0 125
+    [ "$cleanup_request" = "v1|cleanup|$nonce|$pane_pid|$tty_path|$lease_identity" ] || finish controller error:request 0 125
+    trigger=controller
+  elif ! holds_lease "$pane_pid" || ! on_bound_tty "$pane_pid"; then
+    trigger=pane-death
+  else
+    sleep 0.05
+  fi
+done
 for sweep in 1 2 3; do
-  term_tty
-  status=$?
-  case "$status" in 0|1) ;; *) finish "error:term:$status" "$status" ;; esac
+  scan_bound_processes || finish "$trigger" error:scan 0 125
+  signal_bound_processes TERM || finish "$trigger" error:term 0 125
   sleep 0.05
 done
-
+stable_empty=0
 for ((sweep = 1; sweep <= 100; sweep += 1)); do
-  probe_tty
-  status=$?
-  if [ "$status" -eq 1 ]; then finish ok 0; fi
-  if [ "$status" -ne 0 ]; then finish "error:probe:$status" "$status"; fi
-  kill_tty
-  status=$?
-  case "$status" in 0|1) ;; *) finish "error:kill:$status" "$status" ;; esac
+  scan_bound_processes || finish "$trigger" error:scan 0 125
+  survivors=$(/usr/bin/wc -l <"$scan_file")
+  if [ "$survivors" -eq 0 ]; then
+    stable_empty=$((stable_empty + 1))
+    if [ "$stable_empty" -ge 2 ]; then finish "$trigger" ok 0 0; fi
+  else
+    stable_empty=0
+    signal_bound_processes KILL || finish "$trigger" error:kill "$survivors" 125
+  fi
   sleep 0.05
 done
-
-finish error:survivors 124
+scan_bound_processes || finish "$trigger" error:scan 0 125
+survivors=$(/usr/bin/wc -l <"$scan_file")
+finish "$trigger" error:survivors "$survivors" 124
 `;
 }
 
@@ -622,10 +663,9 @@ export function driveTerminal(options: {
       cleanupScript: `${prefix}.cleanup.sh`,
       cleanupResult: `${prefix}.cleanup.result`,
       cleanupResultTemporary: `${prefix}.cleanup.result.tmp`,
+      lease: `${prefix}.lease`,
       status: `${prefix}.status`,
       statusTemporary: `${prefix}.status.tmp`,
-      release: `${prefix}.release`,
-      releaseTemporary: `${prefix}.release.tmp`,
       start: `${prefix}.start`,
       startTemporary: `${prefix}.start.tmp`,
       ready: `${prefix}.ready`,
@@ -1071,7 +1111,7 @@ function runTerminalCommand(
   terminalDeadline: number,
 ): TerminalOutputWindow {
   const target = terminalPane;
-  const quote = (value: string) => `'${value.replaceAll("'", "'\\''")}'`;
+  const quote = quoteTerminalShellArgument;
   for (const path of Object.values(files)) rmSync(path, { force: true });
   writeFileSync(files.command, command.endsWith("\n") ? command : `${command}\n`, {
     encoding: "utf8",
@@ -1085,6 +1125,8 @@ function runTerminalCommand(
     encoding: "utf8",
     mode: 0o700,
   });
+  writeFileSync(files.lease, "", { encoding: "utf8", flag: "wx", mode: 0o600 });
+  const leaseStat = statSync(files.lease);
   const window: TerminalOutputWindow = {
     command,
     files,
@@ -1092,6 +1134,7 @@ function runTerminalCommand(
     chunks: [],
     expectations,
     observedExpectations: new Set(),
+    leaseIdentity: `${leaseStat.dev}:${leaseStat.ino}`,
     nonce: randomUUID(),
     captureOpen: false,
     paneCleaned: false,
@@ -1105,15 +1148,16 @@ function runTerminalCommand(
       "set +m",
       "trap ':' HUP TERM",
       "tty_path=$(/usr/bin/tty)",
-      'case "$tty_path" in /dev/*) tty_name=${tty_path#/dev/} ;; *) exit 125 ;; esac',
-      'while [ ! -e "$5" ]; do sleep 0.05; done',
+      'case "$tty_path" in /dev/*) ;; *) exit 125 ;; esac',
+      'exec 9<"$8" || exit 125',
+      'while [ ! -e "$4" ]; do sleep 0.05; done',
+      'IFS="|" read -r bound_pid bound_tty bound_nonce bound_lease bound_extra <"$4" || exit 125',
+      '[ "$bound_pid" = "$$" ] && [ "$bound_tty" = "$tty_path" ] && [ "$bound_nonce" = "$7" ] && [ "$bound_lease" = "$9" ] && [ -z "${bound_extra-}" ] || exit 125',
       "builtin printf '\\033[2J\\033[H'",
-      '( /usr/bin/env -u TMUX -u TMUX_PANE -u TMUX_TMPDIR /bin/bash --noprofile --norc "$1"; status=$?; builtin printf "%s\\n" "$status" >"$2"; mv -f -- "$2" "$3" ) </dev/tty >/dev/tty 2>&1 &',
-      'builtin printf "%s %s\\n" "$$" "$8" >"$6"',
-      'mv -f -- "$6" "$7"',
-      'while :; do if [ -f "$4" ]; then IFS=" " read -r release_pid release_nonce release_extra 2>/dev/null <"$4" || true; if [ "$release_pid" = "$$" ] && [ "$release_nonce" = "$8" ] && [ -z "${release_extra-}" ]; then break; fi; fi; sleep 0.05; done',
-      'builtin printf -v cleanup_command "%q " /bin/bash "$9" "$tty_name" "$$" "$8" "${10}" "${11}"',
-      'tmux run-shell -b "$cleanup_command" || exit 126',
+      'builtin printf "%s|%s|%s|%s\\n" "$$" "$tty_path" "$7" "$9" >"$5"',
+      'mv -f -- "$5" "$6"',
+      'while :; do IFS= read -r execute_gate <"$6" || exit 125; [ "$execute_gate" = "v1|execute|$7|$$|$tty_path|$9" ] && break; sleep 0.05; done',
+      '( /usr/bin/env -u TMUX -u TMUX_PANE -u TMUX_TMPDIR /bin/bash --noprofile --norc "$1"; status=$?; builtin printf "%s\\n" "$status" >"$2"; mv -f -- "$2" "$3" ) 9<&9 </dev/tty >/dev/tty 2>&1 &',
       "while :; do sleep 3600; done",
     ].join("\n");
     const shellCommand =
@@ -1123,19 +1167,23 @@ function runTerminalCommand(
         files.command,
         files.statusTemporary,
         files.status,
-        files.release,
         files.start,
         files.readyTemporary,
         files.ready,
         window.nonce,
-        files.cleanupScript,
-        files.cleanupResultTemporary,
-        files.cleanupResult,
+        files.lease,
+        window.leaseIdentity,
       ]
         .map(quote)
         .join(" ");
     const respawnArgs = ["respawn-pane", "-k", "-t", target, "-c", checkout, shellCommand];
     requireSuccess("tmux", respawnArgs, runner("tmux", respawnArgs, { cwd: checkout }));
+    const launchedState = readTerminalPaneState(runner, checkout, terminalPane);
+    if (launchedState?.status !== "running") {
+      throw new Error("terminal command pane did not remain live after respawn");
+    }
+    window.panePid = launchedState.pid;
+    window.paneTty = launchedState.tty;
     const captureCommand =
       `/usr/bin/env -u TMUX -u TMUX_PANE -u TMUX_TMPDIR node ${quote(files.captureScript)} ` +
       [files.capture, files.captureTemporary, files.captureDone, files.captureDoneTemporary]
@@ -1144,8 +1192,11 @@ function runTerminalCommand(
     const pipeArgs = ["pipe-pane", "-O", "-t", target, captureCommand];
     requireSuccess("tmux", pipeArgs, runner("tmux", pipeArgs, { cwd: checkout }));
     window.captureOpen = true;
-    writeFileSync(files.startTemporary, "start\n", { encoding: "utf8", mode: 0o600 });
-    renameSync(files.startTemporary, files.start);
+    writeTerminalControlFile(
+      files.startTemporary,
+      files.start,
+      `${launchedState.pid}|${launchedState.tty}|${window.nonce}|${window.leaseIdentity}\n`,
+    );
   } catch (error) {
     throw new TerminalCommandExecutionError(
       error instanceof Error ? error.message : String(error),
@@ -1153,35 +1204,28 @@ function runTerminalCommand(
     );
   }
   for (let elapsed = 0; elapsed <= TERMINAL_COMMAND_START_TIMEOUT_SECONDS; elapsed += 1) {
-    const panePid = readTerminalPanePid(runner, checkout, terminalPane);
-    if (panePid) {
-      if (window.panePid === undefined) {
-        window.panePid = panePid;
-      } else if (panePid !== window.panePid) {
-        throw new TerminalCommandExecutionError(
-          `terminal pane identity changed from launch pid ${window.panePid} to ${panePid}`,
-          window,
-        );
-      }
-      try {
-        const state = readTerminalCommandState(window, runner, checkout, terminalPane);
-        const readiness = readBoundedTerminalFile(files.ready, 128);
-        if (readiness !== undefined) {
-          if (readiness !== `${panePid} ${window.nonce}\n`) {
-            throw new Error("terminal command readiness acknowledgement is malformed");
-          }
-          refreshTerminalCommandOutput(window, runner, checkout, terminalPane);
-          return window;
+    try {
+      const state = readTerminalCommandState(window, runner, checkout, terminalPane);
+      const readiness = readBoundedTerminalFile(files.ready, 256);
+      if (readiness !== undefined) {
+        if (
+          readiness !==
+          `${window.panePid}|${window.paneTty}|${window.nonce}|${window.leaseIdentity}\n`
+        ) {
+          throw new Error("terminal command readiness acknowledgement is malformed");
         }
-        if (state?.status === "exited") {
-          throw new Error("terminal command exited before clearing its pane");
-        }
-      } catch (error) {
-        throw new TerminalCommandExecutionError(
-          error instanceof Error ? error.message : String(error),
-          window,
-        );
+        armTerminalCleanupWatchdog(window, terminalPane, runner, checkout);
+        refreshTerminalCommandOutput(window, runner, checkout, terminalPane);
+        return window;
       }
+      if (state?.status === "exited") {
+        throw new Error("terminal command exited before clearing its pane");
+      }
+    } catch (error) {
+      throw new TerminalCommandExecutionError(
+        error instanceof Error ? error.message : String(error),
+        window,
+      );
     }
     if (elapsed < TERMINAL_COMMAND_START_TIMEOUT_SECONDS) {
       pollTerminalSleep(runner, terminalDeadline);
@@ -1191,6 +1235,70 @@ function runTerminalCommand(
     `terminal command pane did not start within ${TERMINAL_COMMAND_START_TIMEOUT_SECONDS} seconds: ${JSON.stringify(command)}`,
     window,
   );
+}
+
+function armTerminalCleanupWatchdog(
+  window: TerminalOutputWindow,
+  terminalPane: string,
+  runner: MediaProofCommandRunner,
+  checkout: string,
+): void {
+  const identity = terminalCleanupIdentity(window);
+  rmSync(window.files.start, { force: true });
+  const cleanupCommand = [
+    "/bin/bash",
+    window.files.cleanupScript,
+    window.paneTty!,
+    String(window.panePid!),
+    window.nonce,
+    window.files.lease,
+    window.leaseIdentity,
+    window.files.start,
+    window.files.cleanupResultTemporary,
+    window.files.cleanupResult,
+  ]
+    .map(quoteTerminalShellArgument)
+    .join(" ");
+  const cleanupArgs = ["run-shell", "-b", cleanupCommand];
+  requireSuccess("tmux", cleanupArgs, runner("tmux", cleanupArgs, { cwd: checkout }));
+  for (let elapsed = 0; elapsed <= TERMINAL_COMMAND_START_TIMEOUT_SECONDS * 10; elapsed += 1) {
+    const state = readTerminalCommandState(window, runner, checkout, terminalPane);
+    if (state?.status === "exited") {
+      throw new Error("terminal pane exited before its cleanup watchdog armed");
+    }
+    const receipt = readBoundedTerminalFile(window.files.cleanupResult, 512);
+    if (receipt !== undefined) {
+      if (receipt.startsWith("v1|done|")) {
+        throw new Error(
+          `terminal cleanup watchdog failed before arming: ${receipt.trim() || "empty result"}`,
+        );
+      }
+      const fields = receipt.trimEnd().split("|");
+      const watchdogPid = Number.parseInt(fields[6] ?? "", 10);
+      if (
+        receipt !== `v1|armed|${identity}|${watchdogPid}\n` ||
+        !Number.isSafeInteger(watchdogPid) ||
+        watchdogPid <= 0
+      ) {
+        throw new Error("terminal cleanup watchdog acknowledgement is malformed");
+      }
+      window.cleanupArmedReceipt = receipt;
+      const armedState = readTerminalCommandState(window, runner, checkout, terminalPane);
+      if (armedState?.status !== "running") {
+        throw new Error("terminal pane exited after its cleanup watchdog armed");
+      }
+      writeTerminalControlFile(
+        window.files.startTemporary,
+        window.files.ready,
+        `v1|execute|${identity}\n`,
+      );
+      return;
+    }
+    if (elapsed < TERMINAL_COMMAND_START_TIMEOUT_SECONDS * 10) {
+      requireSuccess("sleep", ["0.1"], runner("sleep", ["0.1"]));
+    }
+  }
+  throw new Error("terminal cleanup watchdog did not arm before target execution");
 }
 
 function validateFinalTerminalCommand(
@@ -1471,6 +1579,11 @@ function readBoundedTerminalFile(path: string, maximumBytes: number): string | u
   }
 }
 
+function writeTerminalControlFile(temporaryPath: string, path: string, value: string): void {
+  writeFileSync(temporaryPath, value, { encoding: "utf8", mode: 0o600 });
+  renameSync(temporaryPath, path);
+}
+
 function remainingTerminalBudgetSeconds(deadline: number): number {
   return Math.max(0, Math.ceil((deadline - Date.now()) / 1_000));
 }
@@ -1540,6 +1653,13 @@ function renderFailedTerminalOutput(
   return sections.join("\n\n");
 }
 
+function terminalCleanupIdentity(window: TerminalOutputWindow): string {
+  if (window.panePid === undefined || window.paneTty === undefined || !window.leaseIdentity) {
+    throw new Error("terminal cleanup watchdog is missing its launch identity");
+  }
+  return `${window.nonce}|${window.panePid}|${window.paneTty}|${window.leaseIdentity}`;
+}
+
 function cleanupTerminalWindow(
   window: TerminalOutputWindow,
   terminalPane: string,
@@ -1547,33 +1667,33 @@ function cleanupTerminalWindow(
   checkout: string,
 ): void {
   if (window.paneCleaned) return;
+  const identity = terminalCleanupIdentity(window);
   if (window.captureOpen) {
     refreshTerminalCommandOutput(window, runner, checkout, terminalPane);
     closeTerminalCapture(window, runner, checkout, terminalPane);
   }
   const state = readTerminalPaneState(runner, checkout, terminalPane);
-  if (!state) throw new Error("terminal pane disappeared before controller release");
-  if (window.panePid === undefined || state.pid !== window.panePid) {
-    throw new Error(
-      `terminal pane identity changed from launch pid ${window.panePid ?? "unknown"} to ${state.pid}`,
+  if (!state) throw new Error("terminal pane disappeared before controller cleanup");
+  assertTerminalPaneIdentity(window, state);
+  window.finalViewport ??= captureTerminalViewport(runner, checkout, terminalPane);
+  if (!existsSync(window.files.start)) {
+    writeTerminalControlFile(
+      window.files.readyTemporary,
+      window.files.start,
+      `v1|cleanup|${identity}\n`,
     );
   }
-  if (state.status !== "running") {
-    throw new Error("terminal pane wrapper exited before controller release");
-  }
-  window.finalViewport ??= captureTerminalViewport(runner, checkout, terminalPane);
-  writeFileSync(window.files.releaseTemporary, `${state.pid} ${window.nonce}\n`, {
-    encoding: "utf8",
-    mode: 0o600,
-  });
-  renameSync(window.files.releaseTemporary, window.files.release);
-  // The wrapper schedules tty-scoped fixed-point teardown through its private
-  // tmux server. Exact pane death and the matching receipt are both required.
+  // The watchdog was armed before target execution and survives pane death.
+  // Its exact receipt and the original pane's death are both authoritative.
   let cleanupAcknowledged = false;
   for (let elapsed = 0; elapsed <= TERMINAL_COMMAND_START_TIMEOUT_SECONDS * 10; elapsed += 1) {
-    const cleanupResult = readBoundedTerminalFile(window.files.cleanupResult, 128);
-    if (cleanupResult !== undefined) {
-      if (cleanupResult !== `${state.pid} ${window.nonce} ok\n`) {
+    const cleanupResult = readBoundedTerminalFile(window.files.cleanupResult, 512);
+    if (cleanupResult !== undefined && cleanupResult !== window.cleanupArmedReceipt) {
+      if (
+        !["controller", "pane-death"].some(
+          (trigger) => cleanupResult === `v1|done|${identity}|${trigger}|ok|0\n`,
+        )
+      ) {
         throw new Error(`terminal pane cleanup failed: ${cleanupResult.trim() || "empty result"}`);
       }
       cleanupAcknowledged = true;
@@ -1582,11 +1702,7 @@ function cleanupTerminalWindow(
     if (!releasedState) {
       throw new Error("terminal pane disappeared before cleanup completion was observed");
     }
-    if (releasedState.pid !== state.pid) {
-      throw new Error(
-        `terminal pane identity changed during cleanup from ${state.pid} to ${releasedState.pid}`,
-      );
-    }
+    assertTerminalPaneIdentity(window, releasedState);
     if (releasedState.status === "exited" && cleanupAcknowledged) {
       window.paneCleaned = true;
       return;
@@ -1608,13 +1724,22 @@ function readTerminalCommandState(
 ): TerminalPaneState | undefined {
   if (window.frozenExit) return window.frozenExit;
   const state = readTerminalPaneState(runner, checkout, terminalPane);
-  if (state && window.panePid !== undefined && state.pid !== window.panePid) {
-    throw new Error(
-      `terminal pane identity changed from launch pid ${window.panePid} to ${state.pid}`,
-    );
-  }
+  if (state) assertTerminalPaneIdentity(window, state);
   if (state?.status === "exited") window.frozenExit = state;
   return state;
+}
+
+function assertTerminalPaneIdentity(window: TerminalOutputWindow, state: TerminalPaneState): void {
+  if (
+    window.panePid === undefined ||
+    window.paneTty === undefined ||
+    state.pid !== window.panePid ||
+    state.tty !== window.paneTty
+  ) {
+    throw new Error(
+      `terminal pane identity changed from launch ${window.panePid ?? "unknown"}|${window.paneTty ?? "unknown"} to ${state.pid}|${state.tty}`,
+    );
+  }
 }
 
 function readTerminalPaneState(
@@ -1627,42 +1752,34 @@ function readTerminalPaneState(
     "-p",
     "-t",
     terminalPane,
-    "#{pane_pid}|#{pane_dead}|#{pane_dead_status}|#{pane_dead_signal}",
+    "#{pane_pid}|#{pane_tty}|#{pane_dead}|#{pane_dead_status}|#{pane_dead_signal}",
   ];
   const result = runner("tmux", args, { cwd: checkout });
   if (result.status !== 0) return undefined;
-  const match = /^(\d+)\|(0|1)\|([^|]*)\|([^|]*)$/.exec(String(result.stdout ?? "").trim());
+  const match = /^(\d+)\|(\/dev\/[^|]+)\|(0|1)\|([^|]*)\|([^|]*)$/.exec(
+    String(result.stdout ?? "").trim(),
+  );
   if (!match) throw new Error("terminal pane status is malformed");
   const pid = Number.parseInt(match[1]!, 10);
   if (!Number.isSafeInteger(pid) || pid <= 0) throw new Error("terminal pane status is malformed");
-  if (match[2] === "0") {
-    if (match[3] || match[4]) throw new Error("terminal pane status is malformed");
-    return { status: "running", pid };
+  const tty = match[2]!;
+  if (match[3] === "0") {
+    if (match[4] || match[5]) throw new Error("terminal pane status is malformed");
+    return { status: "running", pid, tty };
   }
-  const status = match[3]!;
-  const signal = match[4]!;
+  const status = match[4]!;
+  const signal = match[5]!;
   if (/^\d+$/.test(status) && !signal) {
     const exitStatus = Number.parseInt(status, 10);
-    if (exitStatus >= 0 && exitStatus <= 255) return { status: "exited", pid, exitStatus };
+    if (exitStatus >= 0 && exitStatus <= 255) return { status: "exited", pid, tty, exitStatus };
   } else if (!status && signal) {
-    return { status: "exited", pid, exitStatus: terminalSignalExitStatus(signal) };
+    return { status: "exited", pid, tty, exitStatus: terminalSignalExitStatus(signal) };
   }
   throw new Error("terminal pane status is malformed");
 }
 
-function readTerminalPanePid(
-  runner: MediaProofCommandRunner,
-  checkout: string,
-  terminalPane: string,
-): number | undefined {
-  const args = ["display-message", "-p", "-t", terminalPane, "#{pane_pid}"];
-  const result = runner("tmux", args, { cwd: checkout });
-  if (result.status !== 0) return undefined;
-  const pid = Number.parseInt(String(result.stdout ?? "").trim(), 10);
-  if (!Number.isSafeInteger(pid) || pid <= 0) {
-    throw new Error("terminal pane pid is malformed");
-  }
-  return pid;
+function quoteTerminalShellArgument(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
 function terminalPrivateErrorMessage(error: unknown, privatePaths: readonly string[]): string {

--- a/src/live-proof/drivers.ts
+++ b/src/live-proof/drivers.ts
@@ -58,7 +58,6 @@ const MINIMUM_RECORDING_MILLISECONDS = 6_000;
 const TERMINAL_STREAM_MAX_BYTES = 1_000_000;
 const TERMINAL_HISTORY_LINES = 50_000;
 const TERMINAL_CAPTURE_CHUNK_BYTES = 64 * 1024;
-const TERMINAL_CLEANUP_COMMAND = "exit 0";
 
 type TerminalCommandInvocation = {
   command: string;
@@ -397,11 +396,18 @@ interface TerminalOutputWindow {
   expectations: readonly string[];
   observedExpectations: Set<string>;
   panePid?: number;
+  processGroupId?: number;
   frozenExit?: Extract<TerminalPaneState, { status: "exited" }>;
   finalizedExitStatus?: number;
   captureOpen: boolean;
-  paneCleaned: boolean;
+  processGroupCleaned: boolean;
   finalViewport?: string;
+}
+
+interface TerminalProcessOwnership {
+  parentPid: number;
+  processGroupId: number;
+  terminalProcessGroupId: number;
 }
 
 interface TerminalCommandFiles {
@@ -419,6 +425,8 @@ interface TerminalCommandFiles {
   startTemporary: string;
   ready: string;
   readyTemporary: string;
+  processGroup: string;
+  processGroupTemporary: string;
 }
 
 type TerminalLaunchMode = "held";
@@ -555,6 +563,8 @@ export function driveTerminal(options: {
       startTemporary: `${prefix}.start.tmp`,
       ready: `${prefix}.ready`,
       readyTemporary: `${prefix}.ready.tmp`,
+      processGroup: `${prefix}.process-group`,
+      processGroupTemporary: `${prefix}.process-group.tmp`,
     };
     privatePaths.push(...Object.values(files));
     return { files, launchMode: "held" };
@@ -1004,14 +1014,13 @@ function runTerminalCommand(
     expectations,
     observedExpectations: new Set(),
     captureOpen: false,
-    paneCleaned: false,
+    processGroupCleaned: false,
   };
-  const clearHistoryArgs = ["clear-history", "-t", target];
-  requireSuccess("tmux", clearHistoryArgs, runner("tmux", clearHistoryArgs, { cwd: checkout }));
   try {
     // The start gate keeps the pane alive while capture attaches, so fast
     // commands cannot emit before pipe-pane owns their output.
-    const commandRunner = [
+    const heldCommand = [
+      "trap ':' TERM",
       'while [ ! -e "$5" ]; do sleep 0.05; done',
       "builtin printf '\\033[2J\\033[H'",
       'builtin printf "ready\\n" >"$6"',
@@ -1020,10 +1029,20 @@ function runTerminalCommand(
       "status=$?",
       'builtin printf "%s\\n" "$status" >"$2"',
       'mv -f -- "$2" "$3"',
-      // Keep the pane owner alive until tmux tears down the exact pane job.
-      // pane_pid is an identity check, not a portable process-group id.
       'while [ ! -e "$4" ]; do sleep 0.05; done',
       'exit "$status"',
+    ].join("; ");
+    const commandRunner = [
+      "set -m",
+      `( ${heldCommand} ) &\ngroup=$!`,
+      'group_pgid=$(/bin/ps -o pgid= -p "$group" | /usr/bin/tr -d "[:space:]")',
+      'if [ "$group_pgid" != "$group" ]; then builtin kill "$group" 2>/dev/null || true; exit 125; fi',
+      'builtin printf "%s\\n" "$group" >"$8"',
+      'mv -f -- "$8" "$9"',
+      // fg preserves controlling-terminal semantics while suppressing Bash's
+      // job-command echo. The held subshell keeps the trusted PGID reserved.
+      "fg %1 >/dev/null",
+      'exit "$?"',
     ].join("; ");
     const shellCommand =
       `/usr/bin/env -u TMUX -u TMUX_PANE /bin/bash --noprofile --norc -c ${quote(commandRunner)} ` +
@@ -1036,11 +1055,47 @@ function runTerminalCommand(
         files.start,
         files.readyTemporary,
         files.ready,
+        files.processGroupTemporary,
+        files.processGroup,
       ]
         .map(quote)
         .join(" ");
     const respawnArgs = ["respawn-pane", "-k", "-t", target, "-c", checkout, shellCommand];
     requireSuccess("tmux", respawnArgs, runner("tmux", respawnArgs, { cwd: checkout }));
+    for (let elapsed = 0; elapsed <= TERMINAL_COMMAND_START_TIMEOUT_SECONDS * 10; elapsed += 1) {
+      const panePid = readTerminalPanePid(runner, checkout, terminalPane);
+      const processGroupText = readBoundedTerminalFile(files.processGroup, 64);
+      if (panePid && processGroupText !== undefined) {
+        const rawProcessGroup = processGroupText.trim();
+        if (!/^\d+$/.test(rawProcessGroup)) {
+          throw new Error("terminal command process group is malformed");
+        }
+        const processGroupId = Number.parseInt(rawProcessGroup, 10);
+        if (!Number.isSafeInteger(processGroupId) || processGroupId <= 0) {
+          throw new Error("terminal command process group is malformed");
+        }
+        const ownership = readTerminalProcessOwnership(runner, checkout, processGroupId);
+        if (
+          ownership?.parentPid === panePid &&
+          ownership.processGroupId === processGroupId &&
+          ownership.terminalProcessGroupId === processGroupId
+        ) {
+          window.panePid = panePid;
+          window.processGroupId = processGroupId;
+          rmSync(files.processGroup, { force: true });
+          rmSync(files.processGroupTemporary, { force: true });
+          break;
+        }
+      }
+      if (elapsed < TERMINAL_COMMAND_START_TIMEOUT_SECONDS * 10) {
+        requireSuccess("sleep", ["0.1"], runner("sleep", ["0.1"]));
+      }
+    }
+    if (!window.panePid || !window.processGroupId) {
+      throw new Error("terminal command did not publish its owned process group");
+    }
+    const clearHistoryArgs = ["clear-history", "-t", target];
+    requireSuccess("tmux", clearHistoryArgs, runner("tmux", clearHistoryArgs, { cwd: checkout }));
     const captureCommand =
       `/usr/bin/env -u TMUX -u TMUX_PANE node ${quote(files.captureScript)} ` +
       [files.capture, files.captureTemporary, files.captureDone, files.captureDoneTemporary]
@@ -1060,7 +1115,12 @@ function runTerminalCommand(
   for (let elapsed = 0; elapsed <= TERMINAL_COMMAND_START_TIMEOUT_SECONDS; elapsed += 1) {
     const panePid = readTerminalPanePid(runner, checkout, terminalPane);
     if (panePid) {
-      window.panePid = panePid;
+      if (panePid !== window.panePid) {
+        throw new TerminalCommandExecutionError(
+          `terminal pane identity changed from launch pid ${window.panePid} to ${panePid}`,
+          window,
+        );
+      }
       try {
         const state = readTerminalCommandState(window, runner, checkout, terminalPane);
         const readiness = readBoundedTerminalFile(files.ready, 64);
@@ -1438,28 +1498,77 @@ function renderFailedTerminalOutput(
   return sections.join("\n\n");
 }
 
+function terminateTerminalProcessGroup(
+  runner: MediaProofCommandRunner,
+  checkout: string,
+  processGroupId: number | undefined,
+): void {
+  if (!processGroupId) return;
+  const signalErrors: unknown[] = [];
+  const runSignal = (signal: "-TERM" | "-KILL") => {
+    try {
+      const result = runner("/bin/kill", [signal, `-${processGroupId}`], { cwd: checkout });
+      if (result.status !== 0) {
+        signalErrors.push(
+          new Error(
+            `/bin/kill ${signal} -${processGroupId} failed: ${mediaProofSpawnDetail(result)}`,
+          ),
+        );
+      }
+    } catch (error) {
+      signalErrors.push(error);
+    }
+  };
+  const processGroupExists = (): boolean => {
+    const result = runner("/bin/kill", ["-0", `-${processGroupId}`], { cwd: checkout });
+    return result.status === 0;
+  };
+  runSignal("-TERM");
+  requireSuccess("sleep", ["0.1"], runner("sleep", ["0.1"]));
+  if (!processGroupExists()) return;
+  runSignal("-KILL");
+  for (let attempt = 0; attempt <= TERMINAL_COMMAND_START_TIMEOUT_SECONDS * 10; attempt += 1) {
+    if (!processGroupExists()) return;
+    if (attempt < TERMINAL_COMMAND_START_TIMEOUT_SECONDS * 10) {
+      requireSuccess("sleep", ["0.1"], runner("sleep", ["0.1"]));
+    }
+  }
+  const surviving = new Error(`terminal process group ${processGroupId} survived SIGKILL`);
+  throw signalErrors.length > 0
+    ? new AggregateError(
+        [...signalErrors, surviving],
+        `failed to clean terminal process group ${processGroupId}`,
+      )
+    : surviving;
+}
+
 function cleanupTerminalWindow(
   window: TerminalOutputWindow,
   terminalPane: string,
   runner: MediaProofCommandRunner,
   checkout: string,
 ): void {
-  if (window.paneCleaned) return;
-  let state: TerminalPaneState | undefined;
+  if (window.processGroupCleaned) return;
+  const panePid = readTerminalPanePid(runner, checkout, terminalPane);
+  if (!panePid || panePid !== window.panePid || !window.processGroupId) return;
+  const ownership = readTerminalProcessOwnership(runner, checkout, window.processGroupId);
+  if (!ownership) {
+    window.processGroupCleaned = true;
+    return;
+  }
+  if (
+    ownership.parentPid !== panePid ||
+    ownership.processGroupId !== window.processGroupId ||
+    ownership.terminalProcessGroupId !== window.processGroupId
+  ) {
+    return;
+  }
   try {
-    state = readTerminalCommandState(window, runner, checkout, terminalPane);
-  } catch {
-    // A corrupt or replaced pane is no longer safe to mutate individually.
-    // The enclosing terminal-session teardown remains the cleanup owner.
-    return;
+    terminateTerminalProcessGroup(runner, checkout, window.processGroupId);
+    window.processGroupCleaned = true;
+  } catch (error) {
+    throw new AggregateError([error], "failed to clean terminal process group");
   }
-  if (!state || state.status === "exited") {
-    window.paneCleaned = true;
-    return;
-  }
-  const args = ["respawn-pane", "-k", "-t", terminalPane, "-c", checkout, TERMINAL_CLEANUP_COMMAND];
-  requireSuccess("tmux", args, runner("tmux", args, { cwd: checkout }));
-  window.paneCleaned = true;
 }
 
 function readTerminalCommandState(
@@ -1510,6 +1619,36 @@ function readTerminalPaneState(
     return { status: "exited", pid, exitStatus: terminalSignalExitStatus(signal) };
   }
   throw new Error("terminal pane status is malformed");
+}
+
+function readTerminalProcessOwnership(
+  runner: MediaProofCommandRunner,
+  checkout: string,
+  processGroupId: number,
+): TerminalProcessOwnership | undefined {
+  const args = ["-o", "ppid=,pgid=,tpgid=", "-p", String(processGroupId)];
+  const result = runner("/bin/ps", args, { cwd: checkout });
+  if (result.status !== 0) return undefined;
+  const match = /^\s*(\d+)\s+(\d+)\s+(\d+)\s*$/.exec(String(result.stdout ?? ""));
+  if (!match) throw new Error("terminal command process ownership is malformed");
+  const parentPid = Number.parseInt(match[1]!, 10);
+  const parsedProcessGroupId = Number.parseInt(match[2]!, 10);
+  const terminalProcessGroupId = Number.parseInt(match[3]!, 10);
+  if (
+    !Number.isSafeInteger(parentPid) ||
+    parentPid <= 0 ||
+    !Number.isSafeInteger(parsedProcessGroupId) ||
+    parsedProcessGroupId <= 0 ||
+    !Number.isSafeInteger(terminalProcessGroupId) ||
+    terminalProcessGroupId <= 0
+  ) {
+    throw new Error("terminal command process ownership is malformed");
+  }
+  return {
+    parentPid,
+    processGroupId: parsedProcessGroupId,
+    terminalProcessGroupId,
+  };
 }
 
 function readTerminalPanePid(

--- a/src/live-proof/drivers.ts
+++ b/src/live-proof/drivers.ts
@@ -58,6 +58,7 @@ const MINIMUM_RECORDING_MILLISECONDS = 6_000;
 const TERMINAL_STREAM_MAX_BYTES = 1_000_000;
 const TERMINAL_HISTORY_LINES = 50_000;
 const TERMINAL_CAPTURE_CHUNK_BYTES = 64 * 1024;
+const TERMINAL_CLEANUP_COMMAND = "exit 0";
 
 type TerminalCommandInvocation = {
   command: string;
@@ -399,7 +400,7 @@ interface TerminalOutputWindow {
   frozenExit?: Extract<TerminalPaneState, { status: "exited" }>;
   finalizedExitStatus?: number;
   captureOpen: boolean;
-  processGroupCleaned: boolean;
+  paneCleaned: boolean;
   finalViewport?: string;
 }
 
@@ -735,7 +736,7 @@ export function driveTerminal(options: {
     };
     for (const window of commandWindows) {
       cleanup(() => closeTerminalCapture(window, options.runner, options.checkout, terminalPane));
-      cleanup(() => cleanupTerminalWindow(window, options.runner, options.checkout));
+      cleanup(() => cleanupTerminalWindow(window, terminalPane, options.runner, options.checkout));
     }
     if (recordMedia) {
       cleanup(() => {
@@ -912,7 +913,7 @@ function runTerminalStep(
           terminalDeadline,
           true,
         );
-        cleanupTerminalWindow(outputWindow, runner, checkout);
+        cleanupTerminalWindow(outputWindow, terminalPane, runner, checkout);
       } catch (error) {
         throw new Error(
           `terminal run was blocked by the previous command: ${error instanceof Error ? error.message : String(error)}`,
@@ -1003,7 +1004,7 @@ function runTerminalCommand(
     expectations,
     observedExpectations: new Set(),
     captureOpen: false,
-    processGroupCleaned: false,
+    paneCleaned: false,
   };
   const clearHistoryArgs = ["clear-history", "-t", target];
   requireSuccess("tmux", clearHistoryArgs, runner("tmux", clearHistoryArgs, { cwd: checkout }));
@@ -1019,9 +1020,8 @@ function runTerminalCommand(
       "status=$?",
       'builtin printf "%s\\n" "$status" >"$2"',
       'mv -f -- "$2" "$3"',
-      // Keep the pane's process-group leader alive until the controller kills
-      // the still-owned group. Releasing it first makes pane_pid stale and can
-      // signal an unrelated process after fast PID reuse.
+      // Keep the pane owner alive until tmux tears down the exact pane job.
+      // pane_pid is an identity check, not a portable process-group id.
       'while [ ! -e "$4" ]; do sleep 0.05; done',
       'exit "$status"',
     ].join("; ");
@@ -1438,71 +1438,28 @@ function renderFailedTerminalOutput(
   return sections.join("\n\n");
 }
 
-function terminateTerminalProcessGroup(
-  runner: MediaProofCommandRunner,
-  checkout: string,
-  panePid: number | undefined,
-): void {
-  if (!panePid) return;
-  const signalErrors: unknown[] = [];
-  const runSignal = (signal: "-TERM" | "-KILL") => {
-    try {
-      const result = runner("/bin/kill", [signal, `-${panePid}`], { cwd: checkout });
-      if (result.status !== 0) {
-        signalErrors.push(
-          new Error(`/bin/kill ${signal} -${panePid} failed: ${mediaProofSpawnDetail(result)}`),
-        );
-      }
-    } catch (error) {
-      signalErrors.push(error);
-    }
-  };
-  const processGroupExists = (): boolean => {
-    const result = runner("/bin/kill", ["-0", `-${panePid}`], { cwd: checkout });
-    return result.status === 0;
-  };
-  // Signal command status is advisory because the group may disappear between
-  // calls. Only the final liveness probe decides whether cleanup succeeded.
-  runSignal("-TERM");
-  requireSuccess("sleep", ["0.1"], runner("sleep", ["0.1"]));
-  if (!processGroupExists()) return;
-  runSignal("-KILL");
-  for (let attempt = 0; attempt <= TERMINAL_COMMAND_START_TIMEOUT_SECONDS * 10; attempt += 1) {
-    if (!processGroupExists()) return;
-    if (attempt < TERMINAL_COMMAND_START_TIMEOUT_SECONDS * 10) {
-      requireSuccess("sleep", ["0.1"], runner("sleep", ["0.1"]));
-    }
-  }
-  const surviving = new Error(`terminal process group ${panePid} survived SIGKILL`);
-  throw signalErrors.length > 0
-    ? new AggregateError(
-        [...signalErrors, surviving],
-        `failed to clean terminal process group ${panePid}`,
-      )
-    : surviving;
-}
-
 function cleanupTerminalWindow(
   window: TerminalOutputWindow,
+  terminalPane: string,
   runner: MediaProofCommandRunner,
   checkout: string,
 ): void {
-  const errors: unknown[] = [];
-  if (!window.processGroupCleaned) {
-    if (window.frozenExit) {
-      window.processGroupCleaned = true;
-      return;
-    }
-    try {
-      terminateTerminalProcessGroup(runner, checkout, window.panePid);
-      window.processGroupCleaned = true;
-    } catch (error) {
-      errors.push(error);
-    }
+  if (window.paneCleaned) return;
+  let state: TerminalPaneState | undefined;
+  try {
+    state = readTerminalCommandState(window, runner, checkout, terminalPane);
+  } catch {
+    // A corrupt or replaced pane is no longer safe to mutate individually.
+    // The enclosing terminal-session teardown remains the cleanup owner.
+    return;
   }
-  if (errors.length > 0) {
-    throw new AggregateError(errors, "failed to clean terminal process group");
+  if (!state || state.status === "exited") {
+    window.paneCleaned = true;
+    return;
   }
+  const args = ["respawn-pane", "-k", "-t", terminalPane, "-c", checkout, TERMINAL_CLEANUP_COMMAND];
+  requireSuccess("tmux", args, runner("tmux", args, { cwd: checkout }));
+  window.paneCleaned = true;
 }
 
 function readTerminalCommandState(

--- a/src/live-proof/drivers.ts
+++ b/src/live-proof/drivers.ts
@@ -60,6 +60,7 @@ const MINIMUM_RECORDING_MILLISECONDS = 6_000;
 const TERMINAL_STREAM_MAX_BYTES = 1_000_000;
 const TERMINAL_HISTORY_LINES = 50_000;
 const TERMINAL_CAPTURE_CHUNK_BYTES = 64 * 1024;
+const TERMINAL_LEASE_FD = 9;
 
 type TerminalCommandInvocation = {
   command: string;
@@ -546,17 +547,15 @@ if [ "$(/usr/bin/uname -s)" = Darwin ]; then
   holds_lease() { /usr/sbin/lsof -t -a -p "$1" -- "$lease_path" 2>/dev/null | /usr/bin/grep -qx "$1"; }
 else
   lease_identity_now() { /usr/bin/stat -Lc '%d:%i' -- "$lease_path" 2>/dev/null; }
-  holds_lease() {
-    for descriptor in /proc/"$1"/fd/*; do
-      [ -e "$descriptor" ] || continue
-      [ "$(/usr/bin/stat -Lc '%d:%i' -- "$descriptor" 2>/dev/null)" = "$lease_identity" ] && return 0
-    done
-    return 1
-  }
-  lease_pids() { for process_path in /proc/[0-9]*; do holder_pid=\${process_path#/proc/}; holds_lease "$holder_pid" && builtin printf "%s\\n" "$holder_pid"; done; return 0; }
+  holds_lease() { [ "$(/usr/bin/stat -Lc '%d:%i' -- /proc/"$1"/fd/${TERMINAL_LEASE_FD} 2>/dev/null)" = "$lease_identity" ]; }
+  lease_pids() { /usr/bin/find -L /proc/[0-9]*/fd/${TERMINAL_LEASE_FD} -maxdepth 0 -samefile "$lease_path" -printf '%h\\n' 2>/dev/null | /usr/bin/awk -F/ 'NF == 4 && $2 == "proc" && $3 ~ /^[0-9]+$/ && $4 == "fd" { print $3 }'; }
 fi
-tty_pids() { /bin/ps -axo pid=,tty= | /usr/bin/awk -v tty="$tty_name" '$2 == tty { print $1 }'; }
 on_bound_tty() { [ "$(/bin/ps -o tty= -p "$1" 2>/dev/null | /usr/bin/tr -d '[:space:]')" = "$tty_name" ]; }
+pane_owns_tty() { holds_lease "$pane_pid" && on_bound_tty "$pane_pid"; }
+tty_pids() {
+  pane_owns_tty || return 0
+  /bin/ps -axo pid=,tty= | /usr/bin/awk -v tty="$tty_name" '$2 == tty { print $1 }'
+}
 scan_bound_processes() {
   : >"$scan_file"
   lease_pids >>"$scan_file" || return $?
@@ -566,12 +565,15 @@ scan_bound_processes() {
 signal_bound_processes() {
   while IFS= read -r candidate; do
     case "$candidate" in ""|*[!0-9]*) continue ;; esac
-    holds_lease "$candidate" || on_bound_tty "$candidate" || continue
+    if ! holds_lease "$candidate"; then
+      on_bound_tty "$candidate" || continue
+      pane_owns_tty || continue
+    fi
     /bin/kill "-$1" "$candidate" 2>/dev/null || [ "$?" -eq 1 ] || return $?
   done <"$scan_file"
 }
 [ "$(lease_identity_now)" = "$lease_identity" ] || finish startup error:lease-identity 0 125
-holds_lease "$pane_pid" && on_bound_tty "$pane_pid" || finish startup error:pane-identity 0 125
+pane_owns_tty || finish startup error:pane-identity 0 125
 receipt "v1|armed|$nonce|$pane_pid|$tty_path|$lease_identity|$$"
 trigger=
 while [ -z "$trigger" ]; do
@@ -579,7 +581,7 @@ while [ -z "$trigger" ]; do
     IFS= read -r cleanup_request <"$request" || finish controller error:request 0 125
     [ "$cleanup_request" = "v1|cleanup|$nonce|$pane_pid|$tty_path|$lease_identity" ] || finish controller error:request 0 125
     trigger=controller
-  elif ! holds_lease "$pane_pid" || ! on_bound_tty "$pane_pid"; then
+  elif ! pane_owns_tty; then
     trigger=pane-death
   else
     sleep 0.05
@@ -1149,7 +1151,7 @@ function runTerminalCommand(
       "trap ':' HUP TERM",
       "tty_path=$(/usr/bin/tty)",
       'case "$tty_path" in /dev/*) ;; *) exit 125 ;; esac',
-      'exec 9<"$8" || exit 125',
+      `exec ${TERMINAL_LEASE_FD}<"$8" || exit 125`,
       'while [ ! -e "$4" ]; do sleep 0.05; done',
       'IFS="|" read -r bound_pid bound_tty bound_nonce bound_lease bound_extra <"$4" || exit 125',
       '[ "$bound_pid" = "$$" ] && [ "$bound_tty" = "$tty_path" ] && [ "$bound_nonce" = "$7" ] && [ "$bound_lease" = "$9" ] && [ -z "${bound_extra-}" ] || exit 125',
@@ -1157,7 +1159,7 @@ function runTerminalCommand(
       'builtin printf "%s|%s|%s|%s\\n" "$$" "$tty_path" "$7" "$9" >"$5"',
       'mv -f -- "$5" "$6"',
       'while :; do IFS= read -r execute_gate <"$6" || exit 125; [ "$execute_gate" = "v1|execute|$7|$$|$tty_path|$9" ] && break; sleep 0.05; done',
-      '( /usr/bin/env -u TMUX -u TMUX_PANE -u TMUX_TMPDIR /bin/bash --noprofile --norc "$1"; status=$?; builtin printf "%s\\n" "$status" >"$2"; mv -f -- "$2" "$3" ) 9<&9 </dev/tty >/dev/tty 2>&1 &',
+      `( /usr/bin/env -u TMUX -u TMUX_PANE -u TMUX_TMPDIR /bin/bash --noprofile --norc "$1"; status=$?; builtin printf "%s\\n" "$status" >"$2"; mv -f -- "$2" "$3" ) ${TERMINAL_LEASE_FD}<&${TERMINAL_LEASE_FD} </dev/tty >/dev/tty 2>&1 &`,
       "while :; do sleep 3600; done",
     ].join("\n");
     const shellCommand =

--- a/src/live-proof/drivers.ts
+++ b/src/live-proof/drivers.ts
@@ -420,7 +420,7 @@ interface TerminalCommandFiles {
   readyTemporary: string;
 }
 
-type TerminalLaunchMode = "held" | "direct";
+type TerminalLaunchMode = "held";
 
 interface TerminalStepResult {
   outputWindow: TerminalOutputWindow | undefined;
@@ -536,10 +536,8 @@ export function driveTerminal(options: {
   const commandWindows: TerminalOutputWindow[] = [];
   let commandIndex = 0;
   let terminalDeadline = 0;
-  const totalCommands = 1 + options.plan.steps.filter((step) => step.action === "run").length;
   const nextCommand = (): { files: TerminalCommandFiles; launchMode: TerminalLaunchMode } => {
     const prefix = `${options.rawVideoPath}.command-${process.pid}-${commandIndex}`;
-    const isFinalCommand = commandIndex === totalCommands - 1;
     commandIndex += 1;
     const files = {
       command: `${prefix}.sh`,
@@ -558,13 +556,7 @@ export function driveTerminal(options: {
       readyTemporary: `${prefix}.ready.tmp`,
     };
     privatePaths.push(...Object.values(files));
-    return {
-      files,
-      launchMode:
-        isFinalCommand && options.plan.terminalCompletion === "ready_while_running"
-          ? "direct"
-          : "held",
-    };
+    return { files, launchMode: "held" };
   };
   try {
     for (const invocation of terminalCommandPlan({
@@ -954,46 +946,20 @@ function runTerminalStep(
     if (outputWindow.observedExpectations.has(step.text)) {
       return { outputWindow, expectationSatisfied: true };
     }
-    if (outputWindow.launchMode === "held") {
-      const status = readHeldTerminalStatus(outputWindow);
-      if (status !== undefined) {
-        finalizeHeldTerminalCommand(outputWindow, status, terminalPane, runner, checkout);
-        if (outputWindow.observedExpectations.has(step.text)) {
-          return { outputWindow, expectationSatisfied: true };
-        }
-        if (status !== 0) throw terminalCommandFailure(outputWindow, status);
-        throw new Error(
-          `terminal command exited successfully before expected output appeared: ${JSON.stringify(step.text)}`,
-        );
-      }
-      const state = readTerminalCommandState(outputWindow, runner, checkout, terminalPane);
-      if (state?.status === "exited") {
-        throw new Error("held terminal command exited before recording its completion status");
-      }
-    } else {
-      const state = readTerminalCommandState(outputWindow, runner, checkout, terminalPane);
-      if (state?.status !== "exited") {
-        if (elapsed < TERMINAL_EXPECT_OUTPUT_TIMEOUT_SECONDS) {
-          pollTerminalSleep(runner, terminalDeadline);
-        }
-        continue;
-      }
-      refreshTerminalCommandOutput(outputWindow, runner, checkout, terminalPane);
-      closeTerminalCapture(outputWindow, runner, checkout, terminalPane);
-      observeTerminalSnapshot(
-        outputWindow,
-        captureTerminalHistory(runner, checkout, terminalPane).replaceAll(
-          outputWindow.files.command,
-          "<private command>",
-        ),
-      );
+    const status = readHeldTerminalStatus(outputWindow);
+    if (status !== undefined) {
+      finalizeHeldTerminalCommand(outputWindow, status, terminalPane, runner, checkout);
       if (outputWindow.observedExpectations.has(step.text)) {
         return { outputWindow, expectationSatisfied: true };
       }
-      if (state.exitStatus !== 0) throw terminalCommandFailure(outputWindow, state.exitStatus);
+      if (status !== 0) throw terminalCommandFailure(outputWindow, status);
       throw new Error(
         `terminal command exited successfully before expected output appeared: ${JSON.stringify(step.text)}`,
       );
+    }
+    const state = readTerminalCommandState(outputWindow, runner, checkout, terminalPane);
+    if (state?.status === "exited") {
+      throw new Error("held terminal command exited before recording its completion status");
     }
     if (elapsed < TERMINAL_EXPECT_OUTPUT_TIMEOUT_SECONDS) {
       pollTerminalSleep(runner, terminalDeadline);
@@ -1044,27 +1010,21 @@ function runTerminalCommand(
   try {
     // The start gate keeps the pane alive while capture attaches, so fast
     // commands cannot emit before pipe-pane owns their output.
-    const commandRunner =
-      launchMode === "held"
-        ? [
-            'while [ ! -e "$5" ]; do sleep 0.05; done',
-            "builtin printf '\\033[2J\\033[H'",
-            'builtin printf "ready\\n" >"$6"',
-            'mv -f -- "$6" "$7"',
-            '/bin/bash --noprofile --norc "$1"',
-            "status=$?",
-            'builtin printf "%s\\n" "$status" >"$2"',
-            'mv -f -- "$2" "$3"',
-            'while [ ! -e "$4" ]; do sleep 0.05; done',
-            'exit "$status"',
-          ].join("; ")
-        : [
-            'while [ ! -e "$5" ]; do sleep 0.05; done',
-            "builtin printf '\\033[2J\\033[H'",
-            'builtin printf "ready\\n" >"$6"',
-            'mv -f -- "$6" "$7"',
-            'exec /bin/bash --noprofile --norc "$1"',
-          ].join("; ");
+    const commandRunner = [
+      'while [ ! -e "$5" ]; do sleep 0.05; done',
+      "builtin printf '\\033[2J\\033[H'",
+      'builtin printf "ready\\n" >"$6"',
+      'mv -f -- "$6" "$7"',
+      '/bin/bash --noprofile --norc "$1"',
+      "status=$?",
+      'builtin printf "%s\\n" "$status" >"$2"',
+      'mv -f -- "$2" "$3"',
+      // Keep the pane's process-group leader alive until the controller kills
+      // the still-owned group. Releasing it first makes pane_pid stale and can
+      // signal an unrelated process after fast PID reuse.
+      'while [ ! -e "$4" ]; do sleep 0.05; done',
+      'exit "$status"',
+    ].join("; ");
     const shellCommand =
       `/usr/bin/env -u TMUX -u TMUX_PANE /bin/bash --noprofile --norc -c ${quote(commandRunner)} ` +
       [
@@ -1157,13 +1117,19 @@ function validateFinalTerminalCommand(
   if (completion !== "ready_while_running") {
     throw new Error("terminal proof is missing a terminal completion contract");
   }
-  if (window.launchMode !== "direct") {
-    throw new Error("ready_while_running terminal proof did not execute the target directly");
+  if (window.launchMode !== "held") {
+    throw new Error("ready_while_running terminal proof did not use held command supervision");
   }
   if (window.observedExpectations.size === 0) {
     throw new Error("ready_while_running terminal proof requires a satisfied output expectation");
   }
   refreshTerminalCommandOutput(window, runner, checkout, terminalPane);
+  const status = readHeldTerminalStatus(window);
+  if (status !== undefined) {
+    throw new Error(
+      `ready_while_running terminal command exited after satisfying its expectation: ${terminalCommandFailure(window, status).message}`,
+    );
+  }
   const state = readTerminalCommandState(window, runner, checkout, terminalPane);
   if (state?.status === "running") {
     if (cutover) {
@@ -1180,6 +1146,12 @@ function validateFinalTerminalCommand(
         throw error;
       }
       window.finalViewport = captureTerminalViewport(runner, checkout, terminalPane);
+      const sealedStatus = readHeldTerminalStatus(window);
+      if (sealedStatus !== undefined) {
+        throw new Error(
+          `ready_while_running terminal command exited after satisfying its expectation: ${terminalCommandFailure(window, sealedStatus).message}`,
+        );
+      }
       const sealedState = readTerminalCommandState(window, runner, checkout, terminalPane);
       if (sealedState?.status === "exited") {
         throw new Error(
@@ -1275,10 +1247,10 @@ function finalizeHeldTerminalCommand(
 ): void {
   const heldState = readTerminalCommandState(window, runner, checkout, terminalPane);
   if (heldState?.status !== "running") {
-    throw new Error("held terminal command wrapper exited before controller release");
+    throw new Error("held terminal command wrapper exited before controller cleanup");
   }
-  // The wrapper remains the live pane owner until the stream and viewport are
-  // frozen; only then may tmux publish the child's recorded exit status.
+  // The wrapper remains the live pane owner until cleanup signals its process
+  // group. The recorded child status is authoritative; pane exit is cleanup.
   closeTerminalCapture(window, runner, checkout, terminalPane);
   observeTerminalSnapshot(
     window,
@@ -1288,36 +1260,7 @@ function finalizeHeldTerminalCommand(
     ),
   );
   window.finalViewport = captureTerminalViewport(runner, checkout, terminalPane);
-  releaseHeldTerminalCommand(window);
-  for (let elapsed = 0; elapsed <= TERMINAL_COMMAND_START_TIMEOUT_SECONDS * 10; elapsed += 1) {
-    const state = readTerminalCommandState(window, runner, checkout, terminalPane);
-    if (state?.status === "exited") {
-      if (state.exitStatus !== recordedStatus) {
-        throw new Error(
-          `held terminal command status mismatch: recorded ${recordedStatus}, tmux reported ${state.exitStatus}`,
-        );
-      }
-      window.finalizedExitStatus = recordedStatus;
-      return;
-    }
-    if (!state) {
-      throw new Error("held terminal command lost its authoritative pane after release");
-    }
-    if (elapsed < TERMINAL_COMMAND_START_TIMEOUT_SECONDS * 10) {
-      requireSuccess("sleep", ["0.1"], runner("sleep", ["0.1"]));
-    }
-  }
-  throw new Error(
-    `held terminal command did not exit within ${TERMINAL_COMMAND_START_TIMEOUT_SECONDS} seconds after release`,
-  );
-}
-
-function releaseHeldTerminalCommand(window: TerminalOutputWindow): void {
-  writeFileSync(window.files.releaseTemporary, "release\n", {
-    encoding: "utf8",
-    mode: 0o600,
-  });
-  renameSync(window.files.releaseTemporary, window.files.release);
+  window.finalizedExitStatus = recordedStatus;
 }
 
 function refreshTerminalCommandOutput(
@@ -1546,6 +1489,10 @@ function cleanupTerminalWindow(
 ): void {
   const errors: unknown[] = [];
   if (!window.processGroupCleaned) {
+    if (window.frozenExit) {
+      window.processGroupCleaned = true;
+      return;
+    }
     try {
       terminateTerminalProcessGroup(runner, checkout, window.panePid);
       window.processGroupCleaned = true;

--- a/src/live-proof/drivers.ts
+++ b/src/live-proof/drivers.ts
@@ -1,5 +1,18 @@
-import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import {
+  closeSync,
+  constants as fsConstants,
+  existsSync,
+  fstatSync,
+  openSync,
+  readFileSync,
+  readSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { constants as osConstants } from "node:os";
+import { stripVTControlCharacters } from "node:util";
 import type {
   LiveProofBrowserStep,
   LiveProofPlan,
@@ -36,15 +49,15 @@ export interface LiveProofDriveResult {
 const DISPLAY_READY_TIMEOUT_SECONDS = 30;
 const RECORDER_READY_TIMEOUT_SECONDS = 15;
 const RECORDER_FINALIZE_TIMEOUT_SECONDS = 20;
-const TERMINAL_RUN_OUTPUT_TIMEOUT_SECONDS = 30;
+const TERMINAL_COMMAND_START_TIMEOUT_SECONDS = 10;
 const TERMINAL_EXPECT_OUTPUT_TIMEOUT_SECONDS = 30;
-const TERMINAL_COMMAND_STATUS_GRACE_SECONDS = 2;
+const TERMINAL_READY_STABILITY_SECONDS = 3;
 const STEP_SETTLE_MILLISECONDS = 700;
 const END_STATE_HOLD_MILLISECONDS = 3_000;
 const MINIMUM_RECORDING_MILLISECONDS = 6_000;
-
-export const TERMINAL_OUTPUT_NOT_OBSERVED_DETAIL =
-  "command exited successfully; expected output was not observed in the captured pane";
+const TERMINAL_STREAM_MAX_BYTES = 1_000_000;
+const TERMINAL_HISTORY_LINES = 50_000;
+const TERMINAL_CAPTURE_CHUNK_BYTES = 64 * 1024;
 
 type TerminalCommandInvocation = {
   command: string;
@@ -220,17 +233,64 @@ export function terminalCommandPlan(options: {
   recordMedia?: boolean;
 }): TerminalCommandInvocation[] {
   const terminalSession = `${options.sessionPrefix}-terminal`;
+  const terminalPane = `${terminalSession}:0.0`;
   const displaySession = `${options.sessionPrefix}-display`;
   const xtermSession = `${options.sessionPrefix}-xterm`;
   const recorderSession = `${options.sessionPrefix}-recorder`;
   const commands: TerminalCommandInvocation[] = [
     {
       command: "tmux",
-      args: ["new-session", "-d", "-s", terminalSession, "-x", "160", "-y", "50"],
+      args: [
+        "new-session",
+        "-d",
+        "-s",
+        terminalSession,
+        "-x",
+        "160",
+        "-y",
+        "50",
+        "/bin/bash --noprofile --norc",
+      ],
     },
     {
       command: "tmux",
-      args: ["set-option", "-w", "-t", `${terminalSession}:0`, "remain-on-exit", "on"],
+      args: ["set-option", "-t", terminalSession, "history-limit", String(TERMINAL_HISTORY_LINES)],
+    },
+    {
+      command: "tmux",
+      args: ["set-option", "-t", terminalSession, "base-index", "0"],
+    },
+    {
+      command: "tmux",
+      args: ["move-window", "-r", "-t", terminalSession],
+    },
+    {
+      command: "tmux",
+      args: ["new-window", "-d", "-t", `${terminalSession}:`, "/bin/bash --noprofile --norc"],
+    },
+    {
+      command: "tmux",
+      args: ["resize-window", "-t", `${terminalSession}:1`, "-x", "160", "-y", "50"],
+    },
+    {
+      command: "tmux",
+      args: ["kill-window", "-t", `${terminalSession}:0`],
+    },
+    {
+      command: "tmux",
+      args: ["move-window", "-r", "-t", terminalSession],
+    },
+    {
+      command: "tmux",
+      args: ["set-option", "-w", "-t", `${terminalSession}:0`, "pane-base-index", "0"],
+    },
+    {
+      command: "tmux",
+      args: ["set-option", "-w", "-t", terminalPane, "remain-on-exit", "on"],
+    },
+    {
+      command: "tmux",
+      args: ["set-option", "-w", "-t", terminalPane, "remain-on-exit-format", ""],
     },
   ];
   if (options.recordMedia === false) return commands;
@@ -242,7 +302,7 @@ export function terminalCommandPlan(options: {
     },
     {
       command: "tmux",
-      args: ["set-option", "-w", "-t", `${displaySession}:0`, "remain-on-exit", "on"],
+      args: ["set-option", "-w", "-t", displaySession, "remain-on-exit", "on"],
     },
     {
       command: "tmux",
@@ -250,7 +310,7 @@ export function terminalCommandPlan(options: {
         "respawn-pane",
         "-k",
         "-t",
-        `${displaySession}:0.0`,
+        displaySession,
         "Xvfb",
         ":99",
         "-screen",
@@ -287,7 +347,7 @@ export function terminalCommandPlan(options: {
     },
     {
       command: "tmux",
-      args: ["set-option", "-w", "-t", `${recorderSession}:0`, "remain-on-exit", "on"],
+      args: ["set-option", "-w", "-t", recorderSession, "remain-on-exit", "on"],
     },
     {
       command: "tmux",
@@ -295,7 +355,7 @@ export function terminalCommandPlan(options: {
         "respawn-pane",
         "-k",
         "-t",
-        `${recorderSession}:0.0`,
+        recorderSession,
         "timeout",
         `${options.maxRecordingSeconds}s`,
         "ffmpeg",
@@ -329,11 +389,38 @@ export function terminalCommandPlan(options: {
 }
 
 interface TerminalOutputWindow {
-  echoSnapshot: string;
   command: string;
-  commandPath: string;
-  output: string;
+  files: TerminalCommandFiles;
+  launchMode: TerminalLaunchMode;
+  chunks: Buffer[];
+  expectations: readonly string[];
+  observedExpectations: Set<string>;
+  panePid?: number;
+  frozenExit?: Extract<TerminalPaneState, { status: "exited" }>;
+  finalizedExitStatus?: number;
+  captureOpen: boolean;
+  processGroupCleaned: boolean;
+  finalViewport?: string;
 }
+
+interface TerminalCommandFiles {
+  command: string;
+  captureScript: string;
+  capture: string;
+  captureTemporary: string;
+  captureDone: string;
+  captureDoneTemporary: string;
+  status: string;
+  statusTemporary: string;
+  release: string;
+  releaseTemporary: string;
+  start: string;
+  startTemporary: string;
+  ready: string;
+  readyTemporary: string;
+}
+
+type TerminalLaunchMode = "held" | "direct";
 
 interface TerminalStepResult {
   outputWindow: TerminalOutputWindow | undefined;
@@ -351,6 +438,77 @@ class TerminalCommandExecutionError extends Error {
   }
 }
 
+type TerminalPaneState =
+  | { status: "running"; pid: number }
+  | { status: "exited"; pid: number; exitStatus: number };
+
+function generateTerminalCaptureScript(): string {
+  return `import {
+  closeSync,
+  fsyncSync,
+  openSync,
+  renameSync,
+  writeSync,
+} from "node:fs";
+
+const [capturePath, captureTemporaryPath, donePath, doneTemporaryPath] = process.argv.slice(2);
+if (!capturePath || !captureTemporaryPath || !donePath || !doneTemporaryPath) {
+  throw new Error("missing terminal capture paths");
+}
+const maxBytes = ${TERMINAL_STREAM_MAX_BYTES};
+const chunks = [];
+let byteLength = 0;
+let finished = false;
+
+function retain(chunk) {
+  chunks.push(chunk);
+  byteLength += chunk.length;
+  while (byteLength > maxBytes && chunks.length > 0) {
+    const excess = byteLength - maxBytes;
+    const first = chunks[0];
+    if (first.length <= excess) {
+      chunks.shift();
+      byteLength -= first.length;
+    } else {
+      chunks[0] = first.subarray(excess);
+      byteLength -= excess;
+    }
+  }
+}
+
+function writeAtomic(path, temporaryPath, value) {
+  const fd = openSync(temporaryPath, "w", 0o600);
+  try {
+    writeSync(fd, value);
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+  renameSync(temporaryPath, path);
+}
+
+function finish(completion = "eof") {
+  if (finished) return;
+  finished = true;
+  writeAtomic(capturePath, captureTemporaryPath, Buffer.concat(chunks, byteLength));
+  writeAtomic(donePath, doneTemporaryPath, completion + "\\n");
+}
+
+process.stdin.on("data", (chunk) => {
+  const bytes = Buffer.from(chunk);
+  retain(bytes);
+});
+process.stdin.on("end", finish);
+process.stdin.on("close", finish);
+process.stdin.on("error", (error) => {
+  process.stderr.write(String(error) + "\\n");
+  process.exitCode = 1;
+  finish("error");
+});
+process.stdin.resume();
+`;
+}
+
 export function driveTerminal(options: {
   plan: LiveProofPlan;
   checkout: string;
@@ -358,10 +516,10 @@ export function driveTerminal(options: {
   maxRecordingSeconds: number;
   recordMedia?: boolean;
   runner: MediaProofCommandRunner;
-  readCommandStatus?: () => number | undefined;
 }): LiveProofDriveResult {
-  const sessionPrefix = `clawsweeper-live-proof-${process.pid}`;
+  const sessionPrefix = `clawsweeper-live-proof-${process.pid}-${randomUUID()}`;
   const terminalSession = `${sessionPrefix}-terminal`;
+  const terminalPane = `${terminalSession}:0.0`;
   const displaySession = `${sessionPrefix}-display`;
   const xtermSession = `${sessionPrefix}-xterm`;
   const recorderSession = `${sessionPrefix}-recorder`;
@@ -372,16 +530,41 @@ export function driveTerminal(options: {
   let outputWindow: TerminalOutputWindow | undefined;
   let initialPaneSnapshot = "";
   let capturedOutput = "";
+  let failureReason = "";
   const recordMedia = options.recordMedia !== false;
-  const commandPaths: string[] = [];
+  const privatePaths: string[] = [];
   const commandWindows: TerminalOutputWindow[] = [];
-  const readCommandStatus =
-    options.readCommandStatus ??
-    (() => readTerminalPaneExitStatus(options.runner, options.checkout, terminalSession));
-  const nextCommandPath = () => {
-    const path = `${options.rawVideoPath}.command-${process.pid}-${commandPaths.length}`;
-    commandPaths.push(path);
-    return path;
+  let commandIndex = 0;
+  let terminalDeadline = 0;
+  const totalCommands = 1 + options.plan.steps.filter((step) => step.action === "run").length;
+  const nextCommand = (): { files: TerminalCommandFiles; launchMode: TerminalLaunchMode } => {
+    const prefix = `${options.rawVideoPath}.command-${process.pid}-${commandIndex}`;
+    const isFinalCommand = commandIndex === totalCommands - 1;
+    commandIndex += 1;
+    const files = {
+      command: `${prefix}.sh`,
+      captureScript: `${prefix}.capture.mjs`,
+      capture: `${prefix}.combined.log`,
+      captureTemporary: `${prefix}.combined.tmp`,
+      captureDone: `${prefix}.capture.done`,
+      captureDoneTemporary: `${prefix}.capture.done.tmp`,
+      status: `${prefix}.status`,
+      statusTemporary: `${prefix}.status.tmp`,
+      release: `${prefix}.release`,
+      releaseTemporary: `${prefix}.release.tmp`,
+      start: `${prefix}.start`,
+      startTemporary: `${prefix}.start.tmp`,
+      ready: `${prefix}.ready`,
+      readyTemporary: `${prefix}.ready.tmp`,
+    };
+    privatePaths.push(...Object.values(files));
+    return {
+      files,
+      launchMode:
+        isFinalCommand && options.plan.terminalCompletion === "ready_while_running"
+          ? "direct"
+          : "held",
+    };
   };
   try {
     for (const invocation of terminalCommandPlan({
@@ -402,19 +585,20 @@ export function driveTerminal(options: {
         recordingStartedAt = Date.now();
       }
     }
-    initialPaneSnapshot = captureTerminalPane(
-      options.runner,
-      options.checkout,
-      `${terminalSession}:0.0`,
-    );
+    const expectations = terminalExpectations(options.plan);
+    terminalDeadline = Date.now() + options.maxRecordingSeconds * 1_000;
+    initialPaneSnapshot = captureTerminalPane(options.runner, options.checkout, terminalPane);
     try {
+      const command = nextCommand();
       outputWindow = runTerminalCommand(
         options.plan.entry,
-        terminalSession,
+        terminalPane,
         options.runner,
         options.checkout,
-        nextCommandPath(),
-        readCommandStatus,
+        command.files,
+        expectations,
+        command.launchMode,
+        terminalDeadline,
       );
       commandWindows.push(outputWindow);
     } catch (error) {
@@ -423,19 +607,20 @@ export function driveTerminal(options: {
         outputWindow = error.window;
         commandWindows.push(error.window);
       }
-      capturedOutput = terminalPrivateErrorMessage(error, commandPaths);
+      failureReason = terminalPrivateErrorMessage(error, privatePaths);
     }
     if (!failed) {
       for (const step of options.plan.steps as LiveProofTerminalStep[]) {
         try {
           const result = runTerminalStep(
             step,
-            terminalSession,
+            terminalPane,
             options.runner,
             options.checkout,
             outputWindow,
-            nextCommandPath,
-            readCommandStatus,
+            nextCommand,
+            expectations,
+            terminalDeadline,
           );
           if (result.outputWindow && result.outputWindow !== outputWindow) {
             commandWindows.push(result.outputWindow);
@@ -458,85 +643,130 @@ export function driveTerminal(options: {
             outputWindow = error.window;
             commandWindows.push(error.window);
           }
+          failureReason = terminalPrivateErrorMessage(error, privatePaths);
           log.push(
             step.action === "expect_output"
               ? {
                   action: step.action,
                   status: "failed",
-                  detail: terminalPrivateErrorMessage(error, commandPaths),
+                  detail: failureReason,
                   presentAtStart: initialPaneSnapshot.includes(step.text),
                   satisfied: false,
                 }
               : {
                   action: step.action,
                   status: "failed",
-                  detail: terminalPrivateErrorMessage(error, commandPaths),
+                  detail: failureReason,
                 },
           );
           break;
         }
       }
     }
-    if (outputWindow) {
-      captureCommandOutput(options.runner, options.checkout, terminalSession, outputWindow);
-    }
-    if (recordMedia) {
-      holdEndState(options.runner, recordingStartedAt);
-      finalizeRecorder(options.runner, options.checkout, recorderSession);
-      requireRecording(options.runner, options.checkout, options.rawVideoPath);
-    }
-    if (outputWindow && !failed) {
-      captureCommandOutput(options.runner, options.checkout, terminalSession, outputWindow);
-      const exitStatus = observeTerminalCommandStatus(
-        options.runner,
-        options.checkout,
-        terminalSession,
-        outputWindow,
-        readCommandStatus,
-        TERMINAL_COMMAND_STATUS_GRACE_SECONDS,
-        true,
-      );
-      if (exitStatus !== undefined && exitStatus !== 0) {
-        failed = true;
-        const failure = terminalCommandFailure(
-          outputWindow.command,
-          exitStatus,
-          outputWindow.output,
+    const validateCurrentCommand = (cutover: boolean) => {
+      if (!outputWindow || failed) return;
+      try {
+        validateFinalTerminalCommand(
+          outputWindow,
+          options.plan.terminalCompletion,
+          terminalPane,
+          options.runner,
+          options.checkout,
+          cutover,
+          terminalDeadline,
         );
+      } catch (error) {
+        failed = true;
+        failureReason = terminalPrivateErrorMessage(error, privatePaths);
         const previousStep = log.at(-1);
         if (previousStep) {
           previousStep.status = "failed";
-          previousStep.detail = failure.message;
+          previousStep.detail = failureReason;
           if (previousStep.action === "expect_output" || previousStep.action === "expect_text") {
             previousStep.satisfied = false;
           }
-        } else {
-          capturedOutput = failure.message;
         }
       }
+    };
+    if (!recordMedia && !failed && options.plan.terminalCompletion === "ready_while_running") {
+      sleepWithinTerminalBudget(options.runner, TERMINAL_READY_STABILITY_SECONDS, terminalDeadline);
     }
-    const cleanOutput = commandWindows
-      .map((window) => window.output.trim())
-      .filter(Boolean)
-      .join("\n");
-    if (cleanOutput && (!failed || log.length > 0)) capturedOutput = cleanOutput;
+    validateCurrentCommand(!recordMedia);
+    if (recordMedia) {
+      if (!failed) holdEndState(options.runner, recordingStartedAt, terminalDeadline);
+      validateCurrentCommand(false);
+      finalizeRecorder(options.runner, options.checkout, recorderSession);
+      validateCurrentCommand(true);
+      requireRecording(options.runner, options.checkout, options.rawVideoPath);
+    }
+    if (failed) {
+      for (const window of commandWindows) {
+        try {
+          if (window.captureOpen) {
+            refreshTerminalCommandOutput(window, options.runner, options.checkout, terminalPane);
+            closeTerminalCapture(window, options.runner, options.checkout, terminalPane);
+          }
+        } catch (error) {
+          const captureFailure = terminalPrivateErrorMessage(error, privatePaths);
+          failureReason = failureReason ? `${failureReason}; ${captureFailure}` : captureFailure;
+        }
+      }
+      capturedOutput = terminalPrivateErrorMessage(
+        renderFailedTerminalOutput(commandWindows, failureReason),
+        privatePaths,
+      );
+    } else {
+      const viewport =
+        outputWindow?.finalViewport ??
+        captureTerminalViewport(options.runner, options.checkout, terminalPane);
+      capturedOutput = terminalPrivateErrorMessage(
+        viewport.trim() ? viewport.replace(/\n$/, "") : "",
+        privatePaths,
+      );
+    }
   } catch (error) {
     const diagnosticError = terminalErrorWithDiagnostics(error, options.runner, options.checkout, {
-      terminal: terminalSession,
+      terminal: terminalPane,
       display: displaySession,
       xterm: xtermSession,
       recorder: recorderSession,
     });
-    thrown = new Error(terminalPrivateErrorMessage(diagnosticError, commandPaths));
+    thrown = new Error(terminalPrivateErrorMessage(diagnosticError, privatePaths));
   } finally {
-    if (recordMedia) {
-      options.runner("tmux", ["kill-session", "-t", recorderSession]);
-      options.runner("tmux", ["kill-session", "-t", xtermSession]);
-      options.runner("tmux", ["kill-session", "-t", displaySession]);
+    const cleanupErrors: unknown[] = [];
+    const cleanup = (operation: () => void) => {
+      try {
+        operation();
+      } catch (error) {
+        cleanupErrors.push(error);
+      }
+    };
+    for (const window of commandWindows) {
+      cleanup(() => closeTerminalCapture(window, options.runner, options.checkout, terminalPane));
+      cleanup(() => cleanupTerminalWindow(window, options.runner, options.checkout));
     }
-    options.runner("tmux", ["kill-session", "-t", terminalSession]);
-    for (const commandPath of commandPaths) {
-      rmSync(commandPath, { force: true });
+    if (recordMedia) {
+      cleanup(() => {
+        options.runner("tmux", ["kill-session", "-t", recorderSession]);
+      });
+      cleanup(() => {
+        options.runner("tmux", ["kill-session", "-t", xtermSession]);
+      });
+      cleanup(() => {
+        options.runner("tmux", ["kill-session", "-t", displaySession]);
+      });
+    }
+    cleanup(() => {
+      options.runner("tmux", ["kill-session", "-t", terminalSession]);
+    });
+    for (const privatePath of privatePaths) {
+      cleanup(() => rmSync(privatePath, { force: true }));
+    }
+    if (cleanupErrors.length > 0) {
+      thrown = new AggregateError(
+        thrown ? [thrown, ...cleanupErrors] : cleanupErrors,
+        thrown ? "terminal proof and cleanup failed" : "terminal cleanup failed",
+      );
     }
   }
   if (thrown) throw thrown;
@@ -589,7 +819,7 @@ function finalizeRecorder(
   if (recorderExited(runner, checkout, recorderSession)) {
     throw new Error("recorder session exited before finalization");
   }
-  const target = `${recorderSession}:0.0`;
+  const target = recorderSession;
   requireSuccess(
     "tmux",
     ["send-keys", "-t", target, "q"],
@@ -609,11 +839,9 @@ function recorderExited(
   checkout: string,
   recorderSession: string,
 ): boolean {
-  const result = runner(
-    "tmux",
-    ["display-message", "-p", "-t", `${recorderSession}:0.0`, "#{pane_dead}"],
-    { cwd: checkout },
-  );
+  const result = runner("tmux", ["display-message", "-p", "-t", recorderSession, "#{pane_dead}"], {
+    cwd: checkout,
+  });
   return result.status !== 0 || String(result.stdout ?? "").trim() === "1";
 }
 
@@ -652,7 +880,7 @@ function terminalErrorWithDiagnostics(
   const message = error instanceof Error ? error.message : String(error);
   const diagnostics = (Object.entries(sessions) as Array<[keyof typeof sessions, string]>).map(
     ([label, session]) => {
-      const result = runner("tmux", ["capture-pane", "-p", "-t", `${session}:0.0`, "-S", "-40"], {
+      const result = runner("tmux", ["capture-pane", "-p", "-t", session, "-S", "-40"], {
         cwd: checkout,
       });
       const output =
@@ -673,275 +901,732 @@ function lastLines(value: string, count: number): string {
 
 function runTerminalStep(
   step: LiveProofTerminalStep,
-  terminalSession: string,
+  terminalPane: string,
   runner: MediaProofCommandRunner,
   checkout: string,
   outputWindow: TerminalOutputWindow | undefined,
-  nextCommandPath: () => string,
-  readCommandStatus: () => number | undefined,
+  nextCommand: () => { files: TerminalCommandFiles; launchMode: TerminalLaunchMode },
+  expectations: readonly string[],
+  terminalDeadline: number,
 ): TerminalStepResult {
   if (step.action === "run") {
     if (outputWindow) {
-      captureCommandOutput(runner, checkout, terminalSession, outputWindow);
-      const exitStatus = observeTerminalCommandStatus(
-        runner,
-        checkout,
-        terminalSession,
-        outputWindow,
-        readCommandStatus,
-        TERMINAL_EXPECT_OUTPUT_TIMEOUT_SECONDS,
-      );
-      if (exitStatus === undefined) {
+      try {
+        requireTerminalCommandExitZero(
+          outputWindow,
+          terminalPane,
+          runner,
+          checkout,
+          terminalDeadline,
+          true,
+        );
+        cleanupTerminalWindow(outputWindow, runner, checkout);
+      } catch (error) {
         throw new Error(
-          `previous terminal command was still running after ${TERMINAL_EXPECT_OUTPUT_TIMEOUT_SECONDS} seconds: ${JSON.stringify(outputWindow.command)}`,
+          `terminal run was blocked by the previous command: ${error instanceof Error ? error.message : String(error)}`,
+          { cause: error },
         );
       }
-      if (exitStatus !== 0) {
-        const failure = terminalCommandFailure(
-          outputWindow.command,
-          exitStatus,
-          outputWindow.output,
-        );
-        throw new Error(`terminal run was blocked by the previous command: ${failure.message}`);
-      }
-      rmSync(outputWindow.commandPath, { force: true });
     }
+    const command = nextCommand();
     return {
       outputWindow: runTerminalCommand(
         step.command,
-        terminalSession,
+        terminalPane,
         runner,
         checkout,
-        nextCommandPath(),
-        readCommandStatus,
+        command.files,
+        expectations,
+        command.launchMode,
+        terminalDeadline,
       ),
     };
   }
   if (step.action === "wait") {
-    const seconds = String(step.seconds);
-    requireSuccess("sleep", [seconds], runner("sleep", [seconds]));
+    sleepWithinTerminalBudget(runner, step.seconds, terminalDeadline);
     return { outputWindow };
   }
   if (!outputWindow) {
     throw new Error("expected terminal output without a preceding command");
   }
-  let capturedOutput = "";
   for (let elapsed = 0; elapsed <= TERMINAL_EXPECT_OUTPUT_TIMEOUT_SECONDS; elapsed += 1) {
-    capturedOutput = captureCommandOutput(runner, checkout, terminalSession, outputWindow);
-    const exitStatus = readCommandStatus();
-    if (exitStatus !== undefined && exitStatus !== 0) {
-      throw terminalCommandFailure(outputWindow.command, exitStatus, capturedOutput);
+    refreshTerminalCommandOutput(outputWindow, runner, checkout, terminalPane);
+    if (outputWindow.observedExpectations.has(step.text)) {
+      return { outputWindow, expectationSatisfied: true };
     }
-    if (capturedOutput.includes(step.text)) return { outputWindow, expectationSatisfied: true };
-    if (exitStatus === 0) {
-      const settledStatus = observeTerminalCommandStatus(
-        runner,
-        checkout,
-        terminalSession,
-        outputWindow,
-        readCommandStatus,
-        TERMINAL_COMMAND_STATUS_GRACE_SECONDS,
-        true,
-      );
-      if (settledStatus !== undefined && settledStatus !== 0) {
-        throw terminalCommandFailure(outputWindow.command, settledStatus, outputWindow.output);
+    if (outputWindow.launchMode === "held") {
+      const status = readHeldTerminalStatus(outputWindow);
+      if (status !== undefined) {
+        finalizeHeldTerminalCommand(outputWindow, status, terminalPane, runner, checkout);
+        if (outputWindow.observedExpectations.has(step.text)) {
+          return { outputWindow, expectationSatisfied: true };
+        }
+        if (status !== 0) throw terminalCommandFailure(outputWindow, status);
+        throw new Error(
+          `terminal command exited successfully before expected output appeared: ${JSON.stringify(step.text)}`,
+        );
       }
-      capturedOutput = outputWindow.output;
-      if (capturedOutput.includes(step.text)) {
+      const state = readTerminalCommandState(outputWindow, runner, checkout, terminalPane);
+      if (state?.status === "exited") {
+        throw new Error("held terminal command exited before recording its completion status");
+      }
+    } else {
+      const state = readTerminalCommandState(outputWindow, runner, checkout, terminalPane);
+      if (state?.status !== "exited") {
+        if (elapsed < TERMINAL_EXPECT_OUTPUT_TIMEOUT_SECONDS) {
+          pollTerminalSleep(runner, terminalDeadline);
+        }
+        continue;
+      }
+      refreshTerminalCommandOutput(outputWindow, runner, checkout, terminalPane);
+      closeTerminalCapture(outputWindow, runner, checkout, terminalPane);
+      observeTerminalSnapshot(
+        outputWindow,
+        captureTerminalHistory(runner, checkout, terminalPane).replaceAll(
+          outputWindow.files.command,
+          "<private command>",
+        ),
+      );
+      if (outputWindow.observedExpectations.has(step.text)) {
         return { outputWindow, expectationSatisfied: true };
       }
-      return {
-        outputWindow,
-        expectationSatisfied: true,
-        detail: TERMINAL_OUTPUT_NOT_OBSERVED_DETAIL,
-      };
+      if (state.exitStatus !== 0) throw terminalCommandFailure(outputWindow, state.exitStatus);
+      throw new Error(
+        `terminal command exited successfully before expected output appeared: ${JSON.stringify(step.text)}`,
+      );
     }
-    if (elapsed < TERMINAL_EXPECT_OUTPUT_TIMEOUT_SECONDS) pollSleep(runner);
+    if (elapsed < TERMINAL_EXPECT_OUTPUT_TIMEOUT_SECONDS) {
+      pollTerminalSleep(runner, terminalDeadline);
+    }
+  }
+  refreshTerminalCommandOutput(outputWindow, runner, checkout, terminalPane);
+  if (outputWindow.observedExpectations.has(step.text)) {
+    return { outputWindow, expectationSatisfied: true };
   }
   throw new Error(
-    `expected terminal output was not visible within ${TERMINAL_EXPECT_OUTPUT_TIMEOUT_SECONDS} seconds: ${JSON.stringify(step.text)}\n\nCaptured output:\n${capturedOutput || "<empty>"}`,
+    `expected terminal output was not visible within ${TERMINAL_EXPECT_OUTPUT_TIMEOUT_SECONDS} seconds: ${JSON.stringify(step.text)}`,
   );
 }
 
 function runTerminalCommand(
   command: string,
-  terminalSession: string,
+  terminalPane: string,
   runner: MediaProofCommandRunner,
   checkout: string,
-  commandPath: string,
-  readCommandStatus: () => number | undefined,
+  files: TerminalCommandFiles,
+  expectations: readonly string[],
+  launchMode: TerminalLaunchMode,
+  terminalDeadline: number,
 ): TerminalOutputWindow {
-  const target = `${terminalSession}:0.0`;
+  const target = terminalPane;
   const quote = (value: string) => `'${value.replaceAll("'", "'\\''")}'`;
-  rmSync(commandPath, { force: true });
-  writeFileSync(commandPath, command.endsWith("\n") ? command : `${command}\n`, {
+  for (const path of Object.values(files)) rmSync(path, { force: true });
+  writeFileSync(files.command, command.endsWith("\n") ? command : `${command}\n`, {
     encoding: "utf8",
     mode: 0o600,
   });
+  writeFileSync(files.captureScript, generateTerminalCaptureScript(), {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  const window: TerminalOutputWindow = {
+    command,
+    files,
+    launchMode,
+    chunks: [],
+    expectations,
+    observedExpectations: new Set(),
+    captureOpen: false,
+    processGroupCleaned: false,
+  };
   const clearHistoryArgs = ["clear-history", "-t", target];
   requireSuccess("tmux", clearHistoryArgs, runner("tmux", clearHistoryArgs, { cwd: checkout }));
-  const commandRunner = `builtin printf '\\033[2J\\033[H'; exec /bin/bash --noprofile --norc "$1"`;
-  const shellCommand =
-    `/usr/bin/env -u TMUX -u TMUX_PANE /bin/bash --noprofile --norc -c ` +
-    `${quote(commandRunner)} clawsweeper ${quote(commandPath)}`;
-  requireSuccess(
-    "tmux",
-    ["respawn-pane", "-k", "-t", target, "-c", checkout, shellCommand],
-    runner("tmux", ["respawn-pane", "-k", "-t", target, "-c", checkout, shellCommand], {
-      cwd: checkout,
-    }),
-  );
-  const window: TerminalOutputWindow = {
-    echoSnapshot: "",
-    command,
-    commandPath,
-    output: "",
-  };
-  for (let elapsed = 0; elapsed <= TERMINAL_RUN_OUTPUT_TIMEOUT_SECONDS; elapsed += 1) {
-    const capturedOutput = captureCommandOutput(runner, checkout, terminalSession, window);
-    const exitStatus = readCommandStatus();
-    if (exitStatus !== undefined && exitStatus !== 0) {
-      const failure = terminalCommandFailure(command, exitStatus, capturedOutput);
-      throw new TerminalCommandExecutionError(failure.message, window);
-    }
-    if (exitStatus === 0) {
-      const settledStatus = observeTerminalCommandStatus(
-        runner,
-        checkout,
-        terminalSession,
-        window,
-        readCommandStatus,
-        TERMINAL_COMMAND_STATUS_GRACE_SECONDS,
-        true,
-      );
-      if (settledStatus !== undefined && settledStatus !== 0) {
-        const failure = terminalCommandFailure(command, settledStatus, window.output);
-        throw new TerminalCommandExecutionError(failure.message, window);
+  try {
+    // The start gate keeps the pane alive while capture attaches, so fast
+    // commands cannot emit before pipe-pane owns their output.
+    const commandRunner =
+      launchMode === "held"
+        ? [
+            'while [ ! -e "$5" ]; do sleep 0.05; done',
+            "builtin printf '\\033[2J\\033[H'",
+            'builtin printf "ready\\n" >"$6"',
+            'mv -f -- "$6" "$7"',
+            '/bin/bash --noprofile --norc "$1"',
+            "status=$?",
+            'builtin printf "%s\\n" "$status" >"$2"',
+            'mv -f -- "$2" "$3"',
+            'while [ ! -e "$4" ]; do sleep 0.05; done',
+            'exit "$status"',
+          ].join("; ")
+        : [
+            'while [ ! -e "$5" ]; do sleep 0.05; done',
+            "builtin printf '\\033[2J\\033[H'",
+            'builtin printf "ready\\n" >"$6"',
+            'mv -f -- "$6" "$7"',
+            'exec /bin/bash --noprofile --norc "$1"',
+          ].join("; ");
+    const shellCommand =
+      `/usr/bin/env -u TMUX -u TMUX_PANE /bin/bash --noprofile --norc -c ${quote(commandRunner)} ` +
+      [
+        "clawsweeper-terminal",
+        files.command,
+        files.statusTemporary,
+        files.status,
+        files.release,
+        files.start,
+        files.readyTemporary,
+        files.ready,
+      ]
+        .map(quote)
+        .join(" ");
+    const respawnArgs = ["respawn-pane", "-k", "-t", target, "-c", checkout, shellCommand];
+    requireSuccess("tmux", respawnArgs, runner("tmux", respawnArgs, { cwd: checkout }));
+    const captureCommand =
+      `/usr/bin/env -u TMUX -u TMUX_PANE node ${quote(files.captureScript)} ` +
+      [files.capture, files.captureTemporary, files.captureDone, files.captureDoneTemporary]
+        .map(quote)
+        .join(" ");
+    const pipeArgs = ["pipe-pane", "-O", "-t", target, captureCommand];
+    requireSuccess("tmux", pipeArgs, runner("tmux", pipeArgs, { cwd: checkout }));
+    window.captureOpen = true;
+    writeFileSync(files.startTemporary, "start\n", { encoding: "utf8", mode: 0o600 });
+    renameSync(files.startTemporary, files.start);
+  } catch (error) {
+    throw new TerminalCommandExecutionError(
+      error instanceof Error ? error.message : String(error),
+      window,
+    );
+  }
+  for (let elapsed = 0; elapsed <= TERMINAL_COMMAND_START_TIMEOUT_SECONDS; elapsed += 1) {
+    const panePid = readTerminalPanePid(runner, checkout, terminalPane);
+    if (panePid) {
+      window.panePid = panePid;
+      try {
+        const state = readTerminalCommandState(window, runner, checkout, terminalPane);
+        const readiness = readBoundedTerminalFile(files.ready, 64);
+        if (readiness !== undefined) {
+          if (readiness !== "ready\n") {
+            throw new Error("terminal command readiness acknowledgement is malformed");
+          }
+          refreshTerminalCommandOutput(window, runner, checkout, terminalPane);
+          return window;
+        }
+        if (state?.status === "exited") {
+          throw new Error("terminal command exited before clearing its pane");
+        }
+      } catch (error) {
+        throw new TerminalCommandExecutionError(
+          error instanceof Error ? error.message : String(error),
+          window,
+        );
       }
-      return window;
     }
-    if (capturedOutput.trim()) {
-      // Output commonly precedes process exit; wait briefly for tmux to publish the
-      // pane's final status before treating it as intentionally long-running.
-      const observedStatus = observeTerminalCommandStatus(
-        runner,
-        checkout,
-        terminalSession,
-        window,
-        readCommandStatus,
-        TERMINAL_COMMAND_STATUS_GRACE_SECONDS,
-        true,
-      );
-      if (observedStatus !== undefined && observedStatus !== 0) {
-        const failure = terminalCommandFailure(command, observedStatus, window.output);
-        throw new TerminalCommandExecutionError(failure.message, window);
-      }
-      return window;
+    if (elapsed < TERMINAL_COMMAND_START_TIMEOUT_SECONDS) {
+      pollTerminalSleep(runner, terminalDeadline);
     }
-    if (elapsed < TERMINAL_RUN_OUTPUT_TIMEOUT_SECONDS) pollSleep(runner);
   }
   throw new TerminalCommandExecutionError(
-    `terminal command did not produce output or exit within ${TERMINAL_RUN_OUTPUT_TIMEOUT_SECONDS} seconds: ${JSON.stringify(command)}\n\nCaptured output:\n${window.output || "<empty>"}`,
+    `terminal command pane did not start within ${TERMINAL_COMMAND_START_TIMEOUT_SECONDS} seconds: ${JSON.stringify(command)}`,
     window,
   );
 }
 
-function observeTerminalCommandStatus(
+function validateFinalTerminalCommand(
+  window: TerminalOutputWindow,
+  completion: LiveProofPlan["terminalCompletion"],
+  terminalPane: string,
   runner: MediaProofCommandRunner,
   checkout: string,
-  terminalSession: string,
-  window: TerminalOutputWindow,
-  readCommandStatus: () => number | undefined,
-  timeoutSeconds: number,
-  settleAfterSuccess = false,
-): number | undefined {
-  let exitStatus = readCommandStatus();
-  if (exitStatus !== undefined && (!settleAfterSuccess || exitStatus !== 0)) return exitStatus;
-  for (let elapsed = 0; elapsed < timeoutSeconds; elapsed += 1) {
-    pollSleep(runner);
-    captureCommandOutput(runner, checkout, terminalSession, window);
-    const observedStatus = readCommandStatus();
-    if (observedStatus !== undefined) {
-      exitStatus = observedStatus;
-      if (observedStatus !== 0 || !settleAfterSuccess) return observedStatus;
+  cutover: boolean,
+  terminalDeadline: number,
+): void {
+  if (completion === "exit_zero") {
+    if (window.launchMode !== "held") {
+      throw new Error("exit_zero terminal proof did not use held command supervision");
     }
+    requireTerminalCommandExitZero(
+      window,
+      terminalPane,
+      runner,
+      checkout,
+      terminalDeadline,
+      cutover,
+    );
+    return;
   }
-  return exitStatus;
+  if (completion !== "ready_while_running") {
+    throw new Error("terminal proof is missing a terminal completion contract");
+  }
+  if (window.launchMode !== "direct") {
+    throw new Error("ready_while_running terminal proof did not execute the target directly");
+  }
+  if (window.observedExpectations.size === 0) {
+    throw new Error("ready_while_running terminal proof requires a satisfied output expectation");
+  }
+  refreshTerminalCommandOutput(window, runner, checkout, terminalPane);
+  const state = readTerminalCommandState(window, runner, checkout, terminalPane);
+  if (state?.status === "running") {
+    if (cutover) {
+      try {
+        closeTerminalCapture(window, runner, checkout, terminalPane);
+      } catch (error) {
+        const sealedState = readTerminalCommandState(window, runner, checkout, terminalPane);
+        if (sealedState?.status === "exited") {
+          throw new Error(
+            `ready_while_running terminal command exited after satisfying its expectation: ${terminalCommandFailure(window, sealedState.exitStatus).message}`,
+            { cause: error },
+          );
+        }
+        throw error;
+      }
+      window.finalViewport = captureTerminalViewport(runner, checkout, terminalPane);
+      const sealedState = readTerminalCommandState(window, runner, checkout, terminalPane);
+      if (sealedState?.status === "exited") {
+        throw new Error(
+          `ready_while_running terminal command exited after satisfying its expectation: ${terminalCommandFailure(window, sealedState.exitStatus).message}`,
+        );
+      }
+      if (sealedState?.status !== "running") {
+        throw new Error("ready_while_running terminal command has no authoritative process state");
+      }
+    }
+    return;
+  }
+  if (state?.status === "exited") {
+    throw new Error(
+      `ready_while_running terminal command exited after satisfying its expectation: ${terminalCommandFailure(window, state.exitStatus).message}`,
+    );
+  }
+  throw new Error("ready_while_running terminal command has no authoritative process state");
 }
 
-function captureCommandOutput(
-  runner: MediaProofCommandRunner,
-  checkout: string,
-  terminalSession: string,
+function requireTerminalCommandExitZero(
   window: TerminalOutputWindow,
-): string {
-  const capturedPane = captureTerminalPane(runner, checkout, `${terminalSession}:0.0`);
-  window.output = capturedPane
-    .replaceAll(window.commandPath, "<private command>")
-    .split("\n")
-    .filter((line) => !/^Pane is dead \((?:status \d+|signal [^,]+),.+\)$/.test(line.trim()))
-    .join("\n");
-  return window.output;
-}
-
-function readTerminalPaneExitStatus(
+  terminalPane: string,
   runner: MediaProofCommandRunner,
   checkout: string,
-  terminalSession: string,
-): number | undefined {
-  const result = runner(
-    "tmux",
-    [
-      "display-message",
-      "-p",
-      "-t",
-      `${terminalSession}:0.0`,
-      "#{pane_dead}:#{pane_dead_status}:#{pane_dead_signal}",
-    ],
-    { cwd: checkout },
+  terminalDeadline: number,
+  cutover: boolean,
+): void {
+  if (window.launchMode !== "held") {
+    throw new Error("terminal command is not using held supervision");
+  }
+  if (window.finalizedExitStatus !== undefined) {
+    if (window.finalizedExitStatus !== 0) {
+      throw terminalCommandFailure(window, window.finalizedExitStatus);
+    }
+    return;
+  }
+  const timeoutSeconds = remainingTerminalBudgetSeconds(terminalDeadline);
+  for (let elapsed = 0; elapsed <= timeoutSeconds; elapsed += 1) {
+    refreshTerminalCommandOutput(window, runner, checkout, terminalPane);
+    const status = readHeldTerminalStatus(window);
+    if (status !== undefined) {
+      if (cutover) {
+        finalizeHeldTerminalCommand(window, status, terminalPane, runner, checkout);
+      }
+      if (status !== 0) throw terminalCommandFailure(window, status);
+      return;
+    }
+    const state = readTerminalCommandState(window, runner, checkout, terminalPane);
+    if (state?.status === "exited") {
+      throw new Error("held terminal command exited before recording its completion status");
+    }
+    if (elapsed < timeoutSeconds) pollTerminalSleep(runner, terminalDeadline);
+  }
+  refreshTerminalCommandOutput(window, runner, checkout, terminalPane);
+  const status = readHeldTerminalStatus(window);
+  if (status !== undefined) {
+    if (cutover) {
+      finalizeHeldTerminalCommand(window, status, terminalPane, runner, checkout);
+    }
+    if (status !== 0) throw terminalCommandFailure(window, status);
+    return;
+  }
+  const state = readTerminalCommandState(window, runner, checkout, terminalPane);
+  if (state?.status === "exited") {
+    throw new Error("held terminal command exited before recording its completion status");
+  }
+  throw new Error(
+    `terminal command was still running after ${timeoutSeconds} seconds: ${JSON.stringify(window.command)}`,
   );
-  if (result.status !== 0) {
-    throw new Error(`tmux pane status probe failed: ${mediaProofSpawnDetail(result)}`);
+}
+
+function readHeldTerminalStatus(window: TerminalOutputWindow): number | undefined {
+  const statusText = readBoundedTerminalFile(window.files.status, 64);
+  if (statusText === undefined) return undefined;
+  const raw = statusText.trim();
+  if (!/^\d+$/.test(raw)) {
+    throw new Error("held terminal command status is malformed");
   }
-  const rawStatus = String(result.stdout ?? "").trim();
-  const match = rawStatus.match(/^([01]):(\d{0,3}):([A-Za-z0-9]*)$/);
-  if (!match) {
-    throw new Error(`tmux pane status probe returned invalid output: ${JSON.stringify(rawStatus)}`);
-  }
-  if (match[1] === "0") {
-    if (match[2] || match[3]) {
-      throw new Error(`tmux live pane unexpectedly reported an exit: ${JSON.stringify(rawStatus)}`);
-    }
-    return undefined;
-  }
-  if (match[3]) {
-    const numericSignal = /^\d+$/.test(match[3]) ? Number.parseInt(match[3], 10) : undefined;
-    if (numericSignal !== undefined && numericSignal > 0 && numericSignal < 128) {
-      return 128 + numericSignal;
-    }
-    const signal =
-      osConstants.signals[`SIG${match[3].toUpperCase()}` as keyof typeof osConstants.signals];
-    return 128 + (signal ?? 127);
-  }
-  if (!match[2]) return undefined;
-  const status = Number.parseInt(match[2], 10);
+  const status = Number.parseInt(raw, 10);
   if (!Number.isSafeInteger(status) || status < 0 || status > 255) {
-    throw new Error(`terminal pane reported an invalid exit status: ${JSON.stringify(match[2])}`);
+    throw new Error("held terminal command status is malformed");
   }
   return status;
 }
 
-function terminalCommandFailure(command: string, status: number, capturedOutput: string): Error {
-  const detail = status === 124 ? "timed out" : status > 128 ? "terminated by a signal" : "failed";
-  return new Error(
-    `terminal command ${detail} with exit status ${status}: ${JSON.stringify(command)}\n\nCaptured output:\n${capturedOutput || "<empty>"}`,
+function finalizeHeldTerminalCommand(
+  window: TerminalOutputWindow,
+  recordedStatus: number,
+  terminalPane: string,
+  runner: MediaProofCommandRunner,
+  checkout: string,
+): void {
+  const heldState = readTerminalCommandState(window, runner, checkout, terminalPane);
+  if (heldState?.status !== "running") {
+    throw new Error("held terminal command wrapper exited before controller release");
+  }
+  // The wrapper remains the live pane owner until the stream and viewport are
+  // frozen; only then may tmux publish the child's recorded exit status.
+  closeTerminalCapture(window, runner, checkout, terminalPane);
+  observeTerminalSnapshot(
+    window,
+    captureTerminalHistory(runner, checkout, terminalPane).replaceAll(
+      window.files.command,
+      "<private command>",
+    ),
+  );
+  window.finalViewport = captureTerminalViewport(runner, checkout, terminalPane);
+  releaseHeldTerminalCommand(window);
+  for (let elapsed = 0; elapsed <= TERMINAL_COMMAND_START_TIMEOUT_SECONDS * 10; elapsed += 1) {
+    const state = readTerminalCommandState(window, runner, checkout, terminalPane);
+    if (state?.status === "exited") {
+      if (state.exitStatus !== recordedStatus) {
+        throw new Error(
+          `held terminal command status mismatch: recorded ${recordedStatus}, tmux reported ${state.exitStatus}`,
+        );
+      }
+      window.finalizedExitStatus = recordedStatus;
+      return;
+    }
+    if (!state) {
+      throw new Error("held terminal command lost its authoritative pane after release");
+    }
+    if (elapsed < TERMINAL_COMMAND_START_TIMEOUT_SECONDS * 10) {
+      requireSuccess("sleep", ["0.1"], runner("sleep", ["0.1"]));
+    }
+  }
+  throw new Error(
+    `held terminal command did not exit within ${TERMINAL_COMMAND_START_TIMEOUT_SECONDS} seconds after release`,
   );
 }
 
-function terminalPrivateErrorMessage(error: unknown, commandPaths: readonly string[]): string {
+function releaseHeldTerminalCommand(window: TerminalOutputWindow): void {
+  writeFileSync(window.files.releaseTemporary, "release\n", {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  renameSync(window.files.releaseTemporary, window.files.release);
+}
+
+function refreshTerminalCommandOutput(
+  window: TerminalOutputWindow,
+  runner: MediaProofCommandRunner,
+  checkout: string,
+  terminalPane: string,
+): void {
+  if (!window.captureOpen) return;
+  const snapshot = captureTerminalHistory(runner, checkout, terminalPane).replaceAll(
+    window.files.command,
+    "<private command>",
+  );
+  observeTerminalSnapshot(window, snapshot);
+}
+
+function observeTerminalSnapshot(window: TerminalOutputWindow, snapshot: string): void {
+  for (const expectation of window.expectations) {
+    if (snapshot.includes(expectation)) window.observedExpectations.add(expectation);
+  }
+  storeTerminalSnapshot(window, snapshot);
+}
+
+function terminalExpectations(plan: LiveProofPlan): string[] {
+  return [
+    ...new Set(plan.steps.flatMap((step) => (step.action === "expect_output" ? [step.text] : []))),
+  ];
+}
+
+function storeTerminalSnapshot(window: TerminalOutputWindow, snapshot: string): void {
+  const bytes = Buffer.from(snapshot);
+  const bounded = bytes.subarray(Math.max(0, bytes.length - TERMINAL_STREAM_MAX_BYTES));
+  const chunks: Buffer[] = [];
+  for (let offset = 0; offset < bounded.length; offset += TERMINAL_CAPTURE_CHUNK_BYTES) {
+    chunks.push(bounded.subarray(offset, offset + TERMINAL_CAPTURE_CHUNK_BYTES));
+  }
+  window.chunks = chunks;
+}
+
+function closeTerminalCapture(
+  window: TerminalOutputWindow,
+  runner: MediaProofCommandRunner,
+  checkout: string,
+  terminalPane: string,
+): void {
+  if (!window.captureOpen) return;
+  const args = ["pipe-pane", "-t", terminalPane];
+  const result = runner("tmux", args, { cwd: checkout });
+  if (result.status !== 0) {
+    const state = readTerminalCommandState(window, runner, checkout, terminalPane);
+    if (state?.status !== "exited") requireSuccess("tmux", args, result);
+  }
+  window.captureOpen = false;
+  for (let elapsed = 0; elapsed <= TERMINAL_COMMAND_START_TIMEOUT_SECONDS * 10; elapsed += 1) {
+    const completionText = readBoundedTerminalFile(window.files.captureDone, 64);
+    if (completionText !== undefined) {
+      const completion = completionText.trim();
+      if (completion !== "eof") {
+        throw new Error(`terminal capture helper ended unexpectedly: ${completion || "empty"}`);
+      }
+      const capture = readBoundedTerminalFile(window.files.capture, TERMINAL_STREAM_MAX_BYTES);
+      if (capture !== undefined) {
+        const output = normalizeTerminalOutput(
+          capture.replaceAll(window.files.command, "<private command>"),
+        );
+        storeTerminalSnapshot(window, output);
+      }
+      return;
+    }
+    if (elapsed < TERMINAL_COMMAND_START_TIMEOUT_SECONDS * 10) {
+      requireSuccess("sleep", ["0.1"], runner("sleep", ["0.1"]));
+    }
+  }
+  throw new Error(
+    `terminal capture helper did not finish after tmux pipe EOF within ${TERMINAL_COMMAND_START_TIMEOUT_SECONDS} seconds`,
+  );
+}
+
+function readBoundedTerminalFile(path: string, maximumBytes: number): string | undefined {
+  let descriptor: number;
+  try {
+    descriptor = openSync(
+      path,
+      fsConstants.O_RDONLY | fsConstants.O_NONBLOCK | fsConstants.O_NOFOLLOW,
+    );
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw error;
+  }
+  try {
+    const stat = fstatSync(descriptor);
+    if (!stat.isFile()) {
+      throw new Error("terminal control path is not a regular file");
+    }
+    if (stat.size > maximumBytes) {
+      throw new Error("terminal control file exceeds its size limit");
+    }
+    const buffer = Buffer.alloc(maximumBytes + 1);
+    const bytesRead = readSync(descriptor, buffer, 0, buffer.length, 0);
+    if (bytesRead > maximumBytes) {
+      throw new Error("terminal control file exceeds its size limit");
+    }
+    return buffer.subarray(0, bytesRead).toString("utf8");
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
+function remainingTerminalBudgetSeconds(deadline: number): number {
+  return Math.max(0, Math.ceil((deadline - Date.now()) / 1_000));
+}
+
+function pollTerminalSleep(runner: MediaProofCommandRunner, deadline: number): void {
+  const remainingMilliseconds = deadline - Date.now();
+  if (remainingMilliseconds <= 0) {
+    throw new Error("terminal proof exceeded its configured time budget");
+  }
+  const seconds = Math.min(1, remainingMilliseconds / 1_000);
+  const duration = String(seconds);
+  requireSuccess("sleep", [duration], runner("sleep", [duration]));
+}
+
+function sleepWithinTerminalBudget(
+  runner: MediaProofCommandRunner,
+  seconds: number,
+  deadline: number,
+): void {
+  if (seconds * 1_000 > deadline - Date.now()) {
+    throw new Error("terminal proof step would exceed its configured time budget");
+  }
+  const duration = String(seconds);
+  requireSuccess("sleep", [duration], runner("sleep", [duration]));
+}
+
+function terminalWindowOutput(window: TerminalOutputWindow): string {
+  return Buffer.concat(window.chunks).toString("utf8");
+}
+
+function normalizeTerminalOutput(value: string): string {
+  return stripVTControlCharacters(value).replaceAll("\r\n", "\n").replaceAll("\r", "\n");
+}
+
+function terminalSignalExitStatus(signal: string): number {
+  const numericSignal = /^\d+$/.test(signal) ? Number.parseInt(signal, 10) : undefined;
+  if (numericSignal !== undefined && numericSignal > 0 && numericSignal < 128) {
+    return 128 + numericSignal;
+  }
+  const signalNumber =
+    osConstants.signals[
+      (signal.startsWith("SIG")
+        ? signal
+        : `SIG${signal.toUpperCase()}`) as keyof typeof osConstants.signals
+    ];
+  return 128 + (signalNumber ?? 127);
+}
+
+function terminalCommandFailure(window: TerminalOutputWindow, status: number): Error {
+  const detail = status > 128 ? "terminated by a signal" : "failed";
+  return new Error(
+    `terminal command ${detail} with exit status ${status}: ${JSON.stringify(window.command)}`,
+  );
+}
+
+function renderFailedTerminalOutput(
+  windows: readonly TerminalOutputWindow[],
+  failureReason: string,
+): string {
+  const sections = failureReason ? [`[failure]\n${failureReason}`] : [];
+  for (const [index, window] of windows.entries()) {
+    const output = terminalWindowOutput(window);
+    if (output.trim()) {
+      sections.push(`[command ${index + 1} combined output]\n${output.trim()}`);
+    }
+  }
+  return sections.join("\n\n");
+}
+
+function terminateTerminalProcessGroup(
+  runner: MediaProofCommandRunner,
+  checkout: string,
+  panePid: number | undefined,
+): void {
+  if (!panePid) return;
+  const signalErrors: unknown[] = [];
+  const runSignal = (signal: "-TERM" | "-KILL") => {
+    try {
+      const result = runner("/bin/kill", [signal, `-${panePid}`], { cwd: checkout });
+      if (result.status !== 0) {
+        signalErrors.push(
+          new Error(`/bin/kill ${signal} -${panePid} failed: ${mediaProofSpawnDetail(result)}`),
+        );
+      }
+    } catch (error) {
+      signalErrors.push(error);
+    }
+  };
+  const processGroupExists = (): boolean => {
+    const result = runner("/bin/kill", ["-0", `-${panePid}`], { cwd: checkout });
+    return result.status === 0;
+  };
+  // Signal command status is advisory because the group may disappear between
+  // calls. Only the final liveness probe decides whether cleanup succeeded.
+  runSignal("-TERM");
+  requireSuccess("sleep", ["0.1"], runner("sleep", ["0.1"]));
+  if (!processGroupExists()) return;
+  runSignal("-KILL");
+  for (let attempt = 0; attempt <= TERMINAL_COMMAND_START_TIMEOUT_SECONDS * 10; attempt += 1) {
+    if (!processGroupExists()) return;
+    if (attempt < TERMINAL_COMMAND_START_TIMEOUT_SECONDS * 10) {
+      requireSuccess("sleep", ["0.1"], runner("sleep", ["0.1"]));
+    }
+  }
+  const surviving = new Error(`terminal process group ${panePid} survived SIGKILL`);
+  throw signalErrors.length > 0
+    ? new AggregateError(
+        [...signalErrors, surviving],
+        `failed to clean terminal process group ${panePid}`,
+      )
+    : surviving;
+}
+
+function cleanupTerminalWindow(
+  window: TerminalOutputWindow,
+  runner: MediaProofCommandRunner,
+  checkout: string,
+): void {
+  const errors: unknown[] = [];
+  if (!window.processGroupCleaned) {
+    try {
+      terminateTerminalProcessGroup(runner, checkout, window.panePid);
+      window.processGroupCleaned = true;
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  if (errors.length > 0) {
+    throw new AggregateError(errors, "failed to clean terminal process group");
+  }
+}
+
+function readTerminalCommandState(
+  window: TerminalOutputWindow,
+  runner: MediaProofCommandRunner,
+  checkout: string,
+  terminalPane: string,
+): TerminalPaneState | undefined {
+  if (window.frozenExit) return window.frozenExit;
+  const state = readTerminalPaneState(runner, checkout, terminalPane);
+  if (state && window.panePid !== undefined && state.pid !== window.panePid) {
+    throw new Error(
+      `terminal pane identity changed from launch pid ${window.panePid} to ${state.pid}`,
+    );
+  }
+  if (state?.status === "exited") window.frozenExit = state;
+  return state;
+}
+
+function readTerminalPaneState(
+  runner: MediaProofCommandRunner,
+  checkout: string,
+  terminalPane: string,
+): TerminalPaneState | undefined {
+  const args = [
+    "display-message",
+    "-p",
+    "-t",
+    terminalPane,
+    "#{pane_pid}|#{pane_dead}|#{pane_dead_status}|#{pane_dead_signal}",
+  ];
+  const result = runner("tmux", args, { cwd: checkout });
+  if (result.status !== 0) return undefined;
+  const match = /^(\d+)\|(0|1)\|([^|]*)\|([^|]*)$/.exec(String(result.stdout ?? "").trim());
+  if (!match) throw new Error("terminal pane status is malformed");
+  const pid = Number.parseInt(match[1]!, 10);
+  if (!Number.isSafeInteger(pid) || pid <= 0) throw new Error("terminal pane status is malformed");
+  if (match[2] === "0") {
+    if (match[3] || match[4]) throw new Error("terminal pane status is malformed");
+    return { status: "running", pid };
+  }
+  const status = match[3]!;
+  const signal = match[4]!;
+  if (/^\d+$/.test(status) && !signal) {
+    const exitStatus = Number.parseInt(status, 10);
+    if (exitStatus >= 0 && exitStatus <= 255) return { status: "exited", pid, exitStatus };
+  } else if (!status && signal) {
+    return { status: "exited", pid, exitStatus: terminalSignalExitStatus(signal) };
+  }
+  throw new Error("terminal pane status is malformed");
+}
+
+function readTerminalPanePid(
+  runner: MediaProofCommandRunner,
+  checkout: string,
+  terminalPane: string,
+): number | undefined {
+  const args = ["display-message", "-p", "-t", terminalPane, "#{pane_pid}"];
+  const result = runner("tmux", args, { cwd: checkout });
+  if (result.status !== 0) return undefined;
+  const pid = Number.parseInt(String(result.stdout ?? "").trim(), 10);
+  if (!Number.isSafeInteger(pid) || pid <= 0) {
+    throw new Error("terminal pane pid is malformed");
+  }
+  return pid;
+}
+
+function terminalPrivateErrorMessage(error: unknown, privatePaths: readonly string[]): string {
   let message = error instanceof Error ? error.message : String(error);
-  for (const commandPath of commandPaths) {
-    message = message.replaceAll(commandPath, "<private command>");
+  for (const privatePath of [...privatePaths].sort((left, right) => right.length - left.length)) {
+    message = message.replaceAll(privatePath, "<private path>");
   }
   return message;
 }
@@ -954,17 +1639,42 @@ function captureTerminalPane(
   const args = ["capture-pane", "-p", "-t", target, "-S", "-200"];
   const capture = runner("tmux", args, { cwd: checkout });
   requireSuccess("tmux", args, capture);
-  return String(capture.stdout ?? "");
+  return normalizeTerminalOutput(String(capture.stdout ?? ""));
 }
 
-function holdEndState(runner: MediaProofCommandRunner, recordingStartedAt: number): void {
+function captureTerminalHistory(
+  runner: MediaProofCommandRunner,
+  checkout: string,
+  target: string,
+): string {
+  const args = ["capture-pane", "-p", "-t", target, "-S", `-${TERMINAL_HISTORY_LINES}`];
+  const capture = runner("tmux", args, { cwd: checkout });
+  requireSuccess("tmux", args, capture);
+  return normalizeTerminalOutput(String(capture.stdout ?? ""));
+}
+
+function captureTerminalViewport(
+  runner: MediaProofCommandRunner,
+  checkout: string,
+  target: string,
+): string {
+  const args = ["capture-pane", "-p", "-t", target];
+  const capture = runner("tmux", args, { cwd: checkout });
+  requireSuccess("tmux", args, capture);
+  return normalizeTerminalOutput(String(capture.stdout ?? ""));
+}
+
+function holdEndState(
+  runner: MediaProofCommandRunner,
+  recordingStartedAt: number,
+  terminalDeadline: number,
+): void {
   const elapsed = Math.max(0, Date.now() - recordingStartedAt);
   const holdMilliseconds = Math.max(
     END_STATE_HOLD_MILLISECONDS,
     MINIMUM_RECORDING_MILLISECONDS - elapsed,
   );
-  const holdSeconds = String(Math.ceil(holdMilliseconds / 1000));
-  requireSuccess("sleep", [holdSeconds], runner("sleep", [holdSeconds]));
+  sleepWithinTerminalBudget(runner, Math.ceil(holdMilliseconds / 1000), terminalDeadline);
 }
 
 function readStepLog(path: string): LiveProofStepLogEntry[] {

--- a/src/live-proof/drivers.ts
+++ b/src/live-proof/drivers.ts
@@ -4,6 +4,7 @@ import {
   constants as fsConstants,
   existsSync,
   fstatSync,
+  mkdtempSync,
   openSync,
   readFileSync,
   readSync,
@@ -230,6 +231,7 @@ export function terminalCommandPlan(options: {
   sessionPrefix: string;
   maxRecordingSeconds: number;
   rawVideoPath: string;
+  tmuxTmpDir: string;
   recordMedia?: boolean;
 }): TerminalCommandInvocation[] {
   const terminalSession = `${options.sessionPrefix}-terminal`;
@@ -329,7 +331,12 @@ export function terminalCommandPlan(options: {
         "-s",
         xtermSession,
         "env",
+        "-u",
+        "TMUX",
+        "-u",
+        "TMUX_PANE",
         "DISPLAY=:99",
+        `TMUX_TMPDIR=${options.tmuxTmpDir}`,
         "xterm",
         "-fullscreen",
         "-geometry",
@@ -396,18 +403,12 @@ interface TerminalOutputWindow {
   expectations: readonly string[];
   observedExpectations: Set<string>;
   panePid?: number;
-  processGroupId?: number;
+  nonce: string;
   frozenExit?: Extract<TerminalPaneState, { status: "exited" }>;
   finalizedExitStatus?: number;
   captureOpen: boolean;
-  processGroupCleaned: boolean;
+  paneCleaned: boolean;
   finalViewport?: string;
-}
-
-interface TerminalProcessOwnership {
-  parentPid: number;
-  processGroupId: number;
-  terminalProcessGroupId: number;
 }
 
 interface TerminalCommandFiles {
@@ -417,6 +418,9 @@ interface TerminalCommandFiles {
   captureTemporary: string;
   captureDone: string;
   captureDoneTemporary: string;
+  cleanupScript: string;
+  cleanupResult: string;
+  cleanupResultTemporary: string;
   status: string;
   statusTemporary: string;
   release: string;
@@ -425,8 +429,6 @@ interface TerminalCommandFiles {
   startTemporary: string;
   ready: string;
   readyTemporary: string;
-  processGroup: string;
-  processGroupTemporary: string;
 }
 
 type TerminalLaunchMode = "held";
@@ -518,6 +520,54 @@ process.stdin.resume();
 `;
 }
 
+function generateTerminalCleanupScript(): string {
+  return `#!/bin/bash
+set +m
+
+tty_name=$1
+pane_pid=$2
+nonce=$3
+result_temporary=$4
+result=$5
+
+finish() {
+  builtin printf "%s %s %s\\n" "$pane_pid" "$nonce" "$1" >"$result_temporary"
+  mv -f -- "$result_temporary" "$result"
+  exit "$2"
+}
+
+if [ "$(/usr/bin/uname -s)" = Darwin ]; then
+  term_tty() { /usr/bin/killall -q -TERM -t "$tty_name" 2>/dev/null; }
+  probe_tty() { /usr/bin/killall -0 -t "$tty_name" >/dev/null 2>&1; }
+  kill_tty() { /usr/bin/killall -q -KILL -t "$tty_name" 2>/dev/null; }
+else
+  term_tty() { /usr/bin/pkill -TERM -t "$tty_name" -f '.*' 2>/dev/null; }
+  probe_tty() { /usr/bin/pgrep -t "$tty_name" -f '.*' >/dev/null 2>&1; }
+  kill_tty() { /usr/bin/pkill -KILL -t "$tty_name" -f '.*' 2>/dev/null; }
+fi
+
+for sweep in 1 2 3; do
+  term_tty
+  status=$?
+  case "$status" in 0|1) ;; *) finish "error:term:$status" "$status" ;; esac
+  sleep 0.05
+done
+
+for ((sweep = 1; sweep <= 100; sweep += 1)); do
+  probe_tty
+  status=$?
+  if [ "$status" -eq 1 ]; then finish ok 0; fi
+  if [ "$status" -ne 0 ]; then finish "error:probe:$status" "$status"; fi
+  kill_tty
+  status=$?
+  case "$status" in 0|1) ;; *) finish "error:kill:$status" "$status" ;; esac
+  sleep 0.05
+done
+
+finish error:survivors 124
+`;
+}
+
 export function driveTerminal(options: {
   plan: LiveProofPlan;
   checkout: string;
@@ -527,6 +577,9 @@ export function driveTerminal(options: {
   runner: MediaProofCommandRunner;
 }): LiveProofDriveResult {
   const sessionPrefix = `clawsweeper-live-proof-${process.pid}-${randomUUID()}`;
+  // tmux Unix sockets have a small path cap on macOS; /tmp is the shared
+  // cross-platform short root, while mkdtemp keeps each proof private.
+  const tmuxTmpDir = mkdtempSync("/tmp/clawsweeper-tmux-");
   const terminalSession = `${sessionPrefix}-terminal`;
   const terminalPane = `${terminalSession}:0.0`;
   const displaySession = `${sessionPrefix}-display`;
@@ -541,10 +594,21 @@ export function driveTerminal(options: {
   let capturedOutput = "";
   let failureReason = "";
   const recordMedia = options.recordMedia !== false;
-  const privatePaths: string[] = [];
+  const privatePaths: string[] = [tmuxTmpDir];
   const commandWindows: TerminalOutputWindow[] = [];
   let commandIndex = 0;
   let terminalDeadline = 0;
+  const runner: MediaProofCommandRunner = (command, args, runOptions = {}) => {
+    if (command !== "tmux") return options.runner(command, args, runOptions);
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      ...runOptions.env,
+      TMUX_TMPDIR: tmuxTmpDir,
+    };
+    delete env.TMUX;
+    delete env.TMUX_PANE;
+    return options.runner(command, args, { ...runOptions, env });
+  };
   const nextCommand = (): { files: TerminalCommandFiles; launchMode: TerminalLaunchMode } => {
     const prefix = `${options.rawVideoPath}.command-${process.pid}-${commandIndex}`;
     commandIndex += 1;
@@ -555,6 +619,9 @@ export function driveTerminal(options: {
       captureTemporary: `${prefix}.combined.tmp`,
       captureDone: `${prefix}.capture.done`,
       captureDoneTemporary: `${prefix}.capture.done.tmp`,
+      cleanupScript: `${prefix}.cleanup.sh`,
+      cleanupResult: `${prefix}.cleanup.result`,
+      cleanupResultTemporary: `${prefix}.cleanup.result.tmp`,
       status: `${prefix}.status`,
       statusTemporary: `${prefix}.status.tmp`,
       release: `${prefix}.release`,
@@ -563,8 +630,6 @@ export function driveTerminal(options: {
       startTemporary: `${prefix}.start.tmp`,
       ready: `${prefix}.ready`,
       readyTemporary: `${prefix}.ready.tmp`,
-      processGroup: `${prefix}.process-group`,
-      processGroupTemporary: `${prefix}.process-group.tmp`,
     };
     privatePaths.push(...Object.values(files));
     return { files, launchMode: "held" };
@@ -574,29 +639,30 @@ export function driveTerminal(options: {
       sessionPrefix,
       maxRecordingSeconds: options.maxRecordingSeconds,
       rawVideoPath: options.rawVideoPath,
+      tmuxTmpDir,
       recordMedia,
     })) {
       requireSuccess(
         invocation.command,
         invocation.args,
-        options.runner(invocation.command, invocation.args, { cwd: options.checkout }),
+        runner(invocation.command, invocation.args, { cwd: options.checkout }),
       );
       if (invocation.waitAfter === "display") {
-        waitForDisplay(options.runner, options.checkout);
+        waitForDisplay(runner, options.checkout);
       } else if (invocation.waitAfter === "recorder") {
-        waitForRecorder(options.runner, options.checkout, recorderSession, options.rawVideoPath);
+        waitForRecorder(runner, options.checkout, recorderSession, options.rawVideoPath);
         recordingStartedAt = Date.now();
       }
     }
     const expectations = terminalExpectations(options.plan);
     terminalDeadline = Date.now() + options.maxRecordingSeconds * 1_000;
-    initialPaneSnapshot = captureTerminalPane(options.runner, options.checkout, terminalPane);
+    initialPaneSnapshot = captureTerminalPane(runner, options.checkout, terminalPane);
     try {
       const command = nextCommand();
       outputWindow = runTerminalCommand(
         options.plan.entry,
         terminalPane,
-        options.runner,
+        runner,
         options.checkout,
         command.files,
         expectations,
@@ -618,7 +684,7 @@ export function driveTerminal(options: {
           const result = runTerminalStep(
             step,
             terminalPane,
-            options.runner,
+            runner,
             options.checkout,
             outputWindow,
             nextCommand,
@@ -673,7 +739,7 @@ export function driveTerminal(options: {
           outputWindow,
           options.plan.terminalCompletion,
           terminalPane,
-          options.runner,
+          runner,
           options.checkout,
           cutover,
           terminalDeadline,
@@ -692,22 +758,22 @@ export function driveTerminal(options: {
       }
     };
     if (!recordMedia && !failed && options.plan.terminalCompletion === "ready_while_running") {
-      sleepWithinTerminalBudget(options.runner, TERMINAL_READY_STABILITY_SECONDS, terminalDeadline);
+      sleepWithinTerminalBudget(runner, TERMINAL_READY_STABILITY_SECONDS, terminalDeadline);
     }
     validateCurrentCommand(!recordMedia);
     if (recordMedia) {
-      if (!failed) holdEndState(options.runner, recordingStartedAt, terminalDeadline);
+      if (!failed) holdEndState(runner, recordingStartedAt, terminalDeadline);
       validateCurrentCommand(false);
-      finalizeRecorder(options.runner, options.checkout, recorderSession);
+      finalizeRecorder(runner, options.checkout, recorderSession);
       validateCurrentCommand(true);
-      requireRecording(options.runner, options.checkout, options.rawVideoPath);
+      requireRecording(runner, options.checkout, options.rawVideoPath);
     }
     if (failed) {
       for (const window of commandWindows) {
         try {
           if (window.captureOpen) {
-            refreshTerminalCommandOutput(window, options.runner, options.checkout, terminalPane);
-            closeTerminalCapture(window, options.runner, options.checkout, terminalPane);
+            refreshTerminalCommandOutput(window, runner, options.checkout, terminalPane);
+            closeTerminalCapture(window, runner, options.checkout, terminalPane);
           }
         } catch (error) {
           const captureFailure = terminalPrivateErrorMessage(error, privatePaths);
@@ -721,14 +787,14 @@ export function driveTerminal(options: {
     } else {
       const viewport =
         outputWindow?.finalViewport ??
-        captureTerminalViewport(options.runner, options.checkout, terminalPane);
+        captureTerminalViewport(runner, options.checkout, terminalPane);
       capturedOutput = terminalPrivateErrorMessage(
         viewport.trim() ? viewport.replace(/\n$/, "") : "",
         privatePaths,
       );
     }
   } catch (error) {
-    const diagnosticError = terminalErrorWithDiagnostics(error, options.runner, options.checkout, {
+    const diagnosticError = terminalErrorWithDiagnostics(error, runner, options.checkout, {
       terminal: terminalPane,
       display: displaySession,
       xterm: xtermSession,
@@ -745,31 +811,40 @@ export function driveTerminal(options: {
       }
     };
     for (const window of commandWindows) {
-      cleanup(() => closeTerminalCapture(window, options.runner, options.checkout, terminalPane));
-      cleanup(() => cleanupTerminalWindow(window, terminalPane, options.runner, options.checkout));
+      cleanup(() => closeTerminalCapture(window, runner, options.checkout, terminalPane));
+      cleanup(() => cleanupTerminalWindow(window, terminalPane, runner, options.checkout));
     }
     if (recordMedia) {
       cleanup(() => {
-        options.runner("tmux", ["kill-session", "-t", recorderSession]);
+        runner("tmux", ["kill-session", "-t", recorderSession]);
       });
       cleanup(() => {
-        options.runner("tmux", ["kill-session", "-t", xtermSession]);
+        runner("tmux", ["kill-session", "-t", xtermSession]);
       });
       cleanup(() => {
-        options.runner("tmux", ["kill-session", "-t", displaySession]);
+        runner("tmux", ["kill-session", "-t", displaySession]);
       });
     }
     cleanup(() => {
-      options.runner("tmux", ["kill-session", "-t", terminalSession]);
+      runner("tmux", ["kill-session", "-t", terminalSession]);
     });
     for (const privatePath of privatePaths) {
-      cleanup(() => rmSync(privatePath, { force: true }));
+      cleanup(() => rmSync(privatePath, { force: true, recursive: privatePath === tmuxTmpDir }));
     }
     if (cleanupErrors.length > 0) {
-      thrown = new AggregateError(
-        thrown ? [thrown, ...cleanupErrors] : cleanupErrors,
-        thrown ? "terminal proof and cleanup failed" : "terminal cleanup failed",
-      );
+      if (failed && !thrown) {
+        const cleanupFailure = cleanupErrors
+          .map((error) => terminalPrivateErrorMessage(error, privatePaths))
+          .join("; ");
+        capturedOutput = [capturedOutput, `[cleanup failure]\n${cleanupFailure}`]
+          .filter(Boolean)
+          .join("\n\n");
+      } else {
+        thrown = new AggregateError(
+          thrown ? [thrown, ...cleanupErrors] : cleanupErrors,
+          thrown ? "terminal proof and cleanup failed" : "terminal cleanup failed",
+        );
+      }
     }
   }
   if (thrown) throw thrown;
@@ -1006,6 +1081,10 @@ function runTerminalCommand(
     encoding: "utf8",
     mode: 0o600,
   });
+  writeFileSync(files.cleanupScript, generateTerminalCleanupScript(), {
+    encoding: "utf8",
+    mode: 0o700,
+  });
   const window: TerminalOutputWindow = {
     command,
     files,
@@ -1013,39 +1092,32 @@ function runTerminalCommand(
     chunks: [],
     expectations,
     observedExpectations: new Set(),
+    nonce: randomUUID(),
     captureOpen: false,
-    processGroupCleaned: false,
+    paneCleaned: false,
   };
+  const clearHistoryArgs = ["clear-history", "-t", target];
+  requireSuccess("tmux", clearHistoryArgs, runner("tmux", clearHistoryArgs, { cwd: checkout }));
   try {
     // The start gate keeps the pane alive while capture attaches, so fast
     // commands cannot emit before pipe-pane owns their output.
-    const heldCommand = [
-      "trap ':' TERM",
+    const commandRunner = [
+      "set +m",
+      "trap ':' HUP TERM",
+      "tty_path=$(/usr/bin/tty)",
+      'case "$tty_path" in /dev/*) tty_name=${tty_path#/dev/} ;; *) exit 125 ;; esac',
       'while [ ! -e "$5" ]; do sleep 0.05; done',
       "builtin printf '\\033[2J\\033[H'",
-      'builtin printf "ready\\n" >"$6"',
+      '( /usr/bin/env -u TMUX -u TMUX_PANE -u TMUX_TMPDIR /bin/bash --noprofile --norc "$1"; status=$?; builtin printf "%s\\n" "$status" >"$2"; mv -f -- "$2" "$3" ) </dev/tty >/dev/tty 2>&1 &',
+      'builtin printf "%s %s\\n" "$$" "$8" >"$6"',
       'mv -f -- "$6" "$7"',
-      '/bin/bash --noprofile --norc "$1"',
-      "status=$?",
-      'builtin printf "%s\\n" "$status" >"$2"',
-      'mv -f -- "$2" "$3"',
-      'while [ ! -e "$4" ]; do sleep 0.05; done',
-      'exit "$status"',
-    ].join("; ");
-    const commandRunner = [
-      "set -m",
-      `( ${heldCommand} ) &\ngroup=$!`,
-      'group_pgid=$(/bin/ps -o pgid= -p "$group" | /usr/bin/tr -d "[:space:]")',
-      'if [ "$group_pgid" != "$group" ]; then builtin kill "$group" 2>/dev/null || true; exit 125; fi',
-      'builtin printf "%s\\n" "$group" >"$8"',
-      'mv -f -- "$8" "$9"',
-      // fg preserves controlling-terminal semantics while suppressing Bash's
-      // job-command echo. The held subshell keeps the trusted PGID reserved.
-      "fg %1 >/dev/null",
-      'exit "$?"',
-    ].join("; ");
+      'while :; do if [ -f "$4" ]; then IFS=" " read -r release_pid release_nonce release_extra 2>/dev/null <"$4" || true; if [ "$release_pid" = "$$" ] && [ "$release_nonce" = "$8" ] && [ -z "${release_extra-}" ]; then break; fi; fi; sleep 0.05; done',
+      'builtin printf -v cleanup_command "%q " /bin/bash "$9" "$tty_name" "$$" "$8" "${10}" "${11}"',
+      'tmux run-shell -b "$cleanup_command" || exit 126',
+      "while :; do sleep 3600; done",
+    ].join("\n");
     const shellCommand =
-      `/usr/bin/env -u TMUX -u TMUX_PANE /bin/bash --noprofile --norc -c ${quote(commandRunner)} ` +
+      `/bin/bash --noprofile --norc -c ${quote(commandRunner)} ` +
       [
         "clawsweeper-terminal",
         files.command,
@@ -1055,49 +1127,17 @@ function runTerminalCommand(
         files.start,
         files.readyTemporary,
         files.ready,
-        files.processGroupTemporary,
-        files.processGroup,
+        window.nonce,
+        files.cleanupScript,
+        files.cleanupResultTemporary,
+        files.cleanupResult,
       ]
         .map(quote)
         .join(" ");
     const respawnArgs = ["respawn-pane", "-k", "-t", target, "-c", checkout, shellCommand];
     requireSuccess("tmux", respawnArgs, runner("tmux", respawnArgs, { cwd: checkout }));
-    for (let elapsed = 0; elapsed <= TERMINAL_COMMAND_START_TIMEOUT_SECONDS * 10; elapsed += 1) {
-      const panePid = readTerminalPanePid(runner, checkout, terminalPane);
-      const processGroupText = readBoundedTerminalFile(files.processGroup, 64);
-      if (panePid && processGroupText !== undefined) {
-        const rawProcessGroup = processGroupText.trim();
-        if (!/^\d+$/.test(rawProcessGroup)) {
-          throw new Error("terminal command process group is malformed");
-        }
-        const processGroupId = Number.parseInt(rawProcessGroup, 10);
-        if (!Number.isSafeInteger(processGroupId) || processGroupId <= 0) {
-          throw new Error("terminal command process group is malformed");
-        }
-        const ownership = readTerminalProcessOwnership(runner, checkout, processGroupId);
-        if (
-          ownership?.parentPid === panePid &&
-          ownership.processGroupId === processGroupId &&
-          ownership.terminalProcessGroupId === processGroupId
-        ) {
-          window.panePid = panePid;
-          window.processGroupId = processGroupId;
-          rmSync(files.processGroup, { force: true });
-          rmSync(files.processGroupTemporary, { force: true });
-          break;
-        }
-      }
-      if (elapsed < TERMINAL_COMMAND_START_TIMEOUT_SECONDS * 10) {
-        requireSuccess("sleep", ["0.1"], runner("sleep", ["0.1"]));
-      }
-    }
-    if (!window.panePid || !window.processGroupId) {
-      throw new Error("terminal command did not publish its owned process group");
-    }
-    const clearHistoryArgs = ["clear-history", "-t", target];
-    requireSuccess("tmux", clearHistoryArgs, runner("tmux", clearHistoryArgs, { cwd: checkout }));
     const captureCommand =
-      `/usr/bin/env -u TMUX -u TMUX_PANE node ${quote(files.captureScript)} ` +
+      `/usr/bin/env -u TMUX -u TMUX_PANE -u TMUX_TMPDIR node ${quote(files.captureScript)} ` +
       [files.capture, files.captureTemporary, files.captureDone, files.captureDoneTemporary]
         .map(quote)
         .join(" ");
@@ -1115,7 +1155,9 @@ function runTerminalCommand(
   for (let elapsed = 0; elapsed <= TERMINAL_COMMAND_START_TIMEOUT_SECONDS; elapsed += 1) {
     const panePid = readTerminalPanePid(runner, checkout, terminalPane);
     if (panePid) {
-      if (panePid !== window.panePid) {
+      if (window.panePid === undefined) {
+        window.panePid = panePid;
+      } else if (panePid !== window.panePid) {
         throw new TerminalCommandExecutionError(
           `terminal pane identity changed from launch pid ${window.panePid} to ${panePid}`,
           window,
@@ -1123,9 +1165,9 @@ function runTerminalCommand(
       }
       try {
         const state = readTerminalCommandState(window, runner, checkout, terminalPane);
-        const readiness = readBoundedTerminalFile(files.ready, 64);
+        const readiness = readBoundedTerminalFile(files.ready, 128);
         if (readiness !== undefined) {
-          if (readiness !== "ready\n") {
+          if (readiness !== `${panePid} ${window.nonce}\n`) {
             throw new Error("terminal command readiness acknowledgement is malformed");
           }
           refreshTerminalCommandOutput(window, runner, checkout, terminalPane);
@@ -1309,8 +1351,8 @@ function finalizeHeldTerminalCommand(
   if (heldState?.status !== "running") {
     throw new Error("held terminal command wrapper exited before controller cleanup");
   }
-  // The wrapper remains the live pane owner until cleanup signals its process
-  // group. The recorded child status is authoritative; pane exit is cleanup.
+  // The wrapper remains the live pane owner until tty-scoped cleanup finishes.
+  // The recorded child status is authoritative; pane exit is cleanup.
   closeTerminalCapture(window, runner, checkout, terminalPane);
   observeTerminalSnapshot(
     window,
@@ -1498,73 +1540,64 @@ function renderFailedTerminalOutput(
   return sections.join("\n\n");
 }
 
-function terminateTerminalProcessGroup(
-  runner: MediaProofCommandRunner,
-  checkout: string,
-  processGroupId: number | undefined,
-): void {
-  if (!processGroupId) return;
-  const signalErrors: unknown[] = [];
-  const runSignal = (signal: "-TERM" | "-KILL") => {
-    try {
-      const result = runner("/bin/kill", [signal, `-${processGroupId}`], { cwd: checkout });
-      if (result.status !== 0) {
-        signalErrors.push(
-          new Error(
-            `/bin/kill ${signal} -${processGroupId} failed: ${mediaProofSpawnDetail(result)}`,
-          ),
-        );
-      }
-    } catch (error) {
-      signalErrors.push(error);
-    }
-  };
-  const processGroupExists = (): boolean => {
-    const result = runner("/bin/kill", ["-0", `-${processGroupId}`], { cwd: checkout });
-    return result.status === 0;
-  };
-  runSignal("-TERM");
-  requireSuccess("sleep", ["0.1"], runner("sleep", ["0.1"]));
-  if (!processGroupExists()) return;
-  runSignal("-KILL");
-  for (let attempt = 0; attempt <= TERMINAL_COMMAND_START_TIMEOUT_SECONDS * 10; attempt += 1) {
-    if (!processGroupExists()) return;
-    if (attempt < TERMINAL_COMMAND_START_TIMEOUT_SECONDS * 10) {
-      requireSuccess("sleep", ["0.1"], runner("sleep", ["0.1"]));
-    }
-  }
-  const surviving = new Error(`terminal process group ${processGroupId} survived SIGKILL`);
-  throw signalErrors.length > 0
-    ? new AggregateError(
-        [...signalErrors, surviving],
-        `failed to clean terminal process group ${processGroupId}`,
-      )
-    : surviving;
-}
-
 function cleanupTerminalWindow(
   window: TerminalOutputWindow,
   terminalPane: string,
   runner: MediaProofCommandRunner,
   checkout: string,
 ): void {
-  if (window.processGroupCleaned) return;
-  const panePid = readTerminalPanePid(runner, checkout, terminalPane);
-  if (!panePid || panePid !== window.panePid || !window.processGroupId) return;
-  const ownership = readTerminalProcessOwnership(runner, checkout, window.processGroupId);
-  if (!ownership) {
-    window.processGroupCleaned = true;
-    return;
+  if (window.paneCleaned) return;
+  if (window.captureOpen) {
+    refreshTerminalCommandOutput(window, runner, checkout, terminalPane);
+    closeTerminalCapture(window, runner, checkout, terminalPane);
   }
-  if (
-    ownership.parentPid !== panePid ||
-    ownership.processGroupId !== window.processGroupId ||
-    ownership.terminalProcessGroupId !== window.processGroupId
-  ) {
-    return;
+  const state = readTerminalPaneState(runner, checkout, terminalPane);
+  if (!state) throw new Error("terminal pane disappeared before controller release");
+  if (window.panePid === undefined || state.pid !== window.panePid) {
+    throw new Error(
+      `terminal pane identity changed from launch pid ${window.panePid ?? "unknown"} to ${state.pid}`,
+    );
   }
-  terminateTerminalProcessGroup(runner, checkout, window.processGroupId);
-  window.processGroupCleaned = true;
+  if (state.status !== "running") {
+    throw new Error("terminal pane wrapper exited before controller release");
+  }
+  window.finalViewport ??= captureTerminalViewport(runner, checkout, terminalPane);
+  writeFileSync(window.files.releaseTemporary, `${state.pid} ${window.nonce}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  renameSync(window.files.releaseTemporary, window.files.release);
+  // The wrapper schedules tty-scoped fixed-point teardown through its private
+  // tmux server. Exact pane death and the matching receipt are both required.
+  let cleanupAcknowledged = false;
+  for (let elapsed = 0; elapsed <= TERMINAL_COMMAND_START_TIMEOUT_SECONDS * 10; elapsed += 1) {
+    const cleanupResult = readBoundedTerminalFile(window.files.cleanupResult, 128);
+    if (cleanupResult !== undefined) {
+      if (cleanupResult !== `${state.pid} ${window.nonce} ok\n`) {
+        throw new Error(`terminal pane cleanup failed: ${cleanupResult.trim() || "empty result"}`);
+      }
+      cleanupAcknowledged = true;
+    }
+    const releasedState = readTerminalPaneState(runner, checkout, terminalPane);
+    if (!releasedState) {
+      throw new Error("terminal pane disappeared before cleanup completion was observed");
+    }
+    if (releasedState.pid !== state.pid) {
+      throw new Error(
+        `terminal pane identity changed during cleanup from ${state.pid} to ${releasedState.pid}`,
+      );
+    }
+    if (releasedState.status === "exited" && cleanupAcknowledged) {
+      window.paneCleaned = true;
+      return;
+    }
+    if (elapsed < TERMINAL_COMMAND_START_TIMEOUT_SECONDS * 10) {
+      requireSuccess("sleep", ["0.1"], runner("sleep", ["0.1"]));
+    }
+  }
+  throw new Error(
+    `terminal pane cleanup did not finish within ${TERMINAL_COMMAND_START_TIMEOUT_SECONDS} seconds`,
+  );
 }
 
 function readTerminalCommandState(
@@ -1615,36 +1648,6 @@ function readTerminalPaneState(
     return { status: "exited", pid, exitStatus: terminalSignalExitStatus(signal) };
   }
   throw new Error("terminal pane status is malformed");
-}
-
-function readTerminalProcessOwnership(
-  runner: MediaProofCommandRunner,
-  checkout: string,
-  processGroupId: number,
-): TerminalProcessOwnership | undefined {
-  const args = ["-o", "ppid=,pgid=,tpgid=", "-p", String(processGroupId)];
-  const result = runner("/bin/ps", args, { cwd: checkout });
-  if (result.status !== 0) return undefined;
-  const match = /^\s*(\d+)\s+(\d+)\s+(\d+)\s*$/.exec(String(result.stdout ?? ""));
-  if (!match) throw new Error("terminal command process ownership is malformed");
-  const parentPid = Number.parseInt(match[1]!, 10);
-  const parsedProcessGroupId = Number.parseInt(match[2]!, 10);
-  const terminalProcessGroupId = Number.parseInt(match[3]!, 10);
-  if (
-    !Number.isSafeInteger(parentPid) ||
-    parentPid <= 0 ||
-    !Number.isSafeInteger(parsedProcessGroupId) ||
-    parsedProcessGroupId <= 0 ||
-    !Number.isSafeInteger(terminalProcessGroupId) ||
-    terminalProcessGroupId <= 0
-  ) {
-    throw new Error("terminal command process ownership is malformed");
-  }
-  return {
-    parentPid,
-    processGroupId: parsedProcessGroupId,
-    terminalProcessGroupId,
-  };
 }
 
 function readTerminalPanePid(

--- a/src/live-proof/drivers.ts
+++ b/src/live-proof/drivers.ts
@@ -1563,12 +1563,8 @@ function cleanupTerminalWindow(
   ) {
     return;
   }
-  try {
-    terminateTerminalProcessGroup(runner, checkout, window.processGroupId);
-    window.processGroupCleaned = true;
-  } catch (error) {
-    throw new AggregateError([error], "failed to clean terminal process group");
-  }
+  terminateTerminalProcessGroup(runner, checkout, window.processGroupId);
+  window.processGroupCleaned = true;
 }
 
 function readTerminalCommandState(

--- a/src/live-proof/execute.ts
+++ b/src/live-proof/execute.ts
@@ -21,7 +21,6 @@ import type { RepositoryProfile } from "../repository-profiles.js";
 import {
   driveBrowser,
   driveTerminal,
-  TERMINAL_OUTPUT_NOT_OBSERVED_DETAIL,
   type LiveProofStepLogEntry,
   liveProofStepActions,
 } from "./drivers.js";
@@ -82,6 +81,9 @@ export async function executeLiveProof(
   }
 
   const plan = readPlan(options, dependencies);
+  if (plan.invalid) {
+    throw new Error(plan.reason);
+  }
   if (plan.status !== "recommended") {
     log(`[live-proof] skip: liveProofPlan status is ${plan.status}`);
     return;
@@ -436,8 +438,7 @@ function demonstratedChange(steps: readonly LiveProofStepLogEntry[]): boolean {
     (step) =>
       (step.action === "expect_text" || step.action === "expect_output") &&
       !step.presentAtStart &&
-      step.satisfied &&
-      step.detail !== TERMINAL_OUTPUT_NOT_OBSERVED_DETAIL,
+      step.satisfied,
   );
 }
 

--- a/src/live-proof/review-artifacts.ts
+++ b/src/live-proof/review-artifacts.ts
@@ -66,6 +66,9 @@ export function inspectReviewLiveProofs(
     const markdown = readFileSync(recordPath, "utf8");
     if (dependencies.frontMatterValue(markdown, "type") !== "pull_request") continue;
     const plan = dependencies.reportLiveProofPlan(markdown);
+    if (plan.invalid) {
+      throw new Error(`live proof plan for ${item} is invalid: ${plan.reason}`);
+    }
     if (plan.status !== "recommended" || plan.surface === "none") continue;
     candidates.push(item);
     recordMedia ||= plan.payoff.kind !== "static_text";

--- a/src/live-proof/verification.ts
+++ b/src/live-proof/verification.ts
@@ -1,11 +1,13 @@
 import type { LiveProofPlan, LiveProofStep } from "../clawsweeper-types.js";
 import type { LiveProofDriveStatus } from "./manifest.js";
-import { TERMINAL_OUTPUT_NOT_OBSERVED_DETAIL, type LiveProofStepLogEntry } from "./drivers.js";
+import type { LiveProofStepLogEntry } from "./drivers.js";
 
 export const LIVE_VERIFICATION_SCHEMA_VERSION = 1;
 export const LIVE_VERIFICATION_OUTPUT_MAX_CHARS = 16_000;
 export const LIVE_VERIFICATION_COMMENT_OUTPUT_MAX_CHARS = 4_000;
 const OUTPUT_TRUNCATION_MARKER = "… output truncated …";
+const LEGACY_TERMINAL_OUTPUT_NOT_OBSERVED_DETAIL =
+  "command exited successfully; expected output was not observed in the captured pane";
 
 export type LiveVerificationStepStatus = "completed" | "failed" | "not_run";
 
@@ -294,31 +296,19 @@ export function renderLiveVerificationCommentBlock(result: LiveVerificationResul
       "**Assertions:**",
       "",
       ...assertions.map((step) => {
-        const outcome =
-          step.status === "completed" && step.satisfied === true
-            ? terminalOutputWasNotObserved(parsed.surface, step)
-              ? "NOT OBSERVED"
-              : "PASS"
-            : "FAIL";
-        const detail = outcome === "NOT OBSERVED" ? ` — ${sanitizeInline(step.detail)}` : "";
+        const passed = step.status === "completed" && step.satisfied === true;
+        const notObserved =
+          passed &&
+          parsed.surface === "terminal" &&
+          step.action === "expect_output" &&
+          step.detail === LEGACY_TERMINAL_OUTPUT_NOT_OBSERVED_DETAIL;
+        const outcome = !passed ? "FAIL" : notObserved ? "NOT OBSERVED" : "PASS";
+        const detail = notObserved ? ` — ${sanitizeInline(step.detail)}` : "";
         return `- ${outcome} \`${sanitizeInline(step.action)}\`: ${sanitizeInline(step.assertion ?? "")}${detail}`;
       }),
     );
   }
   return lines.join("\n");
-}
-
-function terminalOutputWasNotObserved(
-  surface: LiveProofPlan["surface"],
-  step: LiveVerificationStepResult,
-): boolean {
-  return (
-    surface === "terminal" &&
-    step.action === "expect_output" &&
-    step.status === "completed" &&
-    step.satisfied === true &&
-    step.detail === TERMINAL_OUTPUT_NOT_OBSERVED_DETAIL
-  );
 }
 
 export function sanitizeUntrustedOutput(value: string): string {

--- a/test/codex-review-runner.test.ts
+++ b/test/codex-review-runner.test.ts
@@ -853,6 +853,7 @@ test("codex failure decisions expose stderr and stdout separately", () => {
   assert.deepEqual(decision.liveProofPlan, {
     status: "not_applicable",
     surface: "none",
+    terminalCompletion: "not_applicable",
     reason: "Live proof was not assessed because the Codex review failed.",
     payoff: {
       kind: "static_text",

--- a/test/decision-parser.test.ts
+++ b/test/decision-parser.test.ts
@@ -403,6 +403,7 @@ test("decision parser validates typed live-proof plans and report roundtrips", (
   const liveProofPlan = {
     status: "recommended",
     surface: "browser",
+    terminalCompletion: "not_applicable",
     reason: "The changed settings confirmation is visible in the browser.",
     payoff: {
       kind: "ui_interaction",
@@ -431,12 +432,14 @@ test("decision parser validates typed live-proof plans and report roundtrips", (
     { ...liveProofPlan, payoff: { kind: "static_image", justification: "Nothing moves." } },
     { ...liveProofPlan, payoff: { kind: "ui_interaction", justification: "" } },
     { ...liveProofPlan, surface: "none" },
+    { ...liveProofPlan, terminalCompletion: "exit_zero" },
     { ...liveProofPlan, entry: "https://example.com/settings" },
     { ...liveProofPlan, steps: [{ action: "run", command: "pnpm test" }] },
     { ...liveProofPlan, steps: [{ action: "click", target: "text=Save", extra: true }] },
     {
       status: "not_applicable",
       surface: "none",
+      terminalCompletion: "not_applicable",
       reason: "The change is internal plumbing.",
       payoff: {
         kind: "static_text",
@@ -449,12 +452,116 @@ test("decision parser validates typed live-proof plans and report roundtrips", (
   for (const invalidPlan of invalidPlans) {
     assert.throws(() => parseDecision(closeDecision({ liveProofPlan: invalidPlan })), /liveProof/);
   }
+  assert.throws(
+    () =>
+      parseDecision(
+        closeDecision({
+          liveProofPlan: {
+            ...liveProofPlan,
+            surface: "terminal",
+            terminalCompletion: "not_applicable",
+            entry: "pnpm test",
+            steps: [{ action: "expect_output", text: "passed" }],
+          },
+        }),
+      ),
+    /terminalCompletion must identify terminal completion behavior/,
+  );
+  assert.throws(
+    () =>
+      parseDecision(
+        closeDecision({
+          liveProofPlan: {
+            ...liveProofPlan,
+            surface: "terminal",
+            terminalCompletion: "ready_while_running",
+            entry: "pnpm dev",
+            steps: [{ action: "wait", seconds: 1 }],
+          },
+        }),
+      ),
+    /must expect output after the final run for ready_while_running/,
+  );
+  assert.throws(
+    () =>
+      parseDecision(
+        closeDecision({
+          liveProofPlan: {
+            ...liveProofPlan,
+            surface: "terminal",
+            terminalCompletion: "ready_while_running",
+            entry: "pnpm dev",
+            steps: [
+              { action: "expect_output", text: "Ready" },
+              { action: "run", command: "pnpm dev:secondary" },
+            ],
+          },
+        }),
+      ),
+    /must expect output after the final run for ready_while_running/,
+  );
+});
+
+test("report live-proof parsing fails closed when the plan is missing or invalid", () => {
+  for (const markdown of [
+    "## Work Candidate\n\nCandidate: none\n",
+    "## Live Proof\n\nStatus: recommended\n\nSurface: terminal\n\nEntry: pnpm test\n",
+  ]) {
+    const plan = reportLiveProofPlanForTest(markdown);
+    assert.equal(plan.status, "not_applicable");
+    assert.equal(plan.surface, "none");
+    assert.equal(plan.terminalCompletion, "not_applicable");
+    assert.equal(plan.invalid, true);
+    assert.match(plan.reason, /missing or invalid/);
+    assert.match(plan.reason, /regenerate the review report/);
+    assert.equal(plan.entry, "");
+    assert.deepEqual(plan.steps, []);
+  }
+});
+
+test("report live-proof parsing preserves safe legacy plans and rejects ambiguous terminal plans", () => {
+  const browserPlan = {
+    status: "recommended",
+    surface: "browser",
+    terminalCompletion: "not_applicable",
+    reason: "The changed page is visible.",
+    payoff: {
+      kind: "ui_interaction",
+      justification: "The viewer sees the page state after navigation.",
+    },
+    entry: "/settings",
+    steps: [{ action: "expect_text", text: "Saved" }],
+  };
+  const browserSection = renderLiveProofReportSectionForTest(
+    parseDecision(closeDecision({ liveProofPlan: browserPlan })),
+  ).replace(/\nTerminal completion: [^\n]+\n/, "\n");
+  const parsedBrowser = reportLiveProofPlanForTest(
+    `## Live Proof\n\n${browserSection}\n\n## Mantis Recommendation\n`,
+  );
+  assert.deepEqual(parsedBrowser, browserPlan);
+
+  const terminalPlan = {
+    ...browserPlan,
+    surface: "terminal",
+    terminalCompletion: "exit_zero",
+    entry: "pnpm test",
+    steps: [{ action: "expect_output", text: "passed" }],
+  };
+  const terminalSection = renderLiveProofReportSectionForTest(
+    parseDecision(closeDecision({ liveProofPlan: terminalPlan })),
+  ).replace(/\nTerminal completion: [^\n]+\n/, "\n");
+  const parsedTerminal = reportLiveProofPlanForTest(
+    `## Live Proof\n\n${terminalSection}\n\n## Mantis Recommendation\n`,
+  );
+  assert.equal(parsedTerminal.invalid, true);
+  assert.match(parsedTerminal.reason, /regenerate the review report/);
 });
 
 test("decision parser preserves every terminal command including exact entry repeats", () => {
   const terminalPlan = {
     status: "recommended",
     surface: "terminal",
+    terminalCompletion: "exit_zero",
     reason: "The changed CLI output is visible.",
     payoff: {
       kind: "static_text",
@@ -542,6 +649,7 @@ test("decision parser preserves every terminal command including exact entry rep
   const browserPlan = {
     status: "recommended",
     surface: "browser",
+    terminalCompletion: "not_applicable",
     reason: "The changed page is visible.",
     payoff: {
       kind: "ui_interaction",

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -165,6 +165,7 @@ export function closeDecision(overrides = {}) {
     liveProofPlan: {
       status: "not_applicable",
       surface: "none",
+      terminalCompletion: "not_applicable",
       reason: "This non-PR issue triage does not need live proof.",
       payoff: {
         kind: "static_text",

--- a/test/live-proof-review-environment.test.ts
+++ b/test/live-proof-review-environment.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
+import { once } from "node:events";
 import {
   existsSync,
   mkdirSync,
@@ -760,6 +761,97 @@ test(
         processesContaining(processToken).some((line) => line.startsWith(`${backgroundPid} `))
       ) {
         killProcess(backgroundPid);
+      }
+      rmSync(root, { force: true, recursive: true });
+    }
+  },
+);
+
+test(
+  "terminal proof cleanup ignores an unrelated process holding a checkout directory descriptor",
+  { skip: process.platform !== "linux", timeout: 60_000 },
+  async () => {
+    const root = mkdtempSync(join(tmpdir(), "clawsweeper-live-proof-directory-fd-"));
+    const helperPath = join(root, "directory-holder.mjs");
+    writeFileSync(
+      helperPath,
+      [
+        'import { fstatSync } from "node:fs";',
+        "if (!fstatSync(9).isDirectory()) process.exit(2);",
+        "if (process.stdin.isTTY || process.stdout.isTTY || process.stderr.isTTY) process.exit(2);",
+        "process.stdout.write('ready\\n');",
+        "setInterval(() => {}, 1_000);",
+      ].join("\n"),
+    );
+    const checkout = root;
+    const helper = spawn(
+      "/bin/bash",
+      [
+        "--noprofile",
+        "--norc",
+        "-c",
+        'exec 9<"$1" || exit 125\nexec "$2" "$3"',
+        "clawsweeper-directory-holder",
+        checkout,
+        process.execPath,
+        helperPath,
+      ],
+      {
+        detached: true,
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    try {
+      const ready = new Promise<string>((resolveReady, rejectReady) => {
+        const timeout = setTimeout(
+          () => rejectReady(new Error("directory descriptor helper did not become ready")),
+          5_000,
+        );
+        helper.once("error", (error) => {
+          clearTimeout(timeout);
+          rejectReady(error);
+        });
+        helper.once("exit", (code, signal) => {
+          clearTimeout(timeout);
+          rejectReady(
+            new Error(
+              `directory descriptor helper exited before readiness: code=${String(code)} signal=${String(signal)}`,
+            ),
+          );
+        });
+        helper.stdout.once("data", (chunk) => {
+          clearTimeout(timeout);
+          resolveReady(String(chunk));
+        });
+      });
+      assert.equal(await ready, "ready\n");
+      const helperPid = helper.pid;
+      assert.ok(helperPid);
+
+      const result = driveTerminal({
+        plan: {
+          status: "recommended",
+          surface: "terminal",
+          terminalCompletion: "exit_zero",
+          reason: "The command prints a deterministic result.",
+          payoff: { kind: "static_text", justification: "Text is sufficient." },
+          entry: "printf 'directory-fd-ready\\n'",
+          steps: [{ action: "expect_output", text: "directory-fd-ready" }],
+        },
+        checkout,
+        rawVideoPath: join(root, "proof.webm"),
+        maxRecordingSeconds: 90,
+        recordMedia: false,
+        runner: mediaProofCommandRunner,
+      });
+
+      assert.equal(result.status, "completed", result.output);
+      assert.doesNotThrow(() => process.kill(helperPid, 0));
+    } finally {
+      if (helper.exitCode === null && helper.signalCode === null) {
+        const exited = once(helper, "exit");
+        helper.kill("SIGKILL");
+        await exited;
       }
       rmSync(root, { force: true, recursive: true });
     }

--- a/test/live-proof-review-environment.test.ts
+++ b/test/live-proof-review-environment.test.ts
@@ -1,13 +1,16 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import test from "node:test";
 
 import type { LiveProofPlan } from "../dist/clawsweeper-types.js";
+import { mediaProofCommandRunner } from "../dist/clawsweeper-media-proof.js";
+import { driveTerminal } from "../dist/live-proof/drivers.js";
 import {
   executeReviewLiveProofs,
+  inspectReviewLiveProofs,
   reviewLiveProofGoEnvironment,
 } from "../dist/live-proof/review-artifacts.js";
 import { sanitizedLiveProofEnvironment } from "../dist/live-proof/environment.js";
@@ -29,6 +32,62 @@ test("review live proof composes inherited Go environment settings", () => {
   assert.equal(environment.GOMODCACHE, join(profile, "go-mod-cache"));
 });
 
+test("review live proof inspection rejects invalid persisted plans", () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-invalid-live-proof-review-"));
+  const records = join(root, "records");
+  mkdirSync(records);
+  writeFileSync(
+    join(records, "42.md"),
+    "---\ntype: pull_request\n---\n\n## Live Proof\n\nStatus: recommended\n",
+  );
+  try {
+    assert.throws(
+      () =>
+        inspectReviewLiveProofs(
+          { itemNumbers: [42], recordsDir: records, repo: "example/repo" },
+          {
+            frontMatterValue: (markdown, key) =>
+              new RegExp(`^${key}:\\s*(.*)$`, "m").exec(markdown)?.[1]?.trim(),
+            reportLiveProofPlan: () => ({
+              status: "not_applicable",
+              surface: "none",
+              terminalCompletion: "not_applicable",
+              invalid: true,
+              reason:
+                "The live-proof plan is missing or invalid; regenerate the review report before execution.",
+              payoff: {
+                kind: "static_text",
+                justification: "Invalid report plans are non-runnable and fail closed.",
+              },
+              entry: "",
+              steps: [],
+            }),
+            repositoryProfileFor: () => ({
+              targetRepo: "example/repo",
+              slug: "example-repo",
+              displayName: "Example",
+              checkoutDir: "example",
+              packageManager: "pnpm",
+              promptNote: "Example.",
+              applyCloseRules: {},
+              liveTest: {
+                enabled: true,
+                surfaceDefault: "terminal",
+                setup: [],
+                allowInstallScripts: false,
+                readyTimeoutSeconds: 5,
+                maxRecordingSeconds: 90,
+              },
+            }),
+          },
+        ),
+      /live proof plan for 42 is invalid.*regenerate the review report/,
+    );
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
 test(
   "review live proof runs an unsandboxed static plan with a sanitized child environment",
   { timeout: 60_000 },
@@ -42,6 +101,7 @@ test(
     const plan: LiveProofPlan = {
       status: "recommended",
       surface: "terminal",
+      terminalCompletion: "exit_zero",
       reason: "The command prints a deterministic result.",
       payoff: { kind: "static_text", justification: "A recording adds no value." },
       entry:
@@ -72,7 +132,7 @@ test(
       const head = git(target, "rev-parse", "HEAD").trim();
       writeFileSync(
         join(records, "42.md"),
-        `---\nnumber: 42\nrepository: openclaw/sanitized-fixture\ntype: pull_request\npull_head_sha: ${head}\n---\n\n## Live Proof\n\nStatus: recommended\n\nSurface: terminal\n\nReason: The command prints a deterministic result.\n\nPayoff: static_text\n\nPayoff justification: A recording adds no value.\n\nEntry: ${plan.entry}\n\nSteps:\n\n- {"action":"expect_output","text":"sanitized-ready"}\n\n## Work Candidate\n\nCandidate: none\n`,
+        `---\nnumber: 42\nrepository: openclaw/sanitized-fixture\ntype: pull_request\npull_head_sha: ${head}\n---\n\n## Live Proof\n\nStatus: recommended\n\nSurface: terminal\n\nTerminal completion: exit_zero\n\nReason: The command prints a deterministic result.\n\nPayoff: static_text\n\nPayoff justification: A recording adds no value.\n\nEntry: ${plan.entry}\n\nSteps:\n\n- {"action":"expect_output","text":"sanitized-ready"}\n\n## Work Candidate\n\nCandidate: none\n`,
       );
       const logs: string[] = [];
       executeReviewLiveProofs(
@@ -133,6 +193,646 @@ test(
   },
 );
 
+test(
+  "terminal proof cannot pass from package-manager echo before a nonzero exit",
+  { timeout: 30_000 },
+  () => {
+    const root = mkdtempSync(join(tmpdir(), "clawsweeper-live-proof-package-echo-"));
+    try {
+      writeFileSync(
+        join(root, "package.json"),
+        `${JSON.stringify({
+          name: "package-echo-fixture",
+          private: true,
+          scripts: { proof: "node fail.mjs ECHO_ONLY_MARKER" },
+        })}\n`,
+      );
+      writeFileSync(
+        join(root, "fail.mjs"),
+        'process.stderr.write("real command failed\\n"); process.exit(7);\n',
+      );
+      const result = driveTerminal({
+        plan: {
+          status: "recommended",
+          surface: "terminal",
+          terminalCompletion: "exit_zero",
+          reason: "The package script prints a deterministic marker.",
+          payoff: { kind: "static_text", justification: "Text is sufficient." },
+          entry: "pnpm run proof",
+          steps: [{ action: "expect_output", text: "ECHO_ONLY_MARKER" }],
+        },
+        checkout: root,
+        rawVideoPath: join(root, "proof.webm"),
+        maxRecordingSeconds: 90,
+        recordMedia: false,
+        runner: mediaProofCommandRunner,
+      });
+
+      assert.equal(result.status, "failed");
+      assert.equal(result.steps[0]?.status, "failed");
+      assert.match(result.steps[0]?.detail ?? "", /exit status 7/);
+      assert.match(result.output, /\[command 1 combined output\][\s\S]*ECHO_ONLY_MARKER/);
+      assert.match(result.output, /ECHO_ONLY_MARKER[\s\S]*real command failed/);
+      assert.doesNotMatch(result.output, /\[command 1 (?:stdout|stderr)\]/);
+      assert.equal(result.output.match(/real command failed/g)?.length, 1);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  },
+);
+
+test(
+  "terminal proof publishes the clean final viewport across stdout and stderr",
+  { timeout: 30_000 },
+  () => {
+    const root = mkdtempSync(join(tmpdir(), "clawsweeper-live-proof-streams-"));
+    try {
+      writeFileSync(
+        join(root, "help.mjs"),
+        [
+          "for (let index = 1; index <= 75; index += 1) process.stdout.write(`BUILD_WARNING_${index}\\n`);",
+          "for (let index = 1; index <= 59; index += 1) process.stdout.write(`help option ${index}\\n`);",
+          'process.stderr.write("FINAL_HELP_RESULT\\n");',
+        ].join("\n"),
+      );
+      const result = driveTerminal({
+        plan: {
+          status: "recommended",
+          surface: "terminal",
+          terminalCompletion: "exit_zero",
+          reason: "The command prints help after build diagnostics.",
+          payoff: { kind: "static_text", justification: "Text is sufficient." },
+          entry: "node help.mjs",
+          steps: [{ action: "expect_output", text: "FINAL_HELP_RESULT" }],
+        },
+        checkout: root,
+        rawVideoPath: join(root, "proof.webm"),
+        maxRecordingSeconds: 90,
+        recordMedia: false,
+        runner: mediaProofCommandRunner,
+      });
+
+      assert.equal(result.status, "completed", result.output);
+      assert.equal(result.steps[0]?.satisfied, true);
+      assert.match(result.output, /help option 12/);
+      assert.match(result.output, /FINAL_HELP_RESULT/);
+      assert.doesNotMatch(result.output, /BUILD_WARNING_/);
+      assert.equal(result.output.split("\n").length, 50);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  },
+);
+
+test(
+  "terminal proof retains the end of successful output beyond the stream cap",
+  { timeout: 30_000 },
+  () => {
+    const root = mkdtempSync(join(tmpdir(), "clawsweeper-live-proof-tail-"));
+    try {
+      writeFileSync(
+        join(root, "verbose.mjs"),
+        [
+          'process.stdout.write("STALE_PREFIX_0123456789abcdef\\n".repeat(40_000));',
+          "for (let index = 1; index <= 59; index += 1) process.stdout.write(`final option ${index}\\n`);",
+          'process.stdout.write("FINAL_TAIL_RESULT\\n");',
+        ].join("\n"),
+      );
+      const result = driveTerminal({
+        plan: {
+          status: "recommended",
+          surface: "terminal",
+          terminalCompletion: "exit_zero",
+          reason: "The command prints its result after verbose setup output.",
+          payoff: { kind: "static_text", justification: "Text is sufficient." },
+          entry: "node verbose.mjs",
+          steps: [{ action: "expect_output", text: "FINAL_TAIL_RESULT" }],
+        },
+        checkout: root,
+        rawVideoPath: join(root, "tail-proof.webm"),
+        maxRecordingSeconds: 90,
+        recordMedia: false,
+        runner: mediaProofCommandRunner,
+      });
+
+      assert.equal(result.status, "completed");
+      assert.equal(result.steps[0]?.satisfied, true);
+      assert.match(result.output, /final option 12/);
+      assert.match(result.output, /FINAL_TAIL_RESULT/);
+      assert.doesNotMatch(result.output, /STALE_PREFIX/);
+      assert.equal(result.output.split("\n").length, 50);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  },
+);
+
+test(
+  "terminal proof preserves an observed marker after later history eviction",
+  { timeout: 30_000 },
+  () => {
+    const root = mkdtempSync(join(tmpdir(), "clawsweeper-live-proof-observed-"));
+    try {
+      writeFileSync(
+        join(root, "evict-marker.mjs"),
+        [
+          'process.stdout.write("\\u001b[32mEARLY_OBSERVED\\u001b[0m\\nMARKER\\n");',
+          "await new Promise((resolve) => setTimeout(resolve, 1_100));",
+          'process.stdout.write("EVICTING_OUTPUT_0123456789abcdef\\n".repeat(60_000));',
+          "for (let index = 1; index <= 59; index += 1) process.stdout.write(`final result ${index}\\n`);",
+          'process.stdout.write("FINAL_AFTER_EVICTION\\n");',
+        ].join("\n"),
+      );
+      const result = driveTerminal({
+        plan: {
+          status: "recommended",
+          surface: "terminal",
+          terminalCompletion: "exit_zero",
+          reason: "The command prints an early marker before verbose final output.",
+          payoff: { kind: "static_text", justification: "Text is sufficient." },
+          entry: "node evict-marker.mjs",
+          steps: [{ action: "expect_output", text: "EARLY_OBSERVED\nMARKER" }],
+        },
+        checkout: root,
+        rawVideoPath: join(root, "proof.webm"),
+        maxRecordingSeconds: 90,
+        recordMedia: false,
+        runner: mediaProofCommandRunner,
+      });
+
+      assert.equal(result.status, "completed", result.output);
+      assert.equal(result.steps[0]?.satisfied, true);
+      assert.doesNotMatch(result.output, /EARLY_OBSERVED|MARKER|EVICTING_OUTPUT_/);
+      assert.match(result.output, /final result 12/);
+      assert.match(result.output, /FINAL_AFTER_EVICTION/);
+      assert.equal(result.output.split("\n").length, 50);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  },
+);
+
+test(
+  "terminal proof retains a burst marker beyond the default tmux history",
+  { timeout: 30_000 },
+  () => {
+    const root = mkdtempSync(join(tmpdir(), "clawsweeper-live-proof-history-"));
+    try {
+      writeFileSync(
+        join(root, "history-burst.mjs"),
+        [
+          'process.stdout.write("EARLY_BURST_MARKER\\n");',
+          'process.stdout.write("BURST_LINE\\n".repeat(3_000));',
+          'process.stdout.write("FINAL_BURST_RESULT\\n");',
+        ].join("\n"),
+      );
+      const result = driveTerminal({
+        plan: {
+          status: "recommended",
+          surface: "terminal",
+          terminalCompletion: "exit_zero",
+          reason: "The command emits its marker before a burst larger than tmux's default history.",
+          payoff: { kind: "static_text", justification: "Text is sufficient." },
+          entry: "node history-burst.mjs",
+          steps: [{ action: "expect_output", text: "EARLY_BURST_MARKER" }],
+        },
+        checkout: root,
+        rawVideoPath: join(root, "proof.webm"),
+        maxRecordingSeconds: 90,
+        recordMedia: false,
+        runner: mediaProofCommandRunner,
+      });
+
+      assert.equal(result.status, "completed", result.output);
+      assert.equal(result.steps[0]?.satisfied, true);
+      assert.match(result.output, /FINAL_BURST_RESULT/);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  },
+);
+
+test(
+  "terminal proof preserves its PTY and seals immediate mixed-stream output in order",
+  { timeout: 30_000 },
+  () => {
+    const root = mkdtempSync(join(tmpdir(), "clawsweeper-live-proof-pty-"));
+    try {
+      const result = driveTerminal({
+        plan: {
+          status: "recommended",
+          surface: "terminal",
+          terminalCompletion: "exit_zero",
+          reason: "The command requires a real controlling terminal.",
+          payoff: { kind: "static_text", justification: "Text is sufficient." },
+          entry:
+            "test -t 0 && test -t 1 && test -t 2 && " +
+            "printf 'TTY_WRITE\\n' >/dev/tty && " +
+            "printf 'OUT_ONE\\n'; printf 'ERR_TWO\\n' >&2; printf 'IMMEDIATE_FINAL\\n'",
+          steps: [{ action: "expect_output", text: "IMMEDIATE_FINAL" }],
+        },
+        checkout: root,
+        rawVideoPath: join(root, "proof.webm"),
+        maxRecordingSeconds: 90,
+        recordMedia: false,
+        runner: mediaProofCommandRunner,
+      });
+
+      assert.equal(result.status, "completed", result.output);
+      assert.equal(result.steps[0]?.satisfied, true);
+      assert.match(result.output, /TTY_WRITE/);
+      assert.ok(result.output.indexOf("OUT_ONE") < result.output.indexOf("ERR_TWO"));
+      assert.ok(result.output.indexOf("ERR_TWO") < result.output.indexOf("IMMEDIATE_FINAL"));
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  },
+);
+
+test(
+  "terminal proof preserves direct /dev/tty output through held cutover",
+  { timeout: 30_000 },
+  () => {
+    const root = mkdtempSync(join(tmpdir(), "clawsweeper-live-proof-dev-tty-"));
+    try {
+      const result = driveTerminal({
+        plan: {
+          status: "recommended",
+          surface: "terminal",
+          terminalCompletion: "exit_zero",
+          reason: "The command requires a real PTY and writes its result directly to the terminal.",
+          payoff: { kind: "static_text", justification: "Text is sufficient." },
+          entry: "test -t 0 && test -t 1 && test -t 2 && printf 'TTY_READY\\n' >/dev/tty",
+          steps: [{ action: "expect_output", text: "TTY_READY" }],
+        },
+        checkout: root,
+        rawVideoPath: join(root, "proof.webm"),
+        maxRecordingSeconds: 90,
+        recordMedia: false,
+        runner: mediaProofCommandRunner,
+      });
+
+      assert.equal(result.status, "completed", result.output);
+      assert.equal(result.steps[0]?.satisfied, true);
+      assert.match(result.output, /TTY_READY/);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  },
+);
+
+test("terminal proof executes extglob enabled inside the command file", { timeout: 30_000 }, () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-live-proof-extglob-"));
+  try {
+    const result = driveTerminal({
+      plan: {
+        status: "recommended",
+        surface: "terminal",
+        terminalCompletion: "exit_zero",
+        reason: "The command enables Bash extended glob syntax at runtime.",
+        payoff: { kind: "static_text", justification: "Text is sufficient." },
+        entry: "shopt -s extglob\nvalue=proof\n[[ $value == +(proof) ]]\nprintf 'EXTGLOB_READY\\n'",
+        steps: [{ action: "expect_output", text: "EXTGLOB_READY" }],
+      },
+      checkout: root,
+      rawVideoPath: join(root, "proof.webm"),
+      maxRecordingSeconds: 90,
+      recordMedia: false,
+      runner: mediaProofCommandRunner,
+    });
+
+    assert.equal(result.status, "completed", result.output);
+    assert.match(result.output, /EXTGLOB_READY/);
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+test(
+  "terminal proof isolates tmux control variables from the target command",
+  { timeout: 30_000 },
+  () => {
+    const root = mkdtempSync(join(tmpdir(), "clawsweeper-live-proof-tmux-env-"));
+    try {
+      const result = driveTerminal({
+        plan: {
+          status: "recommended",
+          surface: "terminal",
+          terminalCompletion: "exit_zero",
+          reason: "The target command must not inherit ClawSweeper's tmux control session.",
+          payoff: { kind: "static_text", justification: "Text is sufficient." },
+          entry: 'test -z "${TMUX-}" && test -z "${TMUX_PANE-}" && printf \'TMUX_ENV_CLEAN\\n\'',
+          steps: [{ action: "expect_output", text: "TMUX_ENV_CLEAN" }],
+        },
+        checkout: root,
+        rawVideoPath: join(root, "proof.webm"),
+        maxRecordingSeconds: 90,
+        recordMedia: false,
+        runner: mediaProofCommandRunner,
+      });
+
+      assert.equal(result.status, "completed", result.output);
+      assert.match(result.output, /TMUX_ENV_CLEAN/);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  },
+);
+
+test(
+  "terminal proof publishes tmux-rendered clear, erase, overwrite, cursor, and reset states",
+  { timeout: 60_000 },
+  () => {
+    const root = mkdtempSync(join(tmpdir(), "clawsweeper-live-proof-viewport-"));
+    try {
+      for (const [name, entry, expected, stale] of [
+        [
+          "clear",
+          "printf 'STALE_BEFORE_CLEAR\\n\\033[2J\\033[HFINAL_CLEAR\\n'",
+          "FINAL_CLEAR",
+          "STALE_BEFORE_CLEAR",
+        ],
+        [
+          "erase-line",
+          "printf 'STALE_ERASE\\r\\033[2KFINAL_ERASE\\n'",
+          "FINAL_ERASE",
+          "STALE_ERASE",
+        ],
+        ["carriage-return", "printf 'STALE\\rFINAL\\n'", "FINAL", "STALE"],
+        [
+          "cursor-move",
+          "printf 'STALE_CURSOR\\nKEEP\\n\\033[2A\\033[2KFINAL_CURSOR\\n'",
+          "FINAL_CURSOR",
+          "STALE_CURSOR",
+        ],
+        ["reset", "printf 'STALE_RESET\\n\\033cFINAL_RESET\\n'", "FINAL_RESET", "STALE_RESET"],
+      ] as const) {
+        const result = driveTerminal({
+          plan: {
+            status: "recommended",
+            surface: "terminal",
+            terminalCompletion: "exit_zero",
+            reason: `The final ${name} state replaces transient output.`,
+            payoff: { kind: "static_text", justification: "Text is sufficient." },
+            entry,
+            steps: [{ action: "expect_output", text: expected }],
+          },
+          checkout: root,
+          rawVideoPath: join(root, `${name}.webm`),
+          maxRecordingSeconds: 90,
+          recordMedia: false,
+          runner: mediaProofCommandRunner,
+        });
+
+        assert.equal(result.status, "completed", `${name}: ${result.output}`);
+        assert.match(result.output, new RegExp(expected));
+        assert.doesNotMatch(result.output, new RegExp(stale));
+      }
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  },
+);
+
+test(
+  "terminal proof cleanup terminates a background process in the pane group",
+  { timeout: 30_000 },
+  () => {
+    const root = mkdtempSync(join(tmpdir(), "clawsweeper-live-proof-cleanup-"));
+    const rawVideoPath = join(root, `cleanup-${process.pid}-${Date.now()}.webm`);
+    const processToken = `clawsweeper-proof-child-${process.pid}-${Date.now()}`;
+    try {
+      writeFileSync(
+        join(root, "background.mjs"),
+        [
+          'import { writeFileSync } from "node:fs";',
+          'writeFileSync("background.pid", String(process.pid));',
+          "setTimeout(() => process.exit(0), 10_000);",
+          "setInterval(() => {}, 1_000);",
+        ].join("\n"),
+      );
+      const result = driveTerminal({
+        plan: {
+          status: "recommended",
+          surface: "terminal",
+          terminalCompletion: "exit_zero",
+          reason: "The command exits successfully after printing its result.",
+          payoff: { kind: "static_text", justification: "Text is sufficient." },
+          entry:
+            `node background.mjs ${processToken} >/dev/null 2>&1 & ` +
+            "while [ ! -s background.pid ]; do sleep 0.01; done; printf 'cleanup-ready\\n'",
+          steps: [{ action: "expect_output", text: "cleanup-ready" }],
+        },
+        checkout: root,
+        rawVideoPath,
+        maxRecordingSeconds: 90,
+        recordMedia: false,
+        runner: mediaProofCommandRunner,
+      });
+
+      assert.equal(result.status, "completed");
+      const backgroundPid = Number.parseInt(readFileSync(join(root, "background.pid"), "utf8"), 10);
+      assert.equal(Number.isSafeInteger(backgroundPid), true);
+      let matches = processesContaining(processToken);
+      const deadline = Date.now() + 2_000;
+      while (matches.length > 0 && Date.now() < deadline) {
+        execFileSync("sleep", ["0.05"]);
+        matches = processesContaining(processToken);
+      }
+      assert.deepEqual(matches, []);
+      assert.throws(() => process.kill(backgroundPid, 0), { code: "ESRCH" });
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  },
+);
+
+test(
+  "non-recorded ready proof rejects a command that exits during the stability hold",
+  { timeout: 30_000 },
+  () => {
+    const root = mkdtempSync(join(tmpdir(), "clawsweeper-live-proof-ready-stability-"));
+    try {
+      writeFileSync(
+        join(root, "short-server.mjs"),
+        "console.log('READY_MARKER'); setTimeout(() => process.exit(7), 2_000);\n",
+      );
+      const result = driveTerminal({
+        plan: {
+          status: "recommended",
+          surface: "terminal",
+          terminalCompletion: "ready_while_running",
+          reason: "The server must remain live after reporting readiness.",
+          payoff: { kind: "static_text", justification: "Text is sufficient." },
+          entry: "node short-server.mjs",
+          steps: [{ action: "expect_output", text: "READY_MARKER" }],
+        },
+        checkout: root,
+        rawVideoPath: join(root, "proof.webm"),
+        maxRecordingSeconds: 90,
+        recordMedia: false,
+        runner: mediaProofCommandRunner,
+      });
+
+      assert.equal(result.status, "failed");
+      assert.match(result.steps[0]?.detail ?? "", /exit status 7/);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  },
+);
+
+test(
+  "terminal proof stays pinned to its original pane after another window is selected",
+  { timeout: 30_000 },
+  () => {
+    const root = mkdtempSync(join(tmpdir(), "clawsweeper-live-proof-window-"));
+    const rawVideoPath = join(root, "window-proof.webm");
+    const processToken = `clawsweeper-proof-window-${process.pid}-${Date.now()}`;
+    try {
+      writeFileSync(
+        join(root, "linger.mjs"),
+        [
+          'import { writeFileSync } from "node:fs";',
+          "const [pidPath] = process.argv.slice(2);",
+          "writeFileSync(pidPath, String(process.pid));",
+          "setInterval(() => {}, 1_000);",
+        ].join("\n"),
+      );
+      const result = driveTerminal({
+        plan: {
+          status: "recommended",
+          surface: "terminal",
+          terminalCompletion: "exit_zero",
+          reason: "The command changes the selected tmux window before producing its result.",
+          payoff: { kind: "static_text", justification: "Text is sufficient." },
+          entry: [
+            "terminal_session=$(tmux display-message -p '#S')",
+            "printf '%s' \"$terminal_session\" > terminal.session",
+            `node linger.mjs original.pid ${processToken} >/dev/null 2>&1 &`,
+            "while [ ! -s original.pid ]; do sleep 0.01; done",
+            `tmux new-window -d -t "$terminal_session:" -n diversion "node linger.mjs diversion.pid ${processToken}"`,
+            "while [ ! -s diversion.pid ]; do sleep 0.01; done",
+            `tmux select-window -t "$terminal_session:diversion"`,
+            "printf 'original-pane-ready\\n'",
+          ].join("\n"),
+          steps: [{ action: "expect_output", text: "original-pane-ready" }],
+        },
+        checkout: root,
+        rawVideoPath,
+        maxRecordingSeconds: 90,
+        recordMedia: false,
+        runner: mediaProofCommandRunner,
+      });
+
+      assert.equal(result.status, "completed", result.output);
+      assert.equal(result.steps[0]?.satisfied, true);
+      assert.match(result.output, /original-pane-ready/);
+
+      const terminalSession = readFileSync(join(root, "terminal.session"), "utf8");
+      const originalPid = Number.parseInt(readFileSync(join(root, "original.pid"), "utf8"), 10);
+      const diversionPid = Number.parseInt(readFileSync(join(root, "diversion.pid"), "utf8"), 10);
+      let matches = processesContaining(processToken);
+      const deadline = Date.now() + 2_000;
+      while (matches.length > 0 && Date.now() < deadline) {
+        execFileSync("sleep", ["0.05"]);
+        matches = processesContaining(processToken);
+      }
+      assert.deepEqual(matches, []);
+      assert.throws(() => process.kill(originalPid, 0), { code: "ESRCH" });
+      assert.throws(() => process.kill(diversionPid, 0), { code: "ESRCH" });
+      assert.throws(() =>
+        execFileSync("tmux", ["has-session", "-t", terminalSession], { stdio: "ignore" }),
+      );
+      assert.deepEqual(
+        readdirSync(root).filter((name) => name.startsWith("window-proof.webm.")),
+        [],
+      );
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  },
+);
+
+test("terminal proof supervises consecutive commands in the same pane", { timeout: 30_000 }, () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-live-proof-consecutive-"));
+  try {
+    const result = driveTerminal({
+      plan: {
+        status: "recommended",
+        surface: "terminal",
+        terminalCompletion: "exit_zero",
+        reason: "Each proof command must complete and preserve its own output.",
+        payoff: { kind: "static_text", justification: "Text is sufficient." },
+        entry: "printf 'FIRST_OK\\n'",
+        steps: [
+          { action: "expect_output", text: "FIRST_OK" },
+          { action: "run", command: "printf 'SECOND_OK\\n'" },
+          { action: "expect_output", text: "SECOND_OK" },
+        ],
+      },
+      checkout: root,
+      rawVideoPath: join(root, "proof.webm"),
+      maxRecordingSeconds: 90,
+      recordMedia: false,
+      runner: mediaProofCommandRunner,
+    });
+
+    assert.equal(result.status, "completed", result.output);
+    assert.deepEqual(
+      result.steps.map((step) => step.status),
+      ["completed", "completed", "completed"],
+    );
+    assert.match(result.output, /SECOND_OK/);
+    assert.doesNotMatch(result.output, /FIRST_OK/);
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+test(
+  "terminal proof does not satisfy a command from the previous pane state",
+  { timeout: 30_000 },
+  () => {
+    const root = mkdtempSync(join(tmpdir(), "clawsweeper-live-proof-stale-pane-"));
+    try {
+      const result = driveTerminal({
+        plan: {
+          status: "recommended",
+          surface: "terminal",
+          terminalCompletion: "exit_zero",
+          reason: "Each command must satisfy assertions from its own rendered output.",
+          payoff: { kind: "static_text", justification: "Text is sufficient." },
+          entry: "printf 'STALE_FROM_FIRST\\n'",
+          steps: [
+            { action: "run", command: "printf 'SECOND_ONLY\\n'" },
+            { action: "expect_output", text: "STALE_FROM_FIRST" },
+          ],
+        },
+        checkout: root,
+        rawVideoPath: join(root, "proof.webm"),
+        maxRecordingSeconds: 90,
+        recordMedia: false,
+        runner: mediaProofCommandRunner,
+      });
+
+      assert.equal(result.status, "partial", result.output);
+      assert.equal(result.steps[1]?.satisfied, false);
+      assert.match(result.output, /SECOND_ONLY/);
+      assert.match(result.output, /before expected output appeared: "STALE_FROM_FIRST"/);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  },
+);
+
 function git(cwd: string, ...args: string[]): string {
   return execFileSync("git", args, { cwd, encoding: "utf8" });
+}
+
+function processesContaining(fragment: string): string[] {
+  return execFileSync("ps", ["-axo", "pid=,args="], { encoding: "utf8" })
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.includes(fragment));
 }

--- a/test/live-proof-review-environment.test.ts
+++ b/test/live-proof-review-environment.test.ts
@@ -1,11 +1,19 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import test from "node:test";
 
-import type { LiveProofPlan } from "../dist/clawsweeper-types.js";
+import type { LiveProofPlan, MediaProofCommandRunner } from "../dist/clawsweeper-types.js";
 import { mediaProofCommandRunner } from "../dist/clawsweeper-media-proof.js";
 import { driveTerminal } from "../dist/live-proof/drivers.js";
 import {
@@ -218,7 +226,7 @@ test(
           terminalCompletion: "exit_zero",
           reason: "The package script prints a deterministic marker.",
           payoff: { kind: "static_text", justification: "Text is sufficient." },
-          entry: "pnpm run proof",
+          entry: "CI=1 pnpm --reporter=append-only run proof",
           steps: [{ action: "expect_output", text: "ECHO_ONLY_MARKER" }],
         },
         checkout: root,
@@ -521,7 +529,8 @@ test(
           terminalCompletion: "exit_zero",
           reason: "The target command must not inherit ClawSweeper's tmux control session.",
           payoff: { kind: "static_text", justification: "Text is sufficient." },
-          entry: 'test -z "${TMUX-}" && test -z "${TMUX_PANE-}" && printf \'TMUX_ENV_CLEAN\\n\'',
+          entry:
+            'test -z "${TMUX-}" && test -z "${TMUX_PANE-}" && test -z "${TMUX_TMPDIR-}" && printf \'TMUX_ENV_CLEAN\\n\'',
           steps: [{ action: "expect_output", text: "TMUX_ENV_CLEAN" }],
         },
         checkout: root,
@@ -595,54 +604,76 @@ test(
 );
 
 test(
-  "terminal proof cleanup terminates a signal-resistant background process in the owned group",
-  { timeout: 30_000 },
+  "terminal proof cleanup terminates a signal-resistant descendant in a distinct process group",
+  { timeout: 60_000 },
   () => {
     const root = mkdtempSync(join(tmpdir(), "clawsweeper-live-proof-cleanup-"));
-    const rawVideoPath = join(root, `cleanup-${process.pid}-${Date.now()}.webm`);
-    const processToken = `clawsweeper-proof-child-${process.pid}-${Date.now()}`;
     try {
       writeFileSync(
         join(root, "background.mjs"),
         [
           'import { writeFileSync } from "node:fs";',
-          'writeFileSync("background.pid", String(process.pid));',
+          "const [pidPath] = process.argv.slice(2);",
+          "writeFileSync(pidPath, String(process.pid));",
           'process.on("SIGHUP", () => {});',
           'process.on("SIGTERM", () => {});',
-          "setTimeout(() => process.exit(0), 10_000);",
           "setInterval(() => {}, 1_000);",
         ].join("\n"),
       );
-      const result = driveTerminal({
-        plan: {
-          status: "recommended",
-          surface: "terminal",
-          terminalCompletion: "exit_zero",
-          reason: "The command exits successfully after printing its result.",
-          payoff: { kind: "static_text", justification: "Text is sufficient." },
-          entry:
-            `node background.mjs ${processToken} >/dev/null 2>&1 & ` +
-            "while [ ! -s background.pid ]; do sleep 0.01; done; printf 'cleanup-ready\\n'",
-          steps: [{ action: "expect_output", text: "cleanup-ready" }],
-        },
-        checkout: root,
-        rawVideoPath,
-        maxRecordingSeconds: 90,
-        recordMedia: false,
-        runner: mediaProofCommandRunner,
-      });
+      for (const terminalCompletion of ["exit_zero", "ready_while_running"] as const) {
+        const pidPath = `${terminalCompletion}.pid`;
+        const shellGroupPath = `${terminalCompletion}.shell-pgid`;
+        const childGroupPath = `${terminalCompletion}.child-pgid`;
+        const processToken = `clawsweeper-proof-child-${terminalCompletion}-${process.pid}-${Date.now()}`;
+        const entry = [
+          "set -m",
+          `node background.mjs ${pidPath} ${processToken} >/dev/null 2>&1 &`,
+          "child=$!",
+          `while [ ! -s ${pidPath} ]; do sleep 0.01; done`,
+          `/bin/ps -o pgid= -p "$$" | /usr/bin/tr -d '[:space:]' >${shellGroupPath}`,
+          `/bin/ps -o pgid= -p "$child" | /usr/bin/tr -d '[:space:]' >${childGroupPath}`,
+          "printf 'cleanup-ready\\n'",
+          ...(terminalCompletion === "ready_while_running" ? ["while :; do sleep 1; done"] : []),
+        ].join("\n");
+        const result = driveTerminal({
+          plan: {
+            status: "recommended",
+            surface: "terminal",
+            terminalCompletion,
+            reason:
+              terminalCompletion === "exit_zero"
+                ? "The command exits successfully after printing its result."
+                : "The command remains live after printing its readiness result.",
+            payoff: { kind: "static_text", justification: "Text is sufficient." },
+            entry,
+            steps: [{ action: "expect_output", text: "cleanup-ready" }],
+          },
+          checkout: root,
+          rawVideoPath: join(root, `${terminalCompletion}.webm`),
+          maxRecordingSeconds: 90,
+          recordMedia: false,
+          runner: mediaProofCommandRunner,
+        });
 
-      assert.equal(result.status, "completed");
-      const backgroundPid = Number.parseInt(readFileSync(join(root, "background.pid"), "utf8"), 10);
-      assert.equal(Number.isSafeInteger(backgroundPid), true);
-      let matches = processesContaining(processToken);
-      const deadline = Date.now() + 2_000;
-      while (matches.length > 0 && Date.now() < deadline) {
-        execFileSync("sleep", ["0.05"]);
-        matches = processesContaining(processToken);
+        assert.equal(result.status, "completed", `${terminalCompletion}: ${result.output}`);
+        const backgroundPid = Number.parseInt(readFileSync(join(root, pidPath), "utf8"), 10);
+        const shellGroup = readFileSync(join(root, shellGroupPath), "utf8");
+        const childGroup = readFileSync(join(root, childGroupPath), "utf8");
+        assert.equal(Number.isSafeInteger(backgroundPid), true);
+        assert.notEqual(
+          childGroup,
+          shellGroup,
+          `${terminalCompletion} did not create a distinct PGID`,
+        );
+        let matches = processesContaining(processToken);
+        const deadline = Date.now() + 2_000;
+        while (matches.length > 0 && Date.now() < deadline) {
+          execFileSync("sleep", ["0.05"]);
+          matches = processesContaining(processToken);
+        }
+        assert.deepEqual(matches, []);
+        assert.throws(() => process.kill(backgroundPid, 0), { code: "ESRCH" });
       }
-      assert.deepEqual(matches, []);
-      assert.throws(() => process.kill(backgroundPid, 0), { code: "ESRCH" });
     } finally {
       rmSync(root, { force: true, recursive: true });
     }
@@ -691,6 +722,8 @@ test(
     const root = mkdtempSync(join(tmpdir(), "clawsweeper-live-proof-window-"));
     const rawVideoPath = join(root, "window-proof.webm");
     const processToken = `clawsweeper-proof-window-${process.pid}-${Date.now()}`;
+    let terminalSession = "";
+    let privateTmuxEnvironment: NodeJS.ProcessEnv | undefined;
     try {
       writeFileSync(
         join(root, "linger.mjs"),
@@ -701,21 +734,61 @@ test(
           "setInterval(() => {}, 1_000);",
         ].join("\n"),
       );
+      let diversionCreated = false;
+      const runner: MediaProofCommandRunner = (command, args, options = {}) => {
+        const result = mediaProofCommandRunner(command, args, options);
+        if (
+          !diversionCreated &&
+          command === "tmux" &&
+          args[0] === "capture-pane" &&
+          String(result.stdout ?? "").includes("original-pane-ready")
+        ) {
+          const target = String(args[args.indexOf("-t") + 1] ?? "");
+          terminalSession = target.slice(0, target.indexOf(":"));
+          privateTmuxEnvironment = { ...options.env };
+          assert.ok(terminalSession);
+          assert.ok(privateTmuxEnvironment.TMUX_TMPDIR);
+          const create = mediaProofCommandRunner(
+            "tmux",
+            [
+              "new-window",
+              "-d",
+              "-t",
+              `${terminalSession}:`,
+              "-n",
+              "diversion",
+              "-c",
+              root,
+              `node linger.mjs diversion.pid ${processToken}`,
+            ],
+            { cwd: root, env: privateTmuxEnvironment },
+          );
+          assert.equal(create.status, 0, String(create.stderr ?? create.error ?? ""));
+          const deadline = Date.now() + 2_000;
+          while (!existsSync(join(root, "diversion.pid")) && Date.now() < deadline) {
+            execFileSync("sleep", ["0.05"]);
+          }
+          assert.equal(existsSync(join(root, "diversion.pid")), true);
+          const select = mediaProofCommandRunner(
+            "tmux",
+            ["select-window", "-t", `${terminalSession}:diversion`],
+            { cwd: root, env: privateTmuxEnvironment },
+          );
+          assert.equal(select.status, 0, String(select.stderr ?? select.error ?? ""));
+          diversionCreated = true;
+        }
+        return result;
+      };
       const result = driveTerminal({
         plan: {
           status: "recommended",
           surface: "terminal",
           terminalCompletion: "exit_zero",
-          reason: "The command changes the selected tmux window before producing its result.",
+          reason: "The controller changes the selected tmux window after observing target output.",
           payoff: { kind: "static_text", justification: "Text is sufficient." },
           entry: [
-            "terminal_session=$(tmux display-message -p '#S')",
-            "printf '%s' \"$terminal_session\" > terminal.session",
             `node linger.mjs original.pid ${processToken} >/dev/null 2>&1 &`,
             "while [ ! -s original.pid ]; do sleep 0.01; done",
-            `tmux new-window -d -t "$terminal_session:" -n diversion "node linger.mjs diversion.pid ${processToken}"`,
-            "while [ ! -s diversion.pid ]; do sleep 0.01; done",
-            `tmux select-window -t "$terminal_session:diversion"`,
             "printf 'original-pane-ready\\n'",
           ].join("\n"),
           steps: [{ action: "expect_output", text: "original-pane-ready" }],
@@ -724,14 +797,14 @@ test(
         rawVideoPath,
         maxRecordingSeconds: 90,
         recordMedia: false,
-        runner: mediaProofCommandRunner,
+        runner,
       });
 
       assert.equal(result.status, "completed", result.output);
       assert.equal(result.steps[0]?.satisfied, true);
       assert.match(result.output, /original-pane-ready/);
+      assert.equal(diversionCreated, true);
 
-      const terminalSession = readFileSync(join(root, "terminal.session"), "utf8");
       const originalPid = Number.parseInt(readFileSync(join(root, "original.pid"), "utf8"), 10);
       const diversionPid = Number.parseInt(readFileSync(join(root, "diversion.pid"), "utf8"), 10);
       let matches = processesContaining(processToken);
@@ -743,8 +816,12 @@ test(
       assert.deepEqual(matches, []);
       assert.throws(() => process.kill(originalPid, 0), { code: "ESRCH" });
       assert.throws(() => process.kill(diversionPid, 0), { code: "ESRCH" });
-      assert.throws(() =>
-        execFileSync("tmux", ["has-session", "-t", terminalSession], { stdio: "ignore" }),
+      assert.notEqual(
+        mediaProofCommandRunner("tmux", ["has-session", "-t", terminalSession], {
+          cwd: root,
+          env: privateTmuxEnvironment,
+        }).status,
+        0,
       );
       assert.deepEqual(
         readdirSync(root).filter((name) => name.startsWith("window-proof.webm.")),

--- a/test/live-proof-review-environment.test.ts
+++ b/test/live-proof-review-environment.test.ts
@@ -595,7 +595,7 @@ test(
 );
 
 test(
-  "terminal proof cleanup terminates a background process in the pane group",
+  "terminal proof cleanup terminates a signal-resistant background process in the owned group",
   { timeout: 30_000 },
   () => {
     const root = mkdtempSync(join(tmpdir(), "clawsweeper-live-proof-cleanup-"));
@@ -607,6 +607,8 @@ test(
         [
           'import { writeFileSync } from "node:fs";',
           'writeFileSync("background.pid", String(process.pid));',
+          'process.on("SIGHUP", () => {});',
+          'process.on("SIGTERM", () => {});',
           "setTimeout(() => process.exit(0), 10_000);",
           "setInterval(() => {}, 1_000);",
         ].join("\n"),

--- a/test/live-proof-review-environment.test.ts
+++ b/test/live-proof-review-environment.test.ts
@@ -681,6 +681,96 @@ test(
 );
 
 test(
+  "terminal proof cleanup survives target-triggered pane wrapper death",
+  { timeout: 60_000 },
+  () => {
+    const root = mkdtempSync(join(tmpdir(), "clawsweeper-live-proof-wrapper-death-"));
+    let backgroundPid: number | undefined;
+    let processToken = "";
+    const pidPath = "wrapper-death.pid";
+    try {
+      const shellGroupPath = "wrapper-death.shell-pgid";
+      const childGroupPath = "wrapper-death.child-pgid";
+      processToken = `clawsweeper-proof-wrapper-death-${process.pid}-${Date.now()}`;
+      writeFileSync(
+        join(root, "background.mjs"),
+        [
+          'import { writeFileSync } from "node:fs";',
+          "const [pidPath] = process.argv.slice(2);",
+          "writeFileSync(pidPath, String(process.pid));",
+          'process.on("SIGHUP", () => {});',
+          'process.on("SIGTERM", () => {});',
+          "setInterval(() => {}, 1_000);",
+        ].join("\n"),
+      );
+      const entry = [
+        "set -m",
+        `node background.mjs ${pidPath} ${processToken} >/dev/null 2>&1 &`,
+        "child=$!",
+        `while [ ! -s ${pidPath} ]; do sleep 0.01; done`,
+        `/bin/ps -o pgid= -p "$$" | /usr/bin/tr -d '[:space:]' >${shellGroupPath}`,
+        `/bin/ps -o pgid= -p "$child" | /usr/bin/tr -d '[:space:]' >${childGroupPath}`,
+        'pane_wrapper=$(/bin/ps -o ppid= -p "$PPID" | /usr/bin/tr -d "[:space:]")',
+        'case "$pane_wrapper" in ""|*[!0-9]*) exit 125 ;; esac',
+        "printf 'wrapper-death-ready\\n'",
+        "sleep 1",
+        '/bin/kill -KILL "$pane_wrapper"',
+        "while :; do sleep 1; done",
+      ].join("\n");
+      const result = driveTerminal({
+        plan: {
+          status: "recommended",
+          surface: "terminal",
+          terminalCompletion: "ready_while_running",
+          reason: "The command remains live after reporting readiness.",
+          payoff: { kind: "static_text", justification: "Text is sufficient." },
+          entry,
+          steps: [{ action: "expect_output", text: "wrapper-death-ready" }],
+        },
+        checkout: root,
+        rawVideoPath: join(root, "proof.webm"),
+        maxRecordingSeconds: 90,
+        recordMedia: false,
+        runner: mediaProofCommandRunner,
+      });
+
+      assert.equal(result.status, "failed", result.output);
+      assert.match(result.output, /terminated by a signal with exit status 137/);
+      assert.doesNotMatch(result.output, /cleanup failure/);
+      backgroundPid = Number.parseInt(readFileSync(join(root, pidPath), "utf8"), 10);
+      assert.notEqual(
+        readFileSync(join(root, childGroupPath), "utf8"),
+        readFileSync(join(root, shellGroupPath), "utf8"),
+        "wrapper-death fixture did not create a distinct child process group",
+      );
+      let matches = processesContaining(processToken);
+      const deadline = Date.now() + 2_000;
+      while (matches.length > 0 && Date.now() < deadline) {
+        execFileSync("sleep", ["0.05"]);
+        matches = processesContaining(processToken);
+      }
+      assert.deepEqual(matches, []);
+      assert.throws(() => process.kill(backgroundPid, 0), { code: "ESRCH" });
+    } finally {
+      if (backgroundPid === undefined && existsSync(join(root, pidPath))) {
+        backgroundPid = Number.parseInt(readFileSync(join(root, pidPath), "utf8"), 10);
+      }
+      if (
+        Number.isSafeInteger(backgroundPid) &&
+        processesContaining(processToken).some((line) => line.startsWith(`${backgroundPid} `))
+      ) {
+        try {
+          process.kill(backgroundPid, "SIGKILL");
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
+        }
+      }
+      rmSync(root, { force: true, recursive: true });
+    }
+  },
+);
+
+test(
   "non-recorded ready proof rejects a command that exits during the stability hold",
   { timeout: 30_000 },
   () => {

--- a/test/live-proof-review-environment.test.ts
+++ b/test/live-proof-review-environment.test.ts
@@ -759,11 +759,7 @@ test(
         Number.isSafeInteger(backgroundPid) &&
         processesContaining(processToken).some((line) => line.startsWith(`${backgroundPid} `))
       ) {
-        try {
-          process.kill(backgroundPid, "SIGKILL");
-        } catch (error) {
-          if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
-        }
+        killProcess(backgroundPid);
       }
       rmSync(root, { force: true, recursive: true });
     }
@@ -1004,4 +1000,12 @@ function processesContaining(fragment: string): string[] {
     .split("\n")
     .map((line) => line.trim())
     .filter((line) => line.includes(fragment));
+}
+
+function killProcess(pid: number): void {
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
+  }
 }

--- a/test/live-proof.test.ts
+++ b/test/live-proof.test.ts
@@ -541,6 +541,7 @@ test("terminal driver composes direct Xvfb, xterm, and bounded ffmpeg sessions",
     sessionPrefix: "proof",
     maxRecordingSeconds: 90,
     rawVideoPath: "/tmp/live-proof.raw.webm",
+    tmuxTmpDir: "/tmp/clawsweeper-tmux",
   });
   assert.deepEqual(commands[0], {
     command: "tmux",
@@ -617,7 +618,12 @@ test("terminal driver composes direct Xvfb, xterm, and bounded ffmpeg sessions",
       "-s",
       "proof-xterm",
       "env",
+      "-u",
+      "TMUX",
+      "-u",
+      "TMUX_PANE",
       "DISPLAY=:99",
+      "TMUX_TMPDIR=/tmp/clawsweeper-tmux",
       "xterm",
       "-fullscreen",
       "-geometry",
@@ -894,7 +900,7 @@ test("terminal seals rolling capture before rendering a still-running timeout", 
   assert.match(result.output, /EARLY_DIAGNOSTIC/);
   assert.equal(
     calls.findIndex((call) => call.startsWith("tmux pipe-pane -t ")) <
-      calls.findIndex((call) => call.startsWith("/bin/kill -TERM -")),
+      calls.findIndex((call) => call.startsWith("release ")),
     true,
   );
 });
@@ -991,7 +997,7 @@ test("terminal waits for tmux to publish a final zero exit", () => {
   assert.equal(result.steps[0]?.satisfied, true);
 });
 
-test("held terminal cutover seals capture before cleaning the owned process group", () => {
+test("held terminal cutover seals capture before releasing pane-owned cleanup", () => {
   const calls: string[] = [];
   const result = driveTerminal({
     plan: {
@@ -1015,16 +1021,13 @@ test("held terminal cutover seals capture before cleaning the owned process grou
     (call, index) =>
       index > pipeClose && call.startsWith("tmux capture-pane") && !call.includes(" -S "),
   );
-  const cleanup = calls.findIndex((call) => call.startsWith("/bin/kill -TERM -"));
+  const cleanup = calls.findIndex((call) => call.startsWith("release "));
   assert.ok(respawn < pipeOpen);
   assert.ok(pipeOpen < status);
   assert.ok(status < pipeClose);
   assert.ok(pipeClose < viewport);
   assert.ok(viewport < cleanup);
-  assert.equal(
-    calls.some((call) => call.startsWith("release ")),
-    false,
-  );
+  assert.notEqual(cleanup, -1);
 });
 
 test("held terminal completion rejects malformed and missing status evidence", () => {
@@ -1053,7 +1056,7 @@ test("held terminal completion rejects malformed and missing status evidence", (
   }
 });
 
-test("terminal cleanup uses the trusted group even when pane status reports exit", () => {
+test("terminal cleanup rejects a wrapper that exits before controller release", () => {
   const calls: string[] = [];
   const result = driveTerminal({
     plan: {
@@ -1073,9 +1076,11 @@ test("terminal cleanup uses the trusted group even when pane status reports exit
   });
 
   assert.equal(result.status, "failed");
-  assert.match(result.output, /before recording.*status/);
-  assert.ok(calls.includes("/bin/kill -TERM -51001"));
-  assert.equal(calls.includes("/bin/kill -TERM -41001"), false);
+  assert.match(result.output, /wrapper exited before controller release/);
+  assert.equal(
+    calls.some((call) => call.startsWith("release ")),
+    false,
+  );
 });
 
 test("held terminal completion rejects a non-regular status path without blocking", () => {
@@ -1160,7 +1165,7 @@ test("terminal completion uses the configured proof budget beyond thirty seconds
   assert.ok(calls.filter((call) => call === "sleep 1").length > 30);
 });
 
-test("terminal pane status corruption fails closed and still cleans up", () => {
+test("terminal pane status corruption fails closed before controller release", () => {
   const calls: string[] = [];
   const result = driveTerminal({
     plan: {
@@ -1181,8 +1186,10 @@ test("terminal pane status corruption fails closed and still cleans up", () => {
 
   assert.equal(result.status, "failed");
   assert.match(result.output, /pane status is malformed/);
-  assert.ok(calls.includes("/bin/kill -TERM -51001"));
-  assert.equal(calls.includes("/bin/kill -TERM -41001"), false);
+  assert.equal(
+    calls.some((call) => call.startsWith("release ")),
+    false,
+  );
 });
 
 test("terminal command failure after an observed marker is caught after the recording hold", () => {
@@ -1482,13 +1489,15 @@ test("terminal rejects a pane pid change without signaling either identity", () 
 
   assert.equal(result.status, "failed");
   assert.match(result.output, /pane identity changed from launch pid 41001 to 41999/);
-  assert.equal(calls.includes("/bin/kill -TERM -51001"), false);
-  assert.equal(calls.includes("/bin/kill -TERM -41001"), false);
-  assert.equal(calls.includes("/bin/kill -TERM -41999"), false);
+  assert.equal(
+    calls.some((call) => call.startsWith("/bin/kill ")),
+    false,
+  );
 });
 
-test("terminal cleanup uses an explicit process group instead of the pane pid", () => {
+test("terminal cleanup waits for the exact pane to acknowledge its release tuple", () => {
   const calls: string[] = [];
+  let cleanupScript = "";
   const result = driveTerminal({
     plan: {
       ...recommendedPlan("terminal"),
@@ -1503,43 +1512,58 @@ test("terminal cleanup uses an explicit process group instead of the pane pid", 
     runner: terminalLifecycleRunner(calls, {
       commandKeepsRunning: true,
       terminalCaptures: ["Ready\n"],
+      inspectCleanupScript: (script) => {
+        cleanupScript = script;
+      },
     }),
   });
 
   assert.equal(result.status, "completed");
-  assert.ok(calls.includes("/bin/kill -TERM -51001"));
-  assert.equal(calls.includes("/bin/kill -TERM -41001"), false);
+  assert.match(cleanupScript, /killall -q -TERM -t "\$tty_name"/);
+  assert.match(cleanupScript, /killall -0 -t "\$tty_name"/);
+  assert.match(cleanupScript, /killall -q -KILL -t "\$tty_name"/);
+  assert.match(cleanupScript, /pkill -TERM -t "\$tty_name" -f '\.\*'/);
+  assert.match(cleanupScript, /pgrep -t "\$tty_name" -f '\.\*'/);
+  assert.match(cleanupScript, /pkill -KILL -t "\$tty_name" -f '\.\*'/);
+  const respawn = calls.find((call) => call.startsWith("tmux respawn-pane"));
+  assert.match(respawn ?? "", /tmux run-shell -b/);
+  assert.match(respawn ?? "", /while :; do sleep 3600; done/);
+  assert.doesNotMatch(respawn ?? "", /exec tmux run-shell/);
+  assert.match(respawn ?? "", /if \[ -f "\$4" \]; then/);
+  assert.match(
+    respawn ?? "",
+    /read -r release_pid release_nonce release_extra 2>\/dev\/null <"\$4"/,
+  );
+  assert.doesNotMatch(respawn ?? "", /<"\$4" 2>\/dev\/null/);
+  assert.equal(calls.filter((call) => call.startsWith("release ")).length, 1);
+  assert.equal(
+    calls.some((call) => call.startsWith("/bin/kill ") || call.startsWith("/bin/ps ")),
+    false,
+  );
 });
 
-test("terminal cleanup tolerates signal failures only after the owned group is absent", () => {
-  const calls: string[] = [];
+test("terminal rejects a malformed pane readiness acknowledgement", () => {
   const result = driveTerminal({
     plan: {
       ...recommendedPlan("terminal"),
-      terminalCompletion: "ready_while_running",
-      entry: "demo-server",
+      entry: "demo",
       steps: [{ action: "expect_output", text: "Ready" }],
     },
     checkout: "/tmp/checkout",
     rawVideoPath: "/tmp/live-proof.raw.webm",
     maxRecordingSeconds: 90,
     recordMedia: false,
-    runner: terminalLifecycleRunner(calls, {
-      commandKeepsRunning: true,
+    runner: terminalLifecycleRunner([], {
+      readyAcknowledgement: "41001 stale-nonce\n",
       terminalCaptures: ["Ready\n"],
-      termStatus: 1,
-      killStatus: 1,
-      processGroupDisappearsAfterKill: true,
     }),
   });
 
-  assert.equal(result.status, "completed");
-  assert.ok(calls.includes("/bin/kill -TERM -51001"));
-  assert.ok(calls.includes("/bin/kill -KILL -51001"));
-  assert.ok(calls.filter((call) => call === "/bin/kill -0 -51001").length >= 2);
+  assert.equal(result.status, "failed");
+  assert.match(result.output, /readiness acknowledgement is malformed/);
 });
 
-test("terminal cleanup fails when the owned process group survives SIGKILL", () => {
+test("terminal cleanup fails when the pane does not die after release", () => {
   const calls: string[] = [];
   assert.throws(
     () =>
@@ -1557,13 +1581,60 @@ test("terminal cleanup fails when the owned process group survives SIGKILL", () 
         runner: terminalLifecycleRunner(calls, {
           commandKeepsRunning: true,
           terminalCaptures: ["Ready\n"],
-          killStatus: 1,
-          processGroupSurvivesKill: true,
+          cleanupNeverCompletes: true,
         }),
       }),
     /terminal cleanup failed/,
   );
-  assert.ok(calls.filter((call) => call === "/bin/kill -0 -51001").length > 2);
+  assert.equal(calls.filter((call) => call.startsWith("release ")).length, 1);
+});
+
+test("terminal cleanup fails when tmux replaces the pane after release", () => {
+  assert.throws(
+    () =>
+      driveTerminal({
+        plan: {
+          ...recommendedPlan("terminal"),
+          terminalCompletion: "ready_while_running",
+          entry: "demo-server",
+          steps: [{ action: "expect_output", text: "Ready" }],
+        },
+        checkout: "/tmp/checkout",
+        rawVideoPath: "/tmp/live-proof.raw.webm",
+        maxRecordingSeconds: 90,
+        recordMedia: false,
+        runner: terminalLifecycleRunner([], {
+          commandKeepsRunning: true,
+          terminalCaptures: ["Ready\n"],
+          cleanupReplacementPid: 41_999,
+        }),
+      }),
+    /terminal cleanup failed/,
+  );
+});
+
+test("terminal cleanup rejects an operational error receipt after pane death", () => {
+  assert.throws(
+    () =>
+      driveTerminal({
+        plan: {
+          ...recommendedPlan("terminal"),
+          terminalCompletion: "ready_while_running",
+          entry: "demo-server",
+          steps: [{ action: "expect_output", text: "Ready" }],
+        },
+        checkout: "/tmp/checkout",
+        rawVideoPath: "/tmp/live-proof.raw.webm",
+        maxRecordingSeconds: 90,
+        recordMedia: false,
+        runner: terminalLifecycleRunner([], {
+          commandKeepsRunning: true,
+          terminalCaptures: ["Ready\n"],
+          cleanupResult: "error:kill:2",
+        }),
+      }),
+    /terminal cleanup failed/,
+  );
 });
 
 test("ready_while_running fails when the final command exits during the recording hold", () => {
@@ -1727,7 +1798,7 @@ test("terminal entry executes once and publishes only its final visible viewport
   let commandViewport = "";
   let commandStatus = 0;
   let panePid = 42_001;
-  const processGroupId = 52_001;
+  let paneDead = false;
   let invocation: ReturnType<typeof terminalCommandInvocation>;
   let commandExecuted = false;
   let capture:
@@ -1741,7 +1812,7 @@ test("terminal entry executes once and publishes only its final visible viewport
     | undefined;
   const executeCommand = (cwd: string | undefined) => {
     if (commandExecuted || !invocation || !capture || !existsSync(invocation.start)) return;
-    writeFileSync(invocation.readyTemporary, "ready\n", "utf8");
+    writeFileSync(invocation.readyTemporary, `${panePid} ${invocation.nonce}\n`, "utf8");
     renameSync(invocation.readyTemporary, invocation.ready);
     const execution = spawnSync("/bin/bash", ["--noprofile", "--norc", invocation.command], {
       cwd,
@@ -1771,7 +1842,6 @@ test("terminal entry executes once and publishes only its final visible viewport
       invocation = terminalCommandInvocation(args);
       if (!invocation) return { status: 0 };
       commandExecuted = false;
-      writeFileSync(invocation.processGroup, `${processGroupId}\n`, "utf8");
       return { status: 0 };
     }
     if (
@@ -1780,9 +1850,22 @@ test("terminal entry executes once and publishes only its final visible viewport
       args.at(-1) === "#{pane_pid}|#{pane_dead}|#{pane_dead_status}|#{pane_dead_signal}"
     ) {
       executeCommand(options?.cwd);
+      if (
+        invocation &&
+        existsSync(invocation.release) &&
+        readFileSync(invocation.release, "utf8") === `${panePid} ${invocation.nonce}\n`
+      ) {
+        writeFileSync(
+          invocation.cleanupResultTemporary,
+          `${panePid} ${invocation.nonce} ok\n`,
+          "utf8",
+        );
+        renameSync(invocation.cleanupResultTemporary, invocation.cleanupResult);
+        paneDead = true;
+      }
       return {
         status: 0,
-        stdout: `${panePid}|0||\n`,
+        stdout: paneDead ? `${panePid}|1|0|\n` : `${panePid}|0||\n`,
       };
     }
     if (tool === "tmux" && args[0] === "display-message" && args.at(-1) === "#{pane_pid}") {
@@ -1792,10 +1875,6 @@ test("terminal entry executes once and publishes only its final visible viewport
     if (tool === "tmux" && args[0] === "capture-pane") {
       return { status: 0, stdout: args.includes("-S") ? commandOutput : commandViewport };
     }
-    if (tool === "/bin/ps") {
-      return { status: 0, stdout: `${panePid} ${processGroupId} ${processGroupId}\n` };
-    }
-    if (tool === "/bin/kill" && args[0] === "-0") return { status: 1 };
     return { status: 0 };
   };
 
@@ -2120,16 +2199,12 @@ test("terminal recording holds the end state and enforces its minimum before fin
   const completed = calls.findIndex((call) => call.startsWith("status "));
   const hold = calls.findIndex((call) => call === "sleep 6");
   const finalize = calls.findIndex((call) => /tmux send-keys .* q$/.test(call));
-  const cleanup = calls.findIndex((call) => call.startsWith("/bin/kill -TERM -"));
+  const cleanup = calls.findIndex((call) => call.startsWith("release "));
   assert.notEqual(completed, -1);
   assert.notEqual(hold, -1);
   assert.ok(hold > completed);
   assert.ok(finalize > hold);
   assert.ok(cleanup > finalize);
-  assert.equal(
-    calls.some((call) => call.startsWith("release ")),
-    false,
-  );
 });
 
 test("terminal driver reports display readiness timeout with all pane diagnostics", () => {
@@ -3508,10 +3583,11 @@ function terminalLifecycleRunner(
     heldPaneExitsBeforeRelease?: boolean;
     malformedPaneStatus?: string;
     malformedPaneStatusAfterProbe?: number;
-    termStatus?: number;
-    killStatus?: number;
-    processGroupSurvivesKill?: boolean;
-    processGroupDisappearsAfterKill?: boolean;
+    cleanupNeverCompletes?: boolean;
+    cleanupReplacementPid?: number;
+    cleanupResult?: string;
+    readyAcknowledgement?: string;
+    inspectCleanupScript?: (script: string) => void;
     leaveCaptureTemporaryFiles?: boolean;
     recordStatusOnHistoryProbe?: number;
     terminalCaptureAfterStatus?: string;
@@ -3528,9 +3604,8 @@ function terminalLifecycleRunner(
   let commandLaunch = 0;
   let terminalStateProbe = 0;
   let panePid = 41_000;
-  let processGroupId = 51_000;
-  let panePresent = true;
-  let processGroupAlive = false;
+  let paneDead = false;
+  let releaseObserved = false;
   let forcedPaneState: { status: "exited"; exitStatus: number } | undefined;
   let activeCommand:
     | {
@@ -3542,6 +3617,10 @@ function terminalLifecycleRunner(
         start: string;
         ready: string;
         readyTemporary: string;
+        nonce: string;
+        cleanupScript: string;
+        cleanupResult: string;
+        cleanupResultTemporary: string;
       }
     | undefined;
   let activeFiles:
@@ -3589,14 +3668,40 @@ function terminalLifecycleRunner(
     if (!activeCommand || !existsSync(activeCommand.start) || existsSync(activeCommand.ready)) {
       return;
     }
-    writeFileSync(activeCommand.readyTemporary, "ready\n", "utf8");
+    writeFileSync(
+      activeCommand.readyTemporary,
+      options.readyAcknowledgement ?? `${panePid} ${activeCommand.nonce}\n`,
+      "utf8",
+    );
     renameSync(activeCommand.readyTemporary, activeCommand.ready);
+  };
+  const completeTerminalCleanup = () => {
+    if (!activeCommand || paneDead || !existsSync(activeCommand.release)) return;
+    const release = readFileSync(activeCommand.release, "utf8");
+    if (!releaseObserved) {
+      calls.push(`release ${activeCommand.release} ${release.trim()}`);
+      releaseObserved = true;
+    }
+    if (release !== `${panePid} ${activeCommand.nonce}\n` || options.cleanupNeverCompletes) return;
+    if (options.cleanupReplacementPid !== undefined) {
+      panePid = options.cleanupReplacementPid;
+      return;
+    }
+    writeFileSync(
+      activeCommand.cleanupResultTemporary,
+      `${panePid} ${activeCommand.nonce} ${options.cleanupResult ?? "ok"}\n`,
+      "utf8",
+    );
+    renameSync(activeCommand.cleanupResultTemporary, activeCommand.cleanupResult);
+    paneDead = true;
   };
   const terminalPaneState = () => {
     if (commandLaunch === 0) return { status: "running" } as const;
     acknowledgeTerminalReady();
+    completeTerminalCleanup();
     if (activeCommand && existsSync(activeCommand.ready)) updateTerminalFiles();
     if (forcedPaneState) return forcedPaneState;
+    if (paneDead) return { status: "exited", exitStatus: 0 } as const;
     if (activeCommand?.held) {
       if (options.heldPaneExitsBeforeRelease) {
         return { status: "exited", exitStatus: commandExitStatus() } as const;
@@ -3674,17 +3779,16 @@ function terminalLifecycleRunner(
       const invocation = terminalCommandInvocation(args);
       assert.ok(invocation);
       typedCommand = readFileSync(invocation.command, "utf8").trimEnd();
+      options.inspectCleanupScript?.(readFileSync(invocation.cleanupScript, "utf8"));
       activeCommand = invocation;
       commandLaunch += 1;
       panePid += 1;
-      processGroupId += 1;
-      panePresent = true;
-      processGroupAlive = true;
+      paneDead = false;
+      releaseObserved = false;
       forcedPaneState = undefined;
       terminalCaptureProbe = 0;
       terminalHistoryProbe = 0;
       terminalStateProbe = 0;
-      writeFileSync(invocation.processGroup, `${processGroupId}\n`, "utf8");
       return { status: 0 };
     }
     if (command === "tmux" && args[0] === "display-message") {
@@ -3709,9 +3813,7 @@ function terminalLifecycleRunner(
       if (target.includes("-terminal") && args.at(-1) === "#{pane_pid}") {
         acknowledgeTerminalReady();
         if (activeCommand && existsSync(activeCommand.ready)) updateTerminalFiles();
-        return panePresent
-          ? { status: 0, stdout: `${panePid}\n` }
-          : { status: 1, stderr: "pane is gone" };
+        return { status: 0, stdout: `${panePid}\n` };
       }
       if (finalizing) {
         const exited = finalizeProbe >= (options.finalizeExitAfter ?? 0);
@@ -3721,12 +3823,6 @@ function terminalLifecycleRunner(
       const exited = recorderPaneProbe >= (options.recorderDiesAtProbe ?? Number.POSITIVE_INFINITY);
       recorderPaneProbe += 1;
       return { status: 0, stdout: exited ? "1\n" : "0\n" };
-    }
-    if (command === "/bin/ps") {
-      return {
-        status: processGroupAlive ? 0 : 1,
-        stdout: processGroupAlive ? `${panePid} ${processGroupId} ${processGroupId}\n` : "",
-      };
     }
     if (command === "tmux" && args[0] === "capture-pane") {
       const target = String(args[args.indexOf("-t") + 1] ?? "");
@@ -3766,23 +3862,6 @@ function terminalLifecycleRunner(
       if (args[0] !== "0.1") terminalCaptureProbe += 1;
       updateTerminalFiles();
     }
-    if (command === "/bin/kill" && args[0] === "-TERM") {
-      if ((options.termStatus ?? 0) === 0) processGroupAlive = true;
-      return { status: options.termStatus ?? 0 };
-    }
-    if (command === "/bin/kill" && args[0] === "-KILL") {
-      if (
-        options.processGroupDisappearsAfterKill ||
-        ((options.killStatus ?? 0) === 0 && !options.processGroupSurvivesKill)
-      ) {
-        processGroupAlive = false;
-        panePresent = false;
-      }
-      return { status: options.killStatus ?? 0 };
-    }
-    if (command === "/bin/kill" && args[0] === "-0") {
-      return { status: processGroupAlive ? 0 : 1 };
-    }
     return { status: 0 };
   };
 }
@@ -3797,27 +3876,33 @@ function terminalCommandInvocation(args: readonly string[]):
       start: string;
       ready: string;
       readyTemporary: string;
-      processGroup: string;
-      processGroupTemporary: string;
+      nonce: string;
+      cleanupScript: string;
+      cleanupResult: string;
+      cleanupResultTemporary: string;
     }
   | undefined {
   const target = String(args[args.indexOf("-t") + 1] ?? "");
   if (!target.includes("-terminal")) return undefined;
   const shellCommand = String(args.at(-1) ?? "");
   const quoted = [...shellCommand.matchAll(/'([^']*)'/g)].map((match) => match[1]!);
-  const invocation = quoted.slice(-10);
-  if (invocation.length !== 10 || invocation[0] !== "clawsweeper-terminal") return undefined;
+  const invocation = quoted.slice(-12);
+  if (invocation.length !== 12 || invocation[0] !== "clawsweeper-terminal") return undefined;
   return {
     command: invocation[1]!,
-    held: shellCommand.includes('while [ ! -e "$4" ]'),
+    held: shellCommand.includes(
+      'read -r release_pid release_nonce release_extra 2>/dev/null <"$4"',
+    ),
     statusTemporary: invocation[2]!,
     status: invocation[3]!,
     release: invocation[4]!,
     start: invocation[5]!,
     readyTemporary: invocation[6]!,
     ready: invocation[7]!,
-    processGroupTemporary: invocation[8]!,
-    processGroup: invocation[9]!,
+    nonce: invocation[8]!,
+    cleanupScript: invocation[9]!,
+    cleanupResultTemporary: invocation[10]!,
+    cleanupResult: invocation[11]!,
   };
 }
 

--- a/test/live-proof.test.ts
+++ b/test/live-proof.test.ts
@@ -991,7 +991,7 @@ test("terminal waits for tmux to publish a final zero exit", () => {
   assert.equal(result.steps[0]?.satisfied, true);
 });
 
-test("held terminal cutover seals capture and snapshots the live pane before release", () => {
+test("held terminal cutover seals capture before cleaning the live process group", () => {
   const calls: string[] = [];
   const result = driveTerminal({
     plan: {
@@ -1015,19 +1015,22 @@ test("held terminal cutover seals capture and snapshots the live pane before rel
     (call, index) =>
       index > pipeClose && call.startsWith("tmux capture-pane") && !call.includes(" -S "),
   );
-  const release = calls.findIndex((call) => call.startsWith("release "));
+  const cleanup = calls.findIndex((call) => call.startsWith("/bin/kill -TERM "));
   assert.ok(respawn < pipeOpen);
   assert.ok(pipeOpen < status);
   assert.ok(status < pipeClose);
   assert.ok(pipeClose < viewport);
-  assert.ok(viewport < release);
+  assert.ok(viewport < cleanup);
+  assert.equal(
+    calls.some((call) => call.startsWith("release ")),
+    false,
+  );
 });
 
-test("held terminal completion rejects malformed, missing, and mismatched status evidence", () => {
+test("held terminal completion rejects malformed and missing status evidence", () => {
   for (const [options, expected] of [
     [{ recordedStatuses: ["invalid"] }, /status is malformed/],
     [{ recordedStatuses: [null], heldPaneExitsBeforeRelease: true }, /before recording.*status/],
-    [{ tmuxExitStatuses: [9] }, /status mismatch: recorded 0, tmux reported 9/],
   ] as const) {
     const result = driveTerminal({
       plan: {
@@ -1048,6 +1051,33 @@ test("held terminal completion rejects malformed, missing, and mismatched status
     assert.equal(result.status, "failed");
     assert.match(result.output, expected);
   }
+});
+
+test("terminal cleanup never signals a pane pid after tmux reports it exited", () => {
+  const calls: string[] = [];
+  const result = driveTerminal({
+    plan: {
+      ...recommendedPlan("terminal"),
+      entry: "demo",
+      steps: [{ action: "expect_output", text: "Ready" }],
+    },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 90,
+    recordMedia: false,
+    runner: terminalLifecycleRunner(calls, {
+      recordedStatuses: [null],
+      heldPaneExitsBeforeRelease: true,
+      terminalCaptures: ["Ready\n"],
+    }),
+  });
+
+  assert.equal(result.status, "failed");
+  assert.match(result.output, /before recording.*status/);
+  assert.equal(
+    calls.some((call) => call.startsWith("/bin/kill ")),
+    false,
+  );
 });
 
 test("held terminal completion rejects a non-regular status path without blocking", () => {
@@ -1317,10 +1347,10 @@ test("ready_while_running requires a satisfied marker and a live final command",
   assert.equal(calls.includes("sleep 3"), true);
 });
 
-test("terminal launch mode holds intermediates and directly executes only the final ready command", () => {
+test("terminal launch mode keeps intermediates and the final ready command supervised", () => {
   const launchModes: boolean[] = [];
   const fixtureRunner = terminalLifecycleRunner([], {
-    commandKeepsRunning: true,
+    keepsRunningCommands: ["server"],
     terminalCapturesByCommand: {
       prepare: ["prepared\n"],
       server: ["Ready\n"],
@@ -1351,7 +1381,7 @@ test("terminal launch mode holds intermediates and directly executes only the fi
   });
 
   assert.equal(result.status, "completed");
-  assert.deepEqual(launchModes, [true, false]);
+  assert.deepEqual(launchModes, [true, true]);
 });
 
 test("ready_while_running rejects a command that exits during pipe shutdown", () => {
@@ -1716,10 +1746,9 @@ test("terminal entry executes once and publishes only its final visible viewport
       args.at(-1) === "#{pane_pid}|#{pane_dead}|#{pane_dead_status}|#{pane_dead_signal}"
     ) {
       executeCommand(options?.cwd);
-      const released = invocation ? existsSync(invocation.release) : false;
       return {
         status: 0,
-        stdout: released ? `${panePid}|1|${commandStatus}|\n` : `${panePid}|0||\n`,
+        stdout: `${panePid}|0||\n`,
       };
     }
     if (tool === "tmux" && args[0] === "display-message" && args.at(-1) === "#{pane_pid}") {
@@ -2053,12 +2082,16 @@ test("terminal recording holds the end state and enforces its minimum before fin
   const completed = calls.findIndex((call) => call.startsWith("status "));
   const hold = calls.findIndex((call) => call === "sleep 6");
   const finalize = calls.findIndex((call) => /tmux send-keys .* q$/.test(call));
-  const release = calls.findIndex((call) => call.startsWith("release "));
+  const cleanup = calls.findIndex((call) => call.startsWith("/bin/kill -TERM "));
   assert.notEqual(completed, -1);
   assert.notEqual(hold, -1);
   assert.ok(hold > completed);
   assert.ok(finalize > hold);
-  assert.ok(release > finalize);
+  assert.ok(cleanup > finalize);
+  assert.equal(
+    calls.some((call) => call.startsWith("release ")),
+    false,
+  );
 });
 
 test("terminal driver reports display readiness timeout with all pane diagnostics", () => {
@@ -3426,11 +3459,11 @@ function terminalLifecycleRunner(
     commandExitStatuses?: number[];
     commandSignal?: string;
     commandKeepsRunning?: boolean;
+    keepsRunningCommands?: string[];
     heldCommandKeepsRunning?: boolean;
     commandCompletionAfterProbe?: number;
     commandCompletionAfterProbes?: number[];
     recordedStatuses?: Array<number | string | null>;
-    tmuxExitStatuses?: number[];
     captureCompletion?: string;
     paneStatusDuringFinalize?: { status: "exited"; exitStatus: number };
     terminalPaneSequence?: Array<{ status: "running" } | { status: "exited"; exitStatus: number }>;
@@ -3459,7 +3492,6 @@ function terminalLifecycleRunner(
   let panePid = 41_000;
   let panePresent = true;
   let processGroupAlive = false;
-  let releaseObserved = false;
   let forcedPaneState: { status: "exited"; exitStatus: number } | undefined;
   let activeCommand:
     | {
@@ -3491,6 +3523,8 @@ function terminalLifecycleRunner(
     if (
       !activeCommand?.held ||
       options.heldCommandKeepsRunning ||
+      options.commandKeepsRunning ||
+      options.keepsRunningCommands?.includes(typedCommand) ||
       existsSync(activeCommand.status)
     ) {
       return;
@@ -3523,24 +3557,17 @@ function terminalLifecycleRunner(
     if (commandLaunch === 0) return { status: "running" } as const;
     acknowledgeTerminalReady();
     if (activeCommand && existsSync(activeCommand.ready)) updateTerminalFiles();
+    if (forcedPaneState) return forcedPaneState;
     if (activeCommand?.held) {
       if (options.heldPaneExitsBeforeRelease) {
         return { status: "exited", exitStatus: commandExitStatus() } as const;
       }
-      if (!existsSync(activeCommand.release)) return { status: "running" } as const;
-      if (!releaseObserved) {
-        calls.push(`release ${activeCommand.release}`);
-        releaseObserved = true;
-      }
-      processGroupAlive = false;
-      const exitStatus = options.tmuxExitStatuses?.[commandLaunch - 1] ?? commandExitStatus();
-      return { status: "exited", exitStatus } as const;
+      return { status: "running" } as const;
     }
     const explicitState =
       options.terminalPaneSequence?.[
         Math.min(terminalStateProbe, options.terminalPaneSequence.length - 1)
       ];
-    if (forcedPaneState) return forcedPaneState;
     if (explicitState) return explicitState;
     const captures = options.terminalCapturesByCommand?.[typedCommand] ??
       options.terminalCaptures ?? ["command output\n"];
@@ -3613,7 +3640,6 @@ function terminalLifecycleRunner(
       panePid += 1;
       panePresent = true;
       processGroupAlive = true;
-      releaseObserved = false;
       forcedPaneState = undefined;
       terminalCaptureProbe = 0;
       terminalHistoryProbe = 0;

--- a/test/live-proof.test.ts
+++ b/test/live-proof.test.ts
@@ -894,7 +894,7 @@ test("terminal seals rolling capture before rendering a still-running timeout", 
   assert.match(result.output, /EARLY_DIAGNOSTIC/);
   assert.equal(
     calls.findIndex((call) => call.startsWith("tmux pipe-pane -t ")) <
-      calls.findIndex((call) => call.endsWith(" exit 0")),
+      calls.findIndex((call) => call.startsWith("/bin/kill -TERM -")),
     true,
   );
 });
@@ -991,7 +991,7 @@ test("terminal waits for tmux to publish a final zero exit", () => {
   assert.equal(result.steps[0]?.satisfied, true);
 });
 
-test("held terminal cutover seals capture before tmux tears down the live pane", () => {
+test("held terminal cutover seals capture before cleaning the owned process group", () => {
   const calls: string[] = [];
   const result = driveTerminal({
     plan: {
@@ -1015,7 +1015,7 @@ test("held terminal cutover seals capture before tmux tears down the live pane",
     (call, index) =>
       index > pipeClose && call.startsWith("tmux capture-pane") && !call.includes(" -S "),
   );
-  const cleanup = calls.findIndex((call) => call.endsWith(" exit 0"));
+  const cleanup = calls.findIndex((call) => call.startsWith("/bin/kill -TERM -"));
   assert.ok(respawn < pipeOpen);
   assert.ok(pipeOpen < status);
   assert.ok(status < pipeClose);
@@ -1053,7 +1053,7 @@ test("held terminal completion rejects malformed and missing status evidence", (
   }
 });
 
-test("terminal cleanup never signals a pane pid after tmux reports it exited", () => {
+test("terminal cleanup uses the trusted group even when pane status reports exit", () => {
   const calls: string[] = [];
   const result = driveTerminal({
     plan: {
@@ -1074,10 +1074,8 @@ test("terminal cleanup never signals a pane pid after tmux reports it exited", (
 
   assert.equal(result.status, "failed");
   assert.match(result.output, /before recording.*status/);
-  assert.equal(
-    calls.some((call) => call.endsWith(" exit 0")),
-    false,
-  );
+  assert.ok(calls.includes("/bin/kill -TERM -51001"));
+  assert.equal(calls.includes("/bin/kill -TERM -41001"), false);
 });
 
 test("held terminal completion rejects a non-regular status path without blocking", () => {
@@ -1183,13 +1181,8 @@ test("terminal pane status corruption fails closed and still cleans up", () => {
 
   assert.equal(result.status, "failed");
   assert.match(result.output, /pane status is malformed/);
-  assert.equal(
-    calls.some((call) => call.endsWith(" exit 0")),
-    false,
-  );
-  assert.ok(
-    calls.some((call) => call.startsWith("tmux kill-session -t ") && call.endsWith("-terminal")),
-  );
+  assert.ok(calls.includes("/bin/kill -TERM -51001"));
+  assert.equal(calls.includes("/bin/kill -TERM -41001"), false);
 });
 
 test("terminal command failure after an observed marker is caught after the recording hold", () => {
@@ -1446,7 +1439,7 @@ test("ready_while_running rejects a command that exits during pipe shutdown", ()
   assert.equal(calls.filter((call) => call.startsWith("tmux pipe-pane -t ")).length, 1);
 });
 
-test("terminal rejects a pane pid change without tearing down the replacement pane", () => {
+test("terminal rejects a pane pid change without signaling either identity", () => {
   const calls: string[] = [];
   const fixtureRunner = terminalLifecycleRunner(calls, {
     commandKeepsRunning: true,
@@ -1462,6 +1455,14 @@ test("terminal rejects a pane pid change without tearing down the replacement pa
     ) {
       stateProbe += 1;
       if (stateProbe > 1) return { ...result, stdout: "41999|0||\n" };
+    }
+    if (
+      stateProbe > 1 &&
+      tool === "tmux" &&
+      args[0] === "display-message" &&
+      args.at(-1) === "#{pane_pid}"
+    ) {
+      return { ...result, stdout: "41999\n" };
     }
     return result;
   };
@@ -1481,13 +1482,12 @@ test("terminal rejects a pane pid change without tearing down the replacement pa
 
   assert.equal(result.status, "failed");
   assert.match(result.output, /pane identity changed from launch pid 41001 to 41999/);
-  assert.equal(
-    calls.some((call) => call.endsWith(" exit 0")),
-    false,
-  );
+  assert.equal(calls.includes("/bin/kill -TERM -51001"), false);
+  assert.equal(calls.includes("/bin/kill -TERM -41001"), false);
+  assert.equal(calls.includes("/bin/kill -TERM -41999"), false);
 });
 
-test("terminal cleanup uses tmux ownership instead of pane-pid process-group signals", () => {
+test("terminal cleanup uses an explicit process group instead of the pane pid", () => {
   const calls: string[] = [];
   const result = driveTerminal({
     plan: {
@@ -1507,14 +1507,39 @@ test("terminal cleanup uses tmux ownership instead of pane-pid process-group sig
   });
 
   assert.equal(result.status, "completed");
-  assert.equal(calls.filter((call) => call.endsWith(" exit 0")).length, 1);
-  assert.equal(
-    calls.some((call) => call.startsWith("/bin/kill ")),
-    false,
-  );
+  assert.ok(calls.includes("/bin/kill -TERM -51001"));
+  assert.equal(calls.includes("/bin/kill -TERM -41001"), false);
 });
 
-test("terminal cleanup reports a failed tmux-owned teardown", () => {
+test("terminal cleanup tolerates signal failures only after the owned group is absent", () => {
+  const calls: string[] = [];
+  const result = driveTerminal({
+    plan: {
+      ...recommendedPlan("terminal"),
+      terminalCompletion: "ready_while_running",
+      entry: "demo-server",
+      steps: [{ action: "expect_output", text: "Ready" }],
+    },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 90,
+    recordMedia: false,
+    runner: terminalLifecycleRunner(calls, {
+      commandKeepsRunning: true,
+      terminalCaptures: ["Ready\n"],
+      termStatus: 1,
+      killStatus: 1,
+      processGroupDisappearsAfterKill: true,
+    }),
+  });
+
+  assert.equal(result.status, "completed");
+  assert.ok(calls.includes("/bin/kill -TERM -51001"));
+  assert.ok(calls.includes("/bin/kill -KILL -51001"));
+  assert.ok(calls.filter((call) => call === "/bin/kill -0 -51001").length >= 2);
+});
+
+test("terminal cleanup fails when the owned process group survives SIGKILL", () => {
   const calls: string[] = [];
   assert.throws(
     () =>
@@ -1532,12 +1557,13 @@ test("terminal cleanup reports a failed tmux-owned teardown", () => {
         runner: terminalLifecycleRunner(calls, {
           commandKeepsRunning: true,
           terminalCaptures: ["Ready\n"],
-          cleanupStatus: 1,
+          killStatus: 1,
+          processGroupSurvivesKill: true,
         }),
       }),
     /terminal cleanup failed/,
   );
-  assert.equal(calls.filter((call) => call.endsWith(" exit 0")).length, 1);
+  assert.ok(calls.filter((call) => call === "/bin/kill -0 -51001").length > 2);
 });
 
 test("ready_while_running fails when the final command exits during the recording hold", () => {
@@ -1701,6 +1727,7 @@ test("terminal entry executes once and publishes only its final visible viewport
   let commandViewport = "";
   let commandStatus = 0;
   let panePid = 42_001;
+  const processGroupId = 52_001;
   let invocation: ReturnType<typeof terminalCommandInvocation>;
   let commandExecuted = false;
   let capture:
@@ -1744,6 +1771,7 @@ test("terminal entry executes once and publishes only its final visible viewport
       invocation = terminalCommandInvocation(args);
       if (!invocation) return { status: 0 };
       commandExecuted = false;
+      writeFileSync(invocation.processGroup, `${processGroupId}\n`, "utf8");
       return { status: 0 };
     }
     if (
@@ -1763,6 +1791,9 @@ test("terminal entry executes once and publishes only its final visible viewport
     }
     if (tool === "tmux" && args[0] === "capture-pane") {
       return { status: 0, stdout: args.includes("-S") ? commandOutput : commandViewport };
+    }
+    if (tool === "/bin/ps") {
+      return { status: 0, stdout: `${panePid} ${processGroupId} ${processGroupId}\n` };
     }
     if (tool === "/bin/kill" && args[0] === "-0") return { status: 1 };
     return { status: 0 };
@@ -2089,7 +2120,7 @@ test("terminal recording holds the end state and enforces its minimum before fin
   const completed = calls.findIndex((call) => call.startsWith("status "));
   const hold = calls.findIndex((call) => call === "sleep 6");
   const finalize = calls.findIndex((call) => /tmux send-keys .* q$/.test(call));
-  const cleanup = calls.findIndex((call) => call.endsWith(" exit 0"));
+  const cleanup = calls.findIndex((call) => call.startsWith("/bin/kill -TERM -"));
   assert.notEqual(completed, -1);
   assert.notEqual(hold, -1);
   assert.ok(hold > completed);
@@ -3477,7 +3508,10 @@ function terminalLifecycleRunner(
     heldPaneExitsBeforeRelease?: boolean;
     malformedPaneStatus?: string;
     malformedPaneStatusAfterProbe?: number;
-    cleanupStatus?: number;
+    termStatus?: number;
+    killStatus?: number;
+    processGroupSurvivesKill?: boolean;
+    processGroupDisappearsAfterKill?: boolean;
     leaveCaptureTemporaryFiles?: boolean;
     recordStatusOnHistoryProbe?: number;
     terminalCaptureAfterStatus?: string;
@@ -3494,7 +3528,9 @@ function terminalLifecycleRunner(
   let commandLaunch = 0;
   let terminalStateProbe = 0;
   let panePid = 41_000;
+  let processGroupId = 51_000;
   let panePresent = true;
+  let processGroupAlive = false;
   let forcedPaneState: { status: "exited"; exitStatus: number } | undefined;
   let activeCommand:
     | {
@@ -3635,21 +3671,20 @@ function terminalLifecycleRunner(
     if (command === "tmux" && args[0] === "respawn-pane") {
       const target = String(args[args.indexOf("-t") + 1] ?? "");
       if (!target.includes("-terminal")) return { status: 0 };
-      if (args.at(-1) === "exit 0") {
-        if ((options.cleanupStatus ?? 0) === 0) panePresent = false;
-        return { status: options.cleanupStatus ?? 0 };
-      }
       const invocation = terminalCommandInvocation(args);
       assert.ok(invocation);
       typedCommand = readFileSync(invocation.command, "utf8").trimEnd();
       activeCommand = invocation;
       commandLaunch += 1;
       panePid += 1;
+      processGroupId += 1;
       panePresent = true;
+      processGroupAlive = true;
       forcedPaneState = undefined;
       terminalCaptureProbe = 0;
       terminalHistoryProbe = 0;
       terminalStateProbe = 0;
+      writeFileSync(invocation.processGroup, `${processGroupId}\n`, "utf8");
       return { status: 0 };
     }
     if (command === "tmux" && args[0] === "display-message") {
@@ -3686,6 +3721,12 @@ function terminalLifecycleRunner(
       const exited = recorderPaneProbe >= (options.recorderDiesAtProbe ?? Number.POSITIVE_INFINITY);
       recorderPaneProbe += 1;
       return { status: 0, stdout: exited ? "1\n" : "0\n" };
+    }
+    if (command === "/bin/ps") {
+      return {
+        status: processGroupAlive ? 0 : 1,
+        stdout: processGroupAlive ? `${panePid} ${processGroupId} ${processGroupId}\n` : "",
+      };
     }
     if (command === "tmux" && args[0] === "capture-pane") {
       const target = String(args[args.indexOf("-t") + 1] ?? "");
@@ -3725,6 +3766,23 @@ function terminalLifecycleRunner(
       if (args[0] !== "0.1") terminalCaptureProbe += 1;
       updateTerminalFiles();
     }
+    if (command === "/bin/kill" && args[0] === "-TERM") {
+      if ((options.termStatus ?? 0) === 0) processGroupAlive = true;
+      return { status: options.termStatus ?? 0 };
+    }
+    if (command === "/bin/kill" && args[0] === "-KILL") {
+      if (
+        options.processGroupDisappearsAfterKill ||
+        ((options.killStatus ?? 0) === 0 && !options.processGroupSurvivesKill)
+      ) {
+        processGroupAlive = false;
+        panePresent = false;
+      }
+      return { status: options.killStatus ?? 0 };
+    }
+    if (command === "/bin/kill" && args[0] === "-0") {
+      return { status: processGroupAlive ? 0 : 1 };
+    }
     return { status: 0 };
   };
 }
@@ -3739,14 +3797,16 @@ function terminalCommandInvocation(args: readonly string[]):
       start: string;
       ready: string;
       readyTemporary: string;
+      processGroup: string;
+      processGroupTemporary: string;
     }
   | undefined {
   const target = String(args[args.indexOf("-t") + 1] ?? "");
   if (!target.includes("-terminal")) return undefined;
   const shellCommand = String(args.at(-1) ?? "");
   const quoted = [...shellCommand.matchAll(/'([^']*)'/g)].map((match) => match[1]!);
-  const invocation = quoted.slice(-8);
-  if (invocation.length !== 8 || invocation[0] !== "clawsweeper-terminal") return undefined;
+  const invocation = quoted.slice(-10);
+  if (invocation.length !== 10 || invocation[0] !== "clawsweeper-terminal") return undefined;
   return {
     command: invocation[1]!,
     held: shellCommand.includes('while [ ! -e "$4" ]'),
@@ -3756,6 +3816,8 @@ function terminalCommandInvocation(args: readonly string[]):
     start: invocation[5]!,
     readyTemporary: invocation[6]!,
     ready: invocation[7]!,
+    processGroupTemporary: invocation[8]!,
+    processGroup: invocation[9]!,
   };
 }
 

--- a/test/live-proof.test.ts
+++ b/test/live-proof.test.ts
@@ -894,7 +894,7 @@ test("terminal seals rolling capture before rendering a still-running timeout", 
   assert.match(result.output, /EARLY_DIAGNOSTIC/);
   assert.equal(
     calls.findIndex((call) => call.startsWith("tmux pipe-pane -t ")) <
-      calls.findIndex((call) => call.startsWith("/bin/kill -TERM -")),
+      calls.findIndex((call) => call.endsWith(" exit 0")),
     true,
   );
 });
@@ -991,7 +991,7 @@ test("terminal waits for tmux to publish a final zero exit", () => {
   assert.equal(result.steps[0]?.satisfied, true);
 });
 
-test("held terminal cutover seals capture before cleaning the live process group", () => {
+test("held terminal cutover seals capture before tmux tears down the live pane", () => {
   const calls: string[] = [];
   const result = driveTerminal({
     plan: {
@@ -1015,7 +1015,7 @@ test("held terminal cutover seals capture before cleaning the live process group
     (call, index) =>
       index > pipeClose && call.startsWith("tmux capture-pane") && !call.includes(" -S "),
   );
-  const cleanup = calls.findIndex((call) => call.startsWith("/bin/kill -TERM "));
+  const cleanup = calls.findIndex((call) => call.endsWith(" exit 0"));
   assert.ok(respawn < pipeOpen);
   assert.ok(pipeOpen < status);
   assert.ok(status < pipeClose);
@@ -1075,7 +1075,7 @@ test("terminal cleanup never signals a pane pid after tmux reports it exited", (
   assert.equal(result.status, "failed");
   assert.match(result.output, /before recording.*status/);
   assert.equal(
-    calls.some((call) => call.startsWith("/bin/kill ")),
+    calls.some((call) => call.endsWith(" exit 0")),
     false,
   );
 });
@@ -1183,8 +1183,13 @@ test("terminal pane status corruption fails closed and still cleans up", () => {
 
   assert.equal(result.status, "failed");
   assert.match(result.output, /pane status is malformed/);
-  assert.ok(calls.some((call) => call === "/bin/kill -TERM -41001"));
-  assert.ok(calls.some((call) => call === "/bin/kill -KILL -41001"));
+  assert.equal(
+    calls.some((call) => call.endsWith(" exit 0")),
+    false,
+  );
+  assert.ok(
+    calls.some((call) => call.startsWith("tmux kill-session -t ") && call.endsWith("-terminal")),
+  );
 });
 
 test("terminal command failure after an observed marker is caught after the recording hold", () => {
@@ -1441,7 +1446,7 @@ test("ready_while_running rejects a command that exits during pipe shutdown", ()
   assert.equal(calls.filter((call) => call.startsWith("tmux pipe-pane -t ")).length, 1);
 });
 
-test("terminal rejects a pane pid change after launch and cleans the original process group", () => {
+test("terminal rejects a pane pid change without tearing down the replacement pane", () => {
   const calls: string[] = [];
   const fixtureRunner = terminalLifecycleRunner(calls, {
     commandKeepsRunning: true,
@@ -1476,10 +1481,13 @@ test("terminal rejects a pane pid change after launch and cleans the original pr
 
   assert.equal(result.status, "failed");
   assert.match(result.output, /pane identity changed from launch pid 41001 to 41999/);
-  assert.ok(calls.includes("/bin/kill -TERM -41001"));
+  assert.equal(
+    calls.some((call) => call.endsWith(" exit 0")),
+    false,
+  );
 });
 
-test("terminal cleanup tolerates signal failures only after the process group is absent", () => {
+test("terminal cleanup uses tmux ownership instead of pane-pid process-group signals", () => {
   const calls: string[] = [];
   const result = driveTerminal({
     plan: {
@@ -1495,19 +1503,18 @@ test("terminal cleanup tolerates signal failures only after the process group is
     runner: terminalLifecycleRunner(calls, {
       commandKeepsRunning: true,
       terminalCaptures: ["Ready\n"],
-      termStatus: 1,
-      killStatus: 1,
-      processGroupDisappearsAfterKill: true,
     }),
   });
 
   assert.equal(result.status, "completed");
-  assert.ok(calls.includes("/bin/kill -TERM -41001"));
-  assert.ok(calls.includes("/bin/kill -KILL -41001"));
-  assert.ok(calls.filter((call) => call === "/bin/kill -0 -41001").length >= 2);
+  assert.equal(calls.filter((call) => call.endsWith(" exit 0")).length, 1);
+  assert.equal(
+    calls.some((call) => call.startsWith("/bin/kill ")),
+    false,
+  );
 });
 
-test("terminal cleanup fails when a process group survives SIGKILL", () => {
+test("terminal cleanup reports a failed tmux-owned teardown", () => {
   const calls: string[] = [];
   assert.throws(
     () =>
@@ -1525,13 +1532,12 @@ test("terminal cleanup fails when a process group survives SIGKILL", () => {
         runner: terminalLifecycleRunner(calls, {
           commandKeepsRunning: true,
           terminalCaptures: ["Ready\n"],
-          killStatus: 1,
-          processGroupSurvivesKill: true,
+          cleanupStatus: 1,
         }),
       }),
     /terminal cleanup failed/,
   );
-  assert.ok(calls.filter((call) => call === "/bin/kill -0 -41001").length > 2);
+  assert.equal(calls.filter((call) => call.endsWith(" exit 0")).length, 1);
 });
 
 test("ready_while_running fails when the final command exits during the recording hold", () => {
@@ -1827,8 +1833,9 @@ test("a previous terminal command failure blocks a following run step", () => {
   assert.match(result.steps[0]?.detail ?? "", /blocked by the previous command/);
   assert.match(result.steps[0]?.detail ?? "", /failed with exit status 7/);
   assert.equal(
-    calls.filter((call) => call.startsWith("tmux respawn-pane") && !call.endsWith("sleep 30"))
-      .length,
+    calls.filter(
+      (call) => call.startsWith("tmux respawn-pane") && call.includes("clawsweeper-terminal"),
+    ).length,
     1,
   );
 });
@@ -1917,7 +1924,7 @@ test("terminal commands preserve shell syntax in pane command files", () => {
   );
   assert.equal(
     sequentialCalls.filter(
-      (call) => call.startsWith("tmux respawn-pane") && !call.endsWith("sleep 30"),
+      (call) => call.startsWith("tmux respawn-pane") && call.includes("clawsweeper-terminal"),
     ).length,
     2,
   );
@@ -2082,7 +2089,7 @@ test("terminal recording holds the end state and enforces its minimum before fin
   const completed = calls.findIndex((call) => call.startsWith("status "));
   const hold = calls.findIndex((call) => call === "sleep 6");
   const finalize = calls.findIndex((call) => /tmux send-keys .* q$/.test(call));
-  const cleanup = calls.findIndex((call) => call.startsWith("/bin/kill -TERM "));
+  const cleanup = calls.findIndex((call) => call.endsWith(" exit 0"));
   assert.notEqual(completed, -1);
   assert.notEqual(hold, -1);
   assert.ok(hold > completed);
@@ -3470,10 +3477,7 @@ function terminalLifecycleRunner(
     heldPaneExitsBeforeRelease?: boolean;
     malformedPaneStatus?: string;
     malformedPaneStatusAfterProbe?: number;
-    termStatus?: number;
-    killStatus?: number;
-    processGroupSurvivesKill?: boolean;
-    processGroupDisappearsAfterKill?: boolean;
+    cleanupStatus?: number;
     leaveCaptureTemporaryFiles?: boolean;
     recordStatusOnHistoryProbe?: number;
     terminalCaptureAfterStatus?: string;
@@ -3491,7 +3495,6 @@ function terminalLifecycleRunner(
   let terminalStateProbe = 0;
   let panePid = 41_000;
   let panePresent = true;
-  let processGroupAlive = false;
   let forcedPaneState: { status: "exited"; exitStatus: number } | undefined;
   let activeCommand:
     | {
@@ -3632,6 +3635,10 @@ function terminalLifecycleRunner(
     if (command === "tmux" && args[0] === "respawn-pane") {
       const target = String(args[args.indexOf("-t") + 1] ?? "");
       if (!target.includes("-terminal")) return { status: 0 };
+      if (args.at(-1) === "exit 0") {
+        if ((options.cleanupStatus ?? 0) === 0) panePresent = false;
+        return { status: options.cleanupStatus ?? 0 };
+      }
       const invocation = terminalCommandInvocation(args);
       assert.ok(invocation);
       typedCommand = readFileSync(invocation.command, "utf8").trimEnd();
@@ -3639,7 +3646,6 @@ function terminalLifecycleRunner(
       commandLaunch += 1;
       panePid += 1;
       panePresent = true;
-      processGroupAlive = true;
       forcedPaneState = undefined;
       terminalCaptureProbe = 0;
       terminalHistoryProbe = 0;
@@ -3718,25 +3724,6 @@ function terminalLifecycleRunner(
     if (command === "sleep" && activeFiles) {
       if (args[0] !== "0.1") terminalCaptureProbe += 1;
       updateTerminalFiles();
-    }
-    if (command === "/bin/kill" && args[0] === "-TERM") {
-      if ((options.termStatus ?? 0) === 0) {
-        processGroupAlive = true;
-      }
-      return { status: options.termStatus ?? 0 };
-    }
-    if (command === "/bin/kill" && args[0] === "-KILL") {
-      if (
-        options.processGroupDisappearsAfterKill ||
-        ((options.killStatus ?? 0) === 0 && !options.processGroupSurvivesKill)
-      ) {
-        processGroupAlive = false;
-        panePresent = false;
-      }
-      return { status: options.killStatus ?? 0 };
-    }
-    if (command === "/bin/kill" && args[0] === "-0") {
-      return { status: processGroupAlive ? 0 : 1 };
     }
     return { status: 0 };
   };

--- a/test/live-proof.test.ts
+++ b/test/live-proof.test.ts
@@ -1,5 +1,14 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -55,6 +64,7 @@ function recommendedPlan(surface: "browser" | "terminal" = "browser"): LiveProof
     ? {
         status: "recommended",
         surface,
+        terminalCompletion: "not_applicable",
         reason: "The changed setting is visible.",
         payoff: {
           kind: "ui_interaction",
@@ -67,6 +77,7 @@ function recommendedPlan(surface: "browser" | "terminal" = "browser"): LiveProof
     : {
         status: "recommended",
         surface,
+        terminalCompletion: "exit_zero",
         reason: "The changed CLI output is visible.",
         payoff: {
           kind: "progressive_output",
@@ -137,6 +148,7 @@ test("live-proof gates skip in order with a successful result", async (t) => {
       plan: {
         status: "not_applicable",
         surface: "none",
+        terminalCompletion: "not_applicable",
         reason: "No visible behavior.",
         payoff: {
           kind: "static_text",
@@ -156,6 +168,7 @@ test("live-proof gates skip in order with a successful result", async (t) => {
       plan: {
         status: "declined_suspicious",
         surface: "none",
+        terminalCompletion: "not_applicable",
         reason: "The command reads credential storage.",
         payoff: {
           kind: "static_text",
@@ -272,11 +285,55 @@ test("live-proof environments remove known and heuristic credential classes", ()
   );
 });
 
+test("live-proof rejects an invalid recorded plan instead of treating it as a skip", async () => {
+  const directory = mkdtempSync(join(tmpdir(), "clawsweeper-invalid-live-proof-"));
+  const planPath = join(directory, "plan.json");
+  writeFileSync(planPath, "{}\n");
+  let fetches = 0;
+  await assert.rejects(
+    executeLiveProof(
+      {
+        repo: "example/repo",
+        item: 42,
+        outputDir: join(directory, "output"),
+        planPath,
+      },
+      {
+        env: { CLAWSWEEPER_LIVE_PROOF_ENABLED: "1" },
+        repositoryProfileFor: () => profile(),
+        reportLiveProofPlan: () => recommendedPlan(),
+        parseLiveProofPlan: () => ({
+          status: "not_applicable",
+          surface: "none",
+          terminalCompletion: "not_applicable",
+          invalid: true,
+          reason:
+            "The live-proof plan is missing or invalid; regenerate the review report before execution.",
+          payoff: {
+            kind: "static_text",
+            justification: "Invalid report plans are non-runnable and fail closed.",
+          },
+          entry: "",
+          steps: [],
+        }),
+        fetchPullRequest: async () => {
+          fetches += 1;
+          return { kind: "pull_request", state: "open", headSha: HEAD };
+        },
+      },
+    ),
+    /regenerate the review report before execution/,
+  );
+  assert.equal(fetches, 0);
+  rmSync(directory, { force: true, recursive: true });
+});
+
 test("live-proof review child prints the sanitized-environment assertion", async () => {
   const logs: string[] = [];
   const plan: LiveProofPlan = {
     status: "not_applicable",
     surface: "none",
+    terminalCompletion: "not_applicable",
     reason: "No executable behavior.",
     payoff: { kind: "static_text", justification: "Static result." },
     entry: "",
@@ -487,11 +544,57 @@ test("terminal driver composes direct Xvfb, xterm, and bounded ffmpeg sessions",
   });
   assert.deepEqual(commands[0], {
     command: "tmux",
-    args: ["new-session", "-d", "-s", "proof-terminal", "-x", "160", "-y", "50"],
+    args: [
+      "new-session",
+      "-d",
+      "-s",
+      "proof-terminal",
+      "-x",
+      "160",
+      "-y",
+      "50",
+      "/bin/bash --noprofile --norc",
+    ],
   });
   assert.deepEqual(commands[1], {
     command: "tmux",
-    args: ["set-option", "-w", "-t", "proof-terminal:0", "remain-on-exit", "on"],
+    args: ["set-option", "-t", "proof-terminal", "history-limit", "50000"],
+  });
+  assert.deepEqual(commands[2], {
+    command: "tmux",
+    args: ["set-option", "-t", "proof-terminal", "base-index", "0"],
+  });
+  assert.deepEqual(commands[3], {
+    command: "tmux",
+    args: ["move-window", "-r", "-t", "proof-terminal"],
+  });
+  assert.deepEqual(commands[4], {
+    command: "tmux",
+    args: ["new-window", "-d", "-t", "proof-terminal:", "/bin/bash --noprofile --norc"],
+  });
+  assert.deepEqual(commands[5], {
+    command: "tmux",
+    args: ["resize-window", "-t", "proof-terminal:1", "-x", "160", "-y", "50"],
+  });
+  assert.deepEqual(commands[6], {
+    command: "tmux",
+    args: ["kill-window", "-t", "proof-terminal:0"],
+  });
+  assert.deepEqual(commands[7], {
+    command: "tmux",
+    args: ["move-window", "-r", "-t", "proof-terminal"],
+  });
+  assert.deepEqual(commands[8], {
+    command: "tmux",
+    args: ["set-option", "-w", "-t", "proof-terminal:0", "pane-base-index", "0"],
+  });
+  assert.deepEqual(commands[9], {
+    command: "tmux",
+    args: ["set-option", "-w", "-t", "proof-terminal:0.0", "remain-on-exit", "on"],
+  });
+  assert.deepEqual(commands[10], {
+    command: "tmux",
+    args: ["set-option", "-w", "-t", "proof-terminal:0.0", "remain-on-exit-format", ""],
   });
   const display = commands.find((invocation) => invocation.args.includes("Xvfb"));
   const xterm = commands.find((invocation) => invocation.args.includes("xterm"));
@@ -548,7 +651,7 @@ test("terminal driver composes direct Xvfb, xterm, and bounded ffmpeg sessions",
   );
 });
 
-test("terminal run waits for pane content beyond the echoed command", () => {
+test("terminal run waits for output and a successful final exit", () => {
   const calls: string[] = [];
   const result = runTerminalFixture(
     terminalLifecycleRunner(calls, {
@@ -559,12 +662,12 @@ test("terminal run waits for pane content beyond the echoed command", () => {
       ],
     }),
   );
-  assert.equal(result.status, "completed");
+  assert.equal(result.status, "completed", `${result.output}\n\n${calls.join("\n")}`);
   const respawn = calls.findIndex((call) => call.startsWith("tmux respawn-pane"));
   const hold = calls.findIndex((call, index) => index > respawn && call === "sleep 6");
   assert.notEqual(respawn, -1);
   assert.notEqual(hold, -1);
-  assert.equal(calls.slice(respawn + 1, hold).filter((call) => call === "sleep 1").length, 4);
+  assert.match(result.output, /Usage/);
 });
 
 test("terminal keeps silent commands eligible for the full expectation window", () => {
@@ -579,13 +682,12 @@ test("terminal keeps silent commands eligible for the full expectation window", 
     rawVideoPath: "/tmp/live-proof.raw.webm",
     maxRecordingSeconds: 90,
     recordMedia: false,
-    readCommandStatus: () => undefined,
     runner: terminalLifecycleRunner(calls, {
       terminalCaptures: [...Array.from({ length: 21 }, () => ""), "Ready\n"],
     }),
   });
 
-  assert.equal(result.status, "completed");
+  assert.equal(result.status, "completed", JSON.stringify({ result, calls }, null, 2));
   assert.equal(result.steps[0]?.satisfied, true);
   assert.ok(calls.filter((call) => call === "sleep 1").length >= 21);
 });
@@ -633,6 +735,27 @@ test("terminal expect_output preserves leading and trailing marker whitespace", 
   assert.equal(result.steps[0]?.satisfied, true);
 });
 
+test("terminal capture normalizes PTY control sequences and carriage returns", () => {
+  const result = driveTerminal({
+    plan: {
+      ...recommendedPlan("terminal"),
+      entry: "demo",
+      steps: [{ action: "expect_output", text: "Ready\nDone" }],
+    },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 90,
+    recordMedia: false,
+    runner: terminalLifecycleRunner([], {
+      terminalCaptures: ["\u001b[32mReady\u001b[0m\r\nDone\r"],
+    }),
+  });
+
+  assert.equal(result.status, "completed");
+  assert.equal(result.steps[0]?.satisfied, true);
+  assert.equal(result.output, "Ready\nDone");
+});
+
 test("terminal expect_output records text already present in the plan-start snapshot", () => {
   const calls: string[] = [];
   const result = driveTerminal({
@@ -654,9 +777,8 @@ test("terminal expect_output records text already present in the plan-start snap
   assert.equal(result.steps[0]?.satisfied, true);
 });
 
-test("terminal command success is not overturned by an unobserved output marker", () => {
+test("terminal command success cannot waive a missing output expectation", () => {
   const calls: string[] = [];
-  let commandStatusProbes = 0;
   const plan: LiveProofPlan = {
     ...recommendedPlan("terminal"),
     entry: "node scripts/run-vitest.mjs src/agents/code-mode.mcp.test.ts",
@@ -668,7 +790,6 @@ test("terminal command success is not overturned by an unobserved output marker"
     rawVideoPath: "/tmp/live-proof.raw.webm",
     maxRecordingSeconds: 90,
     recordMedia: false,
-    readCommandStatus: () => (++commandStatusProbes >= 30 ? 0 : undefined),
     runner: terminalLifecycleRunner(calls, {
       terminalCaptures: [
         "$ node scripts/run-vitest.mjs src/agents/code-mode.mcp.test.ts\nTests  10 passed (10)\nwrapper passed after 28.37 seconds\n",
@@ -676,11 +797,13 @@ test("terminal command success is not overturned by an unobserved output marker"
     }),
   });
 
-  assert.equal(result.status, "completed");
-  assert.equal(result.steps[0]?.status, "completed");
-  assert.equal(result.steps[0]?.satisfied, true);
-  assert.match(result.steps[0]?.detail ?? "", /not observed/);
-  assert.equal(calls.filter((call) => call === "sleep 1").length, 31);
+  assert.equal(result.status, "failed");
+  assert.equal(result.steps[0]?.status, "failed");
+  assert.equal(result.steps[0]?.satisfied, false);
+  assert.match(
+    result.steps[0]?.detail ?? "",
+    /exited successfully before expected output appeared/,
+  );
   assert.match(result.output, /Tests  10 passed \(10\)/);
   assert.doesNotMatch(result.output, /\.command-\d+-\d+\.|printf '%s'|mv -f|\/tmp\//);
 
@@ -694,27 +817,25 @@ test("terminal command success is not overturned by an unobserved output marker"
     output: result.output,
     verifiedAt: "2026-08-23T12:00:00.000Z",
   });
-  assert.equal(verification.overall_pass, true);
-  assert.equal(verification.steps[0]?.satisfied, true);
+  assert.equal(verification.overall_pass, false);
+  assert.equal(verification.steps[0]?.satisfied, false);
   assert.deepEqual(parseLiveVerificationResult(verification), verification);
   assert.throws(
     () =>
       parseLiveVerificationResult({
         ...verification,
-        steps: [{ ...verification.steps[0], satisfied: false }],
+        failure: undefined,
+        drive_status: "completed",
+        steps: [{ ...verification.steps[0], status: "completed", satisfied: true }],
       }),
     /overall_pass does not match/,
   );
-  assert.match(renderLiveVerificationCommentBlock(verification), /\*\*Result:\*\* PASS/);
-  assert.match(
-    renderLiveVerificationCommentBlock(verification),
-    /NOT OBSERVED `expect_output`: Code Mode MCP namespace/,
-  );
+  assert.match(renderLiveVerificationCommentBlock(verification), /\*\*Result:\*\* FAIL/);
+  assert.match(renderLiveVerificationCommentBlock(verification), /FAIL `expect_output`/);
 });
 
 test("terminal command timeout remains a failed output expectation", () => {
   const calls: string[] = [];
-  let commandStatusProbes = 0;
   const result = driveTerminal({
     plan: {
       ...recommendedPlan("terminal"),
@@ -725,17 +846,78 @@ test("terminal command timeout remains a failed output expectation", () => {
     rawVideoPath: "/tmp/live-proof.raw.webm",
     maxRecordingSeconds: 90,
     recordMedia: false,
-    readCommandStatus: () => (++commandStatusProbes >= 6 ? 124 : undefined),
     runner: terminalLifecycleRunner(calls, {
-      terminalCaptures: ["$ timeout 5 demo\nwaiting for the command\n"],
+      terminalCaptures: [
+        "$ timeout 5 demo\nwaiting for the command\n",
+        "$ timeout 5 demo\nwaiting for the command\n",
+        "$ timeout 5 demo\nwaiting for the command\n",
+        "$ timeout 5 demo\nwaiting for the command\n",
+      ],
+      commandExitStatus: 124,
     }),
   });
 
   assert.equal(result.status, "failed");
   assert.equal(result.steps[0]?.status, "failed");
   assert.equal(result.steps[0]?.satisfied, false);
-  assert.match(result.steps[0]?.detail ?? "", /timed out with exit status 124/);
+  assert.match(result.steps[0]?.detail ?? "", /failed with exit status 124/);
   assert.equal(calls.filter((call) => call === "sleep 1").length, 3);
+});
+
+test("terminal seals rolling capture before rendering a still-running timeout", () => {
+  const calls: string[] = [];
+  const fixtureRunner = terminalLifecycleRunner(calls, {
+    heldCommandKeepsRunning: true,
+    terminalCaptures: ["EARLY_DIAGNOSTIC\n" + "tail\n".repeat(100)],
+  });
+  const runner: MediaProofCommandRunner = (tool, args, options) => {
+    if (tool === "tmux" && args[0] === "capture-pane") {
+      calls.push([tool, ...args].join(" "));
+      return { status: 0, stdout: "tail only\n" };
+    }
+    return fixtureRunner(tool, args, options);
+  };
+  const result = driveTerminal({
+    plan: {
+      ...recommendedPlan("terminal"),
+      entry: "demo-server",
+      steps: [{ action: "expect_output", text: "never-ready" }],
+    },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 90,
+    recordMedia: false,
+    runner,
+  });
+
+  assert.equal(result.status, "failed");
+  assert.match(result.output, /EARLY_DIAGNOSTIC/);
+  assert.equal(
+    calls.findIndex((call) => call.startsWith("tmux pipe-pane -t ")) <
+      calls.findIndex((call) => call.startsWith("/bin/kill -TERM -")),
+    true,
+  );
+});
+
+test("terminal rejects a capture stream that does not seal with clean EOF", () => {
+  const result = driveTerminal({
+    plan: {
+      ...recommendedPlan("terminal"),
+      entry: "demo",
+      steps: [{ action: "expect_output", text: "Ready" }],
+    },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 90,
+    recordMedia: false,
+    runner: terminalLifecycleRunner([], {
+      captureCompletion: "error",
+      terminalCaptures: ["Ready\n"],
+    }),
+  });
+
+  assert.equal(result.status, "failed");
+  assert.match(result.output, /terminal capture helper ended unexpectedly: error/);
 });
 
 test("terminal nonzero and signal exits fail even when the expected marker is present", () => {
@@ -743,7 +925,6 @@ test("terminal nonzero and signal exits fail even when the expected marker is pr
     [7, /failed with exit status 7/],
     [143, /terminated by a signal with exit status 143/],
   ] as const) {
-    let commandStatusProbes = 0;
     const result = driveTerminal({
       plan: {
         ...recommendedPlan("terminal"),
@@ -754,8 +935,8 @@ test("terminal nonzero and signal exits fail even when the expected marker is pr
       rawVideoPath: "/tmp/live-proof.raw.webm",
       maxRecordingSeconds: 90,
       recordMedia: false,
-      readCommandStatus: () => (++commandStatusProbes >= 5 ? exitStatus : undefined),
       runner: terminalLifecycleRunner([], {
+        ...(exitStatus === 143 ? { commandSignal: "SIGTERM" } : { commandExitStatus: exitStatus }),
         terminalCaptures: ["$ demo\nReady\n"],
       }),
     });
@@ -779,7 +960,7 @@ test("terminal pane signals fail even when expected output is present", () => {
       maxRecordingSeconds: 90,
       recordMedia: false,
       runner: terminalLifecycleRunner([], {
-        terminalPaneSignal: signal,
+        commandSignal: signal,
         terminalCaptures: ["Ready\n"],
       }),
     });
@@ -789,7 +970,7 @@ test("terminal pane signals fail even when expected output is present", () => {
   }
 });
 
-test("terminal waits for tmux to publish a dead pane status", () => {
+test("terminal waits for tmux to publish a final zero exit", () => {
   const result = driveTerminal({
     plan: {
       ...recommendedPlan("terminal"),
@@ -801,8 +982,8 @@ test("terminal waits for tmux to publish a dead pane status", () => {
     maxRecordingSeconds: 90,
     recordMedia: false,
     runner: terminalLifecycleRunner([], {
-      terminalPaneStates: ["1::", "1:0:"],
-      terminalCaptures: ["Ready\n"],
+      terminalPaneSequence: [{ status: "running" }, { status: "exited", exitStatus: 0 }],
+      terminalCaptures: ["Ready\n", "Ready\n"],
     }),
   });
 
@@ -810,11 +991,44 @@ test("terminal waits for tmux to publish a dead pane status", () => {
   assert.equal(result.steps[0]?.satisfied, true);
 });
 
-test("terminal status probe errors fail closed", () => {
-  for (const options of [
-    { terminalPaneProbeError: true },
-    { terminalPaneMalformed: "not-a-pane-status" },
-  ]) {
+test("held terminal cutover seals capture and snapshots the live pane before release", () => {
+  const calls: string[] = [];
+  const result = driveTerminal({
+    plan: {
+      ...recommendedPlan("terminal"),
+      entry: "demo",
+      steps: [{ action: "expect_output", text: "Ready" }],
+    },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 90,
+    recordMedia: false,
+    runner: terminalLifecycleRunner(calls, { terminalCaptures: ["Ready\n"] }),
+  });
+
+  assert.equal(result.status, "completed");
+  const respawn = calls.findIndex((call) => call.startsWith("tmux respawn-pane"));
+  const pipeOpen = calls.findIndex((call) => call.startsWith("tmux pipe-pane -O"));
+  const status = calls.findIndex((call) => call.startsWith("status "));
+  const pipeClose = calls.findIndex((call) => call.startsWith("tmux pipe-pane -t "));
+  const viewport = calls.findIndex(
+    (call, index) =>
+      index > pipeClose && call.startsWith("tmux capture-pane") && !call.includes(" -S "),
+  );
+  const release = calls.findIndex((call) => call.startsWith("release "));
+  assert.ok(respawn < pipeOpen);
+  assert.ok(pipeOpen < status);
+  assert.ok(status < pipeClose);
+  assert.ok(pipeClose < viewport);
+  assert.ok(viewport < release);
+});
+
+test("held terminal completion rejects malformed, missing, and mismatched status evidence", () => {
+  for (const [options, expected] of [
+    [{ recordedStatuses: ["invalid"] }, /status is malformed/],
+    [{ recordedStatuses: [null], heldPaneExitsBeforeRelease: true }, /before recording.*status/],
+    [{ tmuxExitStatuses: [9] }, /status mismatch: recorded 0, tmux reported 9/],
+  ] as const) {
     const result = driveTerminal({
       plan: {
         ...recommendedPlan("terminal"),
@@ -832,8 +1046,115 @@ test("terminal status probe errors fail closed", () => {
     });
 
     assert.equal(result.status, "failed");
-    assert.match(result.output, /tmux pane status probe/);
+    assert.match(result.output, expected);
   }
+});
+
+test("held terminal completion rejects a non-regular status path without blocking", () => {
+  const directory = mkdtempSync(join(tmpdir(), "clawsweeper-live-proof-status-"));
+  try {
+    const fixtureRunner = terminalLifecycleRunner([], {
+      terminalCaptures: ["Ready\n"],
+    });
+    const runner: MediaProofCommandRunner = (command, args, options) => {
+      const result = fixtureRunner(command, args, options);
+      if (command === "tmux" && args[0] === "respawn-pane") {
+        const invocation = terminalCommandInvocation(args);
+        if (invocation) {
+          assert.equal(spawnSync("mkfifo", [invocation.status]).status, 0);
+        }
+      }
+      return result;
+    };
+    const result = driveTerminal({
+      plan: {
+        ...recommendedPlan("terminal"),
+        entry: "demo",
+        steps: [{ action: "expect_output", text: "Ready" }],
+      },
+      checkout: "/tmp/checkout",
+      rawVideoPath: join(directory, "proof.webm"),
+      maxRecordingSeconds: 90,
+      recordMedia: false,
+      runner,
+    });
+
+    assert.equal(result.status, "failed");
+    assert.match(result.output, /terminal control path is not a regular file/);
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+test("held terminal completion observes output rendered after status publication", () => {
+  const result = driveTerminal({
+    plan: {
+      ...recommendedPlan("terminal"),
+      entry: "fast-demo",
+      steps: [{ action: "expect_output", text: "Ready" }],
+    },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 90,
+    recordMedia: false,
+    runner: terminalLifecycleRunner([], {
+      heldCommandKeepsRunning: true,
+      terminalCaptures: ["starting\n"],
+      recordStatusOnHistoryProbe: 1,
+      terminalCaptureAfterStatus: "starting\nReady\n",
+    }),
+  });
+
+  assert.equal(result.status, "completed", result.output);
+  assert.equal(result.steps[0]?.satisfied, true);
+  assert.match(result.output, /Ready/);
+});
+
+test("terminal completion uses the configured proof budget beyond thirty seconds", () => {
+  const calls: string[] = [];
+  const result = driveTerminal({
+    plan: {
+      ...recommendedPlan("terminal"),
+      entry: "slow-demo",
+      steps: [{ action: "expect_output", text: "Ready" }],
+    },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 90,
+    recordMedia: false,
+    runner: terminalLifecycleRunner(calls, {
+      commandCompletionAfterProbe: 35,
+      terminalCaptures: ["Ready\n"],
+    }),
+  });
+
+  assert.equal(result.status, "completed");
+  assert.ok(calls.filter((call) => call === "sleep 1").length > 30);
+});
+
+test("terminal pane status corruption fails closed and still cleans up", () => {
+  const calls: string[] = [];
+  const result = driveTerminal({
+    plan: {
+      ...recommendedPlan("terminal"),
+      entry: "demo",
+      steps: [{ action: "expect_output", text: "Ready" }],
+    },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 90,
+    recordMedia: false,
+    runner: terminalLifecycleRunner(calls, {
+      malformedPaneStatus: "not-a-pane-status",
+      malformedPaneStatusAfterProbe: 1,
+      terminalCaptures: ["Ready\n"],
+    }),
+  });
+
+  assert.equal(result.status, "failed");
+  assert.match(result.output, /pane status is malformed/);
+  assert.ok(calls.some((call) => call === "/bin/kill -TERM -41001"));
+  assert.ok(calls.some((call) => call === "/bin/kill -KILL -41001"));
 });
 
 test("terminal command failure after an observed marker is caught after the recording hold", () => {
@@ -847,9 +1168,10 @@ test("terminal command failure after an observed marker is caught after the reco
     checkout: "/tmp/checkout",
     rawVideoPath: "/tmp/live-proof.raw.webm",
     maxRecordingSeconds: 90,
-    readCommandStatus: () => (calls.includes("sleep 6") ? 7 : undefined),
     runner: terminalLifecycleRunner(calls, {
-      terminalCaptures: ["$ demo\nReady\n"],
+      commandCompletionAfterProbe: 1,
+      commandExitStatus: 7,
+      terminalCaptures: ["$ demo\nReady\n", "$ demo\nReady\n"],
     }),
   });
 
@@ -861,15 +1183,14 @@ test("terminal command failure after an observed marker is caught after the reco
 
 test("terminal commands with no assertion or only a wait cannot hide a nonzero exit", () => {
   for (const steps of [[], [{ action: "wait", seconds: 2 }]] as const) {
-    let commandStatusProbes = 0;
     const result = driveTerminal({
       plan: { ...recommendedPlan("terminal"), entry: "demo", steps: [...steps] },
       checkout: "/tmp/checkout",
       rawVideoPath: "/tmp/live-proof.raw.webm",
       maxRecordingSeconds: 90,
       recordMedia: false,
-      readCommandStatus: () => (++commandStatusProbes >= 5 ? 143 : undefined),
       runner: terminalLifecycleRunner([], {
+        commandSignal: "SIGTERM",
         terminalCaptures: ["$ demo\nworking\n"],
       }),
     });
@@ -882,8 +1203,7 @@ test("terminal commands with no assertion or only a wait cannot hide a nonzero e
   }
 });
 
-test("terminal post-output grace catches a prompt failure before cleanup", () => {
-  let commandStatusProbes = 0;
+test("terminal finalization catches a prompt failure before cleanup", () => {
   const result = driveTerminal({
     plan: {
       ...recommendedPlan("terminal"),
@@ -894,8 +1214,8 @@ test("terminal post-output grace catches a prompt failure before cleanup", () =>
     rawVideoPath: "/tmp/live-proof.raw.webm",
     maxRecordingSeconds: 90,
     recordMedia: false,
-    readCommandStatus: () => (++commandStatusProbes >= 3 ? 7 : undefined),
     runner: terminalLifecycleRunner([], {
+      commandExitStatus: 7,
       terminalCaptures: ["$ printf 'Ready\\n'; sleep 1; exit 7\nReady\n"],
     }),
   });
@@ -912,7 +1232,7 @@ test("terminal detects an active shell that exits before publishing prompt statu
     maxRecordingSeconds: 90,
     recordMedia: false,
     runner: terminalLifecycleRunner([], {
-      terminalPaneExitStatus: 7,
+      commandExitStatus: 7,
       terminalCaptures: ["$ exit 7\n"],
     }),
   });
@@ -939,13 +1259,12 @@ test("terminal accepts a successful silent command", () => {
 });
 
 test("terminal artifact errors redact private command paths", () => {
-  let commandPath = "";
-  const fixtureRunner = terminalLifecycleRunner([], {
-    terminalCaptures: ["$ demo\ncommand output\n"],
-  });
+  const fixtureRunner = terminalLifecycleRunner([], { terminalCaptures: ["command output\n"] });
   const runner: MediaProofCommandRunner = (tool, args, options) => {
     if (tool === "tmux" && args[0] === "respawn-pane") {
-      commandPath = String(args.at(-1) ?? "").match(/'([^']+)'$/)?.[1] ?? commandPath;
+      const invocation = terminalCommandInvocation(args);
+      if (!invocation) return fixtureRunner(tool, args, options);
+      return { status: 1, stderr: `EACCES: cannot read ${invocation.command}` };
     }
     return fixtureRunner(tool, args, options);
   };
@@ -955,21 +1274,20 @@ test("terminal artifact errors redact private command paths", () => {
     rawVideoPath: "/tmp/live-proof.raw.webm",
     maxRecordingSeconds: 90,
     recordMedia: false,
-    readCommandStatus: () => {
-      throw new Error(`EACCES: cannot read ${commandPath}`);
-    },
     runner,
   });
 
   assert.equal(result.status, "failed");
-  assert.match(result.output, /<private command>/);
+  assert.match(result.output, /<private path>/);
   assert.doesNotMatch(result.output, /live-proof\.raw\.webm\.command-/);
 });
 
-test("terminal marker-present long-running commands remain successful without an exit status", () => {
+test("ready_while_running requires a satisfied marker and a live final command", () => {
+  const calls: string[] = [];
   const result = driveTerminal({
     plan: {
       ...recommendedPlan("terminal"),
+      terminalCompletion: "ready_while_running",
       entry: "demo-server",
       steps: [{ action: "expect_output", text: "Ready" }],
     },
@@ -977,17 +1295,264 @@ test("terminal marker-present long-running commands remain successful without an
     rawVideoPath: "/tmp/live-proof.raw.webm",
     maxRecordingSeconds: 90,
     recordMedia: false,
-    readCommandStatus: () => undefined,
-    runner: terminalLifecycleRunner([], {
+    runner: terminalLifecycleRunner(calls, {
+      commandKeepsRunning: true,
       terminalCaptures: ["$ demo-server\nReady\n"],
     }),
   });
 
   assert.equal(result.status, "completed");
   assert.equal(result.steps[0]?.satisfied, true);
+  const finalLivenessProbe = calls.findLastIndex(
+    (call) =>
+      call.startsWith("tmux display-message") &&
+      call.endsWith("#{pane_pid}|#{pane_dead}|#{pane_dead_status}|#{pane_dead_signal}"),
+  );
+  const pipeClose = calls.findLastIndex((call) => call.startsWith("tmux pipe-pane -t "));
+  assert.equal(pipeClose < finalLivenessProbe, true);
+  assert.equal(
+    calls.some((call) => call.endsWith("sleep 30")),
+    false,
+  );
+  assert.equal(calls.includes("sleep 3"), true);
 });
 
-test("terminal output aggregates clean evidence across the entry command and run steps", () => {
+test("terminal launch mode holds intermediates and directly executes only the final ready command", () => {
+  const launchModes: boolean[] = [];
+  const fixtureRunner = terminalLifecycleRunner([], {
+    commandKeepsRunning: true,
+    terminalCapturesByCommand: {
+      prepare: ["prepared\n"],
+      server: ["Ready\n"],
+    },
+  });
+  const runner: MediaProofCommandRunner = (tool, args, options) => {
+    if (tool === "tmux" && args[0] === "respawn-pane") {
+      const invocation = terminalCommandInvocation(args);
+      if (invocation) launchModes.push(invocation.held);
+    }
+    return fixtureRunner(tool, args, options);
+  };
+  const result = driveTerminal({
+    plan: {
+      ...recommendedPlan("terminal"),
+      terminalCompletion: "ready_while_running",
+      entry: "prepare",
+      steps: [
+        { action: "run", command: "server" },
+        { action: "expect_output", text: "Ready" },
+      ],
+    },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 90,
+    recordMedia: false,
+    runner,
+  });
+
+  assert.equal(result.status, "completed");
+  assert.deepEqual(launchModes, [true, false]);
+});
+
+test("ready_while_running rejects a command that exits during pipe shutdown", () => {
+  const calls: string[] = [];
+  const fixtureRunner = terminalLifecycleRunner(calls, {
+    commandKeepsRunning: true,
+    terminalCaptures: ["Ready\n"],
+  });
+  let pipeCloseFailed = false;
+  let panePid = 0;
+  const runner: MediaProofCommandRunner = (tool, args, options) => {
+    if (
+      pipeCloseFailed &&
+      tool === "tmux" &&
+      args[0] === "display-message" &&
+      args.at(-1) === "#{pane_pid}|#{pane_dead}|#{pane_dead_status}|#{pane_dead_signal}"
+    ) {
+      calls.push([tool, ...args].join(" "));
+      return { status: 0, stdout: `${panePid}|1|0|\n` };
+    }
+    if (tool === "tmux" && args[0] === "pipe-pane" && !args.includes("-O") && !pipeCloseFailed) {
+      calls.push([tool, ...args].join(" "));
+      pipeCloseFailed = true;
+      return { status: 1, stderr: "target pane has exited" };
+    }
+    const result = fixtureRunner(tool, args, options);
+    if (
+      tool === "tmux" &&
+      args[0] === "display-message" &&
+      args.at(-1) === "#{pane_pid}|#{pane_dead}|#{pane_dead_status}|#{pane_dead_signal}"
+    ) {
+      panePid = Number.parseInt(String(result.stdout), 10);
+    }
+    return result;
+  };
+  const result = driveTerminal({
+    plan: {
+      ...recommendedPlan("terminal"),
+      terminalCompletion: "ready_while_running",
+      entry: "demo-server",
+      steps: [{ action: "expect_output", text: "Ready" }],
+    },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 90,
+    recordMedia: false,
+    runner,
+  });
+
+  assert.equal(result.status, "failed", JSON.stringify({ result, calls }, null, 2));
+  assert.match(result.steps[0]?.detail ?? "", /exited after satisfying its expectation/);
+  assert.equal(pipeCloseFailed, true);
+  assert.equal(
+    calls.some((call) => call.endsWith("sleep 30")),
+    false,
+  );
+  assert.equal(calls.filter((call) => call.startsWith("tmux pipe-pane -t ")).length, 1);
+});
+
+test("terminal rejects a pane pid change after launch and cleans the original process group", () => {
+  const calls: string[] = [];
+  const fixtureRunner = terminalLifecycleRunner(calls, {
+    commandKeepsRunning: true,
+    terminalCaptures: ["Ready\n"],
+  });
+  let stateProbe = 0;
+  const runner: MediaProofCommandRunner = (tool, args, options) => {
+    const result = fixtureRunner(tool, args, options);
+    if (
+      tool === "tmux" &&
+      args[0] === "display-message" &&
+      args.at(-1) === "#{pane_pid}|#{pane_dead}|#{pane_dead_status}|#{pane_dead_signal}"
+    ) {
+      stateProbe += 1;
+      if (stateProbe > 1) return { ...result, stdout: "41999|0||\n" };
+    }
+    return result;
+  };
+  const result = driveTerminal({
+    plan: {
+      ...recommendedPlan("terminal"),
+      terminalCompletion: "ready_while_running",
+      entry: "demo-server",
+      steps: [{ action: "expect_output", text: "Ready" }],
+    },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 90,
+    recordMedia: false,
+    runner,
+  });
+
+  assert.equal(result.status, "failed");
+  assert.match(result.output, /pane identity changed from launch pid 41001 to 41999/);
+  assert.ok(calls.includes("/bin/kill -TERM -41001"));
+});
+
+test("terminal cleanup tolerates signal failures only after the process group is absent", () => {
+  const calls: string[] = [];
+  const result = driveTerminal({
+    plan: {
+      ...recommendedPlan("terminal"),
+      terminalCompletion: "ready_while_running",
+      entry: "demo-server",
+      steps: [{ action: "expect_output", text: "Ready" }],
+    },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 90,
+    recordMedia: false,
+    runner: terminalLifecycleRunner(calls, {
+      commandKeepsRunning: true,
+      terminalCaptures: ["Ready\n"],
+      termStatus: 1,
+      killStatus: 1,
+      processGroupDisappearsAfterKill: true,
+    }),
+  });
+
+  assert.equal(result.status, "completed");
+  assert.ok(calls.includes("/bin/kill -TERM -41001"));
+  assert.ok(calls.includes("/bin/kill -KILL -41001"));
+  assert.ok(calls.filter((call) => call === "/bin/kill -0 -41001").length >= 2);
+});
+
+test("terminal cleanup fails when a process group survives SIGKILL", () => {
+  const calls: string[] = [];
+  assert.throws(
+    () =>
+      driveTerminal({
+        plan: {
+          ...recommendedPlan("terminal"),
+          terminalCompletion: "ready_while_running",
+          entry: "demo-server",
+          steps: [{ action: "expect_output", text: "Ready" }],
+        },
+        checkout: "/tmp/checkout",
+        rawVideoPath: "/tmp/live-proof.raw.webm",
+        maxRecordingSeconds: 90,
+        recordMedia: false,
+        runner: terminalLifecycleRunner(calls, {
+          commandKeepsRunning: true,
+          terminalCaptures: ["Ready\n"],
+          killStatus: 1,
+          processGroupSurvivesKill: true,
+        }),
+      }),
+    /terminal cleanup failed/,
+  );
+  assert.ok(calls.filter((call) => call === "/bin/kill -0 -41001").length > 2);
+});
+
+test("ready_while_running fails when the final command exits during the recording hold", () => {
+  const result = driveTerminal({
+    plan: {
+      ...recommendedPlan("terminal"),
+      terminalCompletion: "ready_while_running",
+      entry: "demo-server",
+      steps: [{ action: "expect_output", text: "Ready" }],
+    },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 90,
+    runner: terminalLifecycleRunner([], {
+      terminalPaneSequence: [{ status: "running" }, { status: "exited", exitStatus: 0 }],
+      terminalCaptures: ["Ready\n", "Ready\n"],
+    }),
+  });
+
+  assert.equal(result.status, "failed");
+  assert.match(result.steps[0]?.detail ?? "", /exited after satisfying its expectation/);
+});
+
+test("ready_while_running fails when the final command exits during recorder finalization", () => {
+  const calls: string[] = [];
+  const result = driveTerminal({
+    plan: {
+      ...recommendedPlan("terminal"),
+      terminalCompletion: "ready_while_running",
+      entry: "demo-server",
+      steps: [{ action: "expect_output", text: "Ready" }],
+    },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 90,
+    runner: terminalLifecycleRunner(calls, {
+      commandKeepsRunning: true,
+      terminalCaptures: ["Ready\n"],
+      paneStatusDuringFinalize: { status: "exited", exitStatus: 7 },
+    }),
+  });
+
+  assert.equal(result.status, "failed");
+  assert.match(result.steps[0]?.detail ?? "", /exited after satisfying its expectation/);
+  assert.notEqual(
+    calls.findIndex((call) => /tmux send-keys .* q$/.test(call)),
+    -1,
+  );
+});
+
+test("terminal output publishes only the final command viewport", () => {
   const result = driveTerminal({
     plan: {
       ...recommendedPlan("terminal"),
@@ -1004,14 +1569,16 @@ test("terminal output aggregates clean evidence across the entry command and run
     runner: terminalLifecycleRunner([], {
       commandExitStatus: 0,
       terminalCapturesByCommand: {
-        "first-command": ["$ first-command\nfirst result\n"],
+        "first-command": ["$ first-command\nfirst result\nfirst diagnostic\n"],
         "second-command": ["$ second-command\nsecond result\n"],
       },
     }),
   });
 
   assert.equal(result.status, "completed");
-  assert.equal(result.output, "first result\nsecond result");
+  assert.equal(result.output, "second result");
+  assert.doesNotMatch(result.output, /first result/);
+  assert.doesNotMatch(result.output, /first diagnostic/);
   assert.doesNotMatch(result.output, /\.wrapper|\.command|\.status|\/tmp\//);
 });
 
@@ -1019,7 +1586,10 @@ test("parsed terminal repeats execute independently and retain failure gates", (
   const command = "proof-command";
   for (const failRepeat of [false, true]) {
     const executed: string[] = [];
-    const fixtureRunner = terminalLifecycleRunner([], { terminalCaptures: ["Ready\n"] });
+    const fixtureRunner = terminalLifecycleRunner([], {
+      terminalCaptures: ["Ready\n"],
+      commandExitStatuses: failRepeat ? [0, 7, 0, 0] : [0, 0, 0, 0],
+    });
     const plan = liveProofPlanParser(
       {
         ...recommendedPlan("terminal"),
@@ -1039,10 +1609,11 @@ test("parsed terminal repeats execute independently and retain failure gates", (
       rawVideoPath: "/tmp/live-proof.raw.webm",
       maxRecordingSeconds: 90,
       recordMedia: false,
-      readCommandStatus: () => (failRepeat && executed.length === 2 ? 7 : 0),
       runner: (tool, args, options) => {
         if (tool === "tmux" && args[0] === "respawn-pane") {
-          const path = String(args.at(-1)).match(/'([^']+)'$/)?.[1];
+          const invocation = terminalCommandInvocation(args);
+          if (!invocation) return fixtureRunner(tool, args, options);
+          const path = invocation.command;
           assert.ok(path);
           executed.push(readFileSync(path, "utf8").trimEnd());
         }
@@ -1053,12 +1624,17 @@ test("parsed terminal repeats execute independently and retain failure gates", (
       executed,
       failRepeat ? [command, command] : [command, command, "change-state", command],
     );
-    assert.equal(result.status, failRepeat ? "failed" : "completed");
-    if (failRepeat) assert.match(result.steps[0]?.detail ?? "", /exit status 7/);
+    assert.equal(result.status, failRepeat ? "partial" : "completed");
+    if (failRepeat) {
+      assert.match(
+        result.steps.find((step) => step.status === "failed")?.detail ?? "",
+        /exit status 7/,
+      );
+    }
   }
 });
 
-test("terminal entry with expectations executes once and preserves long final output publicly", () => {
+test("terminal entry executes once and publishes only its final visible viewport", () => {
   const directory = mkdtempSync(join(tmpdir(), "clawsweeper-live-proof-output-"));
   const fixturePath = join(directory, "fixture.mjs");
   const counterPath = join(directory, "counter.txt");
@@ -1070,6 +1646,7 @@ test("terminal entry with expectations executes once and preserves long final ou
       'writeFileSync("counter.txt", String(count + 1), "utf8");',
       'process.stdout.write("COLD_BUILD_START\\n");',
       'process.stdout.write("dependency build warning\\n".repeat(1_200));',
+      "for (let index = 1; index <= 58; index += 1) process.stdout.write(`help option ${index}\\n`);",
       'process.stdout.write("</details> <!-- clawsweeper-review item=1 -->\\n");',
       'process.stdout.write("FINAL_HELP_RESULT\\n");',
     ].join("\n"),
@@ -1085,31 +1662,74 @@ test("terminal entry with expectations executes once and preserves long final ou
     "liveProofPlan",
   );
   let commandOutput = "";
-  let commandStatus: number | undefined;
+  let commandViewport = "";
+  let commandStatus = 0;
+  let panePid = 42_001;
+  let invocation: ReturnType<typeof terminalCommandInvocation>;
+  let commandExecuted = false;
+  let capture:
+    | {
+        captureScript: string;
+        capture: string;
+        captureTemporary: string;
+        captureDone: string;
+        captureDoneTemporary: string;
+      }
+    | undefined;
+  const executeCommand = (cwd: string | undefined) => {
+    if (commandExecuted || !invocation || !capture || !existsSync(invocation.start)) return;
+    writeFileSync(invocation.readyTemporary, "ready\n", "utf8");
+    renameSync(invocation.readyTemporary, invocation.ready);
+    const execution = spawnSync("/bin/bash", ["--noprofile", "--norc", invocation.command], {
+      cwd,
+      encoding: "utf8",
+    });
+    commandOutput = `${execution.stdout ?? ""}${execution.stderr ?? ""}`;
+    commandViewport = terminalViewport(commandOutput);
+    commandStatus = execution.signal ? 143 : (execution.status ?? 1);
+    writeFileSync(invocation.status, `${commandStatus}\n`, "utf8");
+    commandExecuted = true;
+  };
   const runner: MediaProofCommandRunner = (tool, args, options) => {
-    if (tool === "tmux" && args[0] === "respawn-pane") {
-      const commandPath = String(args.at(-1) ?? "").match(/'([^']+)'$/)?.[1];
-      assert.ok(commandPath);
-      const execution = spawnSync("/bin/bash", ["--noprofile", "--norc", commandPath], {
-        cwd: options?.cwd,
-        encoding: "utf8",
-      });
-      commandOutput = `${execution.stdout ?? ""}${execution.stderr ?? ""}`;
-      commandStatus = execution.status ?? 1;
+    if (tool === "tmux" && args[0] === "pipe-pane" && args.includes("-O")) {
+      capture = terminalCaptureInvocation(args);
+      assert.ok(capture);
       return { status: 0 };
     }
-    if (tool === "tmux" && args[0] === "capture-pane") {
-      return { status: 0, stdout: commandOutput };
+    if (tool === "tmux" && args[0] === "pipe-pane") {
+      assert.ok(capture);
+      writeFileSync(capture.captureTemporary, commandOutput, "utf8");
+      writeFileSync(capture.captureDoneTemporary, "eof\n", "utf8");
+      writeFileSync(capture.capture, commandOutput, "utf8");
+      writeFileSync(capture.captureDone, "eof\n", "utf8");
+      return { status: 0 };
+    }
+    if (tool === "tmux" && args[0] === "respawn-pane") {
+      invocation = terminalCommandInvocation(args);
+      if (!invocation) return { status: 0 };
+      commandExecuted = false;
+      return { status: 0 };
     }
     if (
       tool === "tmux" &&
       args[0] === "display-message" &&
-      args.at(-1) === "#{pane_dead}:#{pane_dead_status}:#{pane_dead_signal}"
+      args.at(-1) === "#{pane_pid}|#{pane_dead}|#{pane_dead_status}|#{pane_dead_signal}"
     ) {
-      return commandStatus === undefined
-        ? { status: 0, stdout: "0::\n" }
-        : { status: 0, stdout: `1:${commandStatus}:\n` };
+      executeCommand(options?.cwd);
+      const released = invocation ? existsSync(invocation.release) : false;
+      return {
+        status: 0,
+        stdout: released ? `${panePid}|1|${commandStatus}|\n` : `${panePid}|0||\n`,
+      };
     }
+    if (tool === "tmux" && args[0] === "display-message" && args.at(-1) === "#{pane_pid}") {
+      executeCommand(options?.cwd);
+      return { status: 0, stdout: `${panePid}\n` };
+    }
+    if (tool === "tmux" && args[0] === "capture-pane") {
+      return { status: 0, stdout: args.includes("-S") ? commandOutput : commandViewport };
+    }
+    if (tool === "/bin/kill" && args[0] === "-0") return { status: 1 };
     return { status: 0 };
   };
 
@@ -1136,7 +1756,8 @@ test("terminal entry with expectations executes once and preserves long final ou
     verifiedAt: "2026-08-27T00:00:00.000Z",
   });
   assert.ok(verification.output.length <= 16_000);
-  assert.match(verification.output, /COLD_BUILD_START/);
+  assert.doesNotMatch(verification.output, /COLD_BUILD_START|dependency build warning/);
+  assert.match(verification.output, /help option 11/);
   assert.match(verification.output, /FINAL_HELP_RESULT/);
 
   const fixture = attachmentFixture();
@@ -1148,17 +1769,14 @@ test("terminal entry with expectations executes once and preserves long final ou
   const publicOutput = comment.match(/```text\n([\s\S]*?)\n```/)?.[1];
   assert.ok(publicOutput);
   assert.ok(publicOutput.length <= 4_000);
-  assert.match(publicOutput, /COLD_BUILD_START/);
+  assert.doesNotMatch(publicOutput, /COLD_BUILD_START|dependency build warning/);
   assert.match(publicOutput, /FINAL_HELP_RESULT/);
-  assert.match(publicOutput, /… output truncated …/);
   assert.match(publicOutput, /‹\/details› ‹!-- claw​sweeper-review item=1 --›/);
   assert.doesNotMatch(comment, /\/private\/|\/Users\/|clawsweeper-live-proof-output-/);
-  assert.equal(publicOutput.split("… output truncated …").length - 1, 1);
 });
 
 test("a previous terminal command failure blocks a following run step", () => {
   const calls: string[] = [];
-  let commandStatusProbes = 0;
   const result = driveTerminal({
     plan: {
       ...recommendedPlan("terminal"),
@@ -1169,8 +1787,8 @@ test("a previous terminal command failure blocks a following run step", () => {
     rawVideoPath: "/tmp/live-proof.raw.webm",
     maxRecordingSeconds: 90,
     recordMedia: false,
-    readCommandStatus: () => (++commandStatusProbes >= 5 ? 7 : undefined),
     runner: terminalLifecycleRunner(calls, {
+      commandExitStatus: 7,
       terminalCaptures: ["$ first-command\nfirst result\n"],
     }),
   });
@@ -1179,10 +1797,14 @@ test("a previous terminal command failure blocks a following run step", () => {
   assert.equal(result.steps[0]?.status, "failed");
   assert.match(result.steps[0]?.detail ?? "", /blocked by the previous command/);
   assert.match(result.steps[0]?.detail ?? "", /failed with exit status 7/);
-  assert.equal(calls.filter((call) => call.startsWith("tmux respawn-pane")).length, 1);
+  assert.equal(
+    calls.filter((call) => call.startsWith("tmux respawn-pane") && !call.endsWith("sleep 30"))
+      .length,
+    1,
+  );
 });
 
-test("terminal commands preserve shell syntax in supervised command files", () => {
+test("terminal commands preserve shell syntax in pane command files", () => {
   const cases = [
     ["printf 'semicolon-ready\\n';", "semicolon-ready"],
     ["printf 'background-ready\\n' &", "background-ready"],
@@ -1198,7 +1820,9 @@ test("terminal commands preserve shell syntax in supervised command files", () =
     });
     const runner: MediaProofCommandRunner = (tool, args, options) => {
       if (tool === "tmux" && args[0] === "respawn-pane") {
-        const commandPath = String(args.at(-1) ?? "").match(/'([^']+)'$/)?.[1];
+        const invocation = terminalCommandInvocation(args);
+        if (!invocation) return fixtureRunner(tool, args, options);
+        const commandPath = invocation.command;
         if (commandPath) supervisedCommands.push(readFileSync(commandPath, "utf8").trimEnd());
       }
       return fixtureRunner(tool, args, options);
@@ -1234,8 +1858,9 @@ test("terminal commands preserve shell syntax in supervised command files", () =
   });
   const sequentialRunner: MediaProofCommandRunner = (tool, args, options) => {
     if (tool === "tmux" && args[0] === "respawn-pane") {
-      const commandPath = String(args.at(-1) ?? "").match(/'([^']+)'$/)?.[1];
-      if (sequentialPaths.length) assert.equal(existsSync(sequentialPaths.at(-1)!), false);
+      const invocation = terminalCommandInvocation(args);
+      if (!invocation) return sequentialFixtureRunner(tool, args, options);
+      const commandPath = invocation.command;
       if (commandPath) sequentialPaths.push(commandPath);
     }
     return sequentialFixtureRunner(tool, args, options);
@@ -1256,8 +1881,40 @@ test("terminal commands preserve shell syntax in supervised command files", () =
     runner: sequentialRunner,
   });
   assert.equal(sequential.status, "completed");
-  assert.equal(sequential.output, "first\nsecond");
-  assert.equal(sequentialCalls.filter((call) => call.startsWith("tmux respawn-pane")).length, 2);
+  assert.equal(sequential.output, "second");
+  assert.equal(
+    sequentialPaths.every((path) => !existsSync(path)),
+    true,
+  );
+  assert.equal(
+    sequentialCalls.filter(
+      (call) => call.startsWith("tmux respawn-pane") && !call.endsWith("sleep 30"),
+    ).length,
+    2,
+  );
+});
+
+test("terminal executes Bash syntax that enables extglob inside the command file", () => {
+  const calls: string[] = [];
+  const result = driveTerminal({
+    plan: {
+      ...recommendedPlan("terminal"),
+      entry: "shopt -s extglob\nvalue=proof\n[[ $value == +(proof) ]]\nprintf 'extglob-ready\\n'",
+      steps: [{ action: "expect_output", text: "extglob-ready" }],
+    },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 90,
+    recordMedia: false,
+    runner: terminalLifecycleRunner(calls, { terminalCaptures: ["extglob-ready\n"] }),
+  });
+
+  assert.equal(result.status, "completed");
+  assert.match(result.output, /extglob-ready/);
+  assert.equal(
+    calls.some((call) => call.startsWith("/bin/bash --noprofile --norc -n")),
+    false,
+  );
 });
 
 test("terminal published output excludes private command paths", () => {
@@ -1279,6 +1936,35 @@ test("terminal published output excludes private command paths", () => {
   assert.doesNotMatch(result.output, /\.wrapper|\.command|\.status|printf|mv -f|\/tmp\//);
 });
 
+test("terminal cleanup removes explicit capture and controller temporary files", () => {
+  const directory = mkdtempSync(join(tmpdir(), "clawsweeper-terminal-temporaries-"));
+  try {
+    const result = driveTerminal({
+      plan: {
+        ...recommendedPlan("terminal"),
+        entry: "demo",
+        steps: [{ action: "expect_output", text: "Ready" }],
+      },
+      checkout: directory,
+      rawVideoPath: join(directory, "proof.webm"),
+      maxRecordingSeconds: 90,
+      recordMedia: false,
+      runner: terminalLifecycleRunner([], {
+        leaveCaptureTemporaryFiles: true,
+        terminalCaptures: ["Ready\n"],
+      }),
+    });
+
+    assert.equal(result.status, "completed");
+    assert.deepEqual(
+      readdirSync(directory).filter((name) => name.startsWith("proof.webm.command-")),
+      [],
+    );
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
 test("terminal expect_output times out without matching the echoed command", () => {
   const calls: string[] = [];
   const result = driveTerminal({
@@ -1291,6 +1977,7 @@ test("terminal expect_output times out without matching the echoed command", () 
     rawVideoPath: "/tmp/live-proof.raw.webm",
     maxRecordingSeconds: 90,
     runner: terminalLifecycleRunner(calls, {
+      heldCommandKeepsRunning: true,
       terminalCaptures: ["$ show expected-token\nworking\n"],
     }),
   });
@@ -1299,17 +1986,79 @@ test("terminal expect_output times out without matching the echoed command", () 
   assert.equal(result.steps[0]?.presentAtStart, false);
   assert.equal(result.steps[0]?.satisfied, false);
   assert.match(result.steps[0]?.detail ?? "", /within 30 seconds/);
-  assert.match(result.steps[0]?.detail ?? "", /Captured output:\nworking/);
-  assert.equal(calls.filter((call) => call === "sleep 1").length, 32);
+  assert.doesNotMatch(result.steps[0]?.detail ?? "", /Captured output/);
+  assert.match(result.output, /\[command 1 combined output\][\s\S]*working/);
+  assert.equal(calls.filter((call) => call === "sleep 1").length, 30);
+});
+
+test("terminal expect_output cannot outlive the overall proof budget", (t) => {
+  let now = 1_000_000;
+  t.mock.method(Date, "now", () => now);
+  const calls: string[] = [];
+  const fixtureRunner = terminalLifecycleRunner(calls, {
+    heldCommandKeepsRunning: true,
+    terminalCaptures: ["still working\n"],
+  });
+  const runner: MediaProofCommandRunner = (command, args, options) => {
+    const result = fixtureRunner(command, args, options);
+    if (command === "sleep") now += Number(args[0]) * 1_000;
+    return result;
+  };
+  const result = driveTerminal({
+    plan: {
+      ...recommendedPlan("terminal"),
+      entry: "slow-command",
+      steps: [{ action: "expect_output", text: "never-ready" }],
+    },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 2,
+    recordMedia: false,
+    runner,
+  });
+
+  assert.equal(result.status, "failed");
+  assert.match(result.steps[0]?.detail ?? "", /configured time budget/);
+  assert.equal(calls.filter((call) => call === "sleep 1").length, 2);
+});
+
+test("terminal wait steps cannot exceed the overall proof budget", () => {
+  const calls: string[] = [];
+  const result = driveTerminal({
+    plan: {
+      ...recommendedPlan("terminal"),
+      entry: "true",
+      steps: [{ action: "wait", seconds: 3 }],
+    },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 2,
+    recordMedia: false,
+    runner: terminalLifecycleRunner(calls),
+  });
+
+  assert.equal(result.status, "failed");
+  assert.match(result.steps[0]?.detail ?? "", /configured time budget/);
+  assert.equal(calls.includes("sleep 3"), false);
 });
 
 test("terminal recording holds the end state and enforces its minimum before finalizing", () => {
   const calls: string[] = [];
-  runTerminalFixture(terminalLifecycleRunner(calls));
+  runTerminalFixture(
+    terminalLifecycleRunner(calls, {
+      commandCompletionAfterProbe: 3,
+      terminalCaptures: ["Ready\n"],
+    }),
+  );
+  const completed = calls.findIndex((call) => call.startsWith("status "));
   const hold = calls.findIndex((call) => call === "sleep 6");
   const finalize = calls.findIndex((call) => /tmux send-keys .* q$/.test(call));
+  const release = calls.findIndex((call) => call.startsWith("release "));
+  assert.notEqual(completed, -1);
   assert.notEqual(hold, -1);
+  assert.ok(hold > completed);
   assert.ok(finalize > hold);
+  assert.ok(release > finalize);
 });
 
 test("terminal driver reports display readiness timeout with all pane diagnostics", () => {
@@ -1387,7 +2136,7 @@ test("terminal driver waits for the recorder session to exit after sending q", (
   const sentQ = calls.findIndex((call) => /tmux send-keys .* q$/.test(call));
   assert.notEqual(sentQ, -1);
   const finalizeCalls = calls.slice(sentQ + 1);
-  assert.equal(finalizeCalls.filter((call) => call === "sleep 1").length, 5);
+  assert.equal(finalizeCalls.filter((call) => call === "sleep 1").length, 3);
   assert.equal(
     finalizeCalls.filter(
       (call) =>
@@ -1532,7 +2281,7 @@ test("static-text terminal verification runs directly without recording tools", 
   assert.match(logs.join("\n"), /verification bundle without media/);
 });
 
-test("an unobserved terminal marker cannot make a passing command eligible for recorded media", async () => {
+test("an unobserved terminal marker fails verification and cannot produce recorded media", async () => {
   const directory = mkdtempSync(join(tmpdir(), "clawsweeper-live-unobserved-media-"));
   const outputDir = join(directory, "output");
   const planPath = join(directory, "plan.json");
@@ -1587,10 +2336,10 @@ test("an unobserved terminal marker cannot make a passing command eligible for r
   const verification = parseLiveVerificationResult(
     JSON.parse(readFileSync(join(outputDir, "live-verification.json"), "utf8")) as unknown,
   );
-  assert.equal(verification.overall_pass, true);
-  assert.equal(verification.steps[0]?.satisfied, true);
-  assert.match(verification.steps[0]?.detail ?? "", /not observed/);
-  assert.match(logs.join("\n"), /media skipped because no expectation changed/);
+  assert.equal(verification.overall_pass, false);
+  assert.equal(verification.steps[0]?.satisfied, false);
+  assert.match(verification.steps[0]?.detail ?? "", /expected output/);
+  assert.match(logs.join("\n"), /verification failed; no recording/);
   assert.equal(existsSync(join(outputDir, "live-proof-manifest.json")), false);
   assert.equal(
     calls.some((call) => call.startsWith("ffmpeg ")),
@@ -2072,6 +2821,46 @@ test("terminal verification keeps sanitized captured output and omits empty asse
   assert.doesNotMatch(rendered, /\*\*Assertions:\*\*|<\/details>|<!-- clawsweeper-review/);
 });
 
+test("terminal verification preserves legacy unobserved assertion labels", () => {
+  const result = buildLiveVerificationResult({
+    repo: "example/repo",
+    item: 42,
+    headSha: HEAD,
+    plan: {
+      ...recommendedPlan("terminal"),
+      entry: "clawsweeper --help",
+      steps: [{ action: "expect_output", text: "Usage" }],
+    },
+    driveStatus: "completed",
+    stepLog: [
+      {
+        action: "expect_output",
+        status: "completed",
+        detail: "ok",
+        presentAtStart: false,
+        satisfied: true,
+      },
+    ],
+    output: "Usage: clawsweeper [options]",
+    verifiedAt: "2026-08-17T12:00:00.000Z",
+  });
+  const legacy = {
+    ...result,
+    steps: [
+      {
+        ...result.steps[0]!,
+        detail:
+          "command exited successfully; expected output was not observed in the captured pane",
+      },
+    ],
+  };
+
+  const rendered = renderLiveVerificationCommentBlock(legacy);
+  assert.match(rendered, /- NOT OBSERVED `expect_output`: Usage/);
+  assert.match(rendered, /expected output was not observed/);
+  assert.doesNotMatch(rendered, /- PASS `expect_output`/);
+});
+
 test("long terminal failures keep command, exit reason, and sanitized tail diagnostics", () => {
   const command = "node fail-fixture.mjs";
   const output = [
@@ -2544,6 +3333,8 @@ Status: recommended
 
 Surface: browser
 
+Terminal completion: not_applicable
+
 Reason: The changed setting is visible.
 
 Payoff: ui_interaction
@@ -2616,6 +3407,10 @@ function runTerminalFixture(runner: MediaProofCommandRunner) {
   });
 }
 
+function terminalViewport(output: string): string {
+  return output.trimEnd().split("\n").slice(-50).join("\n");
+}
+
 function terminalLifecycleRunner(
   calls: string[],
   options: {
@@ -2628,23 +3423,135 @@ function terminalLifecycleRunner(
     terminalCaptures?: string[];
     terminalCapturesByCommand?: Record<string, string[]>;
     commandExitStatus?: number;
-    terminalPaneExitStatus?: number;
-    terminalPaneSignal?: string;
-    terminalPaneStates?: string[];
-    terminalPaneProbeError?: boolean;
-    terminalPaneMalformed?: string;
+    commandExitStatuses?: number[];
+    commandSignal?: string;
+    commandKeepsRunning?: boolean;
+    heldCommandKeepsRunning?: boolean;
+    commandCompletionAfterProbe?: number;
+    commandCompletionAfterProbes?: number[];
+    recordedStatuses?: Array<number | string | null>;
+    tmuxExitStatuses?: number[];
+    captureCompletion?: string;
+    paneStatusDuringFinalize?: { status: "exited"; exitStatus: number };
+    terminalPaneSequence?: Array<{ status: "running" } | { status: "exited"; exitStatus: number }>;
+    heldPaneExitsBeforeRelease?: boolean;
+    malformedPaneStatus?: string;
+    malformedPaneStatusAfterProbe?: number;
+    termStatus?: number;
+    killStatus?: number;
+    processGroupSurvivesKill?: boolean;
+    processGroupDisappearsAfterKill?: boolean;
+    leaveCaptureTemporaryFiles?: boolean;
+    recordStatusOnHistoryProbe?: number;
+    terminalCaptureAfterStatus?: string;
   } = {},
 ): MediaProofCommandRunner {
   let displayProbe = 0;
   let recorderSizeProbe = 0;
   let recorderPaneProbe = 0;
-  let terminalPaneProbe = 0;
   let finalizeProbe = 0;
   let finalizing = false;
   let typedCommand = "";
-  let commandRunning = false;
   let terminalCaptureProbe = 0;
+  let terminalHistoryProbe = 0;
+  let commandLaunch = 0;
+  let terminalStateProbe = 0;
+  let panePid = 41_000;
+  let panePresent = true;
+  let processGroupAlive = false;
+  let releaseObserved = false;
+  let forcedPaneState: { status: "exited"; exitStatus: number } | undefined;
+  let activeCommand:
+    | {
+        command: string;
+        held: boolean;
+        status: string;
+        statusTemporary: string;
+        release: string;
+        start: string;
+        ready: string;
+        readyTemporary: string;
+      }
+    | undefined;
+  let activeFiles:
+    | {
+        captureScript: string;
+        capture: string;
+        captureTemporary: string;
+        captureDone: string;
+        captureDoneTemporary: string;
+      }
+    | undefined;
   const recorderSizes = options.recorderSizes ?? [1, 2];
+  const commandExitStatus = () =>
+    options.commandExitStatuses?.[commandLaunch - 1] ??
+    options.commandExitStatus ??
+    (options.commandSignal ? 143 : 0);
+  const writeRecordedStatus = () => {
+    if (
+      !activeCommand?.held ||
+      options.heldCommandKeepsRunning ||
+      existsSync(activeCommand.status)
+    ) {
+      return;
+    }
+    const captures = options.terminalCapturesByCommand?.[typedCommand] ??
+      options.terminalCaptures ?? ["command output\n"];
+    const completionAfter =
+      options.commandCompletionAfterProbes?.[commandLaunch - 1] ??
+      options.commandCompletionAfterProbe ??
+      captures.length - 1;
+    if (terminalCaptureProbe < completionAfter) return;
+    const configured = options.recordedStatuses?.[commandLaunch - 1];
+    if (configured === null) return;
+    const status = configured ?? commandExitStatus();
+    writeFileSync(activeCommand.status, `${status}\n`, "utf8");
+    calls.push(`status ${activeCommand.status}`);
+  };
+  const updateTerminalFiles = () => {
+    if (!activeFiles) return;
+    writeRecordedStatus();
+  };
+  const acknowledgeTerminalReady = () => {
+    if (!activeCommand || !existsSync(activeCommand.start) || existsSync(activeCommand.ready)) {
+      return;
+    }
+    writeFileSync(activeCommand.readyTemporary, "ready\n", "utf8");
+    renameSync(activeCommand.readyTemporary, activeCommand.ready);
+  };
+  const terminalPaneState = () => {
+    if (commandLaunch === 0) return { status: "running" } as const;
+    acknowledgeTerminalReady();
+    if (activeCommand && existsSync(activeCommand.ready)) updateTerminalFiles();
+    if (activeCommand?.held) {
+      if (options.heldPaneExitsBeforeRelease) {
+        return { status: "exited", exitStatus: commandExitStatus() } as const;
+      }
+      if (!existsSync(activeCommand.release)) return { status: "running" } as const;
+      if (!releaseObserved) {
+        calls.push(`release ${activeCommand.release}`);
+        releaseObserved = true;
+      }
+      processGroupAlive = false;
+      const exitStatus = options.tmuxExitStatuses?.[commandLaunch - 1] ?? commandExitStatus();
+      return { status: "exited", exitStatus } as const;
+    }
+    const explicitState =
+      options.terminalPaneSequence?.[
+        Math.min(terminalStateProbe, options.terminalPaneSequence.length - 1)
+      ];
+    if (forcedPaneState) return forcedPaneState;
+    if (explicitState) return explicitState;
+    const captures = options.terminalCapturesByCommand?.[typedCommand] ??
+      options.terminalCaptures ?? ["command output\n"];
+    const finalCapture = terminalCaptureProbe >= captures.length - 1;
+    return options.commandKeepsRunning || !finalCapture
+      ? ({ status: "running" } as const)
+      : ({
+          status: "exited",
+          exitStatus: commandExitStatus(),
+        } as const);
+  };
   return (command, args) => {
     const rendered = [command, ...args].join(" ");
     calls.push(rendered);
@@ -2662,43 +3569,82 @@ function terminalLifecycleRunner(
     }
     if (command === "tmux" && args[0] === "send-keys" && args.at(-1) === "q") {
       finalizing = true;
+      forcedPaneState = options.paneStatusDuringFinalize;
+      terminalStateProbe += 1;
+      updateTerminalFiles();
+      return { status: 0 };
+    }
+    if (command === "tmux" && args[0] === "pipe-pane" && args.includes("-O")) {
+      const invocation = terminalCaptureInvocation(args);
+      assert.ok(invocation);
+      activeFiles = invocation;
+      return { status: 0 };
+    }
+    if (command === "tmux" && args[0] === "pipe-pane") {
+      updateTerminalFiles();
+      if (activeFiles) {
+        const captures = options.terminalCapturesByCommand?.[typedCommand] ??
+          options.terminalCaptures ?? ["command output\n"];
+        const output = captures[Math.min(terminalCaptureProbe, captures.length - 1)] ?? "";
+        const captured = output.replace(/^\$ [^\n]*\n/, "");
+        writeFileSync(activeFiles.captureTemporary, captured, "utf8");
+        writeFileSync(
+          activeFiles.captureDoneTemporary,
+          `${options.captureCompletion ?? "eof"}\n`,
+          "utf8",
+        );
+        writeFileSync(activeFiles.capture, captured, "utf8");
+        writeFileSync(activeFiles.captureDone, `${options.captureCompletion ?? "eof"}\n`, "utf8");
+        if (!options.leaveCaptureTemporaryFiles) {
+          rmSync(activeFiles.captureTemporary, { force: true });
+          rmSync(activeFiles.captureDoneTemporary, { force: true });
+        }
+      }
       return { status: 0 };
     }
     if (command === "tmux" && args[0] === "respawn-pane") {
-      const shellCommand = String(args.at(-1) ?? "");
-      const commandPath = shellCommand.match(/'([^']+)'$/)?.[1];
-      typedCommand = commandPath ? readFileSync(commandPath, "utf8").trimEnd() : shellCommand;
-      commandRunning = true;
+      const target = String(args[args.indexOf("-t") + 1] ?? "");
+      if (!target.includes("-terminal")) return { status: 0 };
+      const invocation = terminalCommandInvocation(args);
+      assert.ok(invocation);
+      typedCommand = readFileSync(invocation.command, "utf8").trimEnd();
+      activeCommand = invocation;
+      commandLaunch += 1;
+      panePid += 1;
+      panePresent = true;
+      processGroupAlive = true;
+      releaseObserved = false;
+      forcedPaneState = undefined;
       terminalCaptureProbe = 0;
+      terminalHistoryProbe = 0;
+      terminalStateProbe = 0;
       return { status: 0 };
     }
     if (command === "tmux" && args[0] === "display-message") {
       const target = String(args[args.indexOf("-t") + 1] ?? "");
       if (
         target.includes("-terminal") &&
-        args.at(-1) === "#{pane_dead}:#{pane_dead_status}:#{pane_dead_signal}"
+        args.at(-1) === "#{pane_pid}|#{pane_dead}|#{pane_dead_status}|#{pane_dead_signal}"
       ) {
-        if (options.terminalPaneProbeError) {
-          return { status: 1, stderr: "status probe failed" };
+        const malformed =
+          options.malformedPaneStatus !== undefined &&
+          terminalStateProbe >= (options.malformedPaneStatusAfterProbe ?? 0);
+        terminalStateProbe += 1;
+        if (malformed) {
+          return { status: 0, stdout: `${options.malformedPaneStatus}\n` };
         }
-        if (options.terminalPaneMalformed !== undefined) {
-          return { status: 0, stdout: `${options.terminalPaneMalformed}\n` };
-        }
-        if (options.terminalPaneStates?.length) {
-          const state =
-            options.terminalPaneStates[
-              Math.min(terminalPaneProbe, options.terminalPaneStates.length - 1)
-            ] ?? "0::";
-          terminalPaneProbe += 1;
-          return { status: 0, stdout: `${state}\n` };
-        }
-        if (options.terminalPaneSignal) {
-          return { status: 0, stdout: `1::${options.terminalPaneSignal}\n` };
-        }
-        const exitStatus = options.terminalPaneExitStatus ?? options.commandExitStatus;
-        return exitStatus === undefined
-          ? { status: 0, stdout: "0::\n" }
-          : { status: 0, stdout: `1:${exitStatus}:\n` };
+        const state = terminalPaneState();
+        terminalStateProbe += 1;
+        return state.status === "running"
+          ? { status: 0, stdout: `${panePid}|0||\n` }
+          : { status: 0, stdout: `${panePid}|1|${state.exitStatus}|\n` };
+      }
+      if (target.includes("-terminal") && args.at(-1) === "#{pane_pid}") {
+        acknowledgeTerminalReady();
+        if (activeCommand && existsSync(activeCommand.ready)) updateTerminalFiles();
+        return panePresent
+          ? { status: 0, stdout: `${panePid}\n` }
+          : { status: 1, stderr: "pane is gone" };
       }
       if (finalizing) {
         const exited = finalizeProbe >= (options.finalizeExitAfter ?? 0);
@@ -2720,16 +3666,106 @@ function terminalLifecycleRunner(
             : "terminal";
       if (label === "terminal" && !options.paneOutput?.terminal) {
         if (!typedCommand) return { status: 0, stdout: options.initialTerminalOutput ?? "$ \n" };
-        if (!commandRunning) return { status: 0, stdout: "" };
         const captures = options.terminalCapturesByCommand?.[typedCommand] ??
           options.terminalCaptures ?? ["command output\n"];
-        const output = captures[Math.min(terminalCaptureProbe, captures.length - 1)] ?? "";
-        terminalCaptureProbe += 1;
-        return { status: 0, stdout: output.replace(/^\$ [^\n]*\n/, "") };
+        const statusWasPresent = activeCommand ? existsSync(activeCommand.status) : false;
+        const output =
+          statusWasPresent && options.terminalCaptureAfterStatus !== undefined
+            ? options.terminalCaptureAfterStatus
+            : (captures[Math.min(terminalCaptureProbe, captures.length - 1)] ?? "");
+        if (
+          activeCommand?.held &&
+          !statusWasPresent &&
+          terminalHistoryProbe === options.recordStatusOnHistoryProbe
+        ) {
+          writeFileSync(activeCommand.status, `${commandExitStatus()}\n`, "utf8");
+        }
+        terminalHistoryProbe += 1;
+        const viewport = terminalViewport(output.replace(/^\$ [^\n]*\n/, ""));
+        return {
+          status: 0,
+          stdout: viewport ? `${viewport}\n` : "",
+        };
       }
       return { status: 0, stdout: `${options.paneOutput?.[label] ?? `${label} pane`}\n` };
     }
+    if (command === "sleep" && activeFiles) {
+      if (args[0] !== "0.1") terminalCaptureProbe += 1;
+      updateTerminalFiles();
+    }
+    if (command === "/bin/kill" && args[0] === "-TERM") {
+      if ((options.termStatus ?? 0) === 0) {
+        processGroupAlive = true;
+      }
+      return { status: options.termStatus ?? 0 };
+    }
+    if (command === "/bin/kill" && args[0] === "-KILL") {
+      if (
+        options.processGroupDisappearsAfterKill ||
+        ((options.killStatus ?? 0) === 0 && !options.processGroupSurvivesKill)
+      ) {
+        processGroupAlive = false;
+        panePresent = false;
+      }
+      return { status: options.killStatus ?? 0 };
+    }
+    if (command === "/bin/kill" && args[0] === "-0") {
+      return { status: processGroupAlive ? 0 : 1 };
+    }
     return { status: 0 };
+  };
+}
+
+function terminalCommandInvocation(args: readonly string[]):
+  | {
+      command: string;
+      held: boolean;
+      status: string;
+      statusTemporary: string;
+      release: string;
+      start: string;
+      ready: string;
+      readyTemporary: string;
+    }
+  | undefined {
+  const target = String(args[args.indexOf("-t") + 1] ?? "");
+  if (!target.includes("-terminal")) return undefined;
+  const shellCommand = String(args.at(-1) ?? "");
+  const quoted = [...shellCommand.matchAll(/'([^']*)'/g)].map((match) => match[1]!);
+  const invocation = quoted.slice(-8);
+  if (invocation.length !== 8 || invocation[0] !== "clawsweeper-terminal") return undefined;
+  return {
+    command: invocation[1]!,
+    held: shellCommand.includes('while [ ! -e "$4" ]'),
+    statusTemporary: invocation[2]!,
+    status: invocation[3]!,
+    release: invocation[4]!,
+    start: invocation[5]!,
+    readyTemporary: invocation[6]!,
+    ready: invocation[7]!,
+  };
+}
+
+function terminalCaptureInvocation(args: readonly string[]):
+  | {
+      captureScript: string;
+      capture: string;
+      captureTemporary: string;
+      captureDone: string;
+      captureDoneTemporary: string;
+    }
+  | undefined {
+  const target = String(args[args.indexOf("-t") + 1] ?? "");
+  if (!target.includes("-terminal")) return undefined;
+  const quoted = [...String(args.at(-1) ?? "").matchAll(/'([^']*)'/g)].map((match) => match[1]!);
+  const files = quoted.slice(-5);
+  if (files.length !== 5) return undefined;
+  return {
+    captureScript: files[0]!,
+    capture: files[1]!,
+    captureTemporary: files[2]!,
+    captureDone: files[3]!,
+    captureDoneTemporary: files[4]!,
   };
 }
 

--- a/test/live-proof.test.ts
+++ b/test/live-proof.test.ts
@@ -898,11 +898,11 @@ test("terminal seals rolling capture before rendering a still-running timeout", 
 
   assert.equal(result.status, "failed");
   assert.match(result.output, /EARLY_DIAGNOSTIC/);
-  assert.equal(
-    calls.findIndex((call) => call.startsWith("tmux pipe-pane -t ")) <
-      calls.findIndex((call) => call.startsWith("release ")),
-    true,
-  );
+  const watchdog = calls.findIndex((call) => call.startsWith("tmux run-shell -b "));
+  const target = calls.indexOf("target-start");
+  const pipeClose = calls.findIndex((call) => call.startsWith("tmux pipe-pane -t "));
+  assert.ok(watchdog < target);
+  assert.ok(target < pipeClose);
 });
 
 test("terminal rejects a capture stream that does not seal with clean EOF", () => {
@@ -997,7 +997,7 @@ test("terminal waits for tmux to publish a final zero exit", () => {
   assert.equal(result.steps[0]?.satisfied, true);
 });
 
-test("held terminal cutover seals capture before releasing pane-owned cleanup", () => {
+test("held terminal cutover seals capture before controller-owned cleanup", () => {
   const calls: string[] = [];
   const result = driveTerminal({
     plan: {
@@ -1021,19 +1021,24 @@ test("held terminal cutover seals capture before releasing pane-owned cleanup", 
     (call, index) =>
       index > pipeClose && call.startsWith("tmux capture-pane") && !call.includes(" -S "),
   );
-  const cleanup = calls.findIndex((call) => call.startsWith("release "));
+  const cleanupArm = calls.findIndex((call) => call.startsWith("tmux run-shell -b "));
+  const watchdogArmed = calls.indexOf("watchdog-armed");
+  const targetStart = calls.indexOf("target-start");
+  const cleanupRequest = calls.indexOf("cleanup-controller");
   assert.ok(respawn < pipeOpen);
-  assert.ok(pipeOpen < status);
+  assert.ok(pipeOpen < cleanupArm);
+  assert.ok(cleanupArm < watchdogArmed);
+  assert.ok(watchdogArmed < targetStart);
+  assert.ok(targetStart < status);
   assert.ok(status < pipeClose);
   assert.ok(pipeClose < viewport);
-  assert.ok(viewport < cleanup);
-  assert.notEqual(cleanup, -1);
+  assert.ok(viewport < cleanupRequest);
 });
 
 test("held terminal completion rejects malformed and missing status evidence", () => {
   for (const [options, expected] of [
     [{ recordedStatuses: ["invalid"] }, /status is malformed/],
-    [{ recordedStatuses: [null], heldPaneExitsBeforeRelease: true }, /before recording.*status/],
+    [{ recordedStatuses: [null], heldPaneExitsBeforeCleanup: true }, /before recording.*status/],
   ] as const) {
     const result = driveTerminal({
       plan: {
@@ -1056,7 +1061,7 @@ test("held terminal completion rejects malformed and missing status evidence", (
   }
 });
 
-test("terminal cleanup rejects a wrapper that exits before controller release", () => {
+test("terminal cleanup still runs after the pane wrapper exits", () => {
   const calls: string[] = [];
   const result = driveTerminal({
     plan: {
@@ -1070,17 +1075,46 @@ test("terminal cleanup rejects a wrapper that exits before controller release", 
     recordMedia: false,
     runner: terminalLifecycleRunner(calls, {
       recordedStatuses: [null],
-      heldPaneExitsBeforeRelease: true,
+      heldPaneExitsBeforeCleanup: true,
       terminalCaptures: ["Ready\n"],
     }),
   });
 
   assert.equal(result.status, "failed");
-  assert.match(result.output, /wrapper exited before controller release/);
+  assert.match(result.output, /before recording.*status/);
   assert.equal(
-    calls.some((call) => call.startsWith("release ")),
-    false,
+    calls.some((call) => call.startsWith("tmux run-shell -b ")),
+    true,
   );
+  assert.equal(calls.includes("cleanup-pane-death"), true);
+});
+
+test("terminal does not start the target without an exact watchdog arm receipt", () => {
+  for (const options of [
+    { watchdogNeverArms: true },
+    { armedAcknowledgement: "v1|armed|stale|41001|/dev/ttys001|1:2|42001\n" },
+  ]) {
+    const calls: string[] = [];
+    const result = driveTerminal({
+      plan: {
+        ...recommendedPlan("terminal"),
+        entry: "demo",
+        steps: [{ action: "expect_output", text: "Ready" }],
+      },
+      checkout: "/tmp/checkout",
+      rawVideoPath: "/tmp/live-proof.raw.webm",
+      maxRecordingSeconds: 90,
+      recordMedia: false,
+      runner: terminalLifecycleRunner(calls, {
+        ...options,
+        terminalCaptures: ["Ready\n"],
+      }),
+    });
+
+    assert.equal(result.status, "failed");
+    assert.equal(calls.includes("target-start"), false);
+    assert.match(result.output, /cleanup watchdog/);
+  }
 });
 
 test("held terminal completion rejects a non-regular status path without blocking", () => {
@@ -1165,7 +1199,7 @@ test("terminal completion uses the configured proof budget beyond thirty seconds
   assert.ok(calls.filter((call) => call === "sleep 1").length > 30);
 });
 
-test("terminal pane status corruption fails closed before controller release", () => {
+test("terminal pane status corruption fails closed before controller cleanup", () => {
   const calls: string[] = [];
   const result = driveTerminal({
     plan: {
@@ -1187,7 +1221,7 @@ test("terminal pane status corruption fails closed before controller release", (
   assert.equal(result.status, "failed");
   assert.match(result.output, /pane status is malformed/);
   assert.equal(
-    calls.some((call) => call.startsWith("release ")),
+    calls.some((call) => call.startsWith("tmux run-shell -b ")),
     false,
   );
 });
@@ -1341,7 +1375,7 @@ test("ready_while_running requires a satisfied marker and a live final command",
   const finalLivenessProbe = calls.findLastIndex(
     (call) =>
       call.startsWith("tmux display-message") &&
-      call.endsWith("#{pane_pid}|#{pane_dead}|#{pane_dead_status}|#{pane_dead_signal}"),
+      call.endsWith("#{pane_pid}|#{pane_tty}|#{pane_dead}|#{pane_dead_status}|#{pane_dead_signal}"),
   );
   const pipeClose = calls.findLastIndex((call) => call.startsWith("tmux pipe-pane -t "));
   assert.equal(pipeClose < finalLivenessProbe, true);
@@ -1402,10 +1436,10 @@ test("ready_while_running rejects a command that exits during pipe shutdown", ()
       pipeCloseFailed &&
       tool === "tmux" &&
       args[0] === "display-message" &&
-      args.at(-1) === "#{pane_pid}|#{pane_dead}|#{pane_dead_status}|#{pane_dead_signal}"
+      args.at(-1) === "#{pane_pid}|#{pane_tty}|#{pane_dead}|#{pane_dead_status}|#{pane_dead_signal}"
     ) {
       calls.push([tool, ...args].join(" "));
-      return { status: 0, stdout: `${panePid}|1|0|\n` };
+      return { status: 0, stdout: `${panePid}|/dev/ttys001|1|0|\n` };
     }
     if (tool === "tmux" && args[0] === "pipe-pane" && !args.includes("-O") && !pipeCloseFailed) {
       calls.push([tool, ...args].join(" "));
@@ -1416,7 +1450,7 @@ test("ready_while_running rejects a command that exits during pipe shutdown", ()
     if (
       tool === "tmux" &&
       args[0] === "display-message" &&
-      args.at(-1) === "#{pane_pid}|#{pane_dead}|#{pane_dead_status}|#{pane_dead_signal}"
+      args.at(-1) === "#{pane_pid}|#{pane_tty}|#{pane_dead}|#{pane_dead_status}|#{pane_dead_signal}"
     ) {
       panePid = Number.parseInt(String(result.stdout), 10);
     }
@@ -1446,7 +1480,7 @@ test("ready_while_running rejects a command that exits during pipe shutdown", ()
   assert.equal(calls.filter((call) => call.startsWith("tmux pipe-pane -t ")).length, 1);
 });
 
-test("terminal rejects a pane pid change without signaling either identity", () => {
+test("terminal rejects a pane identity change without scheduling tty cleanup", () => {
   const calls: string[] = [];
   const fixtureRunner = terminalLifecycleRunner(calls, {
     commandKeepsRunning: true,
@@ -1458,18 +1492,10 @@ test("terminal rejects a pane pid change without signaling either identity", () 
     if (
       tool === "tmux" &&
       args[0] === "display-message" &&
-      args.at(-1) === "#{pane_pid}|#{pane_dead}|#{pane_dead_status}|#{pane_dead_signal}"
+      args.at(-1) === "#{pane_pid}|#{pane_tty}|#{pane_dead}|#{pane_dead_status}|#{pane_dead_signal}"
     ) {
       stateProbe += 1;
-      if (stateProbe > 1) return { ...result, stdout: "41999|0||\n" };
-    }
-    if (
-      stateProbe > 1 &&
-      tool === "tmux" &&
-      args[0] === "display-message" &&
-      args.at(-1) === "#{pane_pid}"
-    ) {
-      return { ...result, stdout: "41999\n" };
+      if (stateProbe > 1) return { ...result, stdout: "41999|/dev/ttys999|0||\n" };
     }
     return result;
   };
@@ -1488,14 +1514,14 @@ test("terminal rejects a pane pid change without signaling either identity", () 
   });
 
   assert.equal(result.status, "failed");
-  assert.match(result.output, /pane identity changed from launch pid 41001 to 41999/);
+  assert.match(result.output, /pane identity changed from launch 41001\|\/dev\/ttys001/);
   assert.equal(
-    calls.some((call) => call.startsWith("/bin/kill ")),
+    calls.some((call) => call.startsWith("tmux run-shell -b ")),
     false,
   );
 });
 
-test("terminal cleanup waits for the exact pane to acknowledge its release tuple", () => {
+test("terminal cleanup requires the exact pane receipt and pane death", () => {
   const calls: string[] = [];
   let cleanupScript = "";
   const result = driveTerminal({
@@ -1519,23 +1545,21 @@ test("terminal cleanup waits for the exact pane to acknowledge its release tuple
   });
 
   assert.equal(result.status, "completed");
-  assert.match(cleanupScript, /killall -q -TERM -t "\$tty_name"/);
-  assert.match(cleanupScript, /killall -0 -t "\$tty_name"/);
-  assert.match(cleanupScript, /killall -q -KILL -t "\$tty_name"/);
-  assert.match(cleanupScript, /pkill -TERM -t "\$tty_name" -f '\.\*'/);
-  assert.match(cleanupScript, /pgrep -t "\$tty_name" -f '\.\*'/);
-  assert.match(cleanupScript, /pkill -KILL -t "\$tty_name" -f '\.\*'/);
+  assert.match(cleanupScript, /\/usr\/sbin\/lsof -t -- "\$lease_path"/);
+  assert.match(cleanupScript, /for descriptor in \/proc\/"\$1"\/fd\/\*/);
+  assert.match(cleanupScript, /holds_lease "\$candidate" \|\| on_bound_tty "\$candidate"/);
+  assert.match(cleanupScript, /signal_bound_processes TERM/);
+  assert.match(cleanupScript, /signal_bound_processes KILL/);
+  assert.match(cleanupScript, /stable_empty.*-ge 2/s);
   const respawn = calls.find((call) => call.startsWith("tmux respawn-pane"));
-  assert.match(respawn ?? "", /tmux run-shell -b/);
+  assert.doesNotMatch(respawn ?? "", /tmux run-shell -b/);
   assert.match(respawn ?? "", /while :; do sleep 3600; done/);
-  assert.doesNotMatch(respawn ?? "", /exec tmux run-shell/);
-  assert.match(respawn ?? "", /if \[ -f "\$4" \]; then/);
-  assert.match(
-    respawn ?? "",
-    /read -r release_pid release_nonce release_extra 2>\/dev\/null <"\$4"/,
-  );
-  assert.doesNotMatch(respawn ?? "", /<"\$4" 2>\/dev\/null/);
-  assert.equal(calls.filter((call) => call.startsWith("release ")).length, 1);
+  assert.match(respawn ?? "", /exec 9<"\$8"/);
+  assert.match(respawn ?? "", /read -r bound_pid bound_tty bound_nonce bound_lease bound_extra/);
+  assert.match(respawn ?? "", /v1\|execute/);
+  assert.equal(calls.filter((call) => call.startsWith("tmux run-shell -b ")).length, 1);
+  assert.ok(calls.indexOf("watchdog-armed") < calls.indexOf("target-start"));
+  assert.notEqual(calls.indexOf("cleanup-controller"), -1);
   assert.equal(
     calls.some((call) => call.startsWith("/bin/kill ") || call.startsWith("/bin/ps ")),
     false,
@@ -1554,7 +1578,7 @@ test("terminal rejects a malformed pane readiness acknowledgement", () => {
     maxRecordingSeconds: 90,
     recordMedia: false,
     runner: terminalLifecycleRunner([], {
-      readyAcknowledgement: "41001 stale-nonce\n",
+      readyAcknowledgement: "41001|/dev/ttys001|stale-nonce\n",
       terminalCaptures: ["Ready\n"],
     }),
   });
@@ -1563,7 +1587,7 @@ test("terminal rejects a malformed pane readiness acknowledgement", () => {
   assert.match(result.output, /readiness acknowledgement is malformed/);
 });
 
-test("terminal cleanup fails when the pane does not die after release", () => {
+test("terminal cleanup fails when the pane does not die after scheduling", () => {
   const calls: string[] = [];
   assert.throws(
     () =>
@@ -1586,10 +1610,10 @@ test("terminal cleanup fails when the pane does not die after release", () => {
       }),
     /terminal cleanup failed/,
   );
-  assert.equal(calls.filter((call) => call.startsWith("release ")).length, 1);
+  assert.equal(calls.filter((call) => call.startsWith("tmux run-shell -b ")).length, 1);
 });
 
-test("terminal cleanup fails when tmux replaces the pane after release", () => {
+test("terminal cleanup fails when tmux replaces the pane after scheduling", () => {
   assert.throws(
     () =>
       driveTerminal({
@@ -1631,6 +1655,30 @@ test("terminal cleanup rejects an operational error receipt after pane death", (
           commandKeepsRunning: true,
           terminalCaptures: ["Ready\n"],
           cleanupResult: "error:kill:2",
+        }),
+      }),
+    /terminal cleanup failed/,
+  );
+});
+
+test("terminal cleanup cannot accept success while lease survivors remain", () => {
+  assert.throws(
+    () =>
+      driveTerminal({
+        plan: {
+          ...recommendedPlan("terminal"),
+          terminalCompletion: "ready_while_running",
+          entry: "demo-server",
+          steps: [{ action: "expect_output", text: "Ready" }],
+        },
+        checkout: "/tmp/checkout",
+        rawVideoPath: "/tmp/live-proof.raw.webm",
+        maxRecordingSeconds: 90,
+        recordMedia: false,
+        runner: terminalLifecycleRunner([], {
+          commandKeepsRunning: true,
+          terminalCaptures: ["Ready\n"],
+          cleanupSurvivors: 1,
         }),
       }),
     /terminal cleanup failed/,
@@ -1798,8 +1846,10 @@ test("terminal entry executes once and publishes only its final visible viewport
   let commandViewport = "";
   let commandStatus = 0;
   let panePid = 42_001;
+  const paneTty = "/dev/ttys001";
   let paneDead = false;
   let invocation: ReturnType<typeof terminalCommandInvocation>;
+  let cleanup: TerminalCleanupInvocation | undefined;
   let commandExecuted = false;
   let capture:
     | {
@@ -1810,10 +1860,20 @@ test("terminal entry executes once and publishes only its final visible viewport
         captureDoneTemporary: string;
       }
     | undefined;
-  const executeCommand = (cwd: string | undefined) => {
-    if (commandExecuted || !invocation || !capture || !existsSync(invocation.start)) return;
-    writeFileSync(invocation.readyTemporary, `${panePid} ${invocation.nonce}\n`, "utf8");
-    renameSync(invocation.readyTemporary, invocation.ready);
+  const advanceCommand = (cwd: string | undefined) => {
+    if (!invocation || !capture) return;
+    if (!existsSync(invocation.ready)) {
+      if (!existsSync(invocation.start)) return;
+      writeFileSync(
+        invocation.readyTemporary,
+        `${panePid}|${paneTty}|${invocation.nonce}|${invocation.leaseIdentity}\n`,
+        "utf8",
+      );
+      renameSync(invocation.readyTemporary, invocation.ready);
+    }
+    if (commandExecuted || !readFileSync(invocation.ready, "utf8").startsWith("v1|execute|")) {
+      return;
+    }
     const execution = spawnSync("/bin/bash", ["--noprofile", "--norc", invocation.command], {
       cwd,
       encoding: "utf8",
@@ -1823,6 +1883,16 @@ test("terminal entry executes once and publishes only its final visible viewport
     commandStatus = execution.signal ? 143 : (execution.status ?? 1);
     writeFileSync(invocation.status, `${commandStatus}\n`, "utf8");
     commandExecuted = true;
+  };
+  const advanceCleanup = () => {
+    if (!cleanup || !existsSync(cleanup.request) || paneDead) return;
+    writeFileSync(
+      cleanup.resultTemporary,
+      `v1|done|${cleanup.nonce}|${cleanup.panePid}|${cleanup.paneTty}|${cleanup.leaseIdentity}|controller|ok|0\n`,
+      "utf8",
+    );
+    renameSync(cleanup.resultTemporary, cleanup.result);
+    paneDead = true;
   };
   const runner: MediaProofCommandRunner = (tool, args, options) => {
     if (tool === "tmux" && args[0] === "pipe-pane" && args.includes("-O")) {
@@ -1847,30 +1917,25 @@ test("terminal entry executes once and publishes only its final visible viewport
     if (
       tool === "tmux" &&
       args[0] === "display-message" &&
-      args.at(-1) === "#{pane_pid}|#{pane_dead}|#{pane_dead_status}|#{pane_dead_signal}"
+      args.at(-1) === "#{pane_pid}|#{pane_tty}|#{pane_dead}|#{pane_dead_status}|#{pane_dead_signal}"
     ) {
-      executeCommand(options?.cwd);
-      if (
-        invocation &&
-        existsSync(invocation.release) &&
-        readFileSync(invocation.release, "utf8") === `${panePid} ${invocation.nonce}\n`
-      ) {
-        writeFileSync(
-          invocation.cleanupResultTemporary,
-          `${panePid} ${invocation.nonce} ok\n`,
-          "utf8",
-        );
-        renameSync(invocation.cleanupResultTemporary, invocation.cleanupResult);
-        paneDead = true;
-      }
+      advanceCommand(options?.cwd);
+      advanceCleanup();
       return {
         status: 0,
-        stdout: paneDead ? `${panePid}|1|0|\n` : `${panePid}|0||\n`,
+        stdout: paneDead ? `${panePid}|${paneTty}|1|0|\n` : `${panePid}|${paneTty}|0||\n`,
       };
     }
-    if (tool === "tmux" && args[0] === "display-message" && args.at(-1) === "#{pane_pid}") {
-      executeCommand(options?.cwd);
-      return { status: 0, stdout: `${panePid}\n` };
+    if (tool === "tmux" && args[0] === "run-shell") {
+      cleanup = terminalCleanupInvocation(args);
+      assert.ok(cleanup);
+      writeFileSync(
+        cleanup.resultTemporary,
+        `v1|armed|${cleanup.nonce}|${cleanup.panePid}|${cleanup.paneTty}|${cleanup.leaseIdentity}|42001\n`,
+        "utf8",
+      );
+      renameSync(cleanup.resultTemporary, cleanup.result);
+      return { status: 0 };
     }
     if (tool === "tmux" && args[0] === "capture-pane") {
       return { status: 0, stdout: args.includes("-S") ? commandOutput : commandViewport };
@@ -2199,12 +2264,14 @@ test("terminal recording holds the end state and enforces its minimum before fin
   const completed = calls.findIndex((call) => call.startsWith("status "));
   const hold = calls.findIndex((call) => call === "sleep 6");
   const finalize = calls.findIndex((call) => /tmux send-keys .* q$/.test(call));
-  const cleanup = calls.findIndex((call) => call.startsWith("release "));
+  const cleanupArm = calls.findIndex((call) => call.startsWith("tmux run-shell -b "));
+  const cleanupRequest = calls.indexOf("cleanup-controller");
   assert.notEqual(completed, -1);
   assert.notEqual(hold, -1);
   assert.ok(hold > completed);
   assert.ok(finalize > hold);
-  assert.ok(cleanup > finalize);
+  assert.ok(cleanupArm < finalize);
+  assert.ok(cleanupRequest > finalize);
 });
 
 test("terminal driver reports display readiness timeout with all pane diagnostics", () => {
@@ -3580,12 +3647,15 @@ function terminalLifecycleRunner(
     captureCompletion?: string;
     paneStatusDuringFinalize?: { status: "exited"; exitStatus: number };
     terminalPaneSequence?: Array<{ status: "running" } | { status: "exited"; exitStatus: number }>;
-    heldPaneExitsBeforeRelease?: boolean;
+    heldPaneExitsBeforeCleanup?: boolean;
     malformedPaneStatus?: string;
     malformedPaneStatusAfterProbe?: number;
     cleanupNeverCompletes?: boolean;
     cleanupReplacementPid?: number;
     cleanupResult?: string;
+    cleanupSurvivors?: number;
+    watchdogNeverArms?: boolean;
+    armedAcknowledgement?: string;
     readyAcknowledgement?: string;
     inspectCleanupScript?: (script: string) => void;
     leaveCaptureTemporaryFiles?: boolean;
@@ -3604,8 +3674,9 @@ function terminalLifecycleRunner(
   let commandLaunch = 0;
   let terminalStateProbe = 0;
   let panePid = 41_000;
+  let paneTty = "/dev/ttys001";
   let paneDead = false;
-  let releaseObserved = false;
+  let targetStarted = false;
   let forcedPaneState: { status: "exited"; exitStatus: number } | undefined;
   let activeCommand:
     | {
@@ -3613,16 +3684,15 @@ function terminalLifecycleRunner(
         held: boolean;
         status: string;
         statusTemporary: string;
-        release: string;
         start: string;
         ready: string;
         readyTemporary: string;
+        lease: string;
+        leaseIdentity: string;
         nonce: string;
-        cleanupScript: string;
-        cleanupResult: string;
-        cleanupResultTemporary: string;
       }
     | undefined;
+  let activeCleanup: TerminalCleanupInvocation | undefined;
   let activeFiles:
     | {
         captureScript: string;
@@ -3643,6 +3713,8 @@ function terminalLifecycleRunner(
       options.heldCommandKeepsRunning ||
       options.commandKeepsRunning ||
       options.keepsRunningCommands?.includes(typedCommand) ||
+      !existsSync(activeCommand.ready) ||
+      !readFileSync(activeCommand.ready, "utf8").startsWith("v1|execute|") ||
       existsSync(activeCommand.status)
     ) {
       return;
@@ -3670,40 +3742,72 @@ function terminalLifecycleRunner(
     }
     writeFileSync(
       activeCommand.readyTemporary,
-      options.readyAcknowledgement ?? `${panePid} ${activeCommand.nonce}\n`,
+      options.readyAcknowledgement ??
+        `${panePid}|${paneTty}|${activeCommand.nonce}|${activeCommand.leaseIdentity}\n`,
       "utf8",
     );
     renameSync(activeCommand.readyTemporary, activeCommand.ready);
   };
+  const armTerminalCleanup = (cleanup: TerminalCleanupInvocation) => {
+    activeCleanup = cleanup;
+    options.inspectCleanupScript?.(readFileSync(cleanup.script, "utf8"));
+    if (options.watchdogNeverArms) return;
+    writeFileSync(
+      cleanup.resultTemporary,
+      options.armedAcknowledgement ??
+        `v1|armed|${cleanup.nonce}|${cleanup.panePid}|${cleanup.paneTty}|${cleanup.leaseIdentity}|42001\n`,
+      "utf8",
+    );
+    renameSync(cleanup.resultTemporary, cleanup.result);
+    calls.push("watchdog-armed");
+  };
   const completeTerminalCleanup = () => {
-    if (!activeCommand || paneDead || !existsSync(activeCommand.release)) return;
-    const release = readFileSync(activeCommand.release, "utf8");
-    if (!releaseObserved) {
-      calls.push(`release ${activeCommand.release} ${release.trim()}`);
-      releaseObserved = true;
-    }
-    if (release !== `${panePid} ${activeCommand.nonce}\n` || options.cleanupNeverCompletes) return;
+    const cleanup = activeCleanup;
+    if (!cleanup || options.cleanupNeverCompletes) return;
+    const controllerRequested = existsSync(cleanup.request);
+    const paneDied =
+      options.heldPaneExitsBeforeCleanup === true &&
+      activeCommand !== undefined &&
+      existsSync(activeCommand.ready) &&
+      readFileSync(activeCommand.ready, "utf8").startsWith("v1|execute|");
+    if (!controllerRequested && !paneDied) return;
     if (options.cleanupReplacementPid !== undefined) {
       panePid = options.cleanupReplacementPid;
       return;
     }
+    const trigger = controllerRequested ? "controller" : "pane-death";
+    calls.push(`cleanup-${trigger}`);
     writeFileSync(
-      activeCommand.cleanupResultTemporary,
-      `${panePid} ${activeCommand.nonce} ${options.cleanupResult ?? "ok"}\n`,
+      cleanup.resultTemporary,
+      `v1|done|${cleanup.nonce}|${cleanup.panePid}|${cleanup.paneTty}|${cleanup.leaseIdentity}|${trigger}|${options.cleanupResult ?? "ok"}|${options.cleanupSurvivors ?? 0}\n`,
       "utf8",
     );
-    renameSync(activeCommand.cleanupResultTemporary, activeCommand.cleanupResult);
+    renameSync(cleanup.resultTemporary, cleanup.result);
     paneDead = true;
   };
   const terminalPaneState = () => {
     if (commandLaunch === 0) return { status: "running" } as const;
     acknowledgeTerminalReady();
+    if (
+      activeCommand &&
+      existsSync(activeCommand.ready) &&
+      readFileSync(activeCommand.ready, "utf8").startsWith("v1|execute|")
+    ) {
+      if (!targetStarted) {
+        targetStarted = true;
+        calls.push("target-start");
+      }
+      updateTerminalFiles();
+    }
     completeTerminalCleanup();
-    if (activeCommand && existsSync(activeCommand.ready)) updateTerminalFiles();
     if (forcedPaneState) return forcedPaneState;
     if (paneDead) return { status: "exited", exitStatus: 0 } as const;
     if (activeCommand?.held) {
-      if (options.heldPaneExitsBeforeRelease) {
+      if (
+        options.heldPaneExitsBeforeCleanup &&
+        existsSync(activeCommand.ready) &&
+        readFileSync(activeCommand.ready, "utf8").startsWith("v1|execute|")
+      ) {
         return { status: "exited", exitStatus: commandExitStatus() } as const;
       }
       return { status: "running" } as const;
@@ -3779,12 +3883,12 @@ function terminalLifecycleRunner(
       const invocation = terminalCommandInvocation(args);
       assert.ok(invocation);
       typedCommand = readFileSync(invocation.command, "utf8").trimEnd();
-      options.inspectCleanupScript?.(readFileSync(invocation.cleanupScript, "utf8"));
       activeCommand = invocation;
+      activeCleanup = undefined;
       commandLaunch += 1;
       panePid += 1;
       paneDead = false;
-      releaseObserved = false;
+      targetStarted = false;
       forcedPaneState = undefined;
       terminalCaptureProbe = 0;
       terminalHistoryProbe = 0;
@@ -3795,7 +3899,8 @@ function terminalLifecycleRunner(
       const target = String(args[args.indexOf("-t") + 1] ?? "");
       if (
         target.includes("-terminal") &&
-        args.at(-1) === "#{pane_pid}|#{pane_dead}|#{pane_dead_status}|#{pane_dead_signal}"
+        args.at(-1) ===
+          "#{pane_pid}|#{pane_tty}|#{pane_dead}|#{pane_dead_status}|#{pane_dead_signal}"
       ) {
         const malformed =
           options.malformedPaneStatus !== undefined &&
@@ -3807,13 +3912,8 @@ function terminalLifecycleRunner(
         const state = terminalPaneState();
         terminalStateProbe += 1;
         return state.status === "running"
-          ? { status: 0, stdout: `${panePid}|0||\n` }
-          : { status: 0, stdout: `${panePid}|1|${state.exitStatus}|\n` };
-      }
-      if (target.includes("-terminal") && args.at(-1) === "#{pane_pid}") {
-        acknowledgeTerminalReady();
-        if (activeCommand && existsSync(activeCommand.ready)) updateTerminalFiles();
-        return { status: 0, stdout: `${panePid}\n` };
+          ? { status: 0, stdout: `${panePid}|${paneTty}|0||\n` }
+          : { status: 0, stdout: `${panePid}|${paneTty}|1|${state.exitStatus}|\n` };
       }
       if (finalizing) {
         const exited = finalizeProbe >= (options.finalizeExitAfter ?? 0);
@@ -3858,9 +3958,16 @@ function terminalLifecycleRunner(
       }
       return { status: 0, stdout: `${options.paneOutput?.[label] ?? `${label} pane`}\n` };
     }
+    if (command === "tmux" && args[0] === "run-shell") {
+      const cleanup = terminalCleanupInvocation(args);
+      assert.ok(cleanup);
+      armTerminalCleanup(cleanup);
+      return { status: 0 };
+    }
     if (command === "sleep" && activeFiles) {
       if (args[0] !== "0.1") terminalCaptureProbe += 1;
       updateTerminalFiles();
+      completeTerminalCleanup();
     }
     return { status: 0 };
   };
@@ -3872,37 +3979,61 @@ function terminalCommandInvocation(args: readonly string[]):
       held: boolean;
       status: string;
       statusTemporary: string;
-      release: string;
       start: string;
       ready: string;
       readyTemporary: string;
+      lease: string;
+      leaseIdentity: string;
       nonce: string;
-      cleanupScript: string;
-      cleanupResult: string;
-      cleanupResultTemporary: string;
     }
   | undefined {
   const target = String(args[args.indexOf("-t") + 1] ?? "");
   if (!target.includes("-terminal")) return undefined;
   const shellCommand = String(args.at(-1) ?? "");
   const quoted = [...shellCommand.matchAll(/'([^']*)'/g)].map((match) => match[1]!);
-  const invocation = quoted.slice(-12);
-  if (invocation.length !== 12 || invocation[0] !== "clawsweeper-terminal") return undefined;
+  const invocation = quoted.slice(-10);
+  if (invocation.length !== 10 || invocation[0] !== "clawsweeper-terminal") return undefined;
   return {
     command: invocation[1]!,
-    held: shellCommand.includes(
-      'read -r release_pid release_nonce release_extra 2>/dev/null <"$4"',
-    ),
+    held: shellCommand.includes("while :; do sleep 3600; done"),
     statusTemporary: invocation[2]!,
     status: invocation[3]!,
-    release: invocation[4]!,
-    start: invocation[5]!,
-    readyTemporary: invocation[6]!,
-    ready: invocation[7]!,
-    nonce: invocation[8]!,
-    cleanupScript: invocation[9]!,
-    cleanupResultTemporary: invocation[10]!,
-    cleanupResult: invocation[11]!,
+    start: invocation[4]!,
+    readyTemporary: invocation[5]!,
+    ready: invocation[6]!,
+    nonce: invocation[7]!,
+    lease: invocation[8]!,
+    leaseIdentity: invocation[9]!,
+  };
+}
+
+interface TerminalCleanupInvocation {
+  script: string;
+  paneTty: string;
+  panePid: string;
+  nonce: string;
+  lease: string;
+  leaseIdentity: string;
+  request: string;
+  resultTemporary: string;
+  result: string;
+}
+
+function terminalCleanupInvocation(args: readonly string[]): TerminalCleanupInvocation | undefined {
+  const shellCommand = String(args.at(-1) ?? "");
+  const quoted = [...shellCommand.matchAll(/'([^']*)'/g)].map((match) => match[1]!);
+  const invocation = quoted.slice(-10);
+  if (invocation.length !== 10 || invocation[0] !== "/bin/bash") return undefined;
+  return {
+    script: invocation[1]!,
+    paneTty: invocation[2]!,
+    panePid: invocation[3]!,
+    nonce: invocation[4]!,
+    lease: invocation[5]!,
+    leaseIdentity: invocation[6]!,
+    request: invocation[7]!,
+    resultTemporary: invocation[8]!,
+    result: invocation[9]!,
   };
 }
 

--- a/test/live-proof.test.ts
+++ b/test/live-proof.test.ts
@@ -1546,8 +1546,39 @@ test("terminal cleanup requires the exact pane receipt and pane death", () => {
 
   assert.equal(result.status, "completed");
   assert.match(cleanupScript, /\/usr\/sbin\/lsof -t -- "\$lease_path"/);
-  assert.match(cleanupScript, /for descriptor in \/proc\/"\$1"\/fd\/\*/);
-  assert.match(cleanupScript, /holds_lease "\$candidate" \|\| on_bound_tty "\$candidate"/);
+  assert.match(cleanupScript, /stat -Lc '%d:%i' -- \/proc\/"\$1"\/fd\/9/);
+  assert.match(
+    cleanupScript,
+    /find -L \/proc\/\[0-9\]\*\/fd\/9 -maxdepth 0 -samefile "\$lease_path"/,
+  );
+  assert.match(
+    cleanupScript,
+    /awk -F\/ 'NF == 4 && \$2 == "proc" && \$3 ~ \/\^\[0-9\]\+\$\/ && \$4 == "fd" \{ print \$3 \}'/,
+  );
+  assert.doesNotMatch(cleanupScript, /\/proc\/"\$1"\/fd\/\*/);
+  assert.doesNotMatch(cleanupScript, /find -L \/proc\/\[0-9\]\*\/fd -/);
+  assert.match(
+    cleanupScript,
+    /pane_owns_tty\(\) \{ holds_lease "\$pane_pid" && on_bound_tty "\$pane_pid"; \}/,
+  );
+  assert.match(
+    cleanupScript,
+    /tty_pids\(\) \{\s+pane_owns_tty \|\| return 0\s+\/bin\/ps -axo pid=,tty=/,
+  );
+  assert.match(
+    cleanupScript,
+    /scan_bound_processes\(\) \{\s+: >"\$scan_file"\s+lease_pids >>"\$scan_file" \|\| return \$\?\s+tty_pids >>"\$scan_file"/,
+  );
+  assert.match(
+    cleanupScript,
+    /if ! holds_lease "\$candidate"; then\s+on_bound_tty "\$candidate" \|\| continue\s+pane_owns_tty \|\| continue\s+fi\s+\/bin\/kill/,
+  );
+  assert.match(cleanupScript, /pane_owns_tty \|\| finish startup error:pane-identity/);
+  assert.match(cleanupScript, /elif ! pane_owns_tty; then\s+trigger=pane-death/);
+  assert.doesNotMatch(
+    cleanupScript,
+    /holds_lease "\$candidate" \|\| on_bound_tty "\$candidate" \|\| continue/,
+  );
   assert.match(cleanupScript, /signal_bound_processes TERM/);
   assert.match(cleanupScript, /signal_bound_processes KILL/);
   assert.match(cleanupScript, /stable_empty.*-ge 2/s);
@@ -1555,6 +1586,7 @@ test("terminal cleanup requires the exact pane receipt and pane death", () => {
   assert.doesNotMatch(respawn ?? "", /tmux run-shell -b/);
   assert.match(respawn ?? "", /while :; do sleep 3600; done/);
   assert.match(respawn ?? "", /exec 9<"\$8"/);
+  assert.match(respawn ?? "", /\) 9<&9 <\/dev\/tty/);
   assert.match(respawn ?? "", /read -r bound_pid bound_tty bound_nonce bound_lease bound_extra/);
   assert.match(respawn ?? "", /v1\|execute/);
   assert.equal(calls.filter((call) => call.startsWith("tmux run-shell -b ")).length, 1);

--- a/test/review-prompt-policy.test.ts
+++ b/test/review-prompt-policy.test.ts
@@ -653,6 +653,9 @@ test("review prompt and schema classify deterministic live-proof plans in field 
   assert.match(prompt, /`liveProofPlan\.status: "declined_suspicious"`/);
   assert.match(prompt, /never\s+execute the PR or claim that a recording exists/);
   assert.match(prompt, /`entry` executes automatically before all typed steps/);
+  assert.match(prompt, /`terminalCompletion: "exit_zero"`/);
+  assert.match(prompt, /`terminalCompletion: "ready_while_running"`/);
+  assert.match(prompt, /Every terminal command before the final command\s+must exit zero/);
   assert.match(prompt, /Every `run` step executes\s+independently/);
   assert.match(prompt, /nothing is deduplicated/);
   assert.match(prompt, /one-shot proof[\s\S]*stable `expect_output` steps/);
@@ -678,6 +681,7 @@ test("review prompt and schema classify deterministic live-proof plans in field 
   assert.deepEqual(liveProofPlan.required, [
     "status",
     "surface",
+    "terminalCompletion",
     "reason",
     "payoff",
     "entry",
@@ -686,6 +690,7 @@ test("review prompt and schema classify deterministic live-proof plans in field 
   assert.deepEqual(Object.keys(liveProofPlan.properties), [
     "status",
     "surface",
+    "terminalCompletion",
     "reason",
     "payoff",
     "entry",
@@ -697,6 +702,11 @@ test("review prompt and schema classify deterministic live-proof plans in field 
     "declined_suspicious",
   ]);
   assert.deepEqual(liveProofPlan.properties.surface.enum, ["browser", "terminal", "none"]);
+  assert.deepEqual(liveProofPlan.properties.terminalCompletion.enum, [
+    "exit_zero",
+    "ready_while_running",
+    "not_applicable",
+  ]);
   assert.deepEqual(liveProofPlan.properties.payoff.required, ["kind", "justification"]);
   assert.deepEqual(Object.keys(liveProofPlan.properties.payoff.properties), [
     "kind",
@@ -735,6 +745,8 @@ Keep this browser PR open for maintainer review.
 Status: recommended
 
 Surface: browser
+
+Terminal completion: not_applicable
 
 Reason: The settings confirmation is visible in the browser.
 


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/129535

## What Problem This Solves

Terminal live proof could publish cold-build warnings and dependency diagnostics instead of the command's final viewport. A command could also satisfy an output marker before later exiting unsuccessfully, allowing misleading proof to appear successful.

Repeated Linux validation exposed two additional lifecycle defects:

- cleanup treated tmux's `pane_pid` as a portable process-group ID, so negative-PID signaling could target an unrelated runner group;
- all proofs shared tmux's default server, so last-session teardown could race the next proof's `new-session`.

The first cleanup repair still depended on a live process-group leader. The next TTY-scoped repair left the pane wrapper as the sole cleanup scheduler; when the target killed that wrapper, a resistant descendant lost its TTY and cleanup could incorrectly report success.

## Why This Change Was Made

Terminal plans now declare an explicit completion contract: successful exit, ready while still running, or not applicable. The runtime owns a real PTY-backed tmux pane, supervises each command through completion, seals output before publication, reads bounded nonblocking control files, and publishes only the final rendered viewport while retaining bounded diagnostics for failures.

Each proof now uses a private tmux socket directory. Before target execution, the pane wrapper opens an inherited process-family lease, publishes its exact pane PID, TTY, nonce, and lease inode, and waits behind a second gate. The controller pre-arms a cleanup watchdog outside the pane process tree through the private tmux server and opens the execution gate only after an exact armed receipt and a second pane-identity check.

After capture and the final viewport are sealed, the controller requests cleanup from the already-armed watchdog. Pane death triggers the same watchdog independently. Cleanup repeatedly TERM/KILL-sweeps exact lease holders to a stable empty fixed point. Bound-TTY membership is included only while the original pane still owns both reserved descriptor 9 and that TTY, preventing a released `/dev/pts/N` from becoming authority over a later proof. Darwin enumerates lease holders with stock `lsof`; Linux inspects only reserved descriptor 9 through `/proc`. Success requires an exact zero-survivor receipt plus death of the original pane identity. Target commands do not inherit `TMUX`, `TMUX_PANE`, or `TMUX_TMPDIR`.

## User Impact

ClawSweeper terminal proof now shows the final command result rather than build chatter. Nonzero exits cannot pass on an earlier marker, long-running servers must remain live through the stability hold, controller files do not print shell noise into the viewport, resistant descendants across nested process groups are removed even after pane-wrapper death, and one proof cannot race or access another proof's tmux server.

## OpenClaw Bay Impact

Bay's record lifecycle and publication schema are unchanged. The affected surface is the Live Verification block rendered into review records and GitHub comments; schema-v1 records without terminal assertions keep their existing `NOT OBSERVED` rendering.

## Documentation Impact

Updated `docs/live-proof.md` with completion modes, final-viewport publication, timeout ownership, private tmux isolation, pre-armed watchdog receipts, lease-backed cleanup, and the explicit same-UID containment limit. `CHANGELOG.md` is release-owned per `CONTRIBUTING.md`.

## Evidence

Verification at `ac94545bde`:

- `tsc -p tsconfig.json`
- exact type-aware `oxlint` gate
- `oxfmt --check`
- `node scripts/check-docs.mjs`
- `git diff --check`
- 104/104 live-proof unit tests
- 19/19 real tmux environment tests on macOS
- AWS Linux: 6/6 targeted real tmux regressions, run `run_040b798fdb10`
- AWS Linux: recursive-scanner regression failed before the fix and passed after it; four concurrent lanes passed 16/16 with no proof descendants or private tmux sessions left, run `run_11aa8cf78ddd`

AWS proof: https://crabbox.openclaw.ai/portal/runs/run_040b798fdb10
Concurrency proof: https://crabbox.openclaw.ai/portal/runs/run_11aa8cf78ddd

The Linux run proves:

1. package-manager command echo cannot hide exit status 7;
2. successful proof publishes a clean final viewport without controller-file noise;
3. direct `/dev/tty` output remains observable;
4. target code cannot inherit the private tmux control environment;
5. HUP/TERM-resistant descendants in a distinct process group are absent after cleanup;
6. killing the outer pane wrapper cannot leave a resistant descendant in a distinct process group.

The first lease-scanner run, `run_2db246543213`, failed closed with `error:scan` on Linux. Later concurrency runs exposed two connected Linux defects: scanning every process descriptor could exceed the cleanup deadline, and continued TTY-only authority after pane death could collide with a reused `/dev/pts/N`. The final run `run_11aa8cf78ddd` proves the reserved-FD scanner and pane-owned TTY gate under four concurrent proof lanes.

### Repair Evidence

- Root cause: output observation and process completion were separate weak signals. Cleanup authority then moved through process-group and TTY identities but remained target-killable or lost descendant identity after pane death.
- Architectural owner: `src/live-proof/drivers.ts`, with the completion contract propagated through decision schema, parsing, report rendering, and verification.
- Canonical fix: one held PTY/tmux lifecycle with explicit completion policy, exact pane/TTY/nonce/lease identity, a controller-pre-armed watchdog, atomic armed/execute/cleanup receipts, sealed output, final rendered-state observation, private tmux server ownership, reserved-FD process-family discovery, and fixed-point cleanup whose TTY authority expires with the original pane.
- Removed paths: regex/raw-output success fallback, implicit terminal completion, release-before-cleanup, raw pane-PID process-group signaling, leader-dependent group ownership, external per-PID snapshots, wrapper-owned cleanup scheduling, TTY-only success, whole-host per-descriptor lease scans, and post-pane-death TTY authority.
- Sibling coverage: successful exits, nonzero/signal exits, long-running readiness, repeated commands, TTY-only output, mixed streams, pane replacement, selected-window changes, stale viewport/history, malformed/FIFO control paths, missing or stale watchdog receipts, overall deadlines, cleanup failures, wrapper death, distinct process groups, legacy plans, and publication rendering.
- Observed behavior: the stricter macOS reproduction failed before the watchdog because the orphan lost its TTY while cleanup reported success. The repaired outer-wrapper-death path passes on macOS and AWS Linux.

### LOC Review Metric

- Production/policy/schema: `+1241 / -317` (`+924` net)
- Tests/test support: `+2623 / -177`
- Documentation: `+43 / -8`

The final Linux cleanup repair relative to the previously reviewed head is `+16 / -14` production (`+2` net), `+127 / -3` tests, and `+14 / -11` documentation. The two production lines name reserved descriptor 9 and centralize the original pane's live TTY authority; the broader per-descriptor scan and unconditional TTY fallback were removed.

## Limits

The inherited lease is lifecycle cleanup, not hostile same-UID isolation. A target can deliberately close inherited descriptors or attack same-user controller resources; that requires container, VM, namespace, or separate-user containment. Live-proof execution remains explicitly unsandboxed. Browser live proof and remote graphics stacks are unchanged.
