### PR TITLE
fix(live-proof): unblock Crabbox setup and terminal cleanup

### DIFF
--- a/config/target-repositories.json
+++ b/config/target-repositories.json
@@ -90,6 +90,26 @@
       }
     },
     {
+      "target_repo": "openclaw/crabbox",
+      "display_name": "Crabbox",
+      "checkout_dir": "crabbox",
+      "prompt_note": "Use the Crabbox source tree and current default branch. Review its Go CLI, portable Node/PostgreSQL coordinator, Cloudflare coordinator, and documentation using target-native tooling and evidence. Propose auto-close for issues and pull requests that are certainly implemented on main; for pull requests only, also allow age-gated mostly implemented on main. Keep everything else open for maintainer triage.",
+      "apply_close_rules": {
+        "issue": ["implemented_on_main"],
+        "pull_request": ["implemented_on_main", "mostly_implemented_on_main"]
+      },
+      "package_manager": "npm",
+      "validation_commands": [],
+      "changed_gate": null,
+      "live_test": {
+        "enabled": true,
+        "surface_default": "terminal",
+        "setup": ["npm ci --prefix worker"],
+        "ready_timeout_seconds": 240,
+        "max_recording_seconds": 90
+      }
+    },
+    {
       "target_repo": "steipete/camsnap",
       "display_name": "camsnap",
       "checkout_dir": "camsnap",

--- a/docs/live-proof.md
+++ b/docs/live-proof.md
@@ -32,6 +32,14 @@ available before target setup. Installer failures become a failed
 path; they do not fail the review itself. Reviews that do not verify never probe
 or install a target package manager.
 
+The selected repository profile also owns `live_test.setup`. Setup commands run
+from the exact-head target root, not the ClawSweeper checkout or a discovered
+package directory. Nested packages therefore need explicit target-native
+commands: Crabbox uses `npm ci --prefix worker`, which becomes
+`npm ci --ignore-scripts --prefix worker` under the default install-script policy.
+An owner fallback cannot describe every repository's package layout; configure
+the target profile rather than assuming OpenClaw's root pnpm setup applies.
+
 ## Review-job execution
 
 After the review command returns, the job inspects the produced reports before
@@ -133,9 +141,14 @@ dev server could bind its port without publishing an unbounded target log.
 
 Every drive writes `live-verification.json` with the exact reviewed head, entry,
 typed steps and outcomes, bounded terminal output, and overall pass/fail result.
-A setup or drive failure still publishes verification and no media. Media is
-eligible only when an expectation was absent initially and satisfied after the
-plan acted, and the recording passes the three-second floor. Eligible recordings
+A setup or drive failure still publishes verification and no media. Command
+failure summaries retain evidence from both stderr and stdout, sharing a
+1,000-character budget across nonempty streams and any spawn error. Summaries
+are flattened to one line so an informational stderr notice cannot hide a
+stdout failure in the human-readable reason. Existing output bounds and
+publication sanitization still apply. Media is eligible only when an expectation
+was absent initially and satisfied after the plan acted, and the recording passes
+the three-second floor. Eligible recordings
 are capped at 90 seconds and 50 MB, transcoded to H.264 MP4, probed, and paired
 with `poster.jpg` plus a metadata-only manifest.
 
@@ -212,8 +225,12 @@ already-armed watchdog. Pane death triggers the same watchdog independently. It
 TERM-sweeps, then repeatedly KILL-sweeps processes still holding the lease plus
 bound-terminal members only while the original pane still owns both its lease
 and bound terminal. Lease-holder discovery remains active after pane death.
-Darwin finds lease holders with the stock `lsof`; Linux inspects `/proc` for
-reserved inherited descriptor 9. Cleanup succeeds only when an exact
+Darwin finds lease holders with stock `lsof -X`, restricting discovery to open
+descriptors and fileports rather than mapped images or working directories;
+duplicated lease descriptors remain discoverable. Linux inspects `/proc` for
+reserved inherited descriptor 9. Terminal membership queries select the bound
+TTY directly. These queries avoid unrelated host work without changing the
+cleanup budget or identity guards. Cleanup succeeds only when an exact
 zero-survivor receipt matches the bound identity and the original pane is dead.
 Missing, malformed, stale, replaced, surviving-process, or timeout evidence
 fails visibly. Target commands do not inherit `TMUX`, `TMUX_PANE`, or

--- a/docs/target-repositories.md
+++ b/docs/target-repositories.md
@@ -35,6 +35,13 @@ profile alone supplies its release-owned `CHANGELOG.md` review restriction.
 policies; being a non-core target does not grant contributors or workers
 permission to edit release-owned files.
 
+Toolchain and setup ownership is also per repository. The explicit
+`openclaw/crabbox` profile selects npm and installs its nested worker package
+with `npm ci --prefix worker` from the target root. It retains the generic
+OpenClaw fallback's close rules, empty validation commands, and absent changed
+gate; selecting target-native setup does not broaden apply policy or inherit
+the core OpenClaw policy.
+
 Dashboard targets are configured separately with `TARGET_REPOS` in
 `dashboard/wrangler.toml`. Scheduled target selection comes from
 `target_inventory`, and apply-enabled targets use the dashboard's

--- a/src/clawsweeper-media-proof.ts
+++ b/src/clawsweeper-media-proof.ts
@@ -86,11 +86,17 @@ function mediaProofKind(url: string): "image" | "video" {
 
 export function mediaProofSpawnDetail(result: ReturnType<MediaProofCommandRunner>): string {
   if (result.status === 0) return "ok";
-  const stderr = String(result.stderr ?? "").trim();
-  const stdout = String(result.stdout ?? "").trim();
-  const error = result.error?.message ?? "";
-  const detail = stderr || stdout || error || "command failed without output";
-  return trimMiddle(detail, 1000);
+  const details = [result.stderr, result.stdout, result.error?.message]
+    .map((value) => String(value ?? "").trim())
+    .filter(Boolean);
+  if (details.length === 0) return "command failed without output";
+  // Reserve room for each stream, then flatten so one-line reasons retain both.
+  const separator = " | ";
+  const budget = Math.floor((1000 - separator.length * (details.length - 1)) / details.length);
+  return details
+    .map((detail) => trimMiddle(detail, budget))
+    .join(separator)
+    .replace(/\s+/g, " ");
 }
 
 export function ffprobeMedia(path: string, runner: MediaProofCommandRunner) {

--- a/src/live-proof/drivers.ts
+++ b/src/live-proof/drivers.ts
@@ -543,8 +543,10 @@ case "$pane_pid" in ""|*[!0-9]*) finish startup error:pane-pid 0 125 ;; esac
 case "$lease_identity" in *[!0-9:]*|:*|*:|*:*:*|"") finish startup error:lease-identity 0 125 ;; *:*) ;; *) finish startup error:lease-identity 0 125 ;; esac
 if [ "$(/usr/bin/uname -s)" = Darwin ]; then
   lease_identity_now() { /usr/bin/stat -f '%d:%i' -- "$lease_path" 2>/dev/null; }
