### PR TITLE
fix(review): preserve non-executable live-proof reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Preserved empty-step live-proof plans through report rendering and inspection, with explicit JSON empty arrays and strict compatibility for existing solitary `- none` reports.
 - Added schema constraints and explicit prompt guidance for single-line live-proof commands and nonblank run steps while preserving strict parsing.
 - Scoped the `openclaw/openclaw` release-note review restriction to its repository profile so ClawSweeper and other targets follow their own policies without granting release-file edit permission.
 - Routed default apply's bounded source-drift refreshes through exact-event queue intake so full-repository hydration cannot fail before admission.

--- a/docs/live-proof.md
+++ b/docs/live-proof.md
@@ -124,13 +124,15 @@ Persisted reports encode empty steps as `Steps:` followed by a blank line and
 the bare JSON array `[]`. Nonempty steps remain one JSON object per Markdown
 bullet. The renderer/report-parser boundary retains the **legacy-empty-list-v1**
 contract for already-produced reports: a solitary `- none` also means no steps.
-Only surrounding whitespace is ignored; case variants, quoted sentinels,
+Only surrounding payload whitespace is ignored; case variants, quoted sentinels,
 list-wrapped arrays, mixed or duplicated empty markers, missing payloads, and
 malformed or extra step text fail closed. Exactly one `Steps:` payload is
 required. It ends at the next report section or an exact standalone
 `<!-- clawsweeper-live-verification -->` or
-`<!-- clawsweeper-live-proof-recording -->` attachment marker. Those production
-suffixes are not steps; attached verification keeps its separate validation.
+`<!-- clawsweeper-live-proof-recording -->` attachment marker. Markers must match
+raw lines exactly (LF or CRLF); leading or trailing whitespace is not ignored,
+including at the section or report end. Those production suffixes are not steps;
+attached verification keeps its separate validation.
 Both empty formats still pass through decision validation, so a `recommended`
 plan with no steps remains invalid and inspection rejects it before execution.
 

--- a/docs/live-proof.md
+++ b/docs/live-proof.md
@@ -120,6 +120,20 @@ source strings are distinct from literal newlines in the decoded command.
 Browser entries remain URL paths; nonrecommended plans use an empty entry and
 no steps.
 
+Persisted reports encode empty steps as `Steps:` followed by a blank line and
+the bare JSON array `[]`. Nonempty steps remain one JSON object per Markdown
+bullet. The renderer/report-parser boundary retains the **legacy-empty-list-v1**
+contract for already-produced reports: a solitary `- none` also means no steps.
+Only surrounding whitespace is ignored; case variants, quoted sentinels,
+list-wrapped arrays, mixed or duplicated empty markers, missing payloads, and
+malformed or extra step text fail closed. Exactly one `Steps:` payload is
+required. It ends at the next report section or an exact standalone
+`<!-- clawsweeper-live-verification -->` or
+`<!-- clawsweeper-live-proof-recording -->` attachment marker. Those production
+suffixes are not steps; attached verification keeps its separate validation.
+Both empty formats still pass through decision validation, so a `recommended`
+plan with no steps remains invalid and inspection rejects it before execution.
+
 The [decision schema](../schema/clawsweeper-decision.schema.json) constrains
 these strings with ordinary anchored character classes, not regex lookaround
 (which the structured-output provider rejects). The parser remains the final

--- a/src/clawsweeper-report-document.ts
+++ b/src/clawsweeper-report-document.ts
@@ -307,7 +307,9 @@ export function createReportDocumentRendering(
       "",
       "Steps:",
       "",
-      markdownList(decision.liveProofPlan.steps.map((step) => JSON.stringify(step))),
+      decision.liveProofPlan.steps.length
+        ? markdownList(decision.liveProofPlan.steps.map((step) => JSON.stringify(step)))
+        : "[]",
     ].join("\n");
   }
 

