### PR TITLE
fix(review): ignore workflow files in data-model detection

### DIFF
--- a/src/clawsweeper-change-detection.ts
+++ b/src/clawsweeper-change-detection.ts
@@ -84,10 +84,9 @@ export function dataModelChangeFromContext(repo: string, context: ItemContext): 
     const path = typeof file.filename === "string" ? file.filename.trim() : "";
     const previousPath =
       typeof file.previous_filename === "string" ? file.previous_filename.trim() : "";
-    // Scope each rename side before unknown handling, retaining the semantic docs branch.
-    const candidates = [path, previousPath].filter(
-      (candidate) => isProductionSourcePath(candidate) || isDocsPath(candidate),
-    );
+    // Scope each rename side before unknown handling, retaining semantic docs
+    // while excluding CI definitions that cannot define an OpenClaw data model.
+    const candidates = [path, previousPath].filter(isDataModelCandidatePath);
     const likelyPath = candidates.find(isLikelyOpenClawDataModelPath) ?? "";
     const patch = typeof file.patch === "string" ? file.patch : null;
     const lines = patch === null ? [] : changedPatchLines(patch);
@@ -211,6 +210,12 @@ function isProductionSourcePath(path: string): boolean {
     const markerIndex = basename.indexOf(marker);
     return markerIndex >= 0 && markerIndex + marker.length < basename.length;
   });
+}
+
+function isDataModelCandidatePath(path: string): boolean {
+  return (
+    !/^\.github\/workflows\//i.test(path) && (isProductionSourcePath(path) || isDocsPath(path))
+  );
 }
 
 function isLikelySqliteSchemaPath(path: string): boolean {

--- a/test/fixtures/persistence-classifier-119762.json
+++ b/test/fixtures/persistence-classifier-119762.json
@@ -1,0 +1,11 @@
+{
+  "pullRequest": "https://github.com/openclaw/openclaw/pull/119762",
+  "headSha": "0d5398a9233014776b06d26252162cf5664535ca",
+  "source": "GitHub pull-files API carrier hunk fetched 2026-08-27",
+  "pullFiles": [
+    {
+      "filename": ".github/workflows/openclaw-live-and-e2e-checks-reusable.yml",
+      "patch": "@@\n+          metadata=\".artifacts/docker-e2e-package/package-candidate.json\"\n+          if [[ ! -f \"$metadata\" ]]; then\n+            jq -n \\\n+              --arg name \"$name\" \\\n+              '{ name: $name }' > \"$metadata\"\n+          fi\n+          [[ -s \"$metadata\" ]] || {\n+            echo \"Docker E2E package metadata was not created.\" >&2\n+            exit 1\n+          }"
+    }
+  ]
+}

--- a/test/pr-surface-policy.test.ts
+++ b/test/pr-surface-policy.test.ts
@@ -273,6 +273,15 @@ Corrects missing-tool installation guidance and adds a subprocess regression.
   assert.doesNotMatch(comment, /Persistent data-model change detected|### Stored data model/);
 });
 