-  lease_pids() { /usr/sbin/lsof -t -- "$lease_path" 2>/dev/null; status=$?; [ "$status" -le 1 ]; }
-  holds_lease() { /usr/sbin/lsof -t -a -p "$1" -- "$lease_path" 2>/dev/null | /usr/bin/grep -qx "$1"; }
+  # The lease is an inherited open file, not a mapped image or working directory.
+  # Darwin -X skips those expensive scans without excluding duplicated descriptors.
+  lease_pids() { /usr/sbin/lsof -t -X -- "$lease_path" 2>/dev/null; status=$?; [ "$status" -le 1 ]; }
+  holds_lease() { /usr/sbin/lsof -t -X -a -p "$1" -- "$lease_path" 2>/dev/null | /usr/bin/grep -qx "$1"; }
 else
   lease_identity_now() { /usr/bin/stat -Lc '%d:%i' -- "$lease_path" 2>/dev/null; }
   holds_lease() { [ "$(/usr/bin/stat -Lc '%d:%i' -- /proc/"$1"/fd/${TERMINAL_LEASE_FD} 2>/dev/null)" = "$lease_identity" ]; }
@@ -554,7 +556,7 @@ on_bound_tty() { [ "$(/bin/ps -o tty= -p "$1" 2>/dev/null | /usr/bin/tr -d '[:sp
 pane_owns_tty() { holds_lease "$pane_pid" && on_bound_tty "$pane_pid"; }
 tty_pids() {
   pane_owns_tty || return 0
-  /bin/ps -axo pid=,tty= | /usr/bin/awk -v tty="$tty_name" '$2 == tty { print $1 }'
+  /bin/ps -t "$tty_name" -o pid=,tty= | /usr/bin/awk -v tty="$tty_name" '$2 == tty { print $1 }'
 }
 scan_bound_processes() {
   : >"$scan_file"

--- a/test/apply-runtime-budget.test.ts
+++ b/test/apply-runtime-budget.test.ts
@@ -12,6 +12,7 @@ import {
 import { join } from "node:path";
 import test from "node:test";
 
+import { createGitHubRuntime } from "../dist/clawsweeper-github-runtime.js";
 import {
   applyRuntimeBudgetForTest,
   main,
@@ -61,6 +62,22 @@ function assertRuntimeYield(
   assert.deepEqual(cursorTrace, { schema_version: 1, examined_item_numbers: [] });
 }
 
+function applySleepObserverPreload(tracePath: string): string {
+  // Observe sleep intent in the CLI, excluding real subprocess startup time and mock children.
+  return `
+if (process.argv[2] === "apply-decisions" &&
+    require("node:path").resolve(process.argv[1] || "") === ${JSON.stringify(join(process.cwd(), "dist", "clawsweeper.js"))}) {
+  const { appendFileSync } = require("node:fs");
+  const tracePath = ${JSON.stringify(tracePath)};
+  Atomics.wait = (_array, _index, _value, milliseconds) => {
+    appendFileSync(tracePath, JSON.stringify({ event: "wait", milliseconds }) + "\\n");
+    throw new Error("apply attempted an unnecessary synchronous wait");
+  };
+  appendFileSync(tracePath, JSON.stringify({ event: "armed" }) + "\\n");
+}
+`;
+}
+
 test("apply runtime budget uses the token deadline as an absolute wall clock", () => {
   const nowMs = 1_000_000;
   assert.deepEqual(
@@ -95,6 +112,30 @@ test("apply runtime budget uses the token deadline as an absolute wall clock", (
       limitReason: `apply token budget reached at ${nowMs - 1}ms since epoch`,
     },
   );
+});
+
+test("GitHub command timeouts and close delays share the elapsed runtime and flush reserve", (t) => {
+  let nowMs = 1_000_000;
+  t.mock.method(Date, "now", () => nowMs);
+  const runtime = createGitHubRuntime({
+    ROOT: process.cwd(),
+    targetRepo: () => "openclaw/clawsweeper",
+    run: () => assert.fail("budget checks must not run commands"),
+  });
+  const isExpectedYield = (error: unknown): boolean =>
+    error instanceof runtime.GitHubRuntimeBudgetError &&
+    error.reason === "max runtime 15000ms reached before close";
+
+  runtime.withGitHubRuntimeBudget({ startedAtMs: nowMs, maxRuntimeMs: 15_000 }, () => {
+    assert.equal(runtime.githubCommandTimeoutMs(), 14_000);
+    nowMs += 6_000;
+    assert.equal(runtime.githubCommandTimeoutMs(20_000), 8_000);
+    assert.doesNotThrow(() => runtime.ensureRuntimeDelayFits(7_999, "before close"));
+    assert.throws(() => runtime.ensureRuntimeDelayFits(8_000, "before close"), isExpectedYield);
+    assert.throws(() => runtime.githubCommandTimeoutMs(), isExpectedYield);
+  });
+  assert.equal(runtime.githubCommandTimeoutMs(), undefined);
+  assert.doesNotThrow(() => runtime.ensureRuntimeDelayFits(30_000, "before close"));
 });
 
 test("apply-decisions exits cleanly at an expired token deadline and retries the same item", () => {
@@ -430,10 +471,12 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/724\\/timeline(?:\\?|$
   }
 });
 
-test("apply-decisions yields instead of starting a post-close delay that cannot fit", () => {
+test("apply-decisions yields before closing when its post-close delay cannot fit", () => {
   const fixture = runtimeBudgetFixture(725);
   const maxRuntimeMs = 15_000;
   const proofLogPath = join(fixture.root, "proof.log");
+  const closeCommandLogPath = join(fixture.root, "close-command.log");
+  const sleepTracePath = join(fixture.root, "sleep-trace.jsonl");
   const clockHookPath = join(fixture.root, "runtime-clock.cjs");
   const originalNodeOptions = process.env.NODE_OPTIONS;
   const synced = reportWithSyncedReviewComment(
@@ -452,18 +495,22 @@ test("apply-decisions yields instead of starting a post-close delay that cannot 
     "duplicate_or_superseded",
   );
   writeFileSync(join(fixture.itemsDir, "725.md"), synced.report, "utf8");
-  writeFileSync(clockHookPath, `Date.now = () => ${Date.now()};\n`, "utf8");
+  writeFileSync(
+    clockHookPath,
+    `Date.now = () => ${Date.now()};\n${applySleepObserverPreload(sleepTracePath)}`,
+    "utf8",
+  );
   process.env.NODE_OPTIONS = [originalNodeOptions, `--require=${JSON.stringify(clockHookPath)}`]
     .filter(Boolean)
     .join(" ");
   try {
-    const startedAt = Date.now();
     withMockGh(
       fixture.root,
       promotionGhMock({
         number: 725,
         title: "Provider route fallback",
         comment: synced.comment,
+        closeCommandLogPath,
         itemUpdatedAtAfterProofLogPath: proofLogPath,
         linkedPulls: {
           400: {
@@ -508,13 +555,15 @@ test("apply-decisions yields instead of starting a post-close delay that cannot 
       },
     );
 
-    assert.ok(
-      Date.now() - startedAt < maxRuntimeMs + 2_000,
-      "post-close delay ignored the remaining runtime",
-    );
+    assert.equal(readFileSync(sleepTracePath, "utf8"), '{"event":"armed"}\n');
+    assert.equal(readFileSync(proofLogPath, "utf8"), "proof\n");
+    assert.equal(existsSync(closeCommandLogPath), false, "budget yield must precede closing");
     assertRuntimeYield(fixture, maxRuntimeMs);
     const report = JSON.parse(readFileSync(fixture.reportPath, "utf8"));
-    assert.match(report[0]?.reason ?? "", /before close$/);
+    assert.equal(report[0]?.number, 725);
+    assert.equal(report[0]?.reason, "max runtime 15000ms reached before close");
+    assert.equal(existsSync(join(fixture.itemsDir, "725.md")), true);
+    assert.equal(existsSync(join(fixture.closedDir, "725.md")), false);
   } finally {
     if (originalNodeOptions === undefined) delete process.env.NODE_OPTIONS;
     else process.env.NODE_OPTIONS = originalNodeOptions;
@@ -528,6 +577,7 @@ test("apply-decisions records a successful close before yielding after it", () =
   const closeDelayMs = 8_000;
   const proofLogPath = join(fixture.root, "proof.log");
   const closeCommandLogPath = join(fixture.root, "close-command.log");
+  const sleepTracePath = join(fixture.root, "sleep-trace.jsonl");
   const clockHookPath = join(fixture.root, "runtime-clock.cjs");
   const startedAtMs = Date.now();
   const originalNodeOptions = process.env.NODE_OPTIONS;
@@ -554,6 +604,7 @@ test("apply-decisions records a successful close before yielding after it", () =
 Date.now = () => existsSync(${JSON.stringify(closeCommandLogPath)})
   ? ${startedAtMs + maxRuntimeMs - closeDelayMs}
   : ${startedAtMs};
+${applySleepObserverPreload(sleepTracePath)}
 `,
     "utf8",
   );
@@ -612,7 +663,11 @@ Date.now = () => existsSync(${JSON.stringify(closeCommandLogPath)})
       },
     );
 
-    assert.match(readFileSync(closeCommandLogPath, "utf8"), /pr close 727/);
+    assert.equal(readFileSync(sleepTracePath, "utf8"), '{"event":"armed"}\n');
+    assert.equal(readFileSync(proofLogPath, "utf8"), "proof\n");
+    const closeCommands = readFileSync(closeCommandLogPath, "utf8").trim().split("\n");
+    assert.equal(closeCommands.length, 1);
+    assert.match(closeCommands[0] ?? "", /^pr close 727(?: |$)/);
     const report = JSON.parse(readFileSync(fixture.reportPath, "utf8"));
     const cursorTrace = JSON.parse(readFileSync(fixture.cursorTracePath, "utf8"));
     assert.deepEqual(
@@ -622,8 +677,18 @@ Date.now = () => existsSync(${JSON.stringify(closeCommandLogPath)})
         [0, "skipped_runtime_budget"],
       ],
     );
+    assert.deepEqual(report[1], {
+      number: 0,
+      action: "skipped_runtime_budget",
+      reason: "max runtime 25000ms reached before close delay",
+    });
     assert.deepEqual(cursorTrace, { schema_version: 1, examined_item_numbers: [727] });
     assert.equal(existsSync(join(fixture.closedDir, "727.md")), true);
+    assert.match(
+      readFileSync(join(fixture.closedDir, "727.md"), "utf8"),
+      /^action_taken: closed$/m,
+    );
+    assert.equal(existsSync(join(fixture.itemsDir, "727.md")), false);
   } finally {
     if (originalNodeOptions === undefined) delete process.env.NODE_OPTIONS;
     else process.env.NODE_OPTIONS = originalNodeOptions;

--- a/test/live-proof-review-environment.test.ts
+++ b/test/live-proof-review-environment.test.ts
@@ -11,7 +11,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import test from "node:test";
 
 import type { LiveProofPlan, MediaProofCommandRunner } from "../dist/clawsweeper-types.js";
@@ -24,6 +24,7 @@ import {
 } from "../dist/live-proof/review-artifacts.js";
 import { sanitizedLiveProofEnvironment } from "../dist/live-proof/environment.js";
 import { parseLiveVerificationResult } from "../dist/live-proof/verification.js";
+import { repositoryProfileFor } from "../dist/repository-profiles.js";
 
 test("review live proof composes inherited Go environment settings", () => {
   const profile = join("scratch", "profile");
@@ -769,7 +770,7 @@ test(
 
 test(
   "terminal proof cleanup ignores an unrelated process holding a checkout directory descriptor",
-  { skip: process.platform !== "linux", timeout: 60_000 },
+  { timeout: 60_000 },
   async () => {
     const root = mkdtempSync(join(tmpdir(), "clawsweeper-live-proof-directory-fd-"));
     const helperPath = join(root, "directory-holder.mjs");
@@ -1079,6 +1080,185 @@ test(
       assert.match(result.output, /before expected output appeared: "STALE_FROM_FIRST"/);
     } finally {
       rmSync(root, { force: true, recursive: true });
+    }
+  },
+);
+
+test(
+  "Crabbox profile bootstraps a trusted synthetic Go-root/nested npm fixture through the review child",
+  { timeout: 60_000 },
+  () => {
+    const root = mkdtempSync(join(tmpdir(), "clawsweeper-live-proof-nested-npm-"));
+    const target = join(root, "target");
+    const records = join(root, "records");
+    const output = join(root, "output");
+    const repo = "openclaw/crabbox";
+    const dependency = { name: "fixture-dependency", version: "1.0.0", main: "index.cjs" };
+    const worker = {
+      name: "synthetic-worker",
+      version: "1.0.0",
+      private: true,
+      scripts: {
+        preinstall: "node ../hook.cjs",
+        postinstall: "node ../hook.cjs",
+        test: "node ../verify.cjs worker",
+      },
+      dependencies: { "fixture-dependency": "file:../dependency" },
+    };
+    const lock = JSON.stringify({
+      name: worker.name,
+      version: worker.version,
+      lockfileVersion: 3,
+      requires: true,
+      packages: {
+        "": {
+          name: worker.name,
+          version: worker.version,
+          hasInstallScript: true,
+          dependencies: worker.dependencies,
+        },
+        "../dependency": { version: dependency.version },
+        "node_modules/fixture-dependency": { resolved: "../dependency", link: true },
+      },
+    });
+    // Only trusted synthetic code runs here, not Crabbox source, tests, or services.
+    const files = {
+      "go.mod": "module example.invalid/synthetic-fixture\n\ngo 1.24\n",
+      ".node-version": "24\n",
+      "fixture-head.txt": "reviewed fixture",
+      "hook.cjs":
+        "require('node:fs').writeFileSync(require('node:path').join(__dirname, 'install-script-ran'), 'hook ran');\n",
+      "dependency/package.json": JSON.stringify(dependency),
+      "dependency/index.cjs": "module.exports = 'installed local dependency';\n",
+      "worker/package.json": JSON.stringify(worker),
+      "worker/package-lock.json": lock,
+      "worker/.npmrc": "offline=true\naudit=false\nfund=false\nupdate-notifier=false\n",
+      "verify.cjs": `
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const root = __dirname;
+const mode = process.argv[2];
+assert.equal(fs.realpathSync(process.cwd()), path.join(root, ...(mode === 'worker' ? ['worker'] : [])));
+assert.equal(fs.existsSync(path.join(root, 'package.json')), false);
+assert.equal(fs.existsSync(path.join(root, 'go.mod')), true);
+assert.equal(fs.readFileSync(path.join(root, 'fixture-head.txt'), 'utf8'), 'reviewed fixture');
+assert.equal(fs.existsSync(path.join(root, 'install-script-ran')), false);
+for (const name of ['OPENAI_API_KEY', 'GH_TOKEN', 'AWS_SECRET_ACCESS_KEY', 'CLAWSWEEPER_R2_TOKEN', 'DATABASE_PASSWORD', 'PACKAGE_KEY']) {
+  assert.equal(process.env[name], undefined, name);
+}
+const git = (...args) => execFileSync('git', args, { cwd: root, encoding: 'utf8' }).trim();
+assert.equal(fs.readFileSync(path.join(root, 'worker/package-lock.json'), 'utf8'), git('show', 'HEAD:worker/package-lock.json'));
+assert.equal(require(path.join(root, 'worker/node_modules/fixture-dependency')), 'installed local dependency');
+assert.equal(fs.realpathSync(process.env.HOME), path.join(path.dirname(root), 'profile'));
+assert.equal(process.env.npm_config_cache, path.join(process.env.HOME, 'npm-cache'));
+if (mode === 'worker') assert.equal(fs.realpathSync(process.env.INIT_CWD), root);
+console.log('synthetic ' + mode + ' checks passed head=' + git('rev-parse', 'HEAD'));
+process.exit(process.argv.includes('fail') ? 7 : 0);
+`,
+    };
+    try {
+      for (const [name, content] of Object.entries(files)) {
+        const path = join(target, name);
+        mkdirSync(dirname(path), { recursive: true });
+        writeFileSync(path, content);
+      }
+      mkdirSync(records);
+      git(target, "init", "-b", "main");
+      git(target, "config", "user.name", "ClawSweeper Test");
+      git(target, "config", "user.email", "test@example.com");
+      git(target, "add", ".");
+      git(
+        target,
+        "-c",
+        "core.hooksPath=/dev/null",
+        "-c",
+        "commit.gpgsign=false",
+        "commit",
+        "-m",
+        "synthetic fixture",
+      );
+      const head = git(target, "rev-parse", "HEAD").trim();
+      writeFileSync(join(target, "fixture-head.txt"), "unreviewed checkout must not execute");
+      assert.equal(existsSync(join(target, "worker", "node_modules")), false);
+      for (const fails of [false, true]) {
+        const item = fails ? 43 : 42;
+        const plan: LiveProofPlan = {
+          status: "recommended",
+          surface: "terminal",
+          terminalCompletion: "exit_zero",
+          reason: "Verify trusted synthetic nested npm setup.",
+          payoff: { kind: "static_text", justification: "No recording needed." },
+          entry: `node verify.cjs root && npm test --prefix worker -- ${fails ? "fail" : "pass"}`,
+          steps: [{ action: "expect_output", text: "synthetic worker checks passed" }],
+        };
+        writeFileSync(
+          join(records, `${item}.md`),
+          `---\nnumber: ${item}\nrepository: ${repo}\ntype: pull_request\npull_head_sha: ${head}\n---\n\n## Live Proof\n\nStatus: recommended\n\nSurface: terminal\n\nTerminal completion: exit_zero\n\nReason: ${plan.reason}\n\nPayoff: static_text\n\nPayoff justification: ${plan.payoff.justification}\n\nEntry: ${plan.entry}\n\nSteps:\n\n- ${JSON.stringify(plan.steps[0])}\n\n## Work Candidate\n\nCandidate: none\n`,
+        );
+        const logs: string[] = [];
+        const inspection = executeReviewLiveProofs(
+          {
+            checkoutPath: target,
+            entrypoint: resolve("dist/clawsweeper.js"),
+            itemNumbers: [item],
+            outputRoot: output,
+            recordsDir: records,
+            repo,
+          },
+          {
+            env: {
+              ...process.env,
+              OPENAI_API_KEY: "must-not-cross",
+              GH_TOKEN: "must-not-cross",
+              AWS_SECRET_ACCESS_KEY: "must-not-cross",
+              CLAWSWEEPER_R2_TOKEN: "must-not-cross",
+              DATABASE_PASSWORD: "must-not-cross",
+              PACKAGE_KEY: "must-not-cross",
+            },
+            frontMatterValue: (markdown, key) =>
+              new RegExp(`^${key}:\\s*(.*)$`, "m").exec(markdown)?.[1]?.trim(),
+            reportLiveProofPlan: () => plan,
+            repositoryProfileFor,
+            log: (message) => logs.push(message),
+          },
+        );
+        const verification = parseLiveVerificationResult(
+          JSON.parse(
+            readFileSync(join(output, String(item), "live-verification.json"), "utf8"),
+          ) as unknown,
+        );
+        assert.deepEqual(inspection.candidates, [item]);
+        assert.equal(verification.head_sha, head);
+        assert.equal(verification.repo, repo);
+        assert.equal(verification.overall_pass, !fails, JSON.stringify(verification));
+        assert.equal(verification.drive_status, fails ? "failed" : "completed");
+        assert.ok(
+          verification.output.includes(`synthetic root checks passed head=${head}`),
+          verification.output,
+        );
+        assert.ok(
+          verification.output.includes(`synthetic worker checks passed head=${head}`),
+          verification.output,
+        );
+        if (fails) assert.match(verification.failure?.reason ?? "", /failed with exit status 7:/);
+        assert.equal(existsSync(join(output, String(item), "live-proof-manifest.json")), false);
+        assert.match(logs.join("\n"), /execution=unsandboxed credentials=0/);
+        assert.equal(
+          (JSON.stringify(verification) + logs.join("\n")).includes("must-not-cross"),
+          false,
+        );
+        console.log(`[live-proof synthetic nested npm] ${JSON.stringify(verification)}`);
+      }
+      assert.equal(existsSync(join(target, "worker", "node_modules")), false);
+      assert.equal(readFileSync(join(target, "worker", "package-lock.json"), "utf8"), lock);
+      assert.equal(
+        readFileSync(join(target, "fixture-head.txt"), "utf8"),
+        "unreviewed checkout must not execute",
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
     }
   },
 );

--- a/test/live-proof.test.ts
+++ b/test/live-proof.test.ts
@@ -17,6 +17,7 @@ import YAML from "yaml";
 
 import { renderReviewCommentFromReport } from "../dist/clawsweeper.js";
 import { createDecisionParser } from "../dist/clawsweeper-decision-parser.js";
+import { mediaProofSpawnDetail } from "../dist/clawsweeper-media-proof.js";
 import { LIVE_VERIFICATION_MARKER, REVIEW_SECTIONS } from "../dist/clawsweeper-policy.js";
 import type { LiveProofPlan, MediaProofCommandRunner } from "../dist/clawsweeper-types.js";
 import type { RepositoryProfile } from "../dist/repository-profiles.js";
@@ -1545,7 +1546,8 @@ test("terminal cleanup requires the exact pane receipt and pane death", () => {
   });
 
   assert.equal(result.status, "completed");
-  assert.match(cleanupScript, /\/usr\/sbin\/lsof -t -- "\$lease_path"/);
+  assert.match(cleanupScript, /\/usr\/sbin\/lsof -t -X -- "\$lease_path"/);
+  assert.match(cleanupScript, /\/usr\/sbin\/lsof -t -X -a -p "\$1" -- "\$lease_path"/);
   assert.match(cleanupScript, /stat -Lc '%d:%i' -- \/proc\/"\$1"\/fd\/9/);
   assert.match(
     cleanupScript,
@@ -1563,7 +1565,7 @@ test("terminal cleanup requires the exact pane receipt and pane death", () => {
   );
   assert.match(
     cleanupScript,
-    /tty_pids\(\) \{\s+pane_owns_tty \|\| return 0\s+\/bin\/ps -axo pid=,tty=/,
+    /tty_pids\(\) \{\s+pane_owns_tty \|\| return 0\s+\/bin\/ps -t "\$tty_name" -o pid=,tty=/,
   );
   assert.match(
     cleanupScript,
@@ -1596,6 +1598,48 @@ test("terminal cleanup requires the exact pane receipt and pane death", () => {
     calls.some((call) => call.startsWith("/bin/kill ") || call.startsWith("/bin/ps ")),
     false,
   );
+
+  const leaseQueries = cleanupScript.slice(
+    cleanupScript.indexOf('if [ "$(/usr/bin/uname -s)" = Darwin ]; then'),
+    cleanupScript.indexOf("on_bound_tty()"),
+  );
+  assert.ok(leaseQueries);
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-lease-queries-"));
+  const lease = join(root, "lease");
+  writeFileSync(lease, "");
+  try {
+    for (const [descriptors, expected] of [
+      ['exec 9<"$lease_path"', "yes"],
+      ['exec 9<"$lease_path"; exec 8<&9; exec 9<&-', process.platform === "darwin" ? "yes" : "no"],
+      ['exec 9<"$lease_path"; exec 9<&-', "no"],
+      ['exec 9<"$2"', "no"],
+    ]) {
+      const query = spawnSync(
+        "/bin/bash",
+        [
+          "--noprofile",
+          "--norc",
+          "-c",
+          [
+            "lease_path=$1",
+            leaseQueries,
+            "lease_identity=$(lease_identity_now)",
+            descriptors,
+            'if holds_lease "$$"; then echo yes; else echo no; fi',
+            'if lease_pids | /usr/bin/grep -qx "$$"; then echo yes; else echo no; fi',
+          ].join("\n"),
+          "clawsweeper-lease-query",
+          lease,
+          root,
+        ],
+        { encoding: "utf8" },
+      );
+      assert.equal(query.status, 0, query.stderr);
+      assert.equal(query.stdout, `${expected}\n${expected}\n`, descriptors);
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("terminal rejects a malformed pane readiness acknowledgement", () => {
@@ -2592,59 +2636,111 @@ test("an unobserved terminal marker fails verification and cannot produce record
   );
 });
 
-test("execution setup failures still produce a failed verification result", async () => {
-  const directory = mkdtempSync(join(tmpdir(), "clawsweeper-live-verification-failure-"));
-  const outputDir = join(directory, "output");
-  const planPath = join(directory, "plan.json");
-  const plan = recommendedPlan("browser");
-  writeFileSync(planPath, JSON.stringify(plan), "utf8");
-
-  await executeLiveProof(
+test("execution setup failures preserve bounded streams in verification and rendered reasons", async (t) => {
+  for (const scenario of [
     {
-      repo: "example/repo",
-      item: 42,
-      outputDir,
-      planPath,
-      checkoutPath: directory,
+      name: "stderr only",
+      result: { status: 1, stderr: "setup exploded" },
+      evidence: ["setup exploded"],
     },
     {
-      env: { CLAWSWEEPER_LIVE_PROOF_ENABLED: "1" },
-      runner: (command, args) => {
-        if (command === "git") return { status: 0, stdout: `${HEAD}\n` };
-        if (command === "sh" && String(args[1]).startsWith("command -v pnpm")) {
-          return { status: 0 };
+      name: "stdout cause after stderr notice",
+      result: {
+        status: 1,
+        stderr: "tool download notice\r\ncontinuing",
+        stdout: "manifest missing\nworker setup failed",
+      },
+      evidence: ["manifest missing", "tool download notice", "continuing", "worker setup failed"],
+    },
+    {
+      name: "long streams and unsafe markup",
+      result: {
+        status: 1,
+        stderr: `notice ${"n".repeat(2_000)} notice end`,
+        stdout: `manifest missing ${"x".repeat(2_000)} worker setup failed\u2028\u2029\`</details> <!-- clawsweeper-review -->`,
+      },
+      evidence: ["manifest missing", "notice", "notice end", "worker setup failed"],
+    },
+    {
+      name: "stdout only",
+      result: { status: 1, stderr: " \n", stdout: "manifest missing" },
+      evidence: ["manifest missing"],
+    },
+    {
+      name: "spawn error",
+      result: { status: null, error: new Error("tool unavailable") },
+      evidence: ["tool unavailable"],
+    },
+    { name: "no output", result: { status: 1 }, evidence: ["command failed without output"] },
+  ]) {
+    for (const surface of ["browser", "terminal"] as const) {
+      await t.test(`${scenario.name}: ${surface}`, async () => {
+        const directory = mkdtempSync(join(tmpdir(), "clawsweeper-live-verification-failure-"));
+        try {
+          const outputDir = join(directory, "output");
+          const planPath = join(directory, "plan.json");
+          const plan = recommendedPlan(surface);
+          writeFileSync(planPath, JSON.stringify(plan), "utf8");
+
+          await executeLiveProof(
+            {
+              repo: "example/repo",
+              item: 42,
+              outputDir,
+              planPath,
+              checkoutPath: directory,
+            },
+            {
+              env: { CLAWSWEEPER_LIVE_PROOF_ENABLED: "1" },
+              runner: (command, args) => {
+                if (command === "git") return { status: 0, stdout: `${HEAD}\n` };
+                if (command === "sh" && String(args[1]).startsWith("command -v pnpm")) {
+                  return { status: 0 };
+                }
+                return scenario.result;
+              },
+              repositoryProfileFor: () => ({
+                ...profile(),
+                liveTest: { ...profile().liveTest!, setup: ["pnpm install"] },
+              }),
+              reportLiveProofPlan: () => plan,
+              parseLiveProofPlan: () => plan,
+              fetchPullRequest: async () => {
+                throw new Error("local checkout must not fetch the pull request");
+              },
+              now: () => new Date("2026-08-17T12:00:00.000Z"),
+              log: () => undefined,
+            },
+          );
+
+          const verification = parseLiveVerificationResult(
+            JSON.parse(readFileSync(join(outputDir, "live-verification.json"), "utf8")) as unknown,
+          );
+          assert.equal(verification.overall_pass, false);
+          assert.equal(verification.drive_status, "failed");
+          const detail = mediaProofSpawnDetail(scenario.result);
+          assert.ok(detail.length <= 1_000);
+          assert.equal(verification.failure?.phase, "execution");
+          const reason = verification.failure?.reason ?? "";
+          assert.ok(reason.length <= 1_000);
+          assert.match(reason, /^sh -lc pnpm install --ignore-scripts failed:/);
+          const rendered = renderLiveVerificationCommentBlock(verification);
+          assert.match(rendered, /FAIL \(failed\) — execution before step 1/);
+          for (const evidence of scenario.evidence) {
+            assert.ok(reason.includes(evidence), `reason missing ${evidence}: ${reason}`);
+            assert.ok(rendered.includes(evidence), `comment missing ${evidence}`);
+            if (surface === "terminal") assert.ok(verification.output.includes(evidence));
+          }
+          assert.doesNotMatch(detail, /[\r\n\u2028\u2029]/);
+          if (surface === "browser") assert.equal(verification.output, "");
+          assert.doesNotMatch(rendered, /<\/details>|<!-- clawsweeper-review/);
+          assert.equal(existsSync(join(outputDir, "live-proof-manifest.json")), false);
+        } finally {
+          rmSync(directory, { recursive: true, force: true });
         }
-        return { status: 1, stderr: "setup exploded" };
-      },
-      repositoryProfileFor: () => ({
-        ...profile(),
-        liveTest: { ...profile().liveTest!, setup: ["pnpm install"] },
-      }),
-      reportLiveProofPlan: () => plan,
-      parseLiveProofPlan: () => plan,
-      fetchPullRequest: async () => {
-        throw new Error("local checkout must not fetch the pull request");
-      },
-      now: () => new Date("2026-08-17T12:00:00.000Z"),
-      log: () => undefined,
-    },
-  );
-
-  const verification = parseLiveVerificationResult(
-    JSON.parse(readFileSync(join(outputDir, "live-verification.json"), "utf8")) as unknown,
-  );
-  assert.equal(verification.overall_pass, false);
-  assert.equal(verification.drive_status, "failed");
-  assert.equal(verification.output, "");
-  assert.deepEqual(verification.failure, {
-    phase: "execution",
-    reason: "sh -lc pnpm install --ignore-scripts failed: setup exploded",
-  });
-  assert.match(
-    renderLiveVerificationCommentBlock(verification),
-    /FAIL \(failed\) — execution before step 1 `expect_text`: `sh -lc pnpm install --ignore-scripts failed: setup exploded`/,
-  );
-  assert.equal(existsSync(join(outputDir, "live-proof-manifest.json")), false);
+      });
+    }
+  }
 });
 
 test("browser readiness timeout publishes the last 40 sanitized server log lines", async () => {

--- a/test/repository-profiles.test.ts
+++ b/test/repository-profiles.test.ts
@@ -6,6 +6,7 @@ import {
   repositoryProfileFor,
   validateTargetRepositoryConfigForTest,
 } from "../dist/repository-profiles.js";
+import { resolveTargetRepoToolchain } from "../dist/repair/target-toolchain-config.js";
 
 function targetRepositoryConfig(liveTest: Record<string, unknown>, schemaVersion = 2) {
   return {
@@ -130,21 +131,23 @@ test("generic steipete fallback starts review-only", () => {
   assert.deepEqual(profile.liveTest, TERMINAL_LIVE_TEST);
 });
 
-test("camsnap uses its Go-native review-only live-proof profile", () => {
-  const profile = repositoryProfileFor("Steipete/CamSnap");
-
-  assert.equal(profile.targetRepo, "steipete/camsnap");
-  assert.equal(profile.packageManager, "npm");
-  assert.deepEqual(profile.applyCloseRules.issue, []);
-  assert.deepEqual(profile.applyCloseRules.pull_request, []);
-  assert.deepEqual(profile.liveTest, {
-    enabled: true,
-    surfaceDefault: "terminal",
-    setup: [],
-    allowInstallScripts: false,
-    readyTimeoutSeconds: 240,
-    maxRecordingSeconds: 90,
-  });
+test("Go-root targets use explicit npm profiles without broadening close policy", () => {
+  for (const [repo, setup, fallback] of [
+    ["Steipete/CamSnap", [], "steipete/example-tool"],
+    ["OpenClaw/Crabbox", ["npm ci --prefix worker"], "openclaw/example-tool"],
+  ] as const) {
+    const profile = repositoryProfileFor(repo);
+    assert.equal(profile.targetRepo, repo.toLowerCase());
+    assert.equal(profile.packageManager, "npm", repo);
+    assert.ok(REPOSITORY_PROFILES.includes(profile), "must not use an owner fallback");
+    assert.deepEqual(profile.applyCloseRules, repositoryProfileFor(fallback).applyCloseRules);
+    assert.deepEqual(profile.liveTest, { ...TERMINAL_LIVE_TEST, setup });
+    assert.deepEqual(resolveTargetRepoToolchain(repo), {
+      packageManager: "npm",
+      baseValidationCommands: [],
+      changedGate: null,
+    });
+  }
 });
 
 test("generic OpenClaw fallback keeps denied repositories unsupported", () => {


### PR DESCRIPTION
Related: https://github.com/openclaw/crabbox/pull/1557#issuecomment-5436915189 — verification stopped before the requested Node runtime test executed.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where maintainers reviewing Crabbox would receive a failed live-verification result before the requested worker test ran. The published reason showed only Corepack's download notice, hiding the actionable setup error.

The exact receipt came from https://github.com/openclaw/clawsweeper/actions/runs/33059981352, ClawSweeper source `13f77495c4620d3a783eb0b055f9a18723027a7e`, reviewing Crabbox `2477578b9cf3e6767bd6cb9bd0f0fdd06067c386`. All four files in its artifact inventory were verified against recorded byte lengths and SHA-256 hashes. The requested command was `npm test --prefix worker -- test/node-runtime.test.ts`; the receipt marks both assertions as `not_run`.

## Why This Change Was Made

The bootstrap correctly materializes the reviewed head into a scratch target checkout and uses a private HOME/cache. But Crabbox had no explicit repository profile, so it inherited an owner-level `pnpm install --frozen-lockfile` at the target root. That root has no package manifest; Crabbox's npm manifest and lockfile live under `worker/`. Node 24 was appropriate. The repair selects npm and `npm ci --prefix worker` through the existing repository-profile boundary, rather than adding package discovery, changing the target, or bypassing Corepack prompts.

The existing setup normalizer still adds `--ignore-scripts`. Close rules, validation commands, changed-gate settings, plan gates, environment filtering, and execution/publication contracts remain unchanged. Separately, the shared failure-detail producer now reserves bounded space for stderr, stdout, and any spawn error instead of selecting the first nonempty stream. Flattening that summary preserves both streams in one-line verification reasons.

The fresh current-main proof exposed a connected terminal cleanup blocker on a busy Darwin host. Stock `lsof` repeatedly scanned mapped images and working directories, and TTY discovery scanned all host processes. The watchdog was alive and the target had exited zero, but discovery consumed the existing cleanup window. Darwin now uses documented `lsof -X` descriptor/fileport discovery; TTY enumeration selects the already-bound terminal with `ps -t`. Duplicate lease descriptors on Darwin, exact identity checks, pre-signal revalidation, watchdog receipts, sweeps, and budgets are unchanged. Linux's inherited-fd contract is unchanged.

One independent test-only correction replaces a parent wall-clock assertion while its CLI clock was frozen. The fixture now directly observes forbidden sleeps and verifies exact pre/post-close reports, command counts, archives, and cursors. A deterministic shared-budget case checks elapsed time, the report-flush reserve, equality, and scope restoration. Production apply behavior and fixture budgets are unchanged.

## User Impact

Crabbox verification can reach the declared worker command after target-native dependency setup. When setup or another proof command fails, informational stderr no longer suppresses a useful stdout cause. This PR does not change Crabbox runtime behavior, tests, permissions, or release notes.

The related release-owned changelog finding was a separate wrong-target policy injection. It is already fixed by https://github.com/openclaw/clawsweeper/pull/1261. No target changelog entry is removed here, and the old Crabbox public review is not rerun or rewritten.

## OpenClaw Bay Impact

None. No lifecycle, queue, public schema, status, route, or observer contract changes. The existing verification schema and publication path remain in use.

## Documentation Impact

Updated the active `docs/live-proof.md` and `docs/target-repositories.md` references. They document target-root setup CWD, explicit nested-package commands, repository-specific toolchain ownership, bounded multi-stream failure summaries, and descriptor/TTY-scoped cleanup discovery. ClawSweeper maintainers own these references; the source of truth remains repository profiles and the live-proof executor, diagnostic producer, and terminal driver. Revisit them when those contracts change.

## Evidence

Validated commit: `5954ad0dcfd09209269d80f9494395ad627960cb`
Validated base: `6230a9d7c8b4bb103a6872de63add3f7e3b77701`.

Native macOS validation used Node **24.20.0**, repository-pinned pnpm **11.10.0**, npm **11.19.0**, Bash **5.3.15**, and tmux **3.7c**. The generated terminal wrapper/watchdog use the system `/bin/bash`; selecting modern PATH Bash only supplies the unrelated workflow test prerequisite.

| Validation | Result |
| --- | --- |
| `pnpm run check` on the final frozen patch | Exit 0; 3,874 tests: **3,865 passed, 0 failed, 9 platform skips** |
| Separate changed-coverage stage in that check | 12 passed, 0 failed |
| Full two-file terminal surface after cleanup repair | 137 passed, 0 failed/skipped |
| `node --test test/apply-runtime-budget.test.ts` | 11 passed, 0 failed/skipped |
| Existing release-policy prompt matrix | Seven target tests passed; core rule absent for Crabbox and retained for OpenClaw |
| `pnpm build:all`, lint, formatting, docs/limits checks, `git diff --check` | Passed |
| Fresh isolated Codex review before commit | No actionable P0 findings |

Final full-check coverage: **82.22% lines, 74.70% branches, 87.68% functions**. The pre-commit diff SHA-256 remained `ab871792539af5268ab227749ee74be20b4001c8b591b6682206a019b3bf4c69` throughout full validation and review. Source, assertions, suite concurrency, and coverage thresholds were not changed during the run.

The original pre-fix regression run had eight passes and six failures: the profile selected pnpm instead of npm, and browser/terminal setup failures lost stdout evidence behind stderr. The six failures include the parent test's failure accounting; they are not six independent defects.

Earlier full-check attempts are retained as history, not represented as passing proof: macOS Bash 3.2 lacked `mapfile`; the same workflow test passed with installed Bash 5. Two old deadline fixtures later failed when a shared budget expired before an assumed subprocess phase. The current base includes the phase-based fixture repair from https://github.com/openclaw/clawsweeper/pull/1270. This PR neither changes those tests nor increases budgets or changes assertions to accommodate them.

The first refreshed full check then had 3,847 passes, 16 failures, and 10 platform skips: 15 terminal cleanup failures plus the parent-clock apply assertion. These were diagnosed and repaired as described above; the failures are not discarded as retries.

Runtime TypeScript: +16/-8 (net +8), comprising bounded multi-stream diagnostics and three cleanup-query substitutions plus their invariant comments. Configuration: +20, for the explicit existing-contract Crabbox profile. Tests: +418/-74. Docs: +29/-5. No new dependency, configuration option, or production abstraction is introduced.

## Real Behavior Proof

**Claim and exercised surface:** the real `executeReviewLiveProofs` owner materializes the exact reviewed commit, starts its normal child, resolves the authoritative Crabbox profile, runs official npm against the nested worker package, and produces a verification result without weakening install-script, environment, or exit-status controls. The diagnostic producer also retains the actionable stdout from an actual cold Corepack failure.

**Environment and scenario:** native macOS, Node 24, repository-pinned pnpm 11.10.0, npm, tmux, and modern Bash. The executed target is trusted synthetic source: a Go-style root without `package.json`, a `worker/package.json` and frozen lock, an offline local dependency, pre/postinstall hooks that would leave a marker, and root/worker verification scripts. No Crabbox source, credentials, provider, PostgreSQL server, or cloud resource is executed or allocated by this proof. The source fixture is dirtied after its commit to ensure the child uses the recorded head, not current filesystem contents.

**Command:** after building, execute the real-child scenario and its negative exit-status leg:

```sh
node --test --test-name-pattern='Crabbox profile bootstraps a trusted synthetic Go-root/nested npm fixture through the review child' test/live-proof-review-environment.test.ts
```

Inside the child the configured setup is normalized to `npm ci --ignore-scripts --prefix worker`. Its entry executes `node verify.cjs root && npm test --prefix worker -- pass`; a second independent exact-head child uses `fail` and exits 7.

**Observed result and normalized trace:**

```text
profile: openclaw/crabbox; package_manager=npm
setup: npm ci --ignore-scripts --prefix worker
success: root/worker checks passed at the exact fixture head
success: drive_status=completed; overall_pass=true; cleanup completed
negative: same checks passed, then target exited 7
negative: drive_status=failed; overall_pass=false; no cleanup failure
source checkout: still dirty as seeded; no dependencies installed into it
worker lockfile: unchanged; install-hook marker: absent
```

Both legs verify the recorded head, root and worker CWDs, installed local dependency, absent install-hook marker, stripped credential-name sentinels, private HOME/cache, unchanged lockfile, and untouched dirty source checkout. The negative leg prints its completion marker and then exits 7; verification must still fail, so a marker cannot mask a failed command.

**Cold bootstrap reproduction:** an empty root with only a nested worker manifest was run with Corepack 0.35.0, pnpm 11.24.0, piped stdin, and private HOME/cache. It exited 1 rather than waiting for confirmation:

```text
stderr: ! Corepack is about to download https://registry.npmjs.org/pnpm/-/pnpm-11.24.0.tgz
stdout: [ERR_PNPM_NO_PKG_MANIFEST] No package.json found in <scratch>/target
```

Replaying those captured real streams through the repaired producer retains both the notice and manifest error within the existing 1,000-character cap. Corepack's actual interactive confirmation requires `stdin.isTTY && !CI`; the notice alone is not proof of a prompt blockage. Historical raw stdout was discarded, so the exact historical stdout cannot be recovered.

**Cleanup before/after:** an identical real printf/`exit_zero` plan failed before with an armed watchdog, held target exit 0, legitimate wrapper/sleep lease holders, and no completed cleanup receipt. Observed `lsof` calls took 1.93–2.39 seconds; whole-host `ps` scanned roughly 2,300 processes in 1.31 seconds versus 14–30 ms for bound-TTY selection. The complete repair produced the exact `controller|ok|0` receipt and the original pane's death. Total drive time changed from 19.831 seconds (failed) to 16.622 seconds (completed); these are total drive times, not cleanup-budget measurements. An intermediate descriptor-only change was insufficient; both discovery costs were addressed. All 137 terminal tests passed afterward, including duplicated/closed/unrelated descriptors, resistant descendants, pane death, and both npm-fixture outcomes.

**Apply fixture controls:** the complete apply-budget file passed 11 tests. Deliberately inserting a sleep before either close guard was rejected immediately by the armed sleep observer. Ignoring elapsed time, dropping the flush reserve, and permitting the equality boundary each failed the corresponding deterministic assertion. A sixth control omitting pre-close admission was rejected by the report-shape assertion after another freshness guard intervened; the scratch driver's prediction of a close-command assertion was over-specific and failed. That attempt is retained as an observed rejection, not a clean driver run; neither source nor test assertions were changed to accommodate it. No real GitHub close occurred: the existing controlled transport fixtures were used.

**Limits:** this proves ClawSweeper's bootstrap, diagnostic, and native macOS cleanup boundaries, not a rerun of Crabbox's Node/PostgreSQL or managed-provider proof. Those successful target-specific runs remain documented in the original Crabbox PR. The synthetic child is unsandboxed with the existing sanitized scratch environment; environment filtering is not kernel isolation. This change does not expand source-trust permissions or claim to solve that separate containment boundary. No media or agent transcript is attached.