--- a/src/clawsweeper-report-parser.ts
+++ b/src/clawsweeper-report-parser.ts
@@ -12,6 +12,7 @@ import {
   IMPLEMENTATION_COMPLEXITIES,
   IMPACT_LABEL_NAMES,
   LIVE_PROOF_RECORDING_MARKER,
+  LIVE_VERIFICATION_MARKER,
   MANTIS_RECOMMENDATION_SCENARIOS,
   MANTIS_RECOMMENDATION_STATUSES,
   MATURITY_LABEL_NAMES,
@@ -129,7 +130,6 @@ const parseRecordedLiveProofPlan = createDecisionParser({
 
 export function reportLiveProofPlan(markdown: string): LiveProofPlan {
   const section = reportSectionValue(markdown, LIVE_PROOF_SECTION_HEADING);
-  const rawSteps = reportSectionList(section, "Steps");
   const status = reportSectionLineValue(section, "Status");
   const surface = reportSectionLineValue(section, "Surface");
   const terminalCompletion =
@@ -147,7 +147,7 @@ export function reportLiveProofPlan(markdown: string): LiveProofPlan {
           justification: reportSectionLineValue(section, "Payoff justification"),
         },
         entry: reportSectionLineValue(section, "Entry") ?? "",
-        steps: rawSteps.map((step) => JSON.parse(step) as unknown),
+        steps: reportLiveProofSteps(section),
       },
       "report.liveProofPlan",
     );
@@ -186,20 +186,25 @@ function reportSectionLineValue(section: string, label: string): string | undefi
   return undefined;
 }
 
-function reportSectionList(section: string, label: string): string[] {
-  const lines = section.split("\n");
-  const start = lines.findIndex((line) => line.trim() === `${label}:`);
-  if (start === -1) return [];
-  const values: string[] = [];
-  for (let index = start + 1; index < lines.length; index += 1) {
-    const line = lines[index]!;
-    if (/^[A-Z][A-Za-z -]+:/.test(line)) break;
-    const trimmed = line.trimStart();
-    if (!trimmed.startsWith("- ")) continue;
-    const item = trimmed.slice(2).trim();
-    if (item) values.push(item);
+function reportLiveProofSteps(section: string): unknown[] {
+  const lines = section.split("\n").map((line) => line.trim());
+  // Publication appends these owned blocks after the plan in the same section.
+  const attachmentStart = lines.findIndex(
+    (line) => line === LIVE_VERIFICATION_MARKER || line === LIVE_PROOF_RECORDING_MARKER,
+  );
+  const planLines = attachmentStart < 0 ? lines : lines.slice(0, attachmentStart);
+  const start = planLines.indexOf("Steps:");
+  if (start < 0 || planLines.lastIndexOf("Steps:") !== start) {
+    throw new Error("live-proof report requires exactly one Steps payload");
   }
-  return values;
+  const payload = planLines.slice(start + 1).filter(Boolean);
+  // legacy-empty-list-v1: already-produced reports used a solitary "- none".
+  if (payload.length === 1 && (payload[0] === "[]" || payload[0] === "- none")) return [];
+  if (!payload.length) throw new Error("live-proof report is missing its Steps payload");
+  return payload.map((line) => {
+    if (!line.startsWith("- ")) throw new Error("live-proof report step must be a JSON list item");
+    return JSON.parse(line.slice(2)) as unknown;
+  });
 }
 
 function neutralizeLiveProofText(value: string): string {

--- a/src/clawsweeper-report-parser.ts
+++ b/src/clawsweeper-report-parser.ts
@@ -170,15 +170,16 @@ export function reportLiveProofPlan(markdown: string): LiveProofPlan {
 }
 
 function reportSectionValue(markdown: string, heading: string): string {
+  // Preserve marker whitespace and never separate a final CRLF pair.
   const match = markdown.match(
-    new RegExp(`(?:^|\\n)## ${heading}\\n\\n([\\s\\S]*?)(?=\\n## |\\n?$)`),
+    new RegExp(`(?:^|\\n)## ${heading}\\n\\n([\\s\\S]*?)(?=\\r?\\n## |$)`),
   );
-  return match?.[1]?.trim() ?? "";
+  return match?.[1] ?? "";
 }
 
 function reportSectionLineValue(section: string, label: string): string | undefined {
   const prefix = `${label}:`;
-  for (const line of section.split("\n")) {
+  for (const line of section.trim().split("\n")) {
     if (!line.startsWith(prefix)) continue;
     const value = line.slice(prefix.length).trim();
     return value || undefined;
@@ -187,12 +188,14 @@ function reportSectionLineValue(section: string, label: string): string | undefi
 }
 
 function reportLiveProofSteps(section: string): unknown[] {
-  const lines = section.split("\n").map((line) => line.trim());
-  // Publication appends these owned blocks after the plan in the same section.
+  const lines = section.split(/\r?\n/);
+  // Match raw attachment lines exactly, as the verification parser does.
   const attachmentStart = lines.findIndex(
     (line) => line === LIVE_VERIFICATION_MARKER || line === LIVE_PROOF_RECORDING_MARKER,
   );
-  const planLines = attachmentStart < 0 ? lines : lines.slice(0, attachmentStart);
+  const planLines = (attachmentStart < 0 ? lines : lines.slice(0, attachmentStart)).map((line) =>
+    line.trim(),
+  );
   const start = planLines.indexOf("Steps:");
   if (start < 0 || planLines.lastIndexOf("Steps:") !== start) {
     throw new Error("live-proof report requires exactly one Steps payload");

--- a/test/live-proof-report.test.ts
+++ b/test/live-proof-report.test.ts
@@ -1,0 +1,271 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  parseDecision,
+  renderLiveProofReportSectionForTest,
+  reportLiveProofPlan,
+} from "../dist/clawsweeper.js";
+import {
+  LIVE_PROOF_RECORDING_MARKER,
+  LIVE_VERIFICATION_MARKER,
+} from "../dist/clawsweeper-policy.js";
+import type { LiveProofPlan } from "../dist/clawsweeper-types.js";
+import {
+  executeReviewLiveProofs,
+  inspectReviewLiveProofs,
+} from "../dist/live-proof/review-artifacts.js";
+import {
+  buildLiveVerificationResult,
+  encodeLiveVerificationReportPayload,
+  parseAttachedLiveVerification,
+} from "../dist/live-proof/verification.js";
+import { repositoryProfileFor } from "../dist/repository-profiles.js";
+import { closeDecision, reportFrontMatter } from "./helpers.ts";
+
+const HEAD = "a".repeat(40);
+const EMPTY_INSPECTION = {
+  candidates: [],
+  recordMedia: false,
+  requiresBrowser: false,
+  requiresTerminal: false,
+};
+
+function noExecutionPlan(status: "declined_suspicious" | "not_applicable"): LiveProofPlan {
+  return {
+    status,
+    surface: "none",
+    terminalCompletion: "not_applicable",
+    reason: "This synthetic plan must not execute.",
+    payoff: { kind: "static_text", justification: "No execution or recording is needed." },
+    entry: "",
+    steps: [],
+  };
+}
+
+function renderedReport(plan: LiveProofPlan, suffix = ""): string {
+  const decision = parseDecision(closeDecision({ liveProofPlan: plan }));
+  assert.deepEqual(decision.liveProofPlan, plan);
+  return `${reportFrontMatter({ repository: "openclaw/clawsweeper", type: "pull_request", number: 42, pull_head_sha: HEAD })}\n## Live Proof\n\n${renderLiveProofReportSectionForTest(decision)}${suffix}\n\n## Work Candidate\n\nCandidate: none\n`;
+}
+
+function withSteps(report: string, payload: string): string {
+  return report.replace(/Steps:\n\n[\s\S]*?(?=\n\n## Work Candidate)/, `Steps:\n\n${payload}`);
+}
+
+function reviewFixture(t: test.TestContext) {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-report-steps-"));
+  t.after(() => rmSync(root, { force: true, recursive: true }));
+  const options = {
+    recordsDir: root,
+    itemNumbers: [42],
+    repo: "openclaw/clawsweeper",
+    get checkoutPath(): string {
+      assert.fail("must not access a target checkout");
+    },
+    get outputRoot(): string {
+      assert.fail("must not access an output directory");
+    },
+    get entrypoint(): string {
+      assert.fail("must not launch a proof child");
+    },
+  };
+  const dependencies = {
+    repositoryProfileFor,
+    reportLiveProofPlan,
+    frontMatterValue: (markdown: string, key: string) =>
+      new RegExp(`^${key}:\\s*(.*)$`, "m").exec(markdown)?.[1]?.trim(),
+  };
+  assert.equal(repositoryProfileFor(options.repo).liveTest?.enabled, true);
+  return {
+    write: (report: string) => writeFileSync(join(root, "42.md"), report),
+    inspect: () => inspectReviewLiveProofs(options, dependencies),
+    execute: () => executeReviewLiveProofs(options, dependencies),
+    assertRecordsOnly: () => assert.deepEqual(readdirSync(root), ["42.md"]),
+  };
+}
+
+test("non-executable plans roundtrip through the production renderer and skip review execution", (t) => {
+  const fixture = reviewFixture(t);
+  for (const status of ["declined_suspicious", "not_applicable"] as const) {
+    const plan = noExecutionPlan(status);
+    const report = renderedReport(plan);
+    assert.match(report, /Steps:\n\n\[\]\n\n## Work Candidate/);
+    for (const payload of ["[]", "- none", " \t[] \t\n", "\n \t- none \t\n"]) {
+      const persisted = withSteps(report, payload);
+      assert.deepEqual(reportLiveProofPlan(persisted), plan, `${status}: ${payload}`);
+      fixture.write(persisted);
+      assert.deepEqual(fixture.inspect(), EMPTY_INSPECTION);
+      assert.deepEqual(fixture.execute(), EMPTY_INSPECTION);
+      fixture.assertRecordsOnly();
+    }
+  }
+});
+
+test("malformed or ambiguous Steps payloads reject before review execution", (t) => {
+  const fixture = reviewFixture(t);
+  const step = '- {"action":"expect_output","text":"synthetic"}';
+  const invalidPayloads = {
+    "mixed sentinel and step": `- none\n${step}`,
+    "step before sentinel": `${step}\n- none`,
+    "duplicate sentinel": "- none\n- none",
+    "mixed array and step": `[]\n${step}`,
+    "step before array": `${step}\n[]`,
+    "duplicate array": "[]\n[]",
+    "mixed empty markers": "[]\n- none",
+    "reverse mixed markers": "- none\n[]",
+    "array and text": "[]\nunknown",
+    "sentinel and text": "- none\nunknown",
+    "uppercase sentinel": "- None",
+    "quoted sentinel": '- "none"',
+    "sentinel substring": "- nonetheless",
+    "bare sentinel": "none",
+    "extra sentinel spacing": "-  none",
+    "bullet array": "- []",
+    "noncanonical array": "[ ]",
+    "unknown text": "unknown",
+    "non-JSON row": "- broken",
+    "malformed JSON": "- {",
+    "wrong step type": "- 17",
+    "null step": "- null",
+    "unknown action": '- {"action":"unknown"}',
+    "missing command": '- {"action":"run"}',
+    "multiline command": '- {"action":"run","command":"first\\nsecond"}',
+    "empty payload": "",
+    "empty bullet": "- ",
+    "duplicate Steps label": "[]\nSteps:\n[]",
+    "unknown field": "[]\nUnexpected: ignored",
+    "step and unknown text": `${step}\nunknown`,
+    "unbulleted step": '{"action":"expect_output","text":"synthetic"}',
+    "inline verification marker": `[]\ntext ${LIVE_VERIFICATION_MARKER}`,
+    "inexact recording marker": `[]\n${LIVE_PROOF_RECORDING_MARKER} text`,
+  };
+  const plans: LiveProofPlan[] = [
+    noExecutionPlan("declined_suspicious"),
+    noExecutionPlan("not_applicable"),
+    {
+      ...noExecutionPlan("not_applicable"),
+      status: "recommended",
+      surface: "terminal",
+      terminalCompletion: "exit_zero",
+      entry: "must-never-execute",
+      steps: [{ action: "expect_output", text: "synthetic" }],
+    },
+  ];
+  for (const plan of plans) {
+    const report = renderedReport(plan);
+    const cases = [
+      ...Object.entries(invalidPayloads).map(([name, payload]) => [
+        name,
+        withSteps(report, payload),
+      ]),
+      ["missing Steps label", withSteps(report, "").replace("Steps:\n\n", "")],
+      [
+        "attachment without steps",
+        withSteps(report, `${LIVE_VERIFICATION_MARKER}\nResult: absent`),
+      ],
+    ];
+    for (const [name, malformed] of cases) {
+      assert.equal(reportLiveProofPlan(malformed!).invalid, true, `${plan.status}: ${name}`);
+      fixture.write(malformed!);
+      assert.throws(fixture.inspect, /live proof plan for 42 is invalid/);
+      assert.throws(fixture.execute, /live proof plan for 42 is invalid/);
+      fixture.assertRecordsOnly();
+    }
+  }
+});
+
+test("recommended plans still reject both empty report formats", (t) => {
+  const fixture = reviewFixture(t);
+  for (const surface of ["browser", "terminal"] as const) {
+    const plan: LiveProofPlan = {
+      ...noExecutionPlan("not_applicable"),
+      status: "recommended",
+      surface,
+      terminalCompletion: surface === "terminal" ? "exit_zero" : "not_applicable",
+      entry: surface === "terminal" ? "must-never-execute" : "/synthetic",
+      steps: [],
+    };
+    assert.throws(
+      () => parseDecision(closeDecision({ liveProofPlan: plan })),
+      /steps must not be empty/,
+    );
+    const report = renderedReport({
+      ...plan,
+      steps: [
+        surface === "terminal"
+          ? { action: "expect_output", text: "synthetic" }
+          : { action: "expect_text", text: "synthetic" },
+      ],
+    });
+    for (const payload of ["[]", "- none"]) {
+      const malformed = withSteps(report, payload);
+      assert.equal(reportLiveProofPlan(malformed).invalid, true);
+      fixture.write(malformed);
+      assert.throws(fixture.inspect, /live proof plan for 42 is invalid/);
+      assert.throws(fixture.execute, /live proof plan for 42 is invalid/);
+    }
+  }
+});
+
+test("nonempty report steps preserve command order and attached verification/recording suffixes", () => {
+  const plan: LiveProofPlan = {
+    ...noExecutionPlan("not_applicable"),
+    status: "recommended",
+    surface: "terminal",
+    terminalCompletion: "exit_zero",
+    entry: "synthetic-command",
+    steps: [
+      { action: "run", command: "synthetic-command" },
+      { action: "expect_output", text: `none [] ${LIVE_VERIFICATION_MARKER}` },
+      { action: "run", command: "synthetic-command" },
+    ],
+  };
+  const verification = buildLiveVerificationResult({
+    repo: "openclaw/clawsweeper",
+    item: 42,
+    headSha: HEAD,
+    plan,
+    driveStatus: "completed",
+    stepLog: plan.steps.map((step) => ({
+      action: step.action,
+      status: "completed",
+      detail: "Synthetic outcome.",
+      presentAtStart: false,
+      satisfied: true,
+    })),
+    output: "Synthetic output.",
+    verifiedAt: "2026-08-27T00:00:00.000Z",
+  });
+  const verificationBlock = `${LIVE_VERIFICATION_MARKER}\nResult: ${encodeLiveVerificationReportPayload(verification)}`;
+  const recordingBlock = `${LIVE_PROOF_RECORDING_MARKER}\n\n[![Live proof recording](https://media.example.test/poster.jpg)](https://media.example.test/proof.mp4)\n\n*Recorded live on the PR head (\`${HEAD.slice(0, 12)}\`), 4s, terminal surface.*`;
+  for (const suffix of [
+    "",
+    `\n\n${verificationBlock}`,
+    `\n\n${recordingBlock}`,
+    `\n\n${verificationBlock}\n\n${recordingBlock}`,
+  ]) {
+    const report = renderedReport(plan, suffix);
+    assert.match(report, /Steps:\n\n- \{"action":"run"/);
+    assert.deepEqual(reportLiveProofPlan(report), plan);
+    if (suffix.includes(verificationBlock)) {
+      const section = report.split("## Live Proof\n\n")[1]!.split("\n\n## Work Candidate")[0]!;
+      assert.equal(
+        parseAttachedLiveVerification(
+          section,
+          {
+            repository: "openclaw/clawsweeper",
+            number: "42",
+            type: "pull_request",
+            pullHeadSha: HEAD,
+          },
+          plan,
+        ).status,
+        "passed",
+      );
+    }
+  }
+});

--- a/test/live-proof-report.test.ts
+++ b/test/live-proof-report.test.ts
@@ -56,6 +56,33 @@ function withSteps(report: string, payload: string): string {
   return report.replace(/Steps:\n\n[\s\S]*?(?=\n\n## Work Candidate)/, `Steps:\n\n${payload}`);
 }
 
+function reportBoundaryVariants(report: string): [string, string][] {
+  const [prefix, body] = report.split("## Live Proof\n\n");
+  const section = body!.split("\n\n## Work Candidate")[0]!;
+  return ["\n", "\r\n"].flatMap((newline) => {
+    // Keep the existing LF heading grammar; vary the body and attachment line endings.
+    const raw = `${prefix}## Live Proof\n\n${section.replaceAll("\n", newline)}`;
+    return Object.entries({
+      eof: "",
+      "final-newline": newline,
+      "next-section": `${newline}## Work Candidate${newline}${newline}Candidate: none${newline}`,
+    }).map(([ending, suffix]) => [`${JSON.stringify(newline)} ${ending}`, raw + suffix]);
+  });
+}
+
+function attachedVerificationStatus(report: string, plan: LiveProofPlan) {
+  return parseAttachedLiveVerification(
+    report.split("## Live Proof\n\n")[1]!,
+    {
+      repository: "openclaw/clawsweeper",
+      number: "42",
+      type: "pull_request",
+      pullHeadSha: HEAD,
+    },
+    plan,
+  ).status;
+}
+
 function reviewFixture(t: test.TestContext) {
   const root = mkdtempSync(join(tmpdir(), "clawsweeper-report-steps-"));
   t.after(() => rmSync(root, { force: true, recursive: true }));
@@ -95,13 +122,28 @@ test("non-executable plans roundtrip through the production renderer and skip re
     const report = renderedReport(plan);
     assert.match(report, /Steps:\n\n\[\]\n\n## Work Candidate/);
     for (const payload of ["[]", "- none", " \t[] \t\n", "\n \t- none \t\n"]) {
-      const persisted = withSteps(report, payload);
-      assert.deepEqual(reportLiveProofPlan(persisted), plan, `${status}: ${payload}`);
-      fixture.write(persisted);
-      assert.deepEqual(fixture.inspect(), EMPTY_INSPECTION);
-      assert.deepEqual(fixture.execute(), EMPTY_INSPECTION);
-      fixture.assertRecordsOnly();
+      for (const [boundary, persisted] of reportBoundaryVariants(withSteps(report, payload))) {
+        assert.deepEqual(
+          reportLiveProofPlan(persisted),
+          plan,
+          `${status}: ${payload}: ${boundary}`,
+        );
+        fixture.write(persisted);
+        assert.deepEqual(fixture.inspect(), EMPTY_INSPECTION);
+        assert.deepEqual(fixture.execute(), EMPTY_INSPECTION);
+        fixture.assertRecordsOnly();
+      }
     }
+  }
+});
+
+test("plan labels retain whitespace tolerance without normalizing attachment lines", () => {
+  const plan = noExecutionPlan("not_applicable");
+  const rendered = renderedReport(plan)
+    .replace("Status:", " \tStatus:")
+    .replace("Steps:\n", " \tSteps: \t\n");
+  for (const [boundary, report] of reportBoundaryVariants(rendered)) {
+    assert.deepEqual(reportLiveProofPlan(report), plan, boundary);
   }
 });
 
@@ -178,6 +220,69 @@ test("malformed or ambiguous Steps payloads reject before review execution", (t)
   }
 });
 
+test("padded attachment markers reject before inspection or execution at raw section boundaries", (t) => {
+  const fixture = reviewFixture(t);
+  const plans: LiveProofPlan[] = [
+    noExecutionPlan("declined_suspicious"),
+    noExecutionPlan("not_applicable"),
+    {
+      ...noExecutionPlan("not_applicable"),
+      status: "recommended",
+      surface: "terminal",
+      terminalCompletion: "exit_zero",
+      entry: "must-never-execute",
+      steps: [{ action: "expect_output", text: "synthetic" }],
+    },
+  ];
+  for (const plan of plans) {
+    for (const marker of [LIVE_VERIFICATION_MARKER, LIVE_PROOF_RECORDING_MARKER]) {
+      for (const whitespace of [" ", "\t", "\u00a0"]) {
+        for (const padded of [whitespace + marker, marker + whitespace]) {
+          for (const trailer of ["", "\nnot-a-step"]) {
+            for (const [boundary, malformed] of reportBoundaryVariants(
+              renderedReport(plan, `\n\n${padded}${trailer}`),
+            )) {
+              const context = `${plan.status}: ${JSON.stringify(padded + trailer)}: ${boundary}`;
+              assert.equal(attachedVerificationStatus(malformed, plan), "absent", context);
+              assert.equal(reportLiveProofPlan(malformed).invalid, true, context);
+              fixture.write(malformed);
+              assert.throws(fixture.inspect, /live proof plan for 42 is invalid/, context);
+              assert.throws(fixture.execute, /live proof plan for 42 is invalid/, context);
+              fixture.assertRecordsOnly();
+            }
+          }
+        }
+      }
+      // A terminal lone CR is not a CRLF line ending and must not become an exact marker.
+      const malformed = reportBoundaryVariants(renderedReport(plan, `\n\n${marker}\r`))[0]![1];
+      assert.equal(attachedVerificationStatus(malformed, plan), "absent");
+      assert.equal(reportLiveProofPlan(malformed).invalid, true);
+      fixture.write(malformed);
+      assert.throws(fixture.inspect, /live proof plan for 42 is invalid/);
+      assert.throws(fixture.execute, /live proof plan for 42 is invalid/);
+      fixture.assertRecordsOnly();
+    }
+  }
+});
+
+test("exact raw markers delimit steps while malformed attachment validation stays separate", () => {
+  const plan = noExecutionPlan("not_applicable");
+  for (const marker of [LIVE_VERIFICATION_MARKER, LIVE_PROOF_RECORDING_MARKER]) {
+    for (const trailer of ["", "\nnot-a-step"]) {
+      for (const [boundary, report] of reportBoundaryVariants(
+        renderedReport(plan, `\n\n${marker}${trailer}`),
+      )) {
+        assert.deepEqual(reportLiveProofPlan(report), plan, boundary);
+        assert.equal(
+          attachedVerificationStatus(report, plan),
+          marker === LIVE_VERIFICATION_MARKER ? "malformed" : "absent",
+          boundary,
+        );
+      }
+    }
+  }
+});
+
 test("recommended plans still reject both empty report formats", (t) => {
   const fixture = reviewFixture(t);
   for (const surface of ["browser", "terminal"] as const) {
@@ -248,24 +353,13 @@ test("nonempty report steps preserve command order and attached verification/rec
     `\n\n${recordingBlock}`,
     `\n\n${verificationBlock}\n\n${recordingBlock}`,
   ]) {
-    const report = renderedReport(plan, suffix);
-    assert.match(report, /Steps:\n\n- \{"action":"run"/);
-    assert.deepEqual(reportLiveProofPlan(report), plan);
-    if (suffix.includes(verificationBlock)) {
-      const section = report.split("## Live Proof\n\n")[1]!.split("\n\n## Work Candidate")[0]!;
-      assert.equal(
-        parseAttachedLiveVerification(
-          section,
-          {
-            repository: "openclaw/clawsweeper",
-            number: "42",
-            type: "pull_request",
-            pullHeadSha: HEAD,
-          },
-          plan,
-        ).status,
-        "passed",
-      );
+    const rendered = renderedReport(plan, suffix);
+    assert.match(rendered, /Steps:\n\n- \{"action":"run"/);
+    for (const [boundary, report] of reportBoundaryVariants(rendered)) {
+      assert.deepEqual(reportLiveProofPlan(report), plan, boundary);
+      if (suffix.includes(verificationBlock)) {
+        assert.equal(attachedVerificationStatus(report, plan), "passed", boundary);
+      }
     }
   }
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a valid non-executable live-proof plan caused ClawSweeper's review job to fail before it could finish publishing the review. Both `declined_suspicious` and `not_applicable` plans legitimately have an empty entry and no steps. The report renderer wrote that empty list as `- none`, but the report parser tried to JSON-parse `none` and marked the plan invalid before the inspector reached its normal no-execution skip.

This was observed in the retained report from [the earlier PR 1269 review run](https://github.com/openclaw/clawsweeper/actions/runs/33127843733). That PR's unrelated findings were subsequently fixed and merged; this follow-up does not alter [PR 1269](https://github.com/openclaw/clawsweeper/pull/1269) or the separate [single-line generation fix](https://github.com/openclaw/clawsweeper/pull/1268).

## Why This Change Was Made

The fix belongs at the report renderer/parser boundary. New reports encode empty `Steps:` as bare `[]`; nonempty steps keep their existing JSON-object-per-bullet encoding. The named `legacy-empty-list-v1` contract preserves already-produced reports containing a solitary `- none`, with surrounding whitespace allowed.

The dedicated payload parser accepts exactly one complete representation. Missing, malformed, mixed, duplicated, or noncanonical empty payloads fail closed. Only exact standalone production verification/recording markers delimit an attached suffix; its validation remains with the existing owner. The decision parser still validates the result, so recommended plans with empty steps remain invalid. The inspector's invalid-plan-before-skip guard, execution gates, strict command parsing, terminal completion, one-shot sequencing, and attached-verification guards are unchanged.

## User Impact

Valid declined or non-applicable plans survive persisted-report inspection and execution orchestration without launching anything. Their review results can proceed through the existing publication path rather than failing on an empty-list formatting mismatch. Malformed plans still fail before target work starts; this does not create an execution fallback or permission.

## OpenClaw Bay Impact

None. Observer schemas, public APIs, lifecycle states, dashboard projections, and publication ownership do not change. This is an internal persisted-report codec correction.

## Documentation Impact

Updated the active `docs/live-proof.md` runbook with the canonical empty representation, the narrowly scoped legacy contract, strict rejection rules, and attachment boundaries; added a one-line changelog entry. Reviewed `AGENTS.md` and `CONTRIBUTING.md`. No policy, schema-version, dependency, configuration, or workflow changes.

## Review Finding Disposition

Accepted and corrected [P2: Match attachment-marker parsing exactly](https://github.com/openclaw/clawsweeper/pull/1277#issuecomment-5449061591). At the previous head `fae183ab38e015259231bc762420e7efe112c9c2`, the plan parser trimmed marker lines (and the outer section), while attached verification required exact raw lines. Parent reproduction confirmed three malformed reports were admitted as candidate 42 even though verification reported the marker absent.

The correction preserves raw section boundaries, including EOF and CRLF pairs, and matches raw marker lines before trimming only scalar/Steps payload data. The existing verifier, inspector and execution guards are unchanged. Added regression coverage spans leading/trailing spaces, tabs and Unicode whitespace; both marker types; LF/CRLF; report EOF and next-section boundaries; exact-marker positive controls; and separate malformed-attachment validation ownership. The original three report fixtures were replayed unchanged and now fail closed in both real CLI modes. No bot autofix/automerge command or policy override was used.

## Evidence

- **145 focused tests passed**, with no failures or skips, covering the new codec cases and existing decision/live-proof behavior. Builds, static checks, lint, formatting, documentation checks, and diff whitespace checks passed.
- Fresh independent pre-commit Codex review of the correction, with the unchanged verification/inspection/attachment owners supplied as context, found **no actionable P0/P1/P2 defects**.
- The full local `pnpm run check` of the pre-correction source later committed as `fae183ab38e015259231bc762420e7efe112c9c2` **failed**: **3,910 passed, 12 failed, 9 skipped** (3,931 total; separate changed-surface coverage tests passed 12/12). The failures are deadline/dispatch/setup-budget assertions and terminal cleanup failures in four unchanged test files. Source/path diagnosis found no codec rejection behind them: the retry/deadline fixtures do not invoke this codec, direct terminal cases bypass it, and the sanitized-child case accepted the report and failed later in terminal cleanup.
- All **12 failures passed** a precisely selected serial rerun with the same Node 24 runtime, unchanged timeouts, and coverage instrumentation retained. This establishes isolated success, **not a green full run or a proven host-load diagnosis**.
- Full-run aggregate coverage could not be reported because Node encountered an empty child coverage JSON file. No empty files were filtered, no coverage setting or threshold was weakened, and no full aggregate coverage success is claimed. The previous head passed its complete [hosted CI gate](https://github.com/openclaw/clawsweeper/actions/runs/33146257010). That result is historical after this correction: the new committed head must pass the unchanged full hosted CI gate before merge. No post-correction local full-suite success is claimed.

Focused command:

```bash
node --test test/live-proof-report.test.ts test/decision-parser.test.ts test/live-proof.test.ts
```


## Real Behavior Proof

**Claim and source.** Valid non-executable plans must complete the actual ClawSweeper report/CLI path with no candidates and no target execution, while malformed plans still fail. The tested source is `9e784ab9bc5767288dd9eceabb65ca852654a441`, integrated onto `9bad4750e84b4666c0b5e616d0f8c7f191744496`; continuity from the tested pre-commit files to the committed tree is verified before publication. Before-fix proof ran at `f3883a32631b930965fbeaeae4dc70761f2b7647`; the pre-patch renderer, report parser, and inspector are byte-identical at that baseline and the integration base.

**Environment.** Local macOS arm64, Node 24.20.0, pnpm 11.10.0; installed Bash 5.3.15 for workflow fixtures. `AGENTS.md`'s Docker-backed Crabbox clause explicitly applies to a Windows host; this proof ran on macOS. This is not a proof waiver: the general requirement for actual controlled runtime behavior is satisfied below, and no policy or gate has been changed. No container/image/lease claim is made.

**Actual production path, not a mocked substitute.** The production decision parser and renderer generate the reports, then separate real `dist/clawsweeper.js live-proof-review` processes run in both `--inspect` and execution-orchestration modes. The repository profile is enabled. The independent child processes have Node filesystem-read permission only and no filesystem-write or child-process grant, with a minimal environment and no injected hooks or mocks. For this change, launching a target would be a failure of the claim; correct behavior is completing ClawSweeper's own runtime path without target execution.

Before the fix, the original producer's empty reports failed with `live proof plan for 42 is invalid`. After the empty-plan fix and raw-marker correction:

- The broadened raw-boundary proof exercised 233 cases and 430 actual CLI invocations across marker/payload whitespace, LF/CRLF, EOF/section boundaries and valid/invalid plan shapes. All assertions passed with no target/output creation. Valid recommended controls used inspection only; no recommended target command was executed.
- After the correction, the parent independently reran 24 unmocked CLI invocations across 12 empty-plan fixtures. Both statuses passed in canonical and already-produced legacy formats. Eight malformed/recommended-empty controls failed with exit 1 and the expected invalid-plan error.
- The parent additionally replayed the three immutable before-correction padded-marker reports: all six inspection/orchestration invocations now exit 1 with the invalid-plan error. Two exact raw LF/CRLF marker controls remain valid and agree with attached verification; they were inspected only.
- Every successful **non-executable-plan** CLI invocation returned exactly:

```json
{"candidates":[],"recordMedia":false,"requiresBrowser":false,"requiresTerminal":false}
```

No target checkout or output directory was created. The absence of target execution is also enforced by the child permission boundary, not just inferred from an empty result.

Normalized CLI commands below use fixture-path variables. The records directory contains the generated synthetic `42.md`; the target/output paths do not exist. Each case uses its own fresh fixture directory. The production build was created through the repository's build wrapper:

```bash
pnpm run build
```

```bash
node --permission --allow-fs-read='*' dist/clawsweeper.js live-proof-review --repo openclaw/clawsweeper --records-dir "$RECORDS_DIR" --checkout "$NONEXISTENT_CHECKOUT" --output "$ABSENT_OUTPUT" --item-numbers 42 --inspect
```

```bash
node --permission --allow-fs-read='*' dist/clawsweeper.js live-proof-review --repo openclaw/clawsweeper --records-dir "$RECORDS_DIR" --checkout "$NONEXISTENT_CHECKOUT" --output "$ABSENT_OUTPUT" --item-numbers 42
```

**Original incident artifact.** After the marker correction, the parent also reran the fixed built CLI in `--inspect` mode against the actual retained `1269.md`, without changing it, granting write/child permissions, or executing any command contained in it. It returned exit 0 and the exact empty inspection object above. The retained report and failed-step log hashes matched before and after. This was read-only local artifact inspection, not a PR review rerun or live operator action.

**Artifact fingerprints.** Full per-invocation reports, arguments, stdout/stderr, and receipts are retained locally. The public proof above contains the observed outputs without publishing agent transcripts.

| Artifact | SHA-256 |
|---|---|
| Renderer source | `7663b497752bdf9a1408fcb788b46dc8d8635fc5c94688de70228553c2b413da` |
| Report parser source | `591232e076430f432d51e049c29d78120975df94310aa6e35dc3d48fc6efc77a` |
| Focused regression test | `304a0927bf3fb209150223c8aa67fc864495ab52d54ed9582aadae7a10007be2` |
| Independent CLI proof summary | `3bdd6d23880fa53727357260739c6347caa9f04be43dff121712e256f5db99c1` |
| Raw-marker correction proof summary | `ccc572167ab409ea645bfee810cf1b42d1fb773d3146564b1b91cbd816afe486` |
| Original retained report | `f0ef09cb76c1b918401845a79d0f2bce82ce9c4c0fdb89a38975609aa744521d` |
| Original failed-step log | `6248238a1726b78d24cde54a10b4e9313776719bc8e08971615b539a8d77b53f` |

## Scope and Limits

The proof exercises actual local ClawSweeper report parsing and CLI inspection/orchestration. It does not claim target execution, hosted publication, media/UI behavior, a live queue operation, or a deployed rollout. Existing unit/integration tests exercise their own synthetic fixtures. Historical reports and logs were not rewritten, and no live apply/close, repair, or workflow dispatch was used for this proof.
