### PR TITLE
chore: harden local Git and validation test fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,6 +540,10 @@ its final month). The local, GitHub-isolated review engine survives as
 
 ### Safety Model
 
+- Review and repair base fetches use fully qualified branch refspecs so inherited
+  `fetch.prune` or `remote.origin.prune` settings do not delete the requested
+  tracking ref. Validation uses the same repair fetch helper; no host Git
+  configuration changes are required.
 - Maintainer-authored items are excluded from automated closes unless the close
   reason is verified `implemented_on_main`.
 - Protected labels block close proposals.

--- a/test/command.test.ts
+++ b/test/command.test.ts
@@ -956,6 +956,7 @@ test("local exact review explains when GitHub item is not open", () => {
     execFileSync("git", ["branch", "-M", "main"], { cwd: targetDir });
     execFileSync("git", ["remote", "add", "origin", origin], { cwd: targetDir });
     execFileSync("git", ["push", "origin", "main"], { cwd: targetDir, stdio: "ignore" });
+    execFileSync("git", ["config", "fetch.prune", "true"], { cwd: targetDir });
     mkdirSync(binDir);
     const ghPath = join(binDir, "gh.js");
     writeFileSync(
@@ -1024,6 +1025,13 @@ process.exit(1);
     assert.match(result.stderr, /GitHub reports this PR is closed/);
     assert.doesNotMatch(result.stderr, /selected=0/);
     assert.doesNotMatch(result.stderr, /\n\s+at /);
+    assert.equal(
+      execFileSync("git", ["rev-parse", "refs/remotes/origin/main"], {
+        cwd: targetDir,
+        encoding: "utf8",
+      }),
+      execFileSync("git", ["rev-parse", "HEAD"], { cwd: targetDir, encoding: "utf8" }),
+    );
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -1050,6 +1058,8 @@ test("local exact review selects PATH Codex instead of the Desktop app binary", 
     execFileSync("git", ["branch", "-M", "main"], { cwd: targetDir });
     execFileSync("git", ["remote", "add", "origin", origin], { cwd: targetDir });
     execFileSync("git", ["push", "origin", "main"], { cwd: targetDir, stdio: "ignore" });
+    execFileSync("git", ["config", "fetch.prune", "false"], { cwd: targetDir });
+    execFileSync("git", ["config", "remote.origin.prune", "true"], { cwd: targetDir });
     const reviewHeadSha = execFileSync("git", ["rev-parse", "HEAD"], {
       cwd: targetDir,
       encoding: "utf8",

--- a/test/command.test.ts
+++ b/test/command.test.ts
@@ -956,7 +956,6 @@ test("local exact review explains when GitHub item is not open", () => {
     execFileSync("git", ["branch", "-M", "main"], { cwd: targetDir });
     execFileSync("git", ["remote", "add", "origin", origin], { cwd: targetDir });
     execFileSync("git", ["push", "origin", "main"], { cwd: targetDir, stdio: "ignore" });
-    execFileSync("git", ["config", "fetch.prune", "true"], { cwd: targetDir });
     mkdirSync(binDir);
     const ghPath = join(binDir, "gh.js");
     writeFileSync(
@@ -1049,7 +1048,7 @@ test("local exact review selects PATH Codex instead of the Desktop app binary", 
   try {
     execFileSync("git", ["init", "--bare", origin], { stdio: "ignore" });
     execFileSync("git", ["init", targetDir], { stdio: "ignore" });
-    execFileSync("git", ["config", "--local", "fetch.prune", "true"], { cwd: targetDir });
+    execFileSync("git", ["config", "--local", "fetch.prune", "false"], { cwd: targetDir });
     execFileSync("git", ["config", "user.email", "clawsweeper@example.com"], { cwd: targetDir });
     execFileSync("git", ["config", "user.name", "ClawSweeper Test"], { cwd: targetDir });
     writeFileSync(join(targetDir, "README.md"), "base\n");
@@ -1058,7 +1057,6 @@ test("local exact review selects PATH Codex instead of the Desktop app binary", 
     execFileSync("git", ["branch", "-M", "main"], { cwd: targetDir });
     execFileSync("git", ["remote", "add", "origin", origin], { cwd: targetDir });
     execFileSync("git", ["push", "origin", "main"], { cwd: targetDir, stdio: "ignore" });
-    execFileSync("git", ["config", "fetch.prune", "false"], { cwd: targetDir });
     execFileSync("git", ["config", "remote.origin.prune", "true"], { cwd: targetDir });
     const reviewHeadSha = execFileSync("git", ["rev-parse", "HEAD"], {
       cwd: targetDir,

--- a/test/repair/git-repo-utils.test.ts
+++ b/test/repair/git-repo-utils.test.ts
@@ -8,6 +8,7 @@ import { setTimeout as delay } from "node:timers/promises";
 import { pathToFileURL } from "node:url";
 
 import {
+  branchHasBaseDiff,
   completeRebaseIfResolved,
   ensureMergeBaseAvailable,
   rebaseOntoBase,
@@ -100,6 +101,50 @@ test("rebaseOntoBase rebases a repair branch onto latest origin main", () => {
   assert.equal(fs.readFileSync(path.join(work, "feature.txt"), "utf8"), "feature\n");
   assert.equal(fs.readFileSync(path.join(work, "main.txt"), "utf8"), "main\n");
 });
+
+for (const pruneConfig of ["fetch.prune", "remote.origin.prune"]) {
+  test(`base fetch updates its requested ref with ${pruneConfig}=true`, () => {
+    const { root, remote, work } = fixtureRepo();
+    try {
+      const originalBase = run("git", ["rev-parse", "HEAD"], { cwd: work });
+      fs.writeFileSync(path.join(work, "main.txt"), "new base\n");
+      run("git", ["add", "main.txt"], { cwd: work });
+      run("git", ["commit", "-m", "advance main"], { cwd: work });
+      const newBase = run("git", ["rev-parse", "HEAD"], { cwd: work });
+      run("git", ["push", "origin", "main"], { cwd: work });
+      run("git", ["update-ref", "refs/remotes/origin/main", originalBase], { cwd: work });
+      run("git", ["config", pruneConfig, "true"], { cwd: work });
+
+      assert.equal(ensureMergeBaseAvailable({ targetDir: work, baseBranch: "main" }), newBase);
+      assert.equal(run("git", ["rev-parse", "origin/main"], { cwd: work }), newBase);
+
+      // A shallow feature checkout needs the deeper-history fallback before diffing.
+      run("git", ["checkout", "-b", "feature", originalBase], { cwd: work });
+      fs.writeFileSync(path.join(work, "feature.txt"), "feature\n");
+      run("git", ["add", "feature.txt"], { cwd: work });
+      run("git", ["commit", "-m", "feature"], { cwd: work });
+      run("git", ["push", "origin", "feature"], { cwd: work });
+      const shallow = path.join(root, "shallow");
+      run("git", ["clone", "--no-local", "--depth=1", "--branch=feature", remote, shallow]);
+      run("git", ["fetch", "origin", "refs/heads/main:refs/remotes/origin/main", "--depth=1"], {
+        cwd: shallow,
+      });
+      run("git", ["config", pruneConfig, "true"], { cwd: shallow });
+      assert.notEqual(
+        spawnSync("git", ["merge-base", "origin/main", "HEAD"], { cwd: shallow }).status,
+        0,
+      );
+      assert.equal(branchHasBaseDiff({ targetDir: shallow, baseBranch: "main" }), true);
+      assert.equal(run("git", ["rev-parse", "origin/main"], { cwd: shallow }), newBase);
+      assert.equal(
+        run("git", ["merge-base", "origin/main", "HEAD"], { cwd: shallow }),
+        originalBase,
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+}
 
 test("rebaseOntoBase leaves conflicts for Codex repair instead of aborting", () => {
   const { work } = fixtureRepo();

--- a/test/repair/git-repo-utils.test.ts
+++ b/test/repair/git-repo-utils.test.ts
@@ -113,6 +113,9 @@ for (const pruneConfig of ["fetch.prune", "remote.origin.prune"]) {
       const newBase = run("git", ["rev-parse", "HEAD"], { cwd: work });
       run("git", ["push", "origin", "main"], { cwd: work });
       run("git", ["update-ref", "refs/remotes/origin/main", originalBase], { cwd: work });
+      if (pruneConfig === "remote.origin.prune") {
+        run("git", ["config", "fetch.prune", "false"], { cwd: work });
+      }
       run("git", ["config", pruneConfig, "true"], { cwd: work });
 
       assert.equal(ensureMergeBaseAvailable({ targetDir: work, baseBranch: "main" }), newBase);
@@ -129,6 +132,9 @@ for (const pruneConfig of ["fetch.prune", "remote.origin.prune"]) {
       run("git", ["fetch", "origin", "refs/heads/main:refs/remotes/origin/main", "--depth=1"], {
         cwd: shallow,
       });
+      if (pruneConfig === "remote.origin.prune") {
+        run("git", ["config", "fetch.prune", "false"], { cwd: shallow });
+      }
       run("git", ["config", pruneConfig, "true"], { cwd: shallow });
       assert.notEqual(
         spawnSync("git", ["merge-base", "origin/main", "HEAD"], { cwd: shallow }).status,

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -2107,7 +2107,7 @@ test("pinned-base validation reproduction proves the same base failure", () => {
   git(cwd, "add", "src/repair.ts");
   git(cwd, "commit", "-m", "repair change");
 
-  const profiles = withPinnedBasePnpm(() =>
+  const profiles = withPackageScriptPnpm(() =>
     Array.from({ length: 2 }, () => {
       const baseError = reproduceValidationFailureAtPinnedBase({
         commands: ["pnpm check:changed"],
@@ -2181,7 +2181,7 @@ test("pinned-base reproduction avoids fetching unrelated missing partial-clone h
   assert.match(missingObjects, new RegExp(`^\\?${omittedHistoricalBlob}$`, "m"));
   git(target, "remote", "set-url", "origin", "https://invalid.invalid/offline.git");
 
-  const baseError = withPinnedBasePnpm(() =>
+  const baseError = withPackageScriptPnpm(() =>
     reproduceValidationFailureAtPinnedBase({
       commands: ["pnpm check:changed"],
       targetDir: target,
@@ -2226,7 +2226,7 @@ test("pinned-base reproduction preserves the source comparison branch for change
   git(cwd, "update-ref", "refs/remotes/origin/main", pinnedBaseRef);
   assert.notEqual(sourceMainSha, pinnedBaseRef);
 
-  const baseError = withPinnedBasePnpm(() =>
+  const baseError = withPackageScriptPnpm(() =>
     reproduceValidationFailureAtPinnedBase({
       commands: ["pnpm check:changed"],
       targetDir: cwd,
@@ -2279,7 +2279,7 @@ test("pinned-base reproduction hydrates blobs required by the older pinned snaps
     new RegExp(`^\\?${requiredBlob}$`, "m"),
   );
 
-  const baseError = withPinnedBasePnpm(() =>
+  const baseError = withPackageScriptPnpm(() =>
     reproduceValidationFailureAtPinnedBase({
       commands: ["pnpm check:changed"],
       targetDir: target,
@@ -2310,7 +2310,7 @@ test("pinned-base reproduction preserves the source SHA-256 object format", () =
   const pinnedBaseRef = git(cwd, "rev-parse", "HEAD");
   assert.equal(pinnedBaseRef.length, 64);
 
-  const baseError = withPinnedBasePnpm(() =>
+  const baseError = withPackageScriptPnpm(() =>
     reproduceValidationFailureAtPinnedBase({
       commands: ["pnpm check:changed"],
       targetDir: cwd,
@@ -2361,7 +2361,7 @@ test("pinned-base reproduction does not inherit target-controlled checkout hooks
   });
   git(cwd, "config", "core.hooksPath", hooks);
 
-  const baseError = withPinnedBasePnpm(() =>
+  const baseError = withPackageScriptPnpm(() =>
     reproduceValidationFailureAtPinnedBase({
       commands: ["pnpm check:changed"],
       targetDir: cwd,
@@ -6334,6 +6334,42 @@ fs.writeFileSync("source.txt", "mutated\\n");
   );
 });
 
+for (const pruneConfig of ["fetch.prune", "remote.origin.prune"]) {
+  test(`target validation preserves its base ref with ${pruneConfig}=true`, () => {
+    const cwd = gitPackageFixture({});
+    let origin: string | undefined;
+    try {
+      fs.mkdirSync(path.join(cwd, "scripts"));
+      fs.writeFileSync(
+        path.join(cwd, "scripts/verify.mjs"),
+        "console.log('validation reached');\n",
+      );
+      git(cwd, "add", ".");
+      git(cwd, "commit", "-m", "initial");
+      attachOrigin(cwd);
+      origin = git(cwd, "remote", "get-url", "origin");
+      const baseSha = git(cwd, "rev-parse", "HEAD");
+      git(cwd, "config", pruneConfig, "true");
+
+      assert.deepEqual(
+        runAllowedValidationCommands(
+          ["node scripts/verify.mjs", "git diff --check"],
+          cwd,
+          validationOptions("steipete/example", {
+            toolchain: { packageManager: "pnpm", baseValidationCommands: [], changedGate: null },
+          }),
+        ),
+        ["node scripts/verify.mjs", "git diff --check"],
+      );
+      assert.equal(git(cwd, "rev-parse", "refs/remotes/origin/main"), baseSha);
+      assert.equal(git(cwd, "status", "--porcelain"), "");
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+      if (origin) fs.rmSync(origin, { recursive: true, force: true });
+    }
+  });
+}
+
 test("validation rejects scripts that mutate the checkout", () => {
   const cwd = gitPackageFixture({ verify: "node mutate.js" });
   fs.writeFileSync(
@@ -8136,7 +8172,7 @@ fs.writeFileSync("pnpm-lock.yaml", "lockfileVersion: '9.0'\\n");
   );
 });
 
-test("target setup shares one deadline across probes and installs", () => {
+test("target setup shares one deadline across probes and installs", (t) => {
   const cwd = gitPackageFixture({ check: "node check.js" });
   fs.writeFileSync(path.join(cwd, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n");
   git(cwd, "add", ".");
@@ -8145,17 +8181,12 @@ test("target setup shares one deadline across probes and installs", () => {
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-setup-deadline-"));
   const corepackPath = path.join(binDir, "corepack.js");
   const pnpmPath = path.join(binDir, "pnpm.js");
-  const corepackCountPath = path.join(binDir, "corepack-count");
+  const corepackPhasesPath = path.join(binDir, "corepack-phases");
   const pnpmMarkerPath = path.join(binDir, "pnpm-ran");
   fs.writeFileSync(
     corepackPath,
     `const fs = require("node:fs");
-const count = fs.existsSync(${JSON.stringify(corepackCountPath)})
-  ? Number(fs.readFileSync(${JSON.stringify(corepackCountPath)}, "utf8"))
-  : 0;
-fs.writeFileSync(${JSON.stringify(corepackCountPath)}, String(count + 1));
-const delay = process.argv[2] === "enable" ? 100 : 2000;
-Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delay);
+fs.appendFileSync(${JSON.stringify(corepackPhasesPath)}, process.argv[2] + "\\n");
 `,
   );
   fs.writeFileSync(
@@ -8163,28 +8194,42 @@ Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delay);
     `require("node:fs").writeFileSync(${JSON.stringify(pnpmMarkerPath)}, "ran");\n`,
   );
 
-  assert.throws(
-    () =>
-      withMockCommand("corepack", corepackPath, () =>
-        withMockCommand("pnpm", pnpmPath, () =>
-          prepareTargetToolchain(cwd, {
-            ...validationOptions("steipete/example", {
-              toolchain: {
-                packageManager: "pnpm",
-                baseValidationCommands: ["pnpm check"],
-                changedGate: null,
-              },
+  const startedAt = Date.now();
+  // Charge each completed Corepack phase 600ms; Git/probe scheduling consumes no fake time.
+  const clock = t.mock.method(Date, "now", () => {
+    const phases = fs.existsSync(corepackPhasesPath)
+      ? fs.readFileSync(corepackPhasesPath, "utf8").trim().split("\n").length
+      : 0;
+    return startedAt + phases * 600;
+  });
+  try {
+    assert.throws(
+      () =>
+        withMockCommand("corepack", corepackPath, () =>
+          withMockCommand("pnpm", pnpmPath, () =>
+            prepareTargetToolchain(cwd, {
+              ...validationOptions("steipete/example", {
+                toolchain: {
+                  packageManager: "pnpm",
+                  baseValidationCommands: ["pnpm check"],
+                  changedGate: null,
+                },
+              }),
+              installTargetDeps: true,
+              installTimeoutMs: 1200,
+              setupTimeoutMs: 1200,
             }),
-            installTargetDeps: true,
-            installTimeoutMs: 1200,
-            setupTimeoutMs: 1200,
-          }),
+          ),
         ),
-      ),
-    /command timed out after \d+ms: corepack prepare/,
-  );
-  assert.equal(fs.readFileSync(corepackCountPath, "utf8"), "2");
-  assert.equal(fs.existsSync(pnpmMarkerPath), false);
+      /target dependency setup deadline exhausted during pnpm install/,
+    );
+    assert.equal(fs.readFileSync(corepackPhasesPath, "utf8"), "enable\nprepare\n");
+    assert.equal(fs.existsSync(pnpmMarkerPath), false);
+  } finally {
+    clock.mock.restore();
+    fs.rmSync(binDir, { recursive: true, force: true });
+    fs.rmSync(cwd, { recursive: true, force: true });
+  }
 });
 
 test("bun-based target repos still report unrelated missing scripts as blocked", () => {
@@ -8332,33 +8377,28 @@ test("resolveTargetRepoToolchain stays total when the config file is malformed J
 });
 
 test("changed validation retries one transient check:changed failure", () => {
-  const marker = path.join(
-    os.tmpdir(),
-    `clawsweeper-validation-attempt-${process.pid}-${Date.now()}.txt`,
-  );
+  const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-validation-retry-"));
+  const marker = path.join(fixture, "attempts");
   const cwd = gitPackageFixture({ "check:changed": "node check.js" });
   fs.writeFileSync(
     path.join(cwd, "check.js"),
-    [
-      "const fs = require('node:fs');",
-      "const file = process.env.CLAWSWEEPER_TEST_ATTEMPT_FILE;",
-      "const count = fs.existsSync(file) ? Number(fs.readFileSync(file, 'utf8')) : 0;",
-      "fs.writeFileSync(file, String(count + 1));",
-      "if (count === 0) { console.error('transient changed gate failure'); process.exit(1); }",
-      "",
-    ].join("\n"),
+    `const fs = require("node:fs");
+const file = ${JSON.stringify(marker)};
+const count = fs.existsSync(file) ? Number(fs.readFileSync(file, "utf8")) : 0;
+fs.writeFileSync(file, String(count + 1));
+if (count === 0) { console.error("transient changed gate failure"); process.exit(1); }
+`,
   );
   git(cwd, "add", ".");
   git(cwd, "commit", "-m", "initial");
   attachOrigin(cwd);
+  const origin = git(cwd, "remote", "get-url", "origin");
 
   const previous = process.env.CLAWSWEEPER_VALIDATION_RETRIES;
-  const previousMarker = process.env.CLAWSWEEPER_TEST_ATTEMPT_FILE;
   process.env.CLAWSWEEPER_VALIDATION_RETRIES = "1";
-  process.env.CLAWSWEEPER_TEST_ATTEMPT_FILE = marker;
   try {
     assert.deepEqual(
-      withPinnedBasePnpm(() =>
+      withPackageScriptPnpm(() =>
         runAllowedValidationCommands(
           ["pnpm check:changed"],
           cwd,
@@ -8368,91 +8408,135 @@ test("changed validation retries one transient check:changed failure", () => {
       ["pnpm check:changed"],
     );
     assert.equal(fs.readFileSync(marker, "utf8"), "2");
+    assert.equal(git(cwd, "status", "--porcelain"), "");
   } finally {
     restoreEnv("CLAWSWEEPER_VALIDATION_RETRIES", previous);
-    restoreEnv("CLAWSWEEPER_TEST_ATTEMPT_FILE", previousMarker);
-    fs.rmSync(marker, { force: true });
+    fs.rmSync(fixture, { recursive: true, force: true });
+    fs.rmSync(cwd, { recursive: true, force: true });
+    fs.rmSync(origin, { recursive: true, force: true });
   }
 });
 
-test("changed validation shares one timeout with checkout identity proof", () => {
-  const marker = path.join(
-    os.tmpdir(),
-    `clawsweeper-validation-budget-${process.pid}-${Date.now()}.txt`,
-  );
+test("changed validation shares one timeout with checkout identity proof", (t) => {
+  const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-validation-budget-"));
+  const marker = path.join(fixture, "attempts");
   const cwd = gitPackageFixture({ "check:changed": "node check.js" });
-  git(cwd, "add", ".");
-  git(cwd, "commit", "-m", "initial");
-  attachOrigin(cwd);
-
-  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-pnpm-budget-"));
-  const pnpmPath = path.join(binDir, "pnpm.js");
   fs.writeFileSync(
-    pnpmPath,
+    path.join(cwd, "check.js"),
     `const fs = require("node:fs");
 const count = fs.existsSync(${JSON.stringify(marker)})
   ? Number(fs.readFileSync(${JSON.stringify(marker)}, "utf8"))
   : 0;
 fs.writeFileSync(${JSON.stringify(marker)}, String(count + 1));
-setTimeout(() => {}, 5000);
+console.error("transient changed gate failure");
+process.exit(1);
 `,
+  );
+  git(cwd, "add", ".");
+  git(cwd, "commit", "-m", "initial");
+  attachOrigin(cwd);
+  const origin = git(cwd, "remote", "get-url", "origin");
+  const validationTimeoutMs = 4_000;
+  const startedAt = Date.now();
+  // Exhaust the shared budget only after the real command runs, not during Git setup.
+  const clock = t.mock.method(
+    Date,
+    "now",
+    () => startedAt + (fs.existsSync(marker) ? validationTimeoutMs : 0),
   );
   const previousRetries = process.env.CLAWSWEEPER_VALIDATION_RETRIES;
   process.env.CLAWSWEEPER_VALIDATION_RETRIES = "1";
   try {
     assert.throws(
       () =>
-        withMockCommand("pnpm", pnpmPath, () =>
+        withPackageScriptPnpm(() =>
           runAllowedValidationCommands(
             ["pnpm check:changed"],
             cwd,
-            validationOptions("openclaw/openclaw", { validationTimeoutMs: 250 }),
+            validationOptions("openclaw/openclaw", { validationTimeoutMs }),
           ),
         ),
-      /validation command runtime budget exhausted|unsafe validation command checkout identity could not be verified/,
+      (error: Error) => {
+        assert.equal(
+          error.message,
+          "validation command failed (pnpm check:changed): validation command runtime budget exhausted",
+        );
+        assert.match(String(error.cause), /transient changed gate failure/);
+        return true;
+      },
     );
     assert.equal(fs.readFileSync(marker, "utf8"), "1");
+    assert.equal(git(cwd, "status", "--porcelain"), "");
   } finally {
+    clock.mock.restore();
     restoreEnv("CLAWSWEEPER_VALIDATION_RETRIES", previousRetries);
-    fs.rmSync(marker, { force: true });
+    fs.rmSync(fixture, { recursive: true, force: true });
+    fs.rmSync(cwd, { recursive: true, force: true });
+    fs.rmSync(origin, { recursive: true, force: true });
   }
 });
 
-test("validation reserves deadline to prove checkout mutation after command timeout", () => {
+test("validation reserves deadline to prove checkout mutation after command timeout", (t) => {
+  const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-validation-timeout-"));
+  const marker = path.join(fixture, "phases");
   const cwd = gitPackageFixture({ verify: "node verify.js" });
   fs.writeFileSync(path.join(cwd, "source.txt"), "original\n");
+  fs.writeFileSync(
+    path.join(cwd, "verify.js"),
+    `const fs = require("node:fs");
+process.on("SIGTERM", () => {
+  fs.appendFileSync(${JSON.stringify(marker)}, "terminated\\n");
+  process.exit(0);
+});
+fs.writeFileSync("source.txt", "mutated\\n");
+fs.appendFileSync(${JSON.stringify(marker)}, "mutated\\n");
+setInterval(() => {}, 1000);
+`,
+  );
   git(cwd, "add", ".");
   git(cwd, "commit", "-m", "initial");
   attachOrigin(cwd);
-
-  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-pnpm-timeout-mutation-"));
-  const pnpmPath = path.join(binDir, "pnpm.js");
-  fs.writeFileSync(
-    pnpmPath,
-    `const fs = require("node:fs");
-fs.writeFileSync("source.txt", "mutated\\n");
-setTimeout(() => {}, 5000);
-`,
+  const origin = git(cwd, "remote", "get-url", "origin");
+  const validationTimeoutMs = 4_000;
+  const startedAt = Date.now();
+  // Leave command startup real, then require identity proof after the shared budget expires.
+  const clock = t.mock.method(
+    Date,
+    "now",
+    () => startedAt + (fs.existsSync(marker) ? validationTimeoutMs : 0),
   );
-
-  assert.throws(
-    () =>
-      withMockCommand("pnpm", pnpmPath, () =>
-        runAllowedValidationCommands(
-          ["pnpm verify"],
-          cwd,
-          validationOptions("steipete/example", {
-            toolchain: {
-              packageManager: "pnpm",
-              baseValidationCommands: [],
-              changedGate: null,
-            },
-            validationTimeoutMs: 800,
-          }),
+  try {
+    assert.throws(
+      () =>
+        withPackageScriptPnpm(
+          () =>
+            runAllowedValidationCommands(
+              ["pnpm verify"],
+              cwd,
+              validationOptions("steipete/example", {
+                toolchain: {
+                  packageManager: "pnpm",
+                  baseValidationCommands: [],
+                  changedGate: null,
+                },
+                validationTimeoutMs,
+              }),
+            ),
+          { name: "verify", file: "verify.js" },
         ),
-      ),
-    /unsafe validation command mutated checkout identity/,
-  );
+      /unsafe validation command mutated checkout identity/,
+    );
+    assert.equal(fs.readFileSync(path.join(cwd, "source.txt"), "utf8"), "mutated\n");
+    assert.equal(
+      fs.readFileSync(marker, "utf8"),
+      process.platform === "win32" ? "mutated\n" : "mutated\nterminated\n",
+    );
+  } finally {
+    clock.mock.restore();
+    fs.rmSync(fixture, { recursive: true, force: true });
+    fs.rmSync(cwd, { recursive: true, force: true });
+    fs.rmSync(origin, { recursive: true, force: true });
+  }
 });
 
 test(
@@ -8939,9 +9023,9 @@ function linuxValidationContainmentAvailable() {
   return probe.status === 0;
 }
 
-function withPinnedBasePnpm(callback) {
-  // Dependency-free fixtures skip setup and must not resolve host pnpm.
-  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-pinned-base-pnpm-"));
+function withPackageScriptPnpm(callback, { name = "check:changed", file = "check.js" } = {}) {
+  // Dependency-free fixtures execute their real package script without resolving host pnpm.
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-package-script-pnpm-"));
   const pnpmPath = path.join(binDir, "pnpm.cjs");
   fs.writeFileSync(
     pnpmPath,
@@ -8952,9 +9036,9 @@ const args = process.argv.slice(2).filter(arg => ![
   "--config.verify-deps-before-run=false",
   "--config.enable-pre-post-scripts=false",
 ].includes(arg));
-assert.deepEqual(args, ["check:changed"]);
-assert.equal(JSON.parse(fs.readFileSync("package.json", "utf8")).scripts["check:changed"], "node check.js");
-const child = spawnSync(process.execPath, ["check.js"], { stdio: "inherit" });
+assert.deepEqual(args, [${JSON.stringify(name)}]);
+assert.equal(JSON.parse(fs.readFileSync("package.json", "utf8")).scripts[${JSON.stringify(name)}], ${JSON.stringify(`node ${file}`)});
+const child = spawnSync(process.execPath, [${JSON.stringify(file)}], { stdio: "inherit" });
 if (child.error) throw child.error;
 if (child.signal) process.kill(process.pid, child.signal);
 else process.exit(child.status ?? 1);

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -6349,6 +6349,9 @@ for (const pruneConfig of ["fetch.prune", "remote.origin.prune"]) {
       attachOrigin(cwd);
       origin = git(cwd, "remote", "get-url", "origin");
       const baseSha = git(cwd, "rev-parse", "HEAD");
+      if (pruneConfig === "remote.origin.prune") {
+        git(cwd, "config", "fetch.prune", "false");
+      }
       git(cwd, "config", pruneConfig, "true");
 
       assert.deepEqual(


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where local Git and validation tests depend on host pruning settings, package-manager availability, or incidental setup scheduling instead of reliably exercising their intended behavior.

This is a test/docs-only follow-up to https://github.com/openclaw/clawsweeper/pull/1265. That PR already landed the three fully qualified production refspecs, basic retry-fixture isolation and exactly-two-attempt assertion, command-test pruning setup, and shallow helper coverage. This PR does not claim those production fixes again.

## Why This Change Was Made

The remaining fixtures prove stale tracking-ref updates and `branchHasBaseDiff` shallow-history recovery under both pruning settings, exercise real target-validation commands, and explicitly set `fetch.prune=false` for remote-only cases. Deadline fixtures account for completed setup/command phases while retaining actual subprocess execution, a real timeout, tracked-file mutation detection, and clean-checkout assertions. The test-owned package-script runner is generalized without changing the six existing pinned-base scenarios.

Only README and three test files change: +252/-102 lines. The `src/**` diff is empty. Upstream production behavior, absent-lockfile coverage, timeout/retry/security/offline gates, dependencies, suite concurrency, and coverage thresholds remain unchanged.

## User Impact

No production behavior change. Developers get fixtures that test the intended pruning, retry, and identity boundaries with less dependence on local setup timing. No global Git or package-manager configuration changes are required.

## OpenClaw Bay Impact

None: no queue, lifecycle, review-publication, status, dashboard, or UI contract changes.

## Documentation Impact

Reviewed README, CONTRIBUTING.md, AGENTS.md, and the documentation index. README's active Safety Model now explains the already-landed qualified-refspec behavior. ClawSweeper maintainers own that explanation; its source of truth is the review runtime and shared repair fetch helper, verified at the head below. Revisit it when those fetch contracts change. No duplicate changelog entry is needed for this test hardening.

## Evidence

Validated head: `a6089c4eff7d29b53fdbd2e9470c4710050728de`.
Base: `d103c0cf5c98b0f3d4242bb4202c032856c36a49` (`main`).

Native macOS, Node **24.20.0**, Git **2.55.0**, repository-pinned pnpm **11.10.0**. No install or global configuration changes were made for these runs. Independent committed-branch inspection and isolated Codex review reported no P0 findings.

| Validation on this head | Result |
| --- | --- |
| Three complete touched test files | 235 total: 232 passed, 0 failed, 3 skipped |
| Original 53-case regression selection | 53 passed, 0 failed/skipped |
| Dedicated general/remote-only pruning replay, host Git config disabled | 6 passed, 0 failed/skipped |
| Six pinned-base fixtures plus retry with failing host pnpm/Corepack sentinels | 7 passed; neither sentinel invoked |
| Shared-runtime-budget and real-timeout mutation cases, 12 repetitions each across four processes | 24/24 passed |
| Setup-deadline case, 12 repetitions across four processes | 12/12 passed |
| Four retry/identity mutations | All five expected negative assertions failed for their intended reasons |
| First normal full check | 3,857 total: 3,845 passed, 2 failed, 10 skipped |
| Two focused covered reruns of those unchanged terminal cases | 2/2 then 2/2 passed (4/4 total) |
| One explicitly authorized normal full-check retry | 3,857 total: 3,847 passed, 0 failed, 10 skipped; exit 0 |

The first full check failed in unchanged `test/live-proof-review-environment.test.ts`: the original-pane and consecutive-command cases exceeded the terminal cleanup polling allowance. The failing test and driver/helper bytes match the captured base. Both focused reruns and both cases in the final full retry passed without code changes. Host timing is plausible, but the terminal cause remains unknown and is **not fixed by this PR**. The original failure remains part of the evidence, not a discarded attempt.

Both full checks used normal inherited `fetch.prune=true`, unchanged concurrency16, coverage thresholds, and budgets. The successful retry also passed static checks, builds, lint, formatting, docs checks, and the separate 12-test coverage stage. Overall retry coverage: 82.22% lines, 74.64% branches, 87.67% functions.

An additional optional setup-budget mutant was rejected with an identity-deadline error instead of the fixture's required setup-deadline error. A scratch driver's prediction of `Missing expected exception` was over-specific and failed; that driver was not changed or rerun. This is recorded only as an observed mutant rejection, not as a green harness or proof of a complete fresh-global-deadline mutation. It is excluded from the five core negative assertions above.

## Real Behavior Proof

**Claim and surface:** actual local Git repositories and validator/package-script subprocesses preserve requested refs and exercise retries, shared deadlines, real command timeout, and post-command identity checks under explicit pruning, missing host package managers, and setup contention. The changed surface is the fixture behavior, not a production contract.

**Scenarios and observations:** a stale `origin/main` updates to the new remote commit; a shallow feature checkout initially lacks a merge base, then recovers it through `branchHasBaseDiff` without losing the base ref. Target validation reaches its real Node script and retains the base ref and a clean checkout. The retry script runs exactly twice. Setup phases consume the shared budget before install. The runtime-budget case runs once and preserves the actual transient error as its cause. The mutation script changes a tracked file, writes `mutated`, stays alive until the real supervisor timeout, then records `terminated` on macOS; the validator reports the required checkout-identity mutation error.

Reproduce the complete touched-file surface after building, using Node24 and the repository's pinned pnpm:

```sh
pnpm run build:node
node --test --test-reporter=tap \
  test/command.test.ts \
  test/repair/git-repo-utils.test.ts \
  test/repair/target-validation.test.ts

GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_COUNT=0 \
node --test --test-reporter=tap \
  --test-name-pattern='base fetch updates its requested ref|target validation preserves its base ref|local exact review explains when GitHub item is not open|local exact review selects PATH Codex' \
  test/command.test.ts \
  test/repair/git-repo-utils.test.ts \
  test/repair/target-validation.test.ts

pnpm run check
```

For the contention replay, the two selected cases are `changed validation shares one timeout with checkout identity proof` and `validation reserves deadline to prove checkout mutation after command timeout`; each was repeated 12 times in four concurrent test processes with process-local `fetch.prune=false` and `remote.origin.prune=true`. This diagnostic replay did not alter suite concurrency. The no-host replay selected the six `pinned-base` cases and the transient retry case with failing sentinel executables prepended to PATH. Child-local loader controls disabled retry, renewed the retry deadline, removed the identity proof window, or skipped the post-command identity check; each fixture rejected the corresponding broken behavior without modifying source files.

Compact normalized trace from the executed runs:

```text
three files: tests=235 pass=232 fail=0 skipped=3
isolated pruning: tests=6 pass=6 fail=0 skipped=0
no-host: pass=7 pnpm_invocations=0 corepack_invocations=0
retry: attempts=2 checkout=clean
shared budget: attempts=1 cause=transient changed gate failure
timeout mutation: phases=mutated,terminated; error=mutated checkout identity
contention: timing=24/24 setup=12/12
core negative controls: expected_assertion_failures=5 observed=5
full attempt 1: pass=3845 fail=2 skipped=10
focused covered terminal reruns: pass=2 then pass=2
full attempt 2: pass=3847 fail=0 skipped=10 exit=0
```

**Limits:** native macOS proof only; platform skips remain. No Windows or Linux containment claim, live automation/review/apply execution, or real package-manager download/install claim. The focused selections overlap and are not additive unique-test counts. No terminal cleanup fix or proven contention root cause is claimed.