+test("real #119762 workflow metadata carrier does not produce a stored-data warning", () => {
+  const fixture = JSON.parse(
+    readFileSync(new URL("./fixtures/persistence-classifier-119762.json", import.meta.url), "utf8"),
+  );
+  const detection = dataModelChangeFromPullFilesForTest({ pullFiles: fixture.pullFiles });
+
+  assert.deepEqual(detection, { change: false, surfaces: [] });
+});
+
 test("bundled hook prose does not become a persistence warning or migration gate", () => {
   const fixture = JSON.parse(
     readFileSync(new URL("./fixtures/persistence-classifier-130734.json", import.meta.url), "utf8"),
@@ -389,6 +398,23 @@ for (const { name, file, surfaces, pullFilesTruncated } of [
     file: { filename: "test/setup.ts", patch: '@@\n+writeFile("fixture.json", "{}");' },
     pullFilesTruncated: true,
     surfaces: ["unknown-truncated-pull-files"],
+  },
+  {
+    name: "workflow-only persistence vocabulary",
+    file: {
+      filename: ".github/workflows/release.yml",
+      patch:
+        '@@\n+metadata=".artifacts/candidate.json"\n+await upgrade(state)\n+await writeFile(statePath, JSON.stringify(value));',
+    },
+    surfaces: [],
+  },
+  {
+    name: "workflow to production rename with a missing patch",
+    file: {
+      filename: "src/storage/session-state.ts",
+      previous_filename: ".github/workflows/session-state.yml",
+    },
+    surfaces: ["unknown-data-model-change: src/storage/session-state.ts"],
   },
 ]) {
   test(`data model detector scopes ${name}`, () => {


### PR DESCRIPTION
## Summary

- Exclude only `.github/workflows/**` from OpenClaw stored-data-model candidate paths.
- Keep production-source, semantic-documentation, migration, missing-patch, and truncated-list handling unchanged.
- Add the real `openclaw/openclaw#119762` workflow carrier as a regression fixture, plus workflow-only and workflow-to-production rename coverage.

## Problem

The full eight-file pull-files response for `openclaw/openclaw#119762` included workflow metadata in `.github/workflows/openclaw-live-and-e2e-checks-reusable.yml`. The data-model classifier treated that CI-only YAML as vector/embedding metadata and imposed a stored-data migration-proof gate even though the changed file cannot define an OpenClaw persisted data model.

Contributor PR #1081 identified this false-positive family. This replacement deliberately takes only the path-boundary fix; it does not adopt the broader lexical trade-offs from that PR.

## Implementation

`isDataModelCandidatePath` now excludes `.github/workflows/**` before semantic matching. The SQLite schema classifier remains on its existing production-source path logic. No OpenClaw workflow was modified.

Rename sides are still considered independently: a rename from a workflow into `src/storage/session-state.ts` with no patch remains `unknown-data-model-change` and therefore fail-closed.

## Real Behavior Proof

**Claim:** CI workflow vocabulary no longer produces an OpenClaw stored-data warning, while conservative detection still holds for production persistence, semantic documentation, workflow-to-production renames, missing production patches, and truncated pull-file lists.

**Exercised surface:** the built `dist/clawsweeper-change-detection.js` classifier at head `7070f5175eaf3adeba4d9fec4ebb97298d14703f`.

**Scenario and result:** after `pnpm run build:all`, a controlled Node transcript fetched the live public GitHub pull-files response for #119762 (`carrierFiles: 8`) and produced `carrier: { change: false, surfaces: [] }`. In the same execution, semantic docs and production persistence remained `change: true`; the workflow-to-production rename and missing production patch both remained `unknown-data-model-change`; and the truncated file-list case remained `unknown-truncated-pull-files`.

**Commands/environment:** Docker Desktop Linux engine via Crabbox `provider=local-container`, image `mcr.microsoft.com/playwright:v1.60.0-noble`, exact head `7070f5175eaf3adeba4d9fec4ebb97298d14703f`; `crabbox run --provider local-container --local-container-image mcr.microsoft.com/playwright:v1.60.0-noble --no-hydrate --timing-json --script C:/clawsweeper-work/notes/csw-142-aws-crabbox-proof.sh`. The in-container script enabled Corepack in the unprivileged user's `$HOME/.local/bin`, ran `pnpm install --frozen-lockfile`, `pnpm run build:all`, the live built-classifier transcript, then `node --test test/pr-surface-policy.test.ts` (41/41 pass). Local focused validation also ran `pnpm run lint`, focused `oxfmt --check`, and `git diff --check`.

**Artifact/trace:** Docker-backed Crabbox run `run_b498cc9e3038`, lease `cbx_d237f8be92a9` (`golden-crab-8c3e`), exited 0: install 5.101s, build 3.509s, live-carrier 433ms, focused tests 349ms; total command 10.269s. The lease was released automatically after success. `test/fixtures/persistence-classifier-119762.json` is the fixed carrier regression; the main proof is reproduced from the live public REST payload, not only that fixture. The local read-only committed-range ClawSweeper artifact was `artifacts/csw-142-local-range/0.md`, reviewing base `7f9e3f99e312dc14e17084e66f23c1590e559b9e` and head `7070f5175eaf3adeba4d9fec4ebb97298d14703f`; it found no code or security finding.

**Redacted Docker-backed transcript:**

```text
provider=local-container image=mcr.microsoft.com/playwright:v1.60.0-noble
run=run_b498cc9e3038 lease=cbx_d237f8be92a9 slug=golden-crab-8c3e
workdir=/work/crabbox/cbx_d237f8be92a9/clawsweeper
CRABBOX_PHASE:install
Done in 3s using pnpm v11.10.0
CRABBOX_PHASE:build
$ tsc -p tsconfig.json
$ tsc -p tsconfig.repair.json
$ tsc -p tsconfig.dashboard.json
CRABBOX_PHASE:live-carrier
{"head":"7070f5175eaf3adeba4d9fec4ebb97298d14703f","carrierFiles":8,
 "carrier":{"change":false,"surfaces":[]},
 "scenarios":{"workflowOnly":{"change":false,"surfaces":[]},
 "semanticDocs":{"change":true},"productionPersistence":{"change":true},
 "workflowToProductionRename":{"change":true,"surfaces":["unknown-data-model-change: src/storage/session-state.ts"]},
 "missingStoragePatch":{"change":true,"surfaces":["unknown-data-model-change: src/storage/session-state.ts"]},
 "truncatedList":{"change":true,"surfaces":["unknown-truncated-pull-files"]}}}
CRABBOX_PHASE:focused-tests
tests 41; pass 41; fail 0; skipped 0
run summary sync=12.139s command=10.269s exit=0
leaseStopped=true
```

**Limits:** The proof covers the data-model classifier boundary, not a change to any OpenClaw workflow. It fetched only the public GitHub pull-files payload for #119762 and installed the repository's locked dependencies inside the temporary container; it performed no credentialed GitHub mutation, workflow dispatch, or deployment. A separately requested AWS Crabbox attempt (`run_7cc45bfec884`) is alternative-provider evidence only and is not claimed as satisfaction of this Docker local-container gate.

## Validation

- `pnpm run build:all`
- `node --test test/pr-surface-policy.test.ts` — 41 pass, 0 fail
- exact-head built-classifier proof against live #119762 pull-files payload and all five conservative scenarios above
- `pnpm run lint`
- `pnpm exec oxfmt --check src/clawsweeper-change-detection.ts test/pr-surface-policy.test.ts test/fixtures/persistence-classifier-119762.json`
- `git diff --check origin/main...HEAD`
- `pnpm run review -- --local-range --target-repo openclaw/clawsweeper --base origin/main --artifact-dir artifacts/csw-142-local-range` — complete, high confidence, no review comments

The repository-wide `pnpm run check` stopped at the formatter reporting issues across hundreds of untouched repository files; focused formatting for all changed files is clean. This is baseline noise, not changed by this branch.

## Codex Review

- Dirty-patch review: `codex review --uncommitted` after formatting — no accepted/actionable findings.
- Committed-base review: `codex review --base origin/main` — no actionable defects; focused detector suite passes after build.
- One earlier suggestion to exclude `.github/actions/setup-codex/action.yml` was rejected after direct built-classifier reproduction: that `.yml` is not a production candidate and returns `{ change: false, surfaces: [] }` already.

## Risks and Rollout

The exclusion is intentionally limited to `.github/workflows/**` in the data-model classifier. It does not exempt workflows from configuration, security, or workflow review, and it does not relax any production persistence or incomplete-payload fail-closed guard.

No merge or automerge is requested by this PR.

## Links

- Replaces the narrowly relevant workflow false-positive aspect raised in #1081.
- Live carrier: `openclaw/openclaw#119762`.
