### PR TITLE
fix(review): refresh invalid live-proof artifacts

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2630,9 +2630,14 @@ jobs:
           status=0
           result_json="$(node dist/clawsweeper.js live-proof-publish-artifacts --artifact-dir .artifacts/exact-review-bundle)" || status=$?
           printf '%s\n' "$result_json"
-          result="$(jq -r 'if .status == "invalid_artifact" then .status else "unknown" end' <<<"$result_json" 2>/dev/null || echo unknown)"
+          result="$(jq -r 'if type == "object" and (.status == "published" or .status == "invalid_artifact" or .status == "retryable_failure") then .status else empty end' <<<"$result_json" 2>/dev/null || true)"
+          case "$result:$status" in
+            published:0) exit_status=0 ;;
+            invalid_artifact:1|retryable_failure:1) exit_status=1 ;;
+            *) result=retryable_failure; exit_status=1 ;;
+          esac
           echo "result=$result" >> "$GITHUB_OUTPUT"
-          exit "$status"
+          exit "$exit_status"
 
       - name: Identify legacy tuple-less exact artifact
         id: legacy-exact-artifact
@@ -3215,6 +3220,10 @@ jobs:
             outcome=cancelled
             completion_kind=retryable_failure
             reason_code=workflow_cancelled
+          elif [ "$LIVE_PROOF_RESULT" = "retryable_failure" ]; then
+            outcome=failure
+            completion_kind=retryable_failure
+            reason_code=unknown_failure
           elif [ "$PRIOR_JOB_STATUS" = "success" ]; then
             if [ "$PUBLISH_OUTCOME" = "success" ] && [ "$REQUEUE_LATEST" = "true" ] && [ "$SOURCE_DRIFT_OUTCOME" = "success" ]; then
               outcome=success

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2617,18 +2617,26 @@ jobs:
           sudo apt-get install --yes ffmpeg
 
       - name: Fold exact live proof into the review artifact
+        id: fold-exact-live-proof
         if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.publication-context.outputs.direct_lifecycle_recovery != 'true' && steps.validate-exact-review-bundle.outcome == 'success' }}
+        continue-on-error: true
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.CLAWSWEEPER_LIVE_PROOF_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CLAWSWEEPER_LIVE_PROOF_AWS_SECRET_ACCESS_KEY }}
           CLAWSWEEPER_LIVE_PROOF_S3_ENDPOINT: ${{ secrets.CLAWSWEEPER_LIVE_PROOF_S3_ENDPOINT }}
           CLAWSWEEPER_LIVE_PROOF_BUCKET: ${{ secrets.CLAWSWEEPER_LIVE_PROOF_BUCKET }}
           CLAWSWEEPER_LIVE_PROOF_BASE_URL: ${{ secrets.CLAWSWEEPER_LIVE_PROOF_BASE_URL }}
-        run: node dist/clawsweeper.js live-proof-publish-artifacts --artifact-dir .artifacts/exact-review-bundle
+        run: |
+          status=0
+          result_json="$(node dist/clawsweeper.js live-proof-publish-artifacts --artifact-dir .artifacts/exact-review-bundle)" || status=$?
+          printf '%s\n' "$result_json"
+          result="$(jq -r 'if .status == "invalid_artifact" then .status else "unknown" end' <<<"$result_json" 2>/dev/null || echo unknown)"
+          echo "result=$result" >> "$GITHUB_OUTPUT"
+          exit "$status"
 
       - name: Identify legacy tuple-less exact artifact
         id: legacy-exact-artifact
-        if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.publication-context.outputs.direct_lifecycle_recovery != 'true' && steps.validate-exact-review-bundle.outcome == 'success' }}
+        if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.publication-context.outputs.direct_lifecycle_recovery != 'true' && steps.fold-exact-live-proof.outcome == 'success' }}
         env:
           REPORT_PATH: .artifacts/exact-review-bundle/review/${{ steps.publication-context.outputs.item_number }}.md
         run: |
@@ -2654,7 +2662,7 @@ jobs:
           NODE
 
       - name: Stage validated exact review artifact
-        if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.publication-context.outputs.direct_lifecycle_recovery != 'true' && steps.validate-exact-review-bundle.outcome == 'success' }}
+        if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.publication-context.outputs.direct_lifecycle_recovery != 'true' && steps.fold-exact-live-proof.outcome == 'success' }}
         run: |
           set -euo pipefail
           mkdir -p artifacts/event
@@ -2664,7 +2672,7 @@ jobs:
           fi
 
       - name: Create target write token
-        if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.publication-context.outputs.direct_lifecycle_recovery != 'true' && steps.validate-exact-review-bundle.outcome == 'success' }}
+        if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.publication-context.outputs.direct_lifecycle_recovery != 'true' && steps.fold-exact-live-proof.outcome == 'success' }}
         id: target-write-token
         continue-on-error: true
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -2680,7 +2688,7 @@ jobs:
           permission-statuses: read
 
       - uses: ./.github/actions/setup-state
-        if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.publication-context.outputs.direct_lifecycle_recovery != 'true' && steps.validate-exact-review-bundle.outcome == 'success' && steps.legacy-exact-artifact.outputs.legacy_tupleless != 'true' }}
+        if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.publication-context.outputs.direct_lifecycle_recovery != 'true' && steps.fold-exact-live-proof.outcome == 'success' && steps.legacy-exact-artifact.outputs.legacy_tupleless != 'true' }}
         id: setup-state
         with:
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
@@ -2692,7 +2700,7 @@ jobs:
           hydrate-state-blobs: "false"
 
       - name: Publish event result and apply safe close
-        if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.publication-context.outputs.direct_lifecycle_recovery != 'true' && steps.validate-exact-review-bundle.outcome == 'success' && steps.legacy-exact-artifact.outputs.legacy_tupleless != 'true' }}
+        if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.publication-context.outputs.direct_lifecycle_recovery != 'true' && steps.fold-exact-live-proof.outcome == 'success' && steps.legacy-exact-artifact.outputs.legacy_tupleless != 'true' }}
         id: publish-event-result
         env:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
@@ -3136,6 +3144,7 @@ jobs:
           FAILURE_KIND: ${{ steps.publish-event-result.outputs.failure_kind }}
           DOWNLOAD_OUTCOME: ${{ steps.download-exact-review-bundle.outcome }}
           VALIDATE_OUTCOME: ${{ steps.validate-exact-review-bundle.outcome }}
+          LIVE_PROOF_RESULT: ${{ steps.fold-exact-live-proof.outputs.result }}
           PUBLISH_COMPLETION_KIND: ${{ steps.publish-event-result.outputs.completion_kind }}
           PUBLISH_REASON_CODE: ${{ steps.publish-event-result.outputs.reason_code }}
           PUBLISH_RETRY_AT: ${{ steps.publish-event-result.outputs.retry_at }}
@@ -3194,6 +3203,10 @@ jobs:
             completion_kind=retryable_failure
             reason_code=review_lease_active
             retry_at="$PUBLISH_RETRY_AT"
+          elif [ "$LIVE_PROOF_RESULT" = "invalid_artifact" ]; then
+            outcome=success
+            completion_kind=refresh_required
+            reason_code=invalid_artifact
           elif [ "$LEGACY_TUPLELESS" = "true" ] && [ "$SOURCE_DRIFT_OUTCOME" = "success" ]; then
             outcome=success
             completion_kind=superseded

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -11271,7 +11271,12 @@ function exactReviewPublicationCompletion(
     ]),
     // Accept the pre-deployment tuple while an old publisher can still finish.
     // New publishers use deferred/close_coverage_deferred instead.
-    refresh_required: new Set(["artifact_unavailable", "artifact_expired", "close_coverage_retry"]),
+    refresh_required: new Set([
+      "artifact_unavailable",
+      "artifact_expired",
+      "close_coverage_retry",
+      "invalid_artifact",
+    ]),
     deferred: new Set(["close_coverage_deferred"]),
     permanent_failure: new Set([
       "invalid_artifact",

--- a/scripts/prepare-exact-review-batch.mjs
+++ b/scripts/prepare-exact-review-batch.mjs
@@ -419,6 +419,10 @@ async function worker(itemPath, root, workspace) {
     { cwd: workspace, env: process.env, capture: true },
   );
   if (liveProofPublication.code !== 0) {
+    try {
+      if (JSON.parse(liveProofPublication.stdout).status === "invalid_artifact")
+        return writeFailure(outcomePath, "refresh_required", "invalid_artifact");
+    } catch {}
     console.error(liveProofPublication.stderr);
     return writeFailure(outcomePath, "retryable_failure", "unknown_failure");
   }

--- a/src/clawsweeper-runtime.ts
+++ b/src/clawsweeper-runtime.ts
@@ -1555,9 +1555,9 @@ async function liveProofPublishArtifactsCommand(args: Args): Promise<void> {
     fetchPullRequest: async () => {
       throw new Error("merged live-proof publication must not perform a live-head lookup");
     },
-  });
+  }).catch(() => ({ status: "retryable_failure" }) as const);
   console.log(JSON.stringify(result));
