### PR TITLE
fix(review): require observable live-proof commands

### DIFF
--- a/docs/live-proof.md
+++ b/docs/live-proof.md
@@ -97,10 +97,11 @@ These facts are separate from PR-authored context. The proof target is a cold
 checkout of the exact reviewed head: reviewer/controller `dist` and other generated
 output do not transfer. The planner must inspect the relevant package scripts and
 import chain, then include any build or code-generation prerequisites that setup
-does not supply before the first dependent command. Prefer an existing script that
-owns this sequencing; an arbitrary test script need not build. Otherwise use an
-explicit fail-fast command chain. The executor does not infer or repair missing
-prerequisites.
+does not supply before the first dependent command. When an existing repository or
+package-manager script owns the required prerequisites, invoke that wrapper and do
+not bypass it by calling its internal script directly. An arbitrary test script
+need not build. When no owning wrapper exists, use an explicit fail-fast command
+chain. The executor does not infer or repair missing prerequisites.
 
 Plans must use assertions the demonstration can satisfy. Browser interactions
 should derive search or filter values from content the page already renders,
@@ -188,7 +189,9 @@ Failed runs publish each command's bounded combined diagnostics under one label.
 Private supervisor files and runner paths never enter published terminal output.
 Each entry or `run` action executes as a separately supervised Bash process in
 the same checkout, so plans should share state through files or one command
-rather than shell-local mutations.
+rather than shell-local mutations. Terminal assertions observe only bytes emitted
+to the terminal; artifact content must be emitted by the entry or a preceding run,
+for example with `cat`, before an `expect_output` step can assert it.
 The terminal `entry` executes automatically before all typed steps. Every `run`
 executes independently, including a first `run` identical to `entry` or a later
 repeated command; the parser and driver do not deduplicate commands. Intentional

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -574,9 +574,10 @@ or combine dependent setup and execution in one command, not shell-local variabl
 or `cd` from an earlier command. Inspect the relevant package scripts and import
 chain against the trusted live-proof execution context below. Supply any remaining
 build or code-generation prerequisites before the first dependent execution.
-Prefer a repository-defined `pnpm run` (or equivalent package-manager) script when
-it actually owns that sequencing; do not assume an arbitrary test script builds.
-Otherwise use an explicit fail-fast chain such as `prerequisite && command`.
+When an existing repository or package-manager script owns the required
+prerequisites, invoke that wrapper and do not bypass it by calling its internal
+script directly. Do not assume an arbitrary test script builds. When no owning
+wrapper exists, use an explicit fail-fast chain such as `prerequisite && command`.
 Emit at most ten
 deterministic, typed `steps`: browser plans may use `goto`, `click`, `fill`,
 `press`, `wait_for`, `wait`, and `expect_text`; terminal plans may use `run`,
@@ -592,7 +593,9 @@ system should run. Never assert the typed command itself. Targets for `click`,
 `text=...` selectors when appropriate, never prose descriptions of state. The
 plan must be demonstrable from the PR head alone without external accounts,
 credentials, or third-party services. Step values must never contain secrets or
-tokens of any kind.
+tokens of any kind. `expect_output` observes only bytes emitted to the terminal;
+artifact content must be emitted by `entry` or a preceding `run` (for example,
+with `cat`) before asserting it.
 
 Every assertion must name something the demonstration can actually satisfy.
 Assert values that the page or command will genuinely produce: for a search