-  if (result.status === "invalid_artifact") process.exitCode = 1;
+  if (result.status !== "published") process.exitCode = 1;
 }
 
 function liveProofCommentCommand(args: Args): void {

--- a/src/clawsweeper-runtime.ts
+++ b/src/clawsweeper-runtime.ts
@@ -1500,6 +1500,7 @@ const liveProofAttachDependencies = {
   renderReviewCommentFromReport: reportOrchestration.renderReviewCommentFromReport,
   markedReviewCommentBody: reviewCommentWorkflow.markedReviewCommentBody,
   upsertReviewComment: reviewCommentWorkflow.upsertReviewComment,
+  selectTarget: (repo: string) => setTargetRepo(repo),
 };
 
 const liveProofCommands = createLiveProofCommands({
@@ -1512,12 +1513,6 @@ const liveProofCommands = createLiveProofCommands({
 const liveProofCommand = liveProofCommands.liveProofCommand;
 
 async function liveProofAttachCommand(args: Args): Promise<void> {
-  const recordPath = stringArg(args.record, "");
-  if (recordPath) {
-    const markdown = readFileSync(resolve(recordPath), "utf8");
-    const repo = frontMatterValue(markdown, "repository");
-    if (repo) setTargetRepo(repo);
-  }
   await liveProofCommands.liveProofAttachCommand(args);
 }
 
@@ -1554,17 +1549,15 @@ function liveProofReviewCommand(args: Args): void {
 async function liveProofPublishArtifactsCommand(args: Args): Promise<void> {
   const artifactDir = stringArg(args.artifact_dir, "").trim();
   if (!artifactDir) throw new Error("live-proof-publish-artifacts requires --artifact-dir");
-  const results = await publishReviewLiveProofArtifacts(
-    artifactDir,
-    {
-      ...liveProofAttachDependencies,
-      fetchPullRequest: async () => {
-        throw new Error("merged live-proof publication must not perform a live-head lookup");
-      },
+  const result = await publishReviewLiveProofArtifacts(artifactDir, {
+    ...liveProofAttachDependencies,
+    log: () => {},
+    fetchPullRequest: async () => {
+      throw new Error("merged live-proof publication must not perform a live-head lookup");
     },
-    (repo) => setTargetRepo(repo),
-  );
-  console.log(JSON.stringify({ results }));
+  });
+  console.log(JSON.stringify(result));
+  if (result.status === "invalid_artifact") process.exitCode = 1;
 }
 
 function liveProofCommentCommand(args: Args): void {

--- a/src/live-proof/attach.ts
+++ b/src/live-proof/attach.ts
@@ -47,10 +47,15 @@ export interface LiveProofAttachDependencies {
   renderReviewCommentFromReport: (markdown: string, closeReason: CloseReason) => string;
   markedReviewCommentBody: (number: number, body: string) => string;
   upsertReviewComment: (number: number, body: string) => Record<string, unknown> | undefined;
+  selectTarget?: (repo: string) => void;
   log?: (message: string) => void;
 }
 
 export type LiveProofAttachResult = "attached" | "detached" | "unchanged" | "skipped" | "dry-run";
+
+export class LiveProofArtifactValidationError extends Error {
+  override name = "LiveProofArtifactValidationError";
+}
 
 export async function attachLiveProof(
   options: LiveProofAttachOptions,
@@ -76,24 +81,28 @@ async function attachLiveProofInternal(
   const log = dependencies.log ?? console.log;
   const bundleDir = resolve(options.bundleDir);
   const recordPath = resolve(options.recordPath);
-  const verification = parseLiveVerificationResult(
-    JSON.parse(readFileSync(join(bundleDir, "live-verification.json"), "utf8")) as unknown,
-  );
-  const report = readFileSync(recordPath, "utf8");
-  validateReportIdentity(report, verification, dependencies.frontMatterValue);
-  validateLiveVerificationReportPlan(verification, dependencies.reportLiveProofPlan(report));
-  const manifestPath = join(bundleDir, "live-proof-manifest.json");
-  const manifest = existsSync(manifestPath)
-    ? parseLiveProofManifest(JSON.parse(readFileSync(manifestPath, "utf8")) as unknown)
-    : undefined;
-  const mp4Path = join(bundleDir, "live-proof.mp4");
-  const posterPath = join(bundleDir, "poster.jpg");
-  if (manifest) {
-    validateManifestMatchesVerification(manifest, verification);
-    validateAttachedMedia({ manifest, mp4Path, posterPath, runner });
-  } else if (existsSync(mp4Path) || existsSync(posterPath)) {
-    throw new Error("live proof media is present without a manifest");
-  }
+  const { verification, report, manifest, mp4Path, posterPath } = validateArtifact(() => {
+    const verification = parseLiveVerificationResult(
+      JSON.parse(readFileSync(join(bundleDir, "live-verification.json"), "utf8")) as unknown,
+    );
+    const report = readFileSync(recordPath, "utf8");
+    validateReportIdentity(report, verification, dependencies.frontMatterValue);
+    validateLiveVerificationReportPlan(verification, dependencies.reportLiveProofPlan(report));
+    const manifestPath = join(bundleDir, "live-proof-manifest.json");
+    const manifest = existsSync(manifestPath)
+      ? parseLiveProofManifest(JSON.parse(readFileSync(manifestPath, "utf8")) as unknown)
+      : undefined;
+    const mp4Path = join(bundleDir, "live-proof.mp4");
+    const posterPath = join(bundleDir, "poster.jpg");
+    if (manifest) {
+      validateManifestMatchesVerification(manifest, verification);
+      validateAttachedMedia({ manifest, mp4Path, posterPath, runner });
+    } else if (existsSync(mp4Path) || existsSync(posterPath)) {
+      throw new Error("live proof media is present without a manifest");
+    }
+    return { verification, report, manifest, mp4Path, posterPath };
+  });
+  dependencies.selectTarget?.(verification.repo);
 
   const reportHead = dependencies.frontMatterValue(report, "pull_head_sha")?.toLowerCase() ?? "";
   let liveHead: string;
@@ -175,6 +184,17 @@ async function attachLiveProofInternal(
     `[live-proof-attach] prepared ${verification.surface} verification${manifest ? " with media" : " without media"} for ${verification.repo}#${verification.item} at ${verification.head_sha}`,
   );
   return "attached";
+}
+
+function validateArtifact<T>(operation: () => T): T {
+  try {
+    return operation();
+  } catch (error) {
+    throw new LiveProofArtifactValidationError(
+      error instanceof Error ? error.message : "live proof artifact validation failed",
+      { cause: error },
+    );
+  }
 }
 
 export function detachLiveProof(

--- a/src/live-proof/attach.ts
+++ b/src/live-proof/attach.ts
@@ -58,6 +58,16 @@ export class LiveProofArtifactValidationError extends Error {
   override name = "LiveProofArtifactValidationError";
 }
 
+const DETERMINISTIC_INVALID_ARTIFACT_FS_CODES = new Set([
+  "ENOENT",
+  "ENOTDIR",
+  "EISDIR",
+  "ELOOP",
+  "EFBIG",
+  "EOVERFLOW",
+  "ERR_FS_FILE_TOO_LARGE",
+]);
+
 export async function attachLiveProof(
   options: LiveProofAttachOptions,
   dependencies: LiveProofAttachDependencies,
@@ -191,12 +201,24 @@ function validateArtifact<T>(operation: () => T): T {
   try {
     return operation();
   } catch (error) {
-    if (error instanceof MediaProbeExecutionError) throw error;
+    if (error instanceof MediaProbeExecutionError || isRetryableArtifactFsError(error)) throw error;
     throw new LiveProofArtifactValidationError(
       error instanceof Error ? error.message : "live proof artifact validation failed",
       { cause: error },
     );
   }
+}
+
+function isRetryableArtifactFsError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const { code, syscall } = error as NodeJS.ErrnoException;
+  const normalizedCode = typeof code === "string" ? code.trim() : "";
+  return (
+    normalizedCode.length > 0 &&
+    typeof syscall === "string" &&
+    syscall.trim().length > 0 &&
+    !DETERMINISTIC_INVALID_ARTIFACT_FS_CODES.has(normalizedCode)
+  );
 }
 
 export function detachLiveProof(

--- a/src/live-proof/attach.ts
+++ b/src/live-proof/attach.ts
@@ -9,6 +9,7 @@ import {
 import type { CloseReason, LiveProofPlan, MediaProofCommandRunner } from "../clawsweeper-types.js";
 import type { LiveProofPullRequestState } from "./execute.js";
 import {
+  MediaProbeExecutionError,
   parseLiveProofManifest,
   validateAttachedMedia,
   type LiveProofManifest,
@@ -190,6 +191,7 @@ function validateArtifact<T>(operation: () => T): T {
   try {
     return operation();
   } catch (error) {
+    if (error instanceof MediaProbeExecutionError) throw error;
     throw new LiveProofArtifactValidationError(
       error instanceof Error ? error.message : "live proof artifact validation failed",
       { cause: error },

--- a/src/live-proof/manifest.ts
+++ b/src/live-proof/manifest.ts
@@ -29,6 +29,10 @@ export interface ProbedMedia {
   height: number;
 }
 
+export class MediaProbeExecutionError extends Error {
+  override name = "MediaProbeExecutionError";
+}
+
 const MANIFEST_KEYS = new Set([
   "schema_version",
   "repo",
@@ -110,16 +114,31 @@ export function parseLiveProofManifest(value: unknown): LiveProofManifest {
 
 export function probeMedia(path: string, runner: MediaProofCommandRunner): ProbedMedia {
   const result = ffprobeMedia(path, runner);
+  if (result.error || result.status === null) {
+    throw new MediaProbeExecutionError(
+      `ffprobe could not execute for ${path}: ${mediaProofSpawnDetail(result)}`,
+      { cause: result.error },
+    );
+  }
   if (result.status !== 0) {
     throw new Error(`ffprobe failed for ${path}: ${mediaProofSpawnDetail(result)}`);
   }
+  const stdout = String(result.stdout ?? "");
+  if (!stdout.trim()) {
+    throw new MediaProbeExecutionError(`ffprobe returned no output for ${path}`);
+  }
   let parsed: unknown;
   try {
-    parsed = JSON.parse(String(result.stdout ?? "{}"));
+    parsed = JSON.parse(stdout);
   } catch (error) {
-    throw new Error(`ffprobe returned invalid JSON for ${path}`, { cause: error });
+    throw new MediaProbeExecutionError(`ffprobe returned invalid JSON for ${path}`, {
+      cause: error,
+    });
   }
-  const root = requireRecord(parsed, `ffprobe output for ${path}`);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new MediaProbeExecutionError(`ffprobe returned a non-object JSON value for ${path}`);
+  }
+  const root = parsed as Record<string, unknown>;
   const streams = Array.isArray(root.streams) ? root.streams : [];
   const video = streams
     .map((stream) => (stream && typeof stream === "object" ? stream : null))

--- a/src/live-proof/publication-artifacts.ts
+++ b/src/live-proof/publication-artifacts.ts
@@ -1,39 +1,47 @@
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { basename, dirname, join, relative, resolve, sep } from "node:path";
 
 import {
   attachReviewLiveProofArtifact,
+  LiveProofArtifactValidationError,
   type LiveProofAttachDependencies,
   type LiveProofAttachResult,
 } from "./attach.js";
-import { parseLiveVerificationResult } from "./verification.js";
+
+export type PublishReviewLiveProofArtifactsResult =
+  | { status: "published"; results: Array<{ item: number; outcome: LiveProofAttachResult }> }
+  | { status: "invalid_artifact" };
 
 export async function publishReviewLiveProofArtifacts(
   artifactDirInput: string,
   dependencies: LiveProofAttachDependencies,
-  selectTarget?: (repo: string) => void,
-): Promise<Array<{ item: number; outcome: LiveProofAttachResult }>> {
+): Promise<PublishReviewLiveProofArtifactsResult> {
   const artifactDir = resolve(artifactDirInput);
-  if (!existsSync(artifactDir)) return [];
-  const verificationPaths = regularFilesBelow(artifactDir).filter(
-    (path) =>
-      basename(path) === "live-verification.json" &&
-      relative(artifactDir, path).split(sep).includes("live-proof"),
-  );
-  const results: Array<{ item: number; outcome: LiveProofAttachResult }> = [];
-  for (const verificationPath of verificationPaths) {
-    const verification = parseLiveVerificationResult(
-      JSON.parse(readFileSync(verificationPath, "utf8")) as unknown,
+  if (!existsSync(artifactDir)) return { status: "published", results: [] };
+  try {
+    const verificationPaths = regularFilesBelow(artifactDir).filter(
+      (path) =>
+        basename(path) === "live-verification.json" &&
+        relative(artifactDir, path).split(sep).includes("live-proof"),
     );
-    selectTarget?.(verification.repo);
-    const recordPath = uniqueRecordPath(artifactDir, verification.item);
-    const outcome = await attachReviewLiveProofArtifact(
-      { bundleDir: dirname(verificationPath), recordPath },
-      dependencies,
-    );
-    results.push({ item: verification.item, outcome });
+    const results: Array<{ item: number; outcome: LiveProofAttachResult }> = [];
+    for (const verificationPath of verificationPaths) {
+      const bundleDir = dirname(verificationPath);
+      const item = Number(basename(bundleDir));
+      if (!Number.isSafeInteger(item) || item <= 0) {
+        throw new LiveProofArtifactValidationError("live proof artifact path has an invalid item");
+      }
+      const outcome = await attachReviewLiveProofArtifact(
+        { bundleDir, recordPath: uniqueRecordPath(artifactDir, item) },
+        dependencies,
+      );
+      results.push({ item, outcome });
+    }
+    return { status: "published", results };
+  } catch (error) {
+    if (error instanceof LiveProofArtifactValidationError) return { status: "invalid_artifact" };
+    throw error;
   }
-  return results;
 }
 
 function uniqueRecordPath(artifactDir: string, item: number): string {
@@ -43,7 +51,7 @@ function uniqueRecordPath(artifactDir: string, item: number): string {
       basename(path) === filename && !relative(artifactDir, path).split(sep).includes("live-proof"),
   );
   if (candidates.length !== 1) {
-    throw new Error(
+    throw new LiveProofArtifactValidationError(
       `live proof publication expected one review artifact for item ${item}, found ${candidates.length}`,
     );
   }
@@ -55,10 +63,12 @@ function regularFilesBelow(root: string): string[] {
   const visit = (directory: string) => {
     for (const entry of readdirSync(directory, { withFileTypes: true })) {
       const absolute = join(directory, entry.name);
-      if (entry.isSymbolicLink()) throw new Error("live proof artifact must not contain symlinks");
+      if (entry.isSymbolicLink())
+        throw new LiveProofArtifactValidationError("live proof artifact must not contain symlinks");
       if (entry.isDirectory()) visit(absolute);
       else if (entry.isFile()) files.push(absolute);
-      else throw new Error("live proof artifact contains a non-file entry");
+      else
+        throw new LiveProofArtifactValidationError("live proof artifact contains a non-file entry");
     }
   };
   visit(root);

--- a/test/dashboard-worker-queue-runtime.test.ts
+++ b/test/dashboard-worker-queue-runtime.test.ts
@@ -8542,6 +8542,41 @@ test("exact-review publication refreshes an artifact after its third unavailable
   assert.equal(stats.lanes.publication.flow.last_15_minutes.causes.attribution_complete, true);
 });
 
+test("exact-review publication refreshes a deterministic invalid artifact immediately", async () => {
+  const storage = new MemoryDurableStorage();
+  const item = leasedExactReviewPublicationItem(7833, "78330");
+  await storage.put("exact-review-queue", { deliveries: {}, items: { [item.key]: item } });
+  const queue = new ExactReviewQueue({ storage }, { EXACT_REVIEW_DISPATCH_DEBOUNCE_MS: "0" });
+
+  const response = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: item.leaseId,
+        item_key: item.key,
+        lease_revision: item.leaseRevision,
+        claim_generation: item.claimGeneration,
+        run_id: item.claimedRunId,
+        run_attempt: item.claimedRunAttempt,
+        outcome: "success",
+        completion_kind: "refresh_required",
+        reason_code: "invalid_artifact",
+      }),
+    }),
+  );
+
+  assert.deepEqual(await response.json(), { ok: true, requeued: false });
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { decision: { sourceAction: string; publication?: unknown } }>;
+  };
+  assert.equal(state.items[item.key], undefined);
+  assert.equal(
+    state.items["openclaw/openclaw#7833"].decision.sourceAction,
+    "artifact_retention_recovery",
+  );
+  assert.equal(state.items["openclaw/openclaw#7833"].decision.publication, undefined);
+});
+
 test("exact-review publication completes a close-coverage deferral without refreshing", async () => {
   const storage = new MemoryDurableStorage();
   const item = leasedExactReviewPublicationItem(7831, "78310");

--- a/test/exact-review-publication-batches.test.ts
+++ b/test/exact-review-publication-batches.test.ts
@@ -3696,6 +3696,57 @@ test("retryable batch completion releases ownership and preserves queue retry po
   }
 });
 
+test("batch completion refreshes deterministic invalid artifacts", async () => {
+  const storage = new TestStorage();
+  const queue = new ExactReviewQueue(
+    { storage },
+    {
+      EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+      EXACT_REVIEW_DISPATCH_DEBOUNCE_MS: "0",
+    },
+  );
+  await queue.fetch(publicationRequest("delivery-invalid-artifact", 127, "1027"));
+  const claim = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-invalid-artifact",
+        lease_owner: "worker-1",
+        max_items: 1,
+      }),
+    )
+  ).json();
+  const member = claim.batch.items[0];
+
+  const completion = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/complete", {
+        batch_id: claim.batch.batch_id,
+        lease_owner: "worker-1",
+        items: [
+          {
+            item_key: member.item_key,
+            revision: member.revision,
+            claim_generation: member.claim_generation,
+            terminal_outcome: "refresh_required",
+            reason_code: "invalid_artifact",
+          },
+        ],
+      }),
+    )
+  ).json();
+
+  assert.equal(completion.accepted, 1, JSON.stringify(completion));
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { decision: { sourceAction: string; publication?: unknown } }>;
+  };
+  assert.equal(state.items[member.item_key], undefined);
+  assert.equal(
+    state.items["openclaw/openclaw#127"].decision.sourceAction,
+    "artifact_retention_recovery",
+  );
+  assert.equal(state.items["openclaw/openclaw#127"].decision.publication, undefined);
+});
+
 test("credential circuits persist, preserve healthy owners, and defer unattempted members without retry charge", async () => {
   const originalNow = Date.now;
   let now = Date.parse("2026-08-10T14:00:00.000Z");

--- a/test/live-proof.test.ts
+++ b/test/live-proof.test.ts
@@ -25,6 +25,7 @@ import {
   attachReviewLiveProofArtifact,
   attachLiveProof,
   detachLiveProof,
+  LiveProofArtifactValidationError,
   syncDetachedLiveProofComment,
   syncLiveProofComment,
 } from "../dist/live-proof/attach.js";
@@ -3406,6 +3407,107 @@ test("queued publication keeps media probe execution failures retryable", async 
       assert.equal(upserts, 0);
     });
   }
+});
+
+test("queued publication keeps transient artifact filesystem failures retryable", async (t) => {
+  const systemError = (code: string, syscall?: string) =>
+    Object.assign(new Error(`${syscall ?? "operation"} ${code}`), { code, syscall });
+  const scenarios = [
+    { name: "EIO", error: systemError("EIO", "readFile") },
+    { name: "EMFILE", error: systemError("EMFILE", "open") },
+    { name: "ESTALE", error: systemError("ESTALE", "stat") },
+    { name: "missing syscall", error: systemError("EIO"), invalid: true },
+    { name: "deterministic ENOENT", error: systemError("ENOENT", "open"), invalid: true },
+  ];
+
+  for (const scenario of scenarios) {
+    await t.test(scenario.name, async () => {
+      const fixture = publicationFixture();
+      const originalReport = readFileSync(fixture.recordPath, "utf8");
+      let uploads = 0;
+      let upserts = 0;
+      const dependencies = attachDependencies({
+        runner: (command, args, options) => {
+          if (command === "aws") uploads += 1;
+          return mediaRunner([])(command, args, options);
+        },
+        fetchPullRequest: async () => {
+          throw new Error("queued publication must not fetch a live head");
+        },
+        upsertReviewComment: () => {
+          upserts += 1;
+          return {};
+        },
+        logs: fixture.logs,
+      });
+      dependencies.reportLiveProofPlan = () => {
+        throw scenario.error;
+      };
+      const publish = () => publishReviewLiveProofArtifacts(fixture.artifactDir, dependencies);
+
+      if (scenario.invalid) {
+        assert.deepEqual(await publish(), { status: "invalid_artifact" });
+      } else {
+        await assert.rejects(publish, (error: unknown) => error === scenario.error);
+      }
+      assert.equal(readFileSync(fixture.recordPath, "utf8"), originalReport);
+      assert.equal(uploads, 0);
+      assert.equal(upserts, 0);
+    });
+  }
+});
+
+test("missing verification remains an invalid artifact at the attachment boundary", async () => {
+  const fixture = attachmentFixture();
+  rmSync(join(fixture.bundleDir, "live-verification.json"));
+
+  await assert.rejects(
+    attachReviewLiveProofArtifact(
+      { bundleDir: fixture.bundleDir, recordPath: fixture.recordPath },
+      attachDependencies({
+        runner: mediaRunner([]),
+        fetchPullRequest: async () => {
+          throw new Error("invalid artifacts must fail before fetching a live head");
+        },
+        upsertReviewComment: () => {
+          throw new Error("invalid artifacts must not publish");
+        },
+        logs: fixture.logs,
+      }),
+    ),
+    LiveProofArtifactValidationError,
+  );
+});
+
+test("missing live proof media remains an invalid publication artifact", async () => {
+  const fixture = publicationFixture();
+  rmSync(join(fixture.bundleDir, "live-proof.mp4"));
+  const originalReport = readFileSync(fixture.recordPath, "utf8");
+  let uploads = 0;
+  let upserts = 0;
+
+  const result = await publishReviewLiveProofArtifacts(
+    fixture.artifactDir,
+    attachDependencies({
+      runner: (command, args, options) => {
+        if (command === "aws") uploads += 1;
+        return mediaRunner([])(command, args, options);
+      },
+      fetchPullRequest: async () => {
+        throw new Error("invalid artifacts must fail before fetching a live head");
+      },
+      upsertReviewComment: () => {
+        upserts += 1;
+        return {};
+      },
+      logs: fixture.logs,
+    }),
+  );
+
+  assert.deepEqual(result, { status: "invalid_artifact" });
+  assert.equal(readFileSync(fixture.recordPath, "utf8"), originalReport);
+  assert.equal(uploads, 0);
+  assert.equal(upserts, 0);
 });
 
 test("live-proof attach publishes the record before syncing its marker-backed comment", async () => {

--- a/test/live-proof.test.ts
+++ b/test/live-proof.test.ts
@@ -44,7 +44,7 @@ import {
   assertLiveProofEnvironmentSanitized,
   sanitizedLiveProofEnvironment,
 } from "../dist/live-proof/environment.js";
-import { parseLiveProofManifest } from "../dist/live-proof/manifest.js";
+import { MediaProbeExecutionError, parseLiveProofManifest } from "../dist/live-proof/manifest.js";
 import { publishReviewLiveProofArtifacts } from "../dist/live-proof/publication-artifacts.js";
 import {
   buildLiveVerificationResult,
@@ -2525,6 +2525,18 @@ test("live-proof skips a demonstrated recording shorter than three seconds", asy
   );
 });
 
+test("live-proof keeps verification when the media probe cannot execute", async () => {
+  const fixture = executeFixture("probe-failed");
+  await fixture.run();
+  assert.equal(existsSync(fixture.verificationPath), true);
+  assert.equal(existsSync(fixture.manifestPath), false);
+  assert.equal(existsSync(fixture.mp4Path), false);
+  assert.match(
+    fixture.logs.join("\n"),
+    /media pipeline failed and was skipped: ffprobe could not execute/,
+  );
+});
+
 test("static-text terminal verification runs directly without recording tools", async () => {
   const directory = mkdtempSync(join(tmpdir(), "clawsweeper-live-verification-static-"));
   const outputDir = join(directory, "output");
@@ -3301,6 +3313,99 @@ test("queued publication leaves AWS upload failures retryable", async () => {
       /aws s3 cp failed/.test(error.message),
   );
   assert.equal(readFileSync(fixture.recordPath, "utf8"), originalReport);
+});
+
+test("queued publication keeps media probe execution failures retryable", async (t) => {
+  const executionError = (code: string) =>
+    Object.assign(new Error(`spawn ffprobe ${code}`), { code });
+  const scenarios: Array<{
+    name: string;
+    probe: "mp4" | "poster";
+    result: ReturnType<MediaProofCommandRunner>;
+    expected: "retryable" | "invalid_artifact";
+  }> = [
+    {
+      name: "MP4 ENOENT",
+      probe: "mp4",
+      result: { status: null, error: executionError("ENOENT") },
+      expected: "retryable",
+    },
+    {
+      name: "poster ETIMEDOUT",
+      probe: "poster",
+      result: { status: null, error: executionError("ETIMEDOUT") },
+      expected: "retryable",
+    },
+    {
+      name: "empty stdout",
+      probe: "mp4",
+      result: { status: 0, stdout: "" },
+      expected: "retryable",
+    },
+    {
+      name: "malformed JSON",
+      probe: "mp4",
+      result: { status: 0, stdout: "{" },
+      expected: "retryable",
+    },
+    {
+      name: "non-object JSON",
+      probe: "mp4",
+      result: { status: 0, stdout: "[]" },
+      expected: "retryable",
+    },
+    {
+      name: "poster numeric rejection",
+      probe: "poster",
+      result: { status: 1, stderr: "unsupported image" },
+      expected: "invalid_artifact",
+    },
+  ];
+
+  for (const scenario of scenarios) {
+    await t.test(scenario.name, async () => {
+      const fixture = publicationFixture();
+      const originalReport = readFileSync(fixture.recordPath, "utf8");
+      let uploads = 0;
+      let upserts = 0;
+      const successfulMediaRunner = mediaRunner([]);
+      const runner: MediaProofCommandRunner = (command, args, options) => {
+        if (command === "aws") {
+          uploads += 1;
+          return { status: 0 };
+        }
+        if (command === "ffprobe") {
+          const probe = String(args.at(-1)).endsWith("poster.jpg") ? "poster" : "mp4";
+          if (probe === scenario.probe) return scenario.result;
+        }
+        return successfulMediaRunner(command, args, options);
+      };
+      const publish = () =>
+        publishReviewLiveProofArtifacts(
+          fixture.artifactDir,
+          attachDependencies({
+            runner,
+            fetchPullRequest: async () => {
+              throw new Error("queued publication must not fetch a live head");
+            },
+            upsertReviewComment: () => {
+              upserts += 1;
+              return {};
+            },
+            logs: fixture.logs,
+          }),
+        );
+
+      if (scenario.expected === "retryable") {
+        await assert.rejects(publish, MediaProbeExecutionError);
+      } else {
+        assert.deepEqual(await publish(), { status: "invalid_artifact" });
+      }
+      assert.equal(readFileSync(fixture.recordPath, "utf8"), originalReport);
+      assert.equal(uploads, 0);
+      assert.equal(upserts, 0);
+    });
+  }
 });
 
 test("live-proof attach publishes the record before syncing its marker-backed comment", async () => {
@@ -4621,7 +4726,13 @@ function terminalCaptureInvocation(args: readonly string[]):
 }
 
 function executeFixture(
-  mode: "failed" | "present-at-start" | "demonstrated-partial" | "no-expectation" | "too-short",
+  mode:
+    | "failed"
+    | "present-at-start"
+    | "demonstrated-partial"
+    | "no-expectation"
+    | "too-short"
+    | "probe-failed",
 ) {
   const directory = mkdtempSync(join(tmpdir(), "clawsweeper-live-proof-execute-"));
   const outputDir = join(directory, "output");
@@ -4703,6 +4814,12 @@ function executeFixture(
       };
     }
     if (command === "ffprobe") {
+      if (mode === "probe-failed") {
+        return {
+          status: null,
+          error: Object.assign(new Error("spawn ffprobe ENOENT"), { code: "ENOENT" }),
+        };
+      }
       return {
         status: 0,
         stdout: JSON.stringify({

--- a/test/live-proof.test.ts
+++ b/test/live-proof.test.ts
@@ -45,6 +45,7 @@ import {
   sanitizedLiveProofEnvironment,
 } from "../dist/live-proof/environment.js";
 import { parseLiveProofManifest } from "../dist/live-proof/manifest.js";
+import { publishReviewLiveProofArtifacts } from "../dist/live-proof/publication-artifacts.js";
 import {
   buildLiveVerificationResult,
   encodeLiveVerificationReportPayload,
@@ -3232,6 +3233,76 @@ test("merged publication trusts the review-bound head without a GitHub lookup", 
   assert.equal(commands.filter((command) => command.startsWith("aws ")).length, 2);
 });
 
+test("queued publication classifies legacy verification as an invalid artifact before mutation", async () => {
+  const fixture = publicationFixture();
+  const verificationPath = join(fixture.bundleDir, "live-verification.json");
+  const { plan_sha256: _planSha256, ...legacyVerification } = JSON.parse(
+    readFileSync(verificationPath, "utf8"),
+  );
+  writeFileSync(verificationPath, JSON.stringify(legacyVerification), "utf8");
+  const originalReport = readFileSync(fixture.recordPath, "utf8");
+  const commands: string[] = [];
+  let upserts = 0;
+
+  const result = await publishReviewLiveProofArtifacts(
+    fixture.artifactDir,
+    attachDependencies({
+      runner: mediaRunner(commands),
+      fetchPullRequest: async () => {
+        throw new Error("queued publication must not fetch a live head");
+      },
+      upsertReviewComment: () => {
+        upserts += 1;
+        return {};
+      },
+      logs: fixture.logs,
+    }),
+  );
+
+  assert.deepEqual(result, { status: "invalid_artifact" });
+  assert.equal(commands.length, 0);
+  assert.equal(upserts, 0);
+  assert.equal(readFileSync(fixture.recordPath, "utf8"), originalReport);
+
+  const cli = spawnSync(
+    process.execPath,
+    ["dist/clawsweeper.js", "live-proof-publish-artifacts", "--artifact-dir", fixture.artifactDir],
+    { encoding: "utf8" },
+  );
+  assert.equal(cli.status, 1);
+  assert.equal(cli.stderr, "");
+  assert.deepEqual(JSON.parse(cli.stdout), { status: "invalid_artifact" });
+  assert.equal(cli.stdout.trim().split("\n").length, 1);
+});
+
+test("queued publication leaves AWS upload failures retryable", async () => {
+  const fixture = publicationFixture();
+  const originalReport = readFileSync(fixture.recordPath, "utf8");
+  const successfulMediaRunner = mediaRunner([]);
+
+  await assert.rejects(
+    publishReviewLiveProofArtifacts(
+      fixture.artifactDir,
+      attachDependencies({
+        runner: (command, args) =>
+          command === "aws"
+            ? { status: 1, stderr: "temporary upload failure" }
+            : successfulMediaRunner(command, args),
+        fetchPullRequest: async () => {
+          throw new Error("queued publication must not fetch a live head");
+        },
+        upsertReviewComment: () => ({}),
+        logs: fixture.logs,
+      }),
+    ),
+    (error: unknown) =>
+      error instanceof Error &&
+      error.name !== "LiveProofArtifactValidationError" &&
+      /aws s3 cp failed/.test(error.message),
+  );
+  assert.equal(readFileSync(fixture.recordPath, "utf8"), originalReport);
+});
+
 test("live-proof attach publishes the record before syncing its marker-backed comment", async () => {
   const fixture = attachmentFixture();
   const commands: string[] = [];
@@ -4041,6 +4112,21 @@ Candidate: none
     "utf8",
   );
   return { bundleDir, recordPath, logs };
+}
+
+function publicationFixture() {
+  const fixture = attachmentFixture();
+  const artifactDir = dirname(fixture.recordPath);
+  const bundleDir = join(artifactDir, "live-proof", "42");
+  const recordPath = join(artifactDir, "review", "42.md");
+  mkdirSync(bundleDir, { recursive: true });
+  mkdirSync(dirname(recordPath), { recursive: true });
+  for (const filename of readdirSync(fixture.bundleDir)) {
+    renameSync(join(fixture.bundleDir, filename), join(bundleDir, filename));
+  }
+  renameSync(fixture.recordPath, recordPath);
+  rmSync(fixture.bundleDir, { recursive: true });
+  return { ...fixture, artifactDir, bundleDir, recordPath };
 }
 
 function recordedAttachmentFixture() {

--- a/test/live-proof.test.ts
+++ b/test/live-proof.test.ts
@@ -3407,6 +3407,28 @@ test("queued publication keeps media probe execution failures retryable", async 
       assert.equal(upserts, 0);
     });
   }
+
+  const fixture = publicationFixture();
+  const cli = spawnSync(
+    process.execPath,
+    ["dist/clawsweeper.js", "live-proof-publish-artifacts", "--artifact-dir", fixture.artifactDir],
+    {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        AWS_ACCESS_KEY_ID: "",
+        AWS_SECRET_ACCESS_KEY: "",
+        CLAWSWEEPER_LIVE_PROOF_BASE_URL: "",
+        CLAWSWEEPER_LIVE_PROOF_BUCKET: "",
+        CLAWSWEEPER_LIVE_PROOF_S3_ENDPOINT: "",
+        PATH: "",
+      },
+    },
+  );
+  assert.equal(cli.status, 1);
+  assert.equal(cli.stderr, "");
+  assert.deepEqual(JSON.parse(cli.stdout), { status: "retryable_failure" });
+  assert.equal(cli.stdout.trim().split("\n").length, 1);
 });
 
 test("queued publication keeps transient artifact filesystem failures retryable", async (t) => {

--- a/test/repair/exact-review-batch-prepare.test.mjs
+++ b/test/repair/exact-review-batch-prepare.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -69,6 +70,101 @@ test("artifact cache archive rejects corrupted bytes before writing a bundle", (
     archive[archive.length - 1] ^= 0xff;
     assert.throws(() => unpackExactReviewBundle(archive, restored), /file digest mismatch/);
     assert.equal(readFileSync(source + "/bundle.txt", "utf8"), "authoritative bytes\n");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("batch preparation refreshes deterministic invalid live-proof artifacts", () => {
+  const root = mkdtempSync(join(tmpdir(), "exact-review-invalid-live-proof-"));
+  const workspace = join(root, "workspace");
+  const workerRoot = join(root, "worker");
+  const bin = join(root, "bin");
+  const outcomePath = join(workspace, ".artifacts", "exact-review-batch", "outcomes", "item.json");
+  const itemPath = join(root, "item.json");
+  try {
+    mkdirSync(join(workspace, "dist", "repair"), { recursive: true });
+    mkdirSync(bin, { recursive: true });
+    writeFileSync(
+      join(bin, "gh"),
+      `#!/usr/bin/env node
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+const output = process.argv[process.argv.indexOf("--dir") + 1];
+mkdirSync(output, { recursive: true });
+writeFileSync(join(output, "bundle.json"), "{}");
+`,
+      "utf8",
+    );
+    chmodSync(join(bin, "gh"), 0o755);
+    writeFileSync(
+      join(workspace, "dist", "repair", "exact-review-bundle-cli.js"),
+      "process.exitCode = 0;\n",
+      "utf8",
+    );
+    writeFileSync(
+      join(workspace, "dist", "clawsweeper.js"),
+      'console.log(JSON.stringify({ status: "invalid_artifact" })); process.exitCode = 1;\n',
+      "utf8",
+    );
+    writeFileSync(
+      itemPath,
+      JSON.stringify({
+        outcomePath: ".artifacts/exact-review-batch/outcomes/item.json",
+        itemKey: "openclaw/openclaw#42@publish:123:1",
+        revision: 1,
+        claimGeneration: 1,
+        decision: {
+          targetRepo: "openclaw/openclaw",
+          targetBranch: "main",
+          itemNumber: 42,
+          itemKind: "pull_request",
+          publication: {
+            artifactName: "exact-review-123-1",
+            producerRunId: 123,
+            producerRunAttempt: 1,
+            sourceSha: "a".repeat(40),
+            itemKey: "openclaw/openclaw#42",
+            protocolVersion: 2,
+            leaseRevision: 1,
+            claimGeneration: 1,
+            liveProceeded: true,
+            liveTerminalNoop: false,
+            liveTerminalMissing: false,
+            liveGuardedOpen: false,
+            producerDecision: {
+              targetRepo: "openclaw/openclaw",
+              targetBranch: "main",
+              itemNumber: 42,
+              itemKind: "pull_request",
+              sourceEvent: "pull_request",
+              sourceAction: "opened",
+            },
+          },
+        },
+      }),
+      "utf8",
+    );
+
+    const result = spawnSync(
+      process.execPath,
+      ["scripts/prepare-exact-review-batch.mjs", "worker", itemPath, workerRoot, workspace],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${bin}:${process.env.PATH || ""}`,
+          GITHUB_REPOSITORY: "openclaw/clawsweeper",
+          REPO_TOKEN: "test-token",
+        },
+      },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(JSON.parse(readFileSync(outcomePath, "utf8")), {
+      kind: "refresh_required",
+      reasonCode: "invalid_artifact",
+    });
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1331,6 +1331,7 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
 
   const download = step(publisher, "Download exact review artifact bundle");
   const validate = step(publisher, "Validate exact review artifact bundle");
+  const foldLiveProof = step(publisher, "Fold exact live proof into the review artifact");
   const legacyArtifact = step(publisher, "Identify legacy tuple-less exact artifact");
   const targetWriteStep = step(publisher, "Create target write token");
   const stateSetup = publisher.steps.find((candidate) => candidate.uses?.endsWith("/setup-state"));
@@ -1356,12 +1357,27 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
   assert.match(validate.run ?? "", /repair:exact-review-bundle validate/);
   assert.match(validate.if ?? "", /direct_lifecycle_recovery != 'true'/);
   assert.equal(validate["continue-on-error"], true);
+  assert.equal(foldLiveProof.id, "fold-exact-live-proof");
+  assert.equal(foldLiveProof["continue-on-error"], true);
+  assert.match(foldLiveProof.run ?? "", /jq -r/);
+  assert.match(foldLiveProof.run ?? "", /\.status == "invalid_artifact"/);
+  assert.match(foldLiveProof.run ?? "", /GITHUB_OUTPUT/);
   assert.match(legacyArtifact.run ?? "", /review_lease_owner/);
   assert.match(legacyArtifact.run ?? "", /review_lease_comment_id/);
   assert.doesNotMatch(create.run ?? "", /repair:exact-review-bundle -- create/);
   assert.doesNotMatch(validate.run ?? "", /repair:exact-review-bundle -- validate/);
   assert.ok(publisher.steps.indexOf(validate) < publisher.steps.indexOf(targetWriteStep));
   assert.ok(publisher.steps.indexOf(validate) < publisher.steps.indexOf(stateSetup));
+  for (const guardedStep of [
+    legacyArtifact,
+    step(publisher, "Stage validated exact review artifact"),
+    targetWriteStep,
+    stateSetup,
+    step(publisher, "Publish event result and apply safe close"),
+  ]) {
+    assert.match(guardedStep.if ?? "", /fold-exact-live-proof\.outcome == 'success'/);
+    assert.doesNotMatch(guardedStep.if ?? "", /validate-exact-review-bundle/);
+  }
   assert.match(stateSetup.if ?? "", /legacy-exact-artifact\.outputs\.legacy_tupleless != 'true'/);
   assert.match(stateSetup.if ?? "", /direct_lifecycle_recovery != 'true'/);
 
@@ -1453,6 +1469,7 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
   assert.doesNotMatch(publishResult.env?.FAILURE_KIND ?? "", /publication-pressure/);
   assert.match(publishResult.env?.DOWNLOAD_OUTCOME ?? "", /download-exact-review-bundle/);
   assert.match(publishResult.env?.VALIDATE_OUTCOME ?? "", /validate-exact-review-bundle/);
+  assert.match(publishResult.env?.LIVE_PROOF_RESULT ?? "", /fold-exact-live-proof/);
   assert.match(publishResult.env?.PUBLISH_COMPLETION_KIND ?? "", /publish-event-result/);
   assert.match(publishResult.env?.PUBLISH_RETRY_AT ?? "", /publish-event-result/);
   assert.match(publishResult.env?.DIRECT_RECOVERY_OUTCOME ?? "", /replay-direct-lifecycle/);
@@ -1479,6 +1496,66 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
   );
   assert.match(publishResult.run ?? "", /reason_code=artifact_unavailable/);
   assert.match(publishResult.run ?? "", /reason_code=invalid_artifact/);
+  assert.match(
+    publishResult.run ?? "",
+    /LIVE_PROOF_RESULT.*invalid_artifact[\s\S]*completion_kind=refresh_required[\s\S]*reason_code=invalid_artifact/,
+  );
+  const publicationResultRoot = mkdtempSync(`${tmpPrefix}invalid-live-proof-result-`);
+  const publicationResultOutput = join(publicationResultRoot, "github-output");
+  try {
+    execFileSync("bash", ["-c", publishResult.run ?? ""], {
+      env: {
+        ...process.env,
+        PRIOR_JOB_STATUS: "failure",
+        PUBLISH_OUTCOME: "",
+        TERMINAL_NOOP: "",
+        TERMINAL_MISSING: "",
+        TERMINAL_CLOSED: "",
+        GUARDED_OPEN: "",
+        POLICY_NOOP: "",
+        REQUEUE_LATEST: "",
+        LEGACY_TUPLELESS: "",
+        SOURCE_DRIFT_OUTCOME: "",
+        DEFERRED_ROUTE_OUTCOME: "",
+        FAILURE_KIND: "",
+        DOWNLOAD_OUTCOME: "success",
+        VALIDATE_OUTCOME: "success",
+        LIVE_PROOF_RESULT: "invalid_artifact",
+        PUBLISH_COMPLETION_KIND: "",
+        PUBLISH_REASON_CODE: "",
+        PUBLISH_RETRY_AT: "",
+        ERROR_FINGERPRINT: "",
+        STATE_WRITER_JSON: "",
+        DIRECT_RECOVERY_OUTCOME: "",
+        DIRECT_RECOVERY_COMPLETION_KIND: "",
+        DIRECT_RECOVERY_REASON_CODE: "",
+        DIRECT_RECOVERY_REQUEUE_LATEST: "",
+        DIRECT_RECOVERY_DIRECT_REQUEUE: "",
+        REVIEW_ONLY: "false",
+        GITHUB_OUTPUT: publicationResultOutput,
+      },
+    });
+    assert.deepEqual(
+      Object.fromEntries(
+        readFileSync(publicationResultOutput, "utf8")
+          .trim()
+          .split("\n")
+          .map((line) => {
+            const separator = line.indexOf("=");
+            return [line.slice(0, separator), line.slice(separator + 1)];
+          }),
+      ),
+      {
+        outcome: "success",
+        completion_kind: "refresh_required",
+        reason_code: "invalid_artifact",
+        requeue_latest: "",
+        direct_requeue: "false",
+      },
+    );
+  } finally {
+    rmSync(publicationResultRoot, { recursive: true, force: true });
+  }
   assert.doesNotMatch(publishResult.run ?? "", /LIVE_TERMINAL_NOOP/);
   assert.match(publishComplete.run ?? "", /internal\/exact-review\/complete/);
   assert.match(publishComplete.env?.FAILURE_KIND ?? "", /exact-review-publication-result/);

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
   chmodSync,
@@ -1362,6 +1362,75 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
   assert.match(foldLiveProof.run ?? "", /jq -r/);
   assert.match(foldLiveProof.run ?? "", /\.status == "invalid_artifact"/);
   assert.match(foldLiveProof.run ?? "", /GITHUB_OUTPUT/);
+  const foldFixtureRoot = mkdtempSync(`${tmpPrefix}exact-live-proof-fold-`);
+  const fakeBin = join(foldFixtureRoot, "bin");
+  mkdirSync(fakeBin);
+  const fakeNode = join(fakeBin, "node");
+  writeFileSync(
+    fakeNode,
+    '#!/bin/sh\nprintf \'%s\\n\' "$FAKE_NODE_STDOUT"\nexit "${FAKE_NODE_STATUS:-0}"\n',
+    "utf8",
+  );
+  chmodSync(fakeNode, 0o755);
+  try {
+    for (const [index, scenario] of [
+      {
+        name: "published success",
+        stdout: '{"status":"published","results":[]}',
+        commandStatus: 0,
+        expectedStatus: 0,
+        expectedResult: "published",
+      },
+      {
+        name: "invalid artifact",
+        stdout: '{"status":"invalid_artifact"}',
+        commandStatus: 1,
+        expectedStatus: 1,
+        expectedResult: "invalid_artifact",
+      },
+      {
+        name: "retryable failure",
+        stdout: '{"status":"retryable_failure"}',
+        commandStatus: 1,
+        expectedStatus: 1,
+        expectedResult: "retryable_failure",
+      },
+      {
+        name: "nonzero junk",
+        stdout: "not-json",
+        commandStatus: 1,
+        expectedStatus: 1,
+        expectedResult: "retryable_failure",
+      },
+      {
+        name: "zero-exit junk",
+        stdout: "not-json",
+        commandStatus: 0,
+        expectedStatus: 1,
+        expectedResult: "retryable_failure",
+      },
+    ].entries()) {
+      const outputPath = join(foldFixtureRoot, `github-output-${index}`);
+      const execution = spawnSync("bash", ["-c", foldLiveProof.run ?? ""], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FAKE_NODE_STATUS: String(scenario.commandStatus),
+          FAKE_NODE_STDOUT: scenario.stdout,
+          GITHUB_OUTPUT: outputPath,
+          PATH: `${fakeBin}${delimiter}${process.env.PATH ?? ""}`,
+        },
+      });
+      assert.equal(execution.status, scenario.expectedStatus, scenario.name);
+      assert.equal(
+        readFileSync(outputPath, "utf8").trim(),
+        `result=${scenario.expectedResult}`,
+        scenario.name,
+      );
+    }
+  } finally {
+    rmSync(foldFixtureRoot, { recursive: true, force: true });
+  }
   assert.match(legacyArtifact.run ?? "", /review_lease_owner/);
   assert.match(legacyArtifact.run ?? "", /review_lease_comment_id/);
   assert.doesNotMatch(create.run ?? "", /repair:exact-review-bundle -- create/);
@@ -1500,43 +1569,43 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
     publishResult.run ?? "",
     /LIVE_PROOF_RESULT.*invalid_artifact[\s\S]*completion_kind=refresh_required[\s\S]*reason_code=invalid_artifact/,
   );
-  const publicationResultRoot = mkdtempSync(`${tmpPrefix}invalid-live-proof-result-`);
-  const publicationResultOutput = join(publicationResultRoot, "github-output");
-  try {
-    execFileSync("bash", ["-c", publishResult.run ?? ""], {
-      env: {
-        ...process.env,
-        PRIOR_JOB_STATUS: "failure",
-        PUBLISH_OUTCOME: "",
-        TERMINAL_NOOP: "",
-        TERMINAL_MISSING: "",
-        TERMINAL_CLOSED: "",
-        GUARDED_OPEN: "",
-        POLICY_NOOP: "",
-        REQUEUE_LATEST: "",
-        LEGACY_TUPLELESS: "",
-        SOURCE_DRIFT_OUTCOME: "",
-        DEFERRED_ROUTE_OUTCOME: "",
-        FAILURE_KIND: "",
-        DOWNLOAD_OUTCOME: "success",
-        VALIDATE_OUTCOME: "success",
-        LIVE_PROOF_RESULT: "invalid_artifact",
-        PUBLISH_COMPLETION_KIND: "",
-        PUBLISH_REASON_CODE: "",
-        PUBLISH_RETRY_AT: "",
-        ERROR_FINGERPRINT: "",
-        STATE_WRITER_JSON: "",
-        DIRECT_RECOVERY_OUTCOME: "",
-        DIRECT_RECOVERY_COMPLETION_KIND: "",
-        DIRECT_RECOVERY_REASON_CODE: "",
-        DIRECT_RECOVERY_REQUEUE_LATEST: "",
-        DIRECT_RECOVERY_DIRECT_REQUEUE: "",
-        REVIEW_ONLY: "false",
-        GITHUB_OUTPUT: publicationResultOutput,
-      },
-    });
-    assert.deepEqual(
-      Object.fromEntries(
+  const runPublicationResult = (liveProofResult: string) => {
+    const publicationResultRoot = mkdtempSync(`${tmpPrefix}live-proof-result-`);
+    const publicationResultOutput = join(publicationResultRoot, "github-output");
+    try {
+      execFileSync("bash", ["-c", publishResult.run ?? ""], {
+        env: {
+          ...process.env,
+          PRIOR_JOB_STATUS: "failure",
+          PUBLISH_OUTCOME: "",
+          TERMINAL_NOOP: "",
+          TERMINAL_MISSING: "",
+          TERMINAL_CLOSED: "",
+          GUARDED_OPEN: "",
+          POLICY_NOOP: "",
+          REQUEUE_LATEST: "",
+          LEGACY_TUPLELESS: "",
+          SOURCE_DRIFT_OUTCOME: "",
+          DEFERRED_ROUTE_OUTCOME: "",
+          FAILURE_KIND: "",
+          DOWNLOAD_OUTCOME: "success",
+          VALIDATE_OUTCOME: "success",
+          LIVE_PROOF_RESULT: liveProofResult,
+          PUBLISH_COMPLETION_KIND: "",
+          PUBLISH_REASON_CODE: "",
+          PUBLISH_RETRY_AT: "",
+          ERROR_FINGERPRINT: "",
+          STATE_WRITER_JSON: "",
+          DIRECT_RECOVERY_OUTCOME: "",
+          DIRECT_RECOVERY_COMPLETION_KIND: "",
+          DIRECT_RECOVERY_REASON_CODE: "",
+          DIRECT_RECOVERY_REQUEUE_LATEST: "",
+          DIRECT_RECOVERY_DIRECT_REQUEUE: "",
+          REVIEW_ONLY: "false",
+          GITHUB_OUTPUT: publicationResultOutput,
+        },
+      });
+      return Object.fromEntries(
         readFileSync(publicationResultOutput, "utf8")
           .trim()
           .split("\n")
@@ -1544,18 +1613,25 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
             const separator = line.indexOf("=");
             return [line.slice(0, separator), line.slice(separator + 1)];
           }),
-      ),
-      {
-        outcome: "success",
-        completion_kind: "refresh_required",
-        reason_code: "invalid_artifact",
-        requeue_latest: "",
-        direct_requeue: "false",
-      },
-    );
-  } finally {
-    rmSync(publicationResultRoot, { recursive: true, force: true });
-  }
+      );
+    } finally {
+      rmSync(publicationResultRoot, { recursive: true, force: true });
+    }
+  };
+  assert.deepEqual(runPublicationResult("invalid_artifact"), {
+    outcome: "success",
+    completion_kind: "refresh_required",
+    reason_code: "invalid_artifact",
+    requeue_latest: "",
+    direct_requeue: "false",
+  });
+  assert.deepEqual(runPublicationResult("retryable_failure"), {
+    outcome: "failure",
+    completion_kind: "retryable_failure",
+    reason_code: "unknown_failure",
+    requeue_latest: "",
+    direct_requeue: "false",
+  });
   assert.doesNotMatch(publishResult.run ?? "", /LIVE_TERMINAL_NOOP/);
   assert.match(publishComplete.run ?? "", /internal\/exact-review\/complete/);
   assert.match(publishComplete.env?.FAILURE_KIND ?? "", /exact-review-publication-result/);


### PR DESCRIPTION
## What Problem This Solves

Queued exact-review artifacts produced before `plan_sha256` became mandatory
cannot satisfy the current live-proof trust contract. The strict parser
correctly rejects them, but both queued publication paths classified that
deterministic failure as retryable `unknown_failure`, repeatedly consuming
publisher capacity before dead-lettering.

Observed in:

- https://github.com/openclaw/clawsweeper/actions/runs/33138884404

## Solution

- Keep legacy or malformed live proof fail-closed.
- Type only deterministic pre-upload artifact validation failures as
  `invalid_artifact`.
- Preserve media-probe execution, AWS, configuration, network, and upload
  failures as retryable.
- Map invalid artifacts to `refresh_required/invalid_artifact` in the batch and
  single-item queued publishers.
- Reuse the existing queue refresh owner to discard the unusable publication
  reference and regenerate a fresh review under the current producer.

The same-run publisher remains unchanged because its producer and publisher use
the same source contract.

## Review Finding Disposition

The current-head review found that the first validation boundary also converted
`ffprobe` launch, timeout, and invalid-output failures into `invalid_artifact`.
That would regenerate valid artifacts during host/tool failures.

Resolved by:

- introducing `MediaProbeExecutionError` at the media probe owner;
- keeping spawn failures, timeouts, empty output, and invalid JSON retryable;
- preserving numeric `ffprobe` content rejection and content-derived media
  validation as invalid-artifact failures;
- covering both MP4 and poster probes, plus the execution path that retains the
  verification result while omitting failed media.

The next current-head review found that transient artifact filesystem failures
were still folded into the same invalid-artifact wrapper. That would regenerate
valid artifacts during host I/O or file-descriptor pressure.

Resolved by:

- preserving syscall-bearing host failures such as `EIO`, `EMFILE`, and
  `ESTALE` on the retry path;
- keeping deterministic path and artifact-form errors such as `ENOENT`,
  `ENOTDIR`, `EISDIR`, and size overflows classified as invalid;
- covering missing verification and media files as invalid controls without
  adding filesystem mocks or test-only production seams.

The following exact-head review found that the single-item workflow lost
retryable publication exceptions at the CLI boundary. The command printed a
stack trace instead of JSON, and the workflow exported an unknown result that
the finalizer mislabeled as a permanent failure.

Resolved by:

- emitting one structured `retryable_failure` result from the publication CLI
  without weakening the programmatic exception contract;
- validating command status and JSON together so malformed, unknown, or
  contradictory output fails closed as retryable;
- mapping that result to `retryable_failure/unknown_failure` in the single-item
  finalizer, matching the existing batch publisher;
- executing the workflow shell in regression tests for published, invalid,
  retryable, nonzero-junk, and zero-exit-junk outcomes.

## User Impact

Old queued proofs no longer churn through useless retries or dead-letter without
recovery. ClawSweeper regenerates them under the current proof contract without
trusting or synthesizing missing digest data. Temporary media-validator failures
retain the existing retry path instead of discarding valid review artifacts or
printing internal stack traces into operator-facing output.

## Verification

- Pre-fix regression reproduced the missing `plan_sha256` parser failure and
  the incorrect retryable completion.
- Pre-fix probe regression reproduced four transient validator failures being
  classified as invalid artifacts; numeric content rejection already followed
  the intended invalid-artifact path.
- Pre-fix CLI/workflow regression reproduced stack-trace stderr, missing result
  JSON, and the final `permanent_failure/unknown_failure` misclassification.
- `test/live-proof.test.ts`: 140 passed.
- `test/repair/exact-review-batch-prepare.test.mjs`: 5 passed.
- `test/sweep-workflow.test.ts`: 125 passed.
- `test/dashboard-worker-queue-runtime.test.ts`: 147 passed.
- `test/exact-review-publication-batches.test.ts`: 70 passed.
- TypeScript builds passed for runtime, repair, and dashboard projects.
- Oxfmt, Oxlint, and `git diff --check` passed.
- Structured Autoreview was attempted, but the local Codex CLI could not start.

## Real Behavior Proof

- **Claim:** the exact PR head emits structured retryable CLI output and the
  single-item workflow preserves published, invalid, retryable, and malformed
  command outcomes.
- **Provider:** AWS-backed Crabbox, fresh PR checkout.
- **Head:** `1f8e83a08256b7ea54ff71f28e391c2ff0d144e1`.
- **Lease:** `cbx_c2c518c270b1` on `c7a.8xlarge`; released after the run.
- **Run:** `run_99f7f4ae6a1d`
  (`https://crabbox.openclaw.ai/portal/runs/run_99f7f4ae6a1d`).
- **Container:** Docker 29.7.1 running `node:24-bookworm`; limited to 4 CPUs and
  8 GB RAM. The container installed `jq`, the dependency used by the workflow
  shell under test.
- **Artifact:** generated Crabbox proof block plus captured stdout/stderr for
  the run above.
- **Observed result:** `pnpm run build:all` passed; 18 focused live-proof/CLI
  assertions passed; the executable single-item workflow assertion passed; all
  5 batch-preparation assertions passed. Final marker:
  `CRABBOX_PROOF_PASS head=1f8e83a08256b7ea54ff71f28e391c2ff0d144e1 image=node:24-bookworm cpus=4 memory=8g`.
- **Limits:** this proves the CLI and workflow classification path in a clean
  Linux container. It does not perform a live GitHub publication or mutate the
  queue.

## Hosted Proof Target

The full `pnpm run check` gate is green in CI but exceeds the bounded live-proof
window. The focused cold-checkout proof for the repaired behavior is:

```bash
pnpm run build:all &&
node --test \
  --test-name-pattern='queued publication classifies legacy verification|queued publication leaves AWS|queued publication keeps media probe execution failures retryable|queued publication keeps transient artifact filesystem failures retryable|missing verification remains an invalid artifact|missing live proof media remains an invalid publication artifact|live-proof keeps verification when the media probe cannot execute' \
  test/live-proof.test.ts &&
node --test \
  --test-name-pattern='exact event review publishes directly with a queue-bounded canonical fallback' \
  test/sweep-workflow.test.ts &&
node --test test/repair/exact-review-batch-prepare.test.mjs
```

The observable result is the passing legacy-verification, transient-upload,
media-probe, filesystem, CLI-output, and workflow-finalizer classification
tests. They exercise the real `live-proof-publish-artifacts` CLI boundary and
the single-item workflow shell contract.

## Change Shape

- Production/tooling: +97 net lines.
- Tests: +662 net lines.
- No parser fallback, schema, persistence, retry-policy, Bay, docs, or changelog
  change.

The positive production delta introduces the typed validation boundary and
connects both queued publishers to the existing regeneration lifecycle. It does
not add a compatibility reader or parallel runtime path.

OpenClaw Bay is unaffected: the lifecycle values and observer-facing schemas are
unchanged.

Fixes #1276.