--- a/schema/clawsweeper-decision.schema.json
+++ b/schema/clawsweeper-decision.schema.json
@@ -836,7 +836,7 @@
         "entry": {
           "type": "string",
           "pattern": "^[^\\r\\n\\u2028\\u2029]*$",
-          "description": "A single-line URL path for browser proof or command for terminal proof, with no literal CR, LF, U+2028, or U+2029, including leading or trailing line breaks. Terminal entry executes automatically before all steps. For a one-shot proof, put the proof command here followed by stable expect_output steps, or use a safe setup entry followed by exactly one run of the proof command. Each command runs in a separate Bash process in the same checkout; share state through files or combine dependent setup and execution in one command. Use an empty string unless status is recommended."
+          "description": "A single-line URL path for browser proof or command for terminal proof, with no literal CR, LF, U+2028, or U+2029, including leading or trailing line breaks. Terminal entry executes automatically before all steps. For a one-shot proof, put the proof command here followed by stable expect_output steps, or use a safe setup entry followed by exactly one run of the proof command. Each command runs in a separate Bash process in the same checkout; share state through files or combine dependent setup and execution in one command. When a repository or package-manager wrapper owns required prerequisites, invoke it and do not bypass it with an internal script. Use an empty string unless status is recommended."
         },
         "steps": {
           "type": "array",
@@ -917,7 +917,7 @@
                   "command": {
                     "type": "string",
                     "pattern": "^[^\\r\\n\\u2028\\u2029]*\\S[^\\r\\n\\u2028\\u2029]*$",
-                    "description": "A nonblank single-line terminal command with no literal CR, LF, U+2028, or U+2029, including leading or trailing line breaks, not a restatement of entry. Identical commands still execute; include a rerun only when intentional."
+                    "description": "A nonblank single-line terminal command with no literal CR, LF, U+2028, or U+2029, including leading or trailing line breaks, not a restatement of entry. Identical commands still execute; include a rerun only when intentional. When a repository or package-manager wrapper owns required prerequisites, invoke it and do not bypass it with an internal script."
                   }
                 }
               },
@@ -927,7 +927,10 @@
                 "required": ["action", "text"],
                 "properties": {
                   "action": { "type": "string", "const": "expect_output" },
-                  "text": { "type": "string" }
+                  "text": {
+                    "type": "string",
+                    "description": "A stable substring of bytes emitted to the terminal; artifact content must be emitted by entry or a preceding run, for example with cat, before it can be asserted."
+                  }
                 }
               }
             ]

--- a/test/review-prompt-policy.test.ts
+++ b/test/review-prompt-policy.test.ts
@@ -733,6 +733,7 @@ test("review prompt classifies Telegram visible proof candidates", () => {
 test("review prompt and schema classify deterministic live-proof plans in field order", () => {
   const prompt = readFileSync("prompts/review-item.md", "utf8");
   const schema = JSON.parse(readFileSync("schema/clawsweeper-decision.schema.json", "utf8"));
+  const docs = readFileSync("docs/live-proof.md", "utf8");
   const liveProofPlan = schema.properties.liveProofPlan;
 
   assert.ok(
@@ -770,8 +771,20 @@ test("review prompt and schema classify deterministic live-proof plans in field 
   assert.match(prompt, /Intentional reruns,[\s\S]*are valid and will execute/);
   assert.match(prompt, /choose `static_text` and verify once/);
   assert.match(
+    prompt,
+    /When an existing repository or package-manager script owns the required\s+prerequisites,[\s\S]*invoke that wrapper and do not bypass it by calling its internal\s+script directly/,
+  );
+  assert.match(
+    prompt,
+    /`expect_output` observes only bytes emitted to the terminal[\s\S]*artifact content must be emitted by `entry` or a preceding `run`[\s\S]*with `cat`/,
+  );
+  assert.match(
     liveProofPlan.properties.entry.description,
     /executes automatically before all steps/,
+  );
+  assert.match(
+    liveProofPlan.properties.entry.description,
+    /repository or package-manager wrapper owns required prerequisites[\s\S]*do not bypass it with an internal script/,
   );
   assert.match(liveProofPlan.properties.steps.description, /nothing is deduplicated/);
   assert.match(liveProofPlan.properties.steps.description, /Intentional reruns/);
@@ -783,6 +796,26 @@ test("review prompt and schema classify deterministic live-proof plans in field 
     (step: { properties: { action: { const: string } } }) => step.properties.action.const === "run",
   );
   assert.match(runStep.properties.command.description, /Identical commands still execute/);
+  assert.match(
+    runStep.properties.command.description,
+    /repository or package-manager wrapper owns required prerequisites[\s\S]*do not bypass it with an internal script/,
+  );
+  const expectOutputStep = liveProofPlan.properties.steps.items.anyOf.find(
+    (step: { properties: { action: { const: string } } }) =>
+      step.properties.action.const === "expect_output",
+  );
+  assert.match(
+    expectOutputStep.properties.text.description,
+    /bytes emitted to the terminal[\s\S]*artifact content must be emitted by entry or a preceding run[\s\S]*with cat/,
+  );
+  assert.match(
+    docs,
+    /When an existing repository or\s+package-manager script owns the required prerequisites,[\s\S]*invoke that wrapper and do\s+not bypass it by calling its internal script directly/,
+  );
+  assert.match(
+    docs,
+    /Terminal assertions observe only bytes emitted\s+to the terminal[\s\S]*artifact content must be emitted by the entry or a preceding run,[\s\S]*with `cat`/,
+  );
 
   assert.deepEqual(liveProofPlan.required, [
     "status",


### PR DESCRIPTION
Related: #1271

## What Problem This Solves

Fixes an issue where generated terminal live-proof plans could bypass a repository
script that owned build prerequisites, or assert text stored only in an artifact
that the terminal never emitted.

## Why This Change Was Made

The review prompt and decision schema now require the owning package wrapper when
one supplies prerequisites, and define `expect_output` as terminal-byte
observation. Artifact-backed assertions must first emit the artifact, for example
with `cat`. The executor and E2E runtime remain unchanged because they already
enforce the generated plan literally.

## User Impact

ClawSweeper should generate runnable cold-checkout proof plans instead of failing
on missing build output or reporting an assertion for text that never appeared in
the terminal.

## OpenClaw Bay Impact

None. This changes review-plan generation guidance and its schema description; it
does not change Bay records, queues, publication, or telemetry contracts.

## Documentation Impact

Updated the active `docs/live-proof.md` contract owned by ClawSweeper review and
publication maintainers. It now matches the prompt and schema for prerequisite
ownership and terminal observation.

## Evidence

- Regression test first failed on the missing package-wrapper ownership contract.
- Focused policy test: 1 passed.
- Sibling review/context/live-proof tests: 175 passed.
- TypeScript build, schema parse, docs checks, Oxfmt, Oxlint, and diff checks pass.
- LOC: runtime TypeScript +0/-0; prompt/schema/docs +21/-12; tests +33/-0.

## Real Behavior Proof

**Claim:** the production review command assembles the committed prompt with both
live-proof planning invariants before invoking the model.

**Surface:** `clawsweeper review --local-range` production prompt assembly.

**Scenario:** detached cold checkout of commit `7584b1d068`, with no generated
`dist` or dependency tree in the target checkout.

**Command:**

```bash
node dist/clawsweeper.js review --local-range \
  --target-repo openclaw/clawsweeper \
  --target-dir <cold-checkout> \
  --base origin/main \
  --artifact-dir <artifact-dir> \
  --additional-policy <policy-file>
```

**Observed result:** the generated `codex/0.prompt.md` contained both:

```text
When an existing repository or package-manager script owns the required
prerequisites, invoke that wrapper and do not bypass it by calling its internal
script directly.

expect_output observes only bytes emitted to the terminal; artifact content must
be emitted by entry or a preceding run (for example, with cat) before asserting it.
```

**Hosted exact-head result:** [run 33137531329](https://github.com/openclaw/clawsweeper/actions/runs/33137531329)
generated this cold-checkout plan:

```bash
pnpm run build &&
node --test \
  --test-name-pattern='review prompt and schema classify deterministic live-proof plans in field order' \
  test/review-prompt-policy.test.ts
```

The production driver completed, the named terminal assertion was satisfied, and
`overall_pass` was `true`.

**Rank-up move:** applied. The hosted exact-head cold-checkout proof generated and
observed the focused terminal plan.

**Limits:** the local model call failed with missing Codex authentication, and the
automerge E2E cannot execute its production containment path on macOS because that
path requires Linux. The hosted run above supplies the model-generation and Linux
execution proof for this planning-contract change.
