### PR TITLE
fix: stop failing live proof before finite commands finish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ checkpoint, and status-only commits are intentionally omitted.
 - Bounded apply/proof/comment-sync record retention to selected records and paired dependencies, avoiding unrelated archive loads during ledger finalization without changing close guards.
 - Kept projected GitHub reads out of the durable ETag cache so incompatible response shapes cannot hide requested reviewers from close guards. Thanks @goutamadwant! (#1242)
 - Normalized unexpected exact-review failures at the Worker boundary without weakening Durable Object transaction rollback. Thanks @yetval and @vincentkoc! (#1240)
-- Terminal live verification preserves successful commands when a marker is not observed, reports that distinction truthfully, and still rejects real command failures and timeouts.
+- Terminal live verification waits for finite commands to complete within the existing proof budget before judging output, keeps missing assertions unverified, and preserves usable PTY descriptors for detached child processes.
 - Replaced public Worker exception text with endpoint-owned error codes and bounded direct-publication rejection categories, preserving distinct operational fingerprints without exposing submitted values or stack traces.
 - Replaced terminal live proof's authenticated `xvfb-run` wrapper with a TCP-disabled local Xvfb display so readiness probes and recording can connect without X authorization failures.
 - Made terminal live-proof recording wait for Xvfb and ffmpeg readiness and clean finalization, with tmux pane diagnostics on failure.

--- a/docs/live-proof.md
+++ b/docs/live-proof.md
@@ -93,6 +93,9 @@ HOME, package-manager caches, and temporary files point into the scratch profile
 The production review prompt supplies trusted execution context from the effective
 repository profile, including configured/fallback resolution, enablement, package
 manager, normalized setup commands, install-script policy, and browser-only startup.
+It also supplies `terminalExecutionLimitSeconds` from the existing effective
+`live_test.max_recording_seconds` limit (`profile.liveTest.maxRecordingSeconds`),
+which bounds the whole terminal plan even for `static_text` without recording.
 These facts are separate from PR-authored context. The proof target is a cold
 checkout of the exact reviewed head: reviewer/controller `dist` and other generated
 output do not transfer. The planner must inspect the relevant package scripts and
@@ -138,6 +141,18 @@ zero. Version evidence does not establish runtime exposure, security, or
 compatibility; the incident's Vite/Vitest dependents were development-only.
 No executor, schema v1, lifecycle, or rendering contract changes are needed, so
 OpenClaw Bay is unaffected.
+
+Inspect the exact checked-out command, wrapper, and reporter contract. For finite
+test commands, prefer a real final summary with `exit_zero`; require individual
+test names only when an explicitly selected reporter emits them. Default reporters
+may emit slow-test names only after the file completes, not as per-test progress;
+absence before completion does not establish a test failure. Test declarations
+alone do not establish emitted output. Keep existing program/test budgets intact:
+do not weaken tests, increase timeouts, append fabricated success echoes/sentinels,
+or add sleeps as a workaround. If a meaningful scenario cannot reliably fit the
+supplied terminal limit, narrow to a real valid scenario or use `not_applicable`
+with a concrete harness-capability reason. No runnable surface is also a valid
+`not_applicable` reason.
 
 The [review prompt](../prompts/review-item.md) and decision parser require
 `liveProofPlan.entry` and terminal `run.command` strings to contain no literal
@@ -257,11 +272,21 @@ exit_zero` when the final command must finish successfully, or
 `terminalCompletion: ready_while_running` when the final command must remain
 live after satisfying an output expectation. Non-recorded long-running proofs
 must remain live through a three-second stability hold before publication.
-Every earlier command must exit zero. The supervisor exits with the command's
-status, and tmux's pane lifecycle records whether that supervisor is still
-running or how it exited. Each proof uses a private tmux socket directory. The
+Every earlier command must exit zero. Finite commands wait within the remaining
+terminal budget before their expectations are judged against controller-observed
+output after capture sealing. Multiple expectations reuse that completed capture.
+A successful exit never waives missing output: it remains failed/unverified proof
+with a proof-plan assertion mismatch reason asking to verify the
+command/wrapper/reporter contract,
+not by itself evidence of a product/test failure. Product-defect findings require actual
+evidence. Only the final `ready_while_running` command retains the 30-second
+marker wait and the existing stability and liveness checks. The held supervisor
+records the command's exit status and stays alive through capture sealing and
+controller-owned cleanup. Each proof uses a private tmux socket directory. The
 controller binds the exact pane PID and controlling terminal before opening the
-start gate. The pane process validates that tuple and opens a private lease file
+start gate. Child standard I/O opens that concrete PTY path, not `/dev/tty`, so
+inherited descriptors remain usable when a subprocess starts a detached session.
+The pane process validates that tuple and opens a private lease file
 on reserved descriptor 9, inherited by the held target and its descendants.
 Before opening a second execution gate, the controller starts a cleanup watchdog
 outside the pane process tree through the private tmux server and requires an

--- a/docs/live-proof.md
+++ b/docs/live-proof.md
@@ -96,7 +96,10 @@ manager, normalized setup commands, install-script policy, and browser-only star
 It also supplies `terminalExecutionLimitSeconds` from the existing effective
 `live_test.max_recording_seconds` limit (`profile.liveTest.maxRecordingSeconds`),
 which bounds the whole terminal plan even for `static_text` without recording.
-These facts are separate from PR-authored context. The proof target is a cold
+The trusted `terminalStdio: "pty"` fact identifies real terminal standard I/O:
+reporter defaults may differ from redirected logs, and wrappers may pipe their
+own child output. Select a reporter for format-specific assertions or use
+format-independent text. These facts are separate from PR-authored context. The proof target is a cold
 checkout of the exact reviewed head: reviewer/controller `dist` and other generated
 output do not transfer. The planner must inspect the relevant package scripts and
 import chain, then include any build or code-generation prerequisites that setup

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -545,9 +545,9 @@ the real system from the PR head and verify observable behavior, not merely to
 run its tests. This includes refactors, internal plumbing, and CI/config changes:
 plan a narrow smoke verification such as “the binary still starts and prints X”
 or “the command still resolves Y” even when the implementation change is not
-user-visible. Reserve `not_applicable` for a change with genuinely nothing to
-run, such as docs-only edits or generated assets in a repository with no
-meaningful runnable surface. Use `surface: "browser"` for browser behavior and
+user-visible. Use `not_applicable` when there is no meaningful runnable surface
+or no meaningful scenario can run reliably within the supplied harness capabilities;
+give the concrete limitation. Use `surface: "browser"` for browser behavior and
 `surface: "terminal"` for terminal behavior. The `entry` must be a URL path for
 browser verification or a command for terminal verification. Keep `entry` and
 every terminal `run.command` on one line: no literal CR, LF, U+2028, or U+2029,
@@ -578,6 +578,17 @@ When an existing repository or package-manager script owns the required
 prerequisites, invoke that wrapper and do not bypass it by calling its internal
 script directly. Do not assume an arbitrary test script builds. When no owning
 wrapper exists, use an explicit fail-fast chain such as `prerequisite && command`.
+Inspect the exact checked-out command, wrapper, and reporter contract before
+choosing output assertions. For finite test commands, prefer a real final summary
+with `exit_zero`; require individual test names only with an explicitly selected
+reporter that emits them. Default reporters may emit slow-test names only when the
+file completes; those names are not guaranteed per-test progress signals. A test
+declaration is not an output contract.
+The trusted `terminalExecutionLimitSeconds` bounds the whole terminal plan,
+including `static_text`. Respect existing program/test budgets; never weaken tests,
+increase timeouts, append a fabricated success echo/sentinel, or add sleeps to
+make proof pass. If the scenario cannot reliably fit, narrow to a real valid
+scenario or use `not_applicable` with the concrete harness-capability reason.
 Emit at most ten
 deterministic, typed `steps`: browser plans may use `goto`, `click`, `fill`,
 `press`, `wait_for`, `wait`, and `expect_text`; terminal plans may use `run`,
@@ -604,6 +615,9 @@ a stable substring of its output such as a header, flag name, or error string,
 not a count, timing, or number that varies per run. If you cannot name a value
 the run will certainly print or render, assert something more stable rather
 than inventing one.
+Missing output after a successful finite exit leaves the proof unverified. Check
+the assertion's command/wrapper/reporter contract before inferring a product defect;
+exit zero never waives a missing assertion.
 
 For dependency/package-version assertions, prefer the package manager's
 machine-readable output when supported. Inspect the target's pinned CLI version

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -579,10 +579,12 @@ prerequisites, invoke that wrapper and do not bypass it by calling its internal
 script directly. Do not assume an arbitrary test script builds. When no owning
 wrapper exists, use an explicit fail-fast chain such as `prerequisite && command`.
 Inspect the exact checked-out command, wrapper, and reporter contract before
-choosing output assertions. For finite test commands, prefer a real final summary
-with `exit_zero`; require individual test names only with an explicitly selected
-reporter that emits them. Default reporters may emit slow-test names only when the
-file completes; those names are not guaranteed per-test progress signals. A test
+choosing output assertions. Terminal stdio is a real PTY, so reporter defaults can
+differ from redirected logs; inspect wrappers that pipe their own child output.
+For finite test commands, prefer a real final summary with `exit_zero`. Explicitly
+select an emitting reporter for individual test names or format-specific assertions;
+otherwise use format-independent output text. Default reporters may emit slow-test
+names only when the file completes; those names are not guaranteed per-test progress signals. A test
 declaration is not an output contract.
 The trusted `terminalExecutionLimitSeconds` bounds the whole terminal plan,
 including `static_text`. Respect existing program/test budgets; never weaken tests,

--- a/src/clawsweeper-review-runtime.ts
+++ b/src/clawsweeper-review-runtime.ts
@@ -474,6 +474,7 @@ export function createReviewRuntime({
         ) ?? [],
       allowInstallScripts: liveTest?.allowInstallScripts ?? false,
       terminalExecutionLimitSeconds: liveTest?.maxRecordingSeconds ?? null,
+      terminalStdio: "pty",
       checkout: {
         state: "cold",
         revision: "exact reviewed head",

--- a/src/clawsweeper-review-runtime.ts
+++ b/src/clawsweeper-review-runtime.ts
@@ -473,6 +473,7 @@ export function createReviewRuntime({
           liveProofSetupCommand(command, liveTest.allowInstallScripts),
         ) ?? [],
       allowInstallScripts: liveTest?.allowInstallScripts ?? false,
+      terminalExecutionLimitSeconds: liveTest?.maxRecordingSeconds ?? null,
       checkout: {
         state: "cold",
         revision: "exact reviewed head",

--- a/src/live-proof/drivers.ts
+++ b/src/live-proof/drivers.ts
@@ -723,7 +723,11 @@ export function driveTerminal(options: {
       failureReason = terminalPrivateErrorMessage(error, privatePaths);
     }
     if (!failed) {
-      for (const step of options.plan.steps as LiveProofTerminalStep[]) {
+      const steps = options.plan.steps as LiveProofTerminalStep[];
+      for (const [index, step] of steps.entries()) {
+        const completion = steps.slice(index + 1).some((later) => later.action === "run")
+          ? "exit_zero"
+          : options.plan.terminalCompletion;
         try {
           const result = runTerminalStep(
             step,
@@ -734,6 +738,7 @@ export function driveTerminal(options: {
             nextCommand,
             expectations,
             terminalDeadline,
+            completion,
           );
           if (result.outputWindow && result.outputWindow !== outputWindow) {
             commandWindows.push(result.outputWindow);
@@ -1030,6 +1035,7 @@ function runTerminalStep(
   nextCommand: () => { files: TerminalCommandFiles; launchMode: TerminalLaunchMode },
   expectations: readonly string[],
   terminalDeadline: number,
+  completion: LiveProofPlan["terminalCompletion"],
 ): TerminalStepResult {
   if (step.action === "run") {
     if (outputWindow) {
@@ -1070,6 +1076,24 @@ function runTerminalStep(
   }
   if (!outputWindow) {
     throw new Error("expected terminal output without a preceding command");
+  }
+  if (completion === "exit_zero") {
+    // Finite reporters may emit only a final summary; readiness's 30-second
+    // window would reject healthy commands before their output can be observed.
+    requireTerminalCommandExitZero(
+      outputWindow,
+      terminalPane,
+      runner,
+      checkout,
+      terminalDeadline,
+      true,
+    );
+    if (!outputWindow.observedExpectations.has(step.text)) {
+      throw new Error(
+        `proof-plan assertion mismatch: terminal command exited successfully but expected output was not observed; verify the command/wrapper/reporter contract: ${JSON.stringify(step.text)}`,
+      );
+    }
+    return { outputWindow, expectationSatisfied: true };
   }
   for (let elapsed = 0; elapsed <= TERMINAL_EXPECT_OUTPUT_TIMEOUT_SECONDS; elapsed += 1) {
     refreshTerminalCommandOutput(outputWindow, runner, checkout, terminalPane);
@@ -1161,7 +1185,9 @@ function runTerminalCommand(
       'builtin printf "%s|%s|%s|%s\\n" "$$" "$tty_path" "$7" "$9" >"$5"',
       'mv -f -- "$5" "$6"',
       'while :; do IFS= read -r execute_gate <"$6" || exit 125; [ "$execute_gate" = "v1|execute|$7|$$|$tty_path|$9" ] && break; sleep 0.05; done',
-      `( /usr/bin/env -u TMUX -u TMUX_PANE -u TMUX_TMPDIR /bin/bash --noprofile --norc "$1"; status=$?; builtin printf "%s\\n" "$status" >"$2"; mv -f -- "$2" "$3" ) ${TERMINAL_LEASE_FD}<&${TERMINAL_LEASE_FD} </dev/tty >/dev/tty 2>&1 &`,
+      // Concrete PTY descriptors survive detached child sessions. Inherited
+      // /dev/tty descriptors lose their controlling terminal on macOS.
+      `( /usr/bin/env -u TMUX -u TMUX_PANE -u TMUX_TMPDIR /bin/bash --noprofile --norc "$1"; status=$?; builtin printf "%s\\n" "$status" >"$2"; mv -f -- "$2" "$3" ) ${TERMINAL_LEASE_FD}<&${TERMINAL_LEASE_FD} <"$tty_path" >"$tty_path" 2>&1 &`,
       "while :; do sleep 3600; done",
     ].join("\n");
     const shellCommand =

--- a/test/live-proof-package-version.test.ts
+++ b/test/live-proof-package-version.test.ts
@@ -218,7 +218,7 @@ for (const scenario of [
       assert.match(result.output, /postcss@8\.5\.26/);
       assert.match(
         result.steps[0]?.detail ?? "",
-        /exited successfully before expected output appeared/,
+        /proof-plan assertion mismatch: terminal command exited successfully.*verify the command\/wrapper\/reporter contract/,
       );
     } else {
       assert.match(result.output, /pnpm why failed: 7/);

--- a/test/live-proof-review-environment.test.ts
+++ b/test/live-proof-review-environment.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { execFileSync, spawn } from "node:child_process";
+import { execFileSync, spawn, spawnSync } from "node:child_process";
 import { once } from "node:events";
 import {
   existsSync,
@@ -454,6 +454,88 @@ test(
       assert.ok(result.output.indexOf("OUT_ONE") < result.output.indexOf("ERR_TWO"));
       assert.ok(result.output.indexOf("ERR_TWO") < result.output.indexOf("IMMEDIATE_FINAL"));
     } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  },
+);
+
+test(
+  "terminal proof preserves inherited PTY descriptors in a detached Node child",
+  { timeout: 30_000 },
+  () => {
+    const root = mkdtempSync(join(tmpdir(), "clawsweeper-live-proof-detached-stdio-"));
+    const processToken = `clawsweeper-detached-stdio-${process.pid}-${Date.now()}`;
+    try {
+      writeFileSync(
+        join(root, "detached-stdio.mjs"),
+        [
+          'import assert from "node:assert/strict";',
+          'import { spawn } from "node:child_process";',
+          'import { fstatSync, writeFileSync } from "node:fs";',
+          'if (process.argv[3] === "child") {',
+          "  for (const fd of [0, 1, 2]) assert.equal(fstatSync(fd).isCharacterDevice(), true);",
+          "  const terminals = [process.stdin.isTTY, process.stdout.isTTY, process.stderr.isTTY];",
+          "  assert.deepEqual(terminals, [true, true, true]);",
+          '  console.log("DETACHED_CHILD_TTY", ...terminals);',
+          '  console.error("DETACHED_CHILD_STDERR");',
+          "} else {",
+          '  writeFileSync("parent.pid", String(process.pid));',
+          '  const child = spawn(process.execPath, [import.meta.filename, process.argv[2], "child"], { detached: true, stdio: "inherit" });',
+          '  if (child.pid) writeFileSync("child.pid", String(child.pid));',
+          '  child.on("error", (error) => { throw error; });',
+          '  child.on("exit", (code, signal) => {',
+          '    writeFileSync("child-exit.json", JSON.stringify({ code, signal }));',
+          "    if (signal) process.kill(process.pid, signal);",
+          "    else process.exitCode = code ?? 1;",
+          "  });",
+          "}",
+        ].join("\n"),
+      );
+      const result = driveTerminal({
+        plan: {
+          status: "recommended",
+          surface: "terminal",
+          terminalCompletion: "exit_zero",
+          reason: "A detached Node child must retain usable inherited terminal descriptors.",
+          payoff: { kind: "static_text", justification: "Text is sufficient." },
+          entry: `node detached-stdio.mjs ${processToken}`,
+          steps: [
+            { action: "expect_output", text: "DETACHED_CHILD_TTY true true true" },
+            { action: "expect_output", text: "DETACHED_CHILD_STDERR" },
+          ],
+        },
+        checkout: root,
+        rawVideoPath: join(root, "proof.webm"),
+        maxRecordingSeconds: 90,
+        recordMedia: false,
+        runner: mediaProofCommandRunner,
+      });
+
+      assert.equal(result.status, "completed", result.output);
+      assert.equal(
+        result.steps.every((step) => step.satisfied === true),
+        true,
+      );
+      assert.match(result.output, /DETACHED_CHILD_TTY true true true/);
+      assert.match(result.output, /DETACHED_CHILD_STDERR/);
+      assert.deepEqual(JSON.parse(readFileSync(join(root, "child-exit.json"), "utf8")), {
+        code: 0,
+        signal: null,
+      });
+      assert.deepEqual(processesContaining(processToken), []);
+      assert.deepEqual(
+        readdirSync(root).filter((name) => name.startsWith("proof.webm.")),
+        [],
+      );
+    } finally {
+      for (const name of ["child.pid", "parent.pid"]) {
+        const path = join(root, name);
+        if (!existsSync(path)) continue;
+        const pid = Number.parseInt(readFileSync(path, "utf8"), 10);
+        if (processesContaining(processToken).some((line) => line.startsWith(`${pid} `))) {
+          killProcess(pid);
+        }
+      }
       rmSync(root, { force: true, recursive: true });
     }
   },
@@ -1077,7 +1159,7 @@ test(
       assert.equal(result.status, "partial", result.output);
       assert.equal(result.steps[1]?.satisfied, false);
       assert.match(result.output, /SECOND_ONLY/);
-      assert.match(result.output, /before expected output appeared: "STALE_FROM_FIRST"/);
+      assert.match(result.output, /proof-plan assertion mismatch:.*"STALE_FROM_FIRST"/);
     } finally {
       rmSync(root, { force: true, recursive: true });
     }
@@ -1268,10 +1350,16 @@ function git(cwd: string, ...args: string[]): string {
 }
 
 function processesContaining(fragment: string): string[] {
-  return execFileSync("ps", ["-axo", "pid=,args="], { encoding: "utf8" })
+  // Filter before capture so unrelated long command lines cannot overflow the test buffer.
+  const pattern = fragment.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const result = spawnSync("pgrep", ["-fl", pattern], { encoding: "utf8" });
+  if (result.error) throw result.error;
+  if (result.status === 1) return [];
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout
     .split("\n")
     .map((line) => line.trim())
-    .filter((line) => line.includes(fragment));
+    .filter(Boolean);
 }
 
 function killProcess(pid: number): void {

--- a/test/live-proof.test.ts
+++ b/test/live-proof.test.ts
@@ -813,7 +813,7 @@ test("terminal command success cannot waive a missing output expectation", () =>
   assert.equal(result.steps[0]?.satisfied, false);
   assert.match(
     result.steps[0]?.detail ?? "",
-    /exited successfully before expected output appeared/,
+    /proof-plan assertion mismatch: terminal command exited successfully.*verify the command\/wrapper\/reporter contract/,
   );
   assert.match(result.output, /Tests  10 passed \(10\)/);
   assert.doesNotMatch(result.output, /\.command-\d+-\d+\.|printf '%s'|mv -f|\/tmp\//);
@@ -843,6 +843,7 @@ test("terminal command success cannot waive a missing output expectation", () =>
   );
   assert.match(renderLiveVerificationCommentBlock(verification), /\*\*Result:\*\* FAIL/);
   assert.match(renderLiveVerificationCommentBlock(verification), /FAIL `expect_output`/);
+  assert.match(renderLiveVerificationCommentBlock(verification), /proof-plan assertion mismatch/);
 });
 
 test("terminal command timeout remains a failed output expectation", () => {
@@ -1182,26 +1183,96 @@ test("held terminal completion observes output rendered after status publication
   assert.match(result.output, /Ready/);
 });
 
-test("terminal completion uses the configured proof budget beyond thirty seconds", () => {
-  const calls: string[] = [];
-  const result = driveTerminal({
-    plan: {
-      ...recommendedPlan("terminal"),
-      entry: "slow-demo",
-      steps: [{ action: "expect_output", text: "Ready" }],
-    },
-    checkout: "/tmp/checkout",
-    rawVideoPath: "/tmp/live-proof.raw.webm",
-    maxRecordingSeconds: 90,
-    recordMedia: false,
-    runner: terminalLifecycleRunner(calls, {
-      commandCompletionAfterProbe: 35,
-      terminalCaptures: ["Ready\n"],
-    }),
-  });
+test("parsed finite terminal expectations wait for a summary after thirty seconds", async (t) => {
+  for (const form of ["entry", "setup+run", "finite-before-ready"] as const) {
+    await t.test(form, (t) => {
+      let now = 1_000_000;
+      t.mock.method(Date, "now", () => now);
+      const parsed = liveProofPlanParser(
+        {
+          ...recommendedPlan("terminal"),
+          terminalCompletion: form === "finite-before-ready" ? "ready_while_running" : "exit_zero",
+          payoff: { kind: "static_text", justification: "The final summary is sufficient." },
+          entry: form === "setup+run" ? "setup" : "finite-test",
+          steps: [
+            ...(form === "setup+run" ? [{ action: "run", command: "finite-test" }] : []),
+            { action: "expect_output", text: "[test] passed" },
+            { action: "expect_output", text: "Vitest shard" },
+            ...(form === "finite-before-ready"
+              ? [
+                  { action: "run", command: "server" },
+                  { action: "expect_output", text: "Listening" },
+                ]
+              : []),
+          ],
+        },
+        "liveProofPlan",
+      );
+      const plan = reportLiveProofPlanForTest(`## Live Proof
 
-  assert.equal(result.status, "completed");
-  assert.ok(calls.filter((call) => call === "sleep 1").length > 30);
+Status: ${parsed.status}
+Surface: ${parsed.surface}
+Terminal completion: ${parsed.terminalCompletion}
+Reason: ${parsed.reason}
+Payoff: ${parsed.payoff.kind}
+Payoff justification: ${parsed.payoff.justification}
+Entry: ${parsed.entry}
+
+Steps:
+
+${parsed.steps.map((step) => `- ${JSON.stringify(step)}`).join("\n")}
+`);
+      assert.deepEqual(plan, parsed);
+      const calls: string[] = [];
+      const fixtureRunner = terminalLifecycleRunner(calls, {
+        terminalCapturesByCommand: {
+          setup: ["setup complete\n"],
+          "finite-test": [
+            ...Array<string>(35).fill("starting\n"),
+            "starting\n[test] passed 1 Vitest shard in 35s\n",
+          ],
+          server: ["Listening\n"],
+        },
+        keepsRunningCommands: ["server"],
+      });
+      const driven = driveTerminal({
+        plan,
+        checkout: "/tmp/checkout",
+        rawVideoPath: "/tmp/live-proof.raw.webm",
+        maxRecordingSeconds: 90,
+        recordMedia: false,
+        runner: (command, args, options) => {
+          const result = fixtureRunner(command, args, options);
+          if (command === "sleep") now += Number(args[0]) * 1_000;
+          return result;
+        },
+      });
+      const verification = buildLiveVerificationResult({
+        repo: "example/repo",
+        item: 42,
+        headSha: HEAD,
+        plan,
+        driveStatus: driven.status,
+        stepLog: driven.steps,
+        output: driven.output,
+        verifiedAt: "2026-08-27T00:00:00.000Z",
+      });
+      assert.equal(verification.overall_pass, true, JSON.stringify(verification));
+      assert.deepEqual(parseLiveVerificationResult(verification), verification);
+      assert.equal(
+        verification.steps.every((step) => step.status === "completed"),
+        true,
+      );
+      assert.ok(now >= 1_035_000 && now < 1_090_000);
+      const commandCount = form === "entry" ? 1 : 2;
+      assert.equal(
+        calls.filter((call) => call.startsWith("tmux pipe-pane -t ")).length,
+        commandCount,
+      );
+      assert.equal(calls.filter((call) => call === "watchdog-armed").length, commandCount);
+      assert.match(renderLiveVerificationCommentBlock(verification), /\*\*Result:\*\* PASS/);
+    });
+  }
 });
 
 test("terminal pane status corruption fails closed before controller cleanup", () => {
@@ -1231,19 +1302,22 @@ test("terminal pane status corruption fails closed before controller cleanup", (
   );
 });
 
-test("terminal command failure after an observed marker is caught after the recording hold", () => {
+test("finite terminal expectations cannot pass an early summary followed by a nonzero exit", () => {
   const calls: string[] = [];
   const result = driveTerminal({
     plan: {
       ...recommendedPlan("terminal"),
       entry: "demo",
-      steps: [{ action: "expect_output", text: "Ready" }],
+      steps: [
+        { action: "expect_output", text: "Ready" },
+        { action: "expect_output", text: "Ready" },
+      ],
     },
     checkout: "/tmp/checkout",
     rawVideoPath: "/tmp/live-proof.raw.webm",
     maxRecordingSeconds: 90,
     runner: terminalLifecycleRunner(calls, {
-      commandCompletionAfterProbe: 1,
+      commandCompletionAfterProbe: 35,
       commandExitStatus: 7,
       terminalCaptures: ["$ demo\nReady\n", "$ demo\nReady\n"],
     }),
@@ -1252,6 +1326,7 @@ test("terminal command failure after an observed marker is caught after the reco
   assert.equal(result.status, "failed");
   assert.equal(result.steps[0]?.status, "failed");
   assert.equal(result.steps[0]?.satisfied, false);
+  assert.equal(result.steps.length, 1);
   assert.match(result.steps[0]?.detail ?? "", /failed with exit status 7/);
 });
 
@@ -1592,7 +1667,7 @@ test("terminal cleanup requires the exact pane receipt and pane death", () => {
   assert.doesNotMatch(respawn ?? "", /tmux run-shell -b/);
   assert.match(respawn ?? "", /while :; do sleep 3600; done/);
   assert.match(respawn ?? "", /exec 9<"\$8"/);
-  assert.match(respawn ?? "", /\) 9<&9 <\/dev\/tty/);
+  assert.match(respawn ?? "", /\) 9<&9 <"\$tty_path" >"\$tty_path" 2>&1/);
   assert.match(respawn ?? "", /read -r bound_pid bound_tty bound_nonce bound_lease bound_extra/);
   assert.match(respawn ?? "", /v1\|execute/);
   assert.equal(calls.filter((call) => call.startsWith("tmux run-shell -b ")).length, 1);
@@ -2279,11 +2354,12 @@ test("terminal cleanup removes explicit capture and controller temporary files",
   }
 });
 
-test("terminal expect_output times out without matching the echoed command", () => {
+test("ready terminal expect_output times out without matching the echoed command", () => {
   const calls: string[] = [];
   const result = driveTerminal({
     plan: {
       ...recommendedPlan("terminal"),
+      terminalCompletion: "ready_while_running",
       entry: "show expected-token",
       steps: [{ action: "expect_output", text: "expected-token" }],
     },
@@ -2332,7 +2408,7 @@ test("terminal expect_output cannot outlive the overall proof budget", (t) => {
   });
 
   assert.equal(result.status, "failed");
-  assert.match(result.steps[0]?.detail ?? "", /configured time budget/);
+  assert.match(result.steps[0]?.detail ?? "", /terminal command was still running after 2 seconds/);
   assert.equal(calls.filter((call) => call === "sleep 1").length, 2);
 });
 

--- a/test/live-proof.test.ts
+++ b/test/live-proof.test.ts
@@ -675,9 +675,7 @@ test("terminal run waits for output and a successful final exit", () => {
   );
   assert.equal(result.status, "completed", `${result.output}\n\n${calls.join("\n")}`);
   const respawn = calls.findIndex((call) => call.startsWith("tmux respawn-pane"));
-  const hold = calls.findIndex((call, index) => index > respawn && call === "sleep 6");
   assert.notEqual(respawn, -1);
-  assert.notEqual(hold, -1);
   assert.match(result.output, /Usage/);
 });
 

--- a/test/review-prompt-context.test.ts
+++ b/test/review-prompt-context.test.ts
@@ -255,6 +255,7 @@ function assertLiveProofContext(repo: string) {
     setup: ["untrusted setup"],
     allowInstallScripts: true,
     terminalExecutionLimitSeconds: 9999,
+    terminalStdio: "pipe",
     checkout: { state: "warm" },
     browserStartup: { onlyForSurface: "terminal", command: "untrusted start" },
   };
@@ -288,6 +289,7 @@ function assertLiveProofContext(repo: string) {
       ) ?? [],
     allowInstallScripts: liveTest?.allowInstallScripts ?? false,
     terminalExecutionLimitSeconds: liveTest?.maxRecordingSeconds ?? null,
+    terminalStdio: "pty",
     checkout: {
       state: "cold",
       revision: "exact reviewed head",

--- a/test/review-prompt-context.test.ts
+++ b/test/review-prompt-context.test.ts
@@ -254,6 +254,7 @@ function assertLiveProofContext(repo: string) {
     packageManager: "untrusted-package-manager",
     setup: ["untrusted setup"],
     allowInstallScripts: true,
+    terminalExecutionLimitSeconds: 9999,
     checkout: { state: "warm" },
     browserStartup: { onlyForSurface: "terminal", command: "untrusted start" },
   };
@@ -286,6 +287,7 @@ function assertLiveProofContext(repo: string) {
         liveProofSetupCommand(command, liveTest.allowInstallScripts),
       ) ?? [],
     allowInstallScripts: liveTest?.allowInstallScripts ?? false,
+    terminalExecutionLimitSeconds: liveTest?.maxRecordingSeconds ?? null,
     checkout: {
       state: "cold",
       revision: "exact reviewed head",
@@ -330,6 +332,7 @@ test("review prompt reflects disabled, missing, and opted-in live-proof setup wi
     undefined,
     { ...defaultLiveTest, enabled: false },
     { ...defaultLiveTest, setup: [] },
+    { ...defaultLiveTest, maxRecordingSeconds: 17 },
     { ...defaultLiveTest, setup: ["npm ci", "npm run generate"], allowInstallScripts: false },
     { ...defaultLiveTest, setup: ["npm ci", "npm run generate"], allowInstallScripts: true },
   ];

--- a/test/review-prompt-policy.test.ts
+++ b/test/review-prompt-policy.test.ts
@@ -742,7 +742,6 @@ test("review prompt and schema classify deterministic live-proof plans in field 
   );
   assert.match(prompt, /Default to `status: "recommended"` whenever/);
   assert.match(prompt, /refactors, internal plumbing, and CI\/config changes/);
-  assert.match(prompt, /docs-only edits or generated assets/);
   assert.match(prompt, /without\s+external accounts,\s+credentials, or third-party services/);
   assert.match(prompt, /reads environment variables or credential\s+stores/);
   assert.match(prompt, /exfiltrate or display sensitive data\s+on screen/);


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This PR uses a branch in the same repository, which maintainers with repository write access can edit. GitHub reports `maintainerCanModify: false`; no fork permission setting was changed.

</details>

## What Problem This Solves

Fixes an issue where ClawSweeper could report a failed live verification while a healthy finite command was still running. The [observed OpenClaw migration probe](https://github.com/openclaw/openclaw/pull/131276#issuecomment-5446847962) declared `terminalCompletion: exit_zero`, but its output assertion stopped after 30 seconds, before the test file and reporter finished.

The original premise needs an important qualification: the normal Vitest reporter **did emit both slow test names** at file completion. The complete Linux log records 49,727 ms for the memory-test file, with batch/deep cases taking 24,499/24,869 ms. The focused run passed 125 tests with two existing skips. The defect was premature observation, not proof that those names never appear or that the migration failed.

This PR does not edit, review for landing, or change the limits of the OpenClaw migration PR.

## Why This Change Was Made

Reuse the existing terminal completion owner rather than adding another timeout or supervisor. Expectations for finite commands now wait for authoritative exit zero and sealed, controller-observed output within the existing overall proof budget. This includes finite setup commands before a final long-running command; multiple expectations reuse the completed capture. The final `ready_while_running` command retains its existing readiness window, stability hold, and liveness checks.

The planner receives the existing effective terminal execution limit and the trusted fact that terminal standard I/O is a PTY, and must inspect the exact command/wrapper/reporter contract. It prefers final summaries for finite tests, distinguishes late slow-test-name reporting from progress, and reports a concrete harness limitation when a meaningful scenario cannot fit. A successful command never waives a missing assertion: the proof remains unverified with an assertion-mismatch diagnostic, not an inferred product defect.

Real-wrapper validation also exposed a small supervisor bug on macOS: inherited `/dev/tty` descriptors became unusable when Node started a detached child session. Child standard I/O now opens the already-bound concrete PTY path. PID/TTY/lease/nonce validation, capture, and cleanup ownership remain unchanged. The test process-discovery helper filters before capture so unrelated long host command lines cannot overflow its buffer.

No new configuration, dependency, schema, public verification format, heap allowance, or execution/test timeout. OpenClaw's original 256 MiB heap and 180-second case limits are untouched.

The final `git diff --numstat origin/main...HEAD` separates a small runtime change from its regression coverage: production TypeScript is **30 additions / 2 deletions** across two files; tests are **200 additions / 34 deletions** across five files. The production planner prompt is behavior-bearing text, counted separately at **19 additions / 3 deletions**. Documentation and changelog account for **34 additions / 6 deletions**. The larger test share exercises parsed plans through the driver/verifier and detached-child PTY behavior.

## User Impact

Healthy finite commands can finish and provide their real result instead of failing an unrelated 30-second progress-text wait. Missing observations, nonzero exits, signals, expired budgets, and failed cleanup remain nonpassing. Detached Node subprocesses retain usable terminal descriptors on macOS.

## OpenClaw Bay Impact

Bay is unaffected. The verification format, publication identity, and observer-only lifecycle surfaces are unchanged; this corrects existing execution semantics and planning guidance.

## Documentation Impact

Updated the active `docs/live-proof.md` reference and production review prompt with completion-aware/reporting-aware planning, the existing execution limit, and concrete PTY descriptor semantics. The reference retains its review/publication-maintainer ownership and source-of-truth/update triggers. The unreleased ClawSweeper changelog entry now describes strict observation semantics rather than the retired missing-marker success behavior.

## Evidence

Current mechanical refresh targets **`d5780abb16ffebe2bea30da382f4a0d4354f95a6`**, rebased onto `777f3211cd5beaf2dce3b3ecca08cd5d3a0818e8`. The sole manual resolution was in `docs/live-proof.md`, preserving upstream pnpm 11 structured-version guidance alongside finite-completion, reporter, and PTY guidance. The original three commit messages are unchanged; their range-diff shows only integration context changes. A separate test-only integration commit aligns the upstream negative-case diagnostic and removes a redundant timing assertion; no runtime edits were made. This PR's production TypeScript files are byte-identical to `ba73c412`, including driver SHA-256 `2b8656cfdd824b1c82b27aa92be229e1e4ae4223aed3aa66202e941313c05cfb`. The full upstream range also brings the already-merged report parser/renderer fix from [PR 1277](https://github.com/openclaw/clawsweeper/pull/1277); those two production files exactly match main. No runtime, schema, dependency, budget, heap, or Bay contract was changed by the refresh.

On the final tree, Node 24.20.0 and pinned pnpm 11.10.0 passed `pnpm run build:all`, `pnpm run check:static` (including format/docs checks), `pnpm run lint`, and diff checks. All **253 combined executor/context/prompt-policy/package-version/report cases passed, with zero failures or skips**, in 40.318 seconds. The explicit-spec real detached-child PTY command below passed on committed head `d5780abb16ffebe2bea30da382f4a0d4354f95a6`: **1 test, 0 failures, 0 skips**, in 9.768 seconds (selected case: 9.419 seconds). Fresh isolated Codex autoreviews of the uncommitted test correction and then the committed branch against `origin/main` both passed with no actionable P0 findings; mandatory reviewer isolation, guard, and outgoing-pack credential scanning were retained.

The first mechanically rebased run exposed two test integration issues (251/253 passed; a 215-case retry still failed the timing assertion). The package-version negative case correctly rejected the absent literal but expected the retired diagnostic. It now checks the canonical `proof-plan assertion mismatch` diagnostic while retaining failed status, unsatisfied expectation, actual pnpm display, child-failure checks, and all negative cases. The generic completion test redundantly required an exact `sleep 6`, although the production hold subtracts real elapsed recording time. Only that duplicate hold variable/assertion was removed; completed status, respawn, and `Usage` remain. The stronger frozen-clock test still verifies authoritative completion before the exact six-second hold, recorder finalization, and cleanup ordering. No tolerance, timeout, clock, or production behavior changed. The earlier Node 26.7.0 PTY proof also passed (8.501 seconds); those initial failed test runs are preserved as history, not counted as passing gates.

The [previous hosted review/proof](https://github.com/openclaw/clawsweeper/actions/runs/33152892079) passed five selected cases and [published its review](https://github.com/openclaw/clawsweeper/pull/1278#issuecomment-5449473844) for the prior head. The current-main refresh addresses its sole rank-up request; previous CI and hosted review are historical continuity, not approvals for this changed head/body. See [current PR Checks](https://github.com/openclaw/clawsweeper/pull/1278/checks) for new-head status. No new CI or hosted-review success is claimed.

- Before the fix, the delayed-summary regression failed at the 30-second output wait for all three forms: entry-only, setup plus run, and a finite command before a running server. The same parser/report-plan → driver → verification boundary passes after the repair.
- Earlier publication-head focused planner/executor/prompt run: **170 passed, 0 failed, 0 skipped**, in 6.740 seconds with Node 26.7.0 and the existing pnpm 11.10.0 pin. Earlier real PTY/scratch-environment sibling coverage exercised 22 cases; a stale diagnostic assertion was corrected and rerun together with the detached-child regression, both passing. Those real PTY runs preceded publication and were not rerun during this bounded publication pass. Nonzero exits after early success-looking output, missing markers, deadline expiry, stale panes, PTY output ordering, lease cleanup, and readiness liveness remain covered.
- `pnpm run build:all`, `pnpm run check:static` (including documentation and formatting), `pnpm run lint`, and `git diff --check origin/main...HEAD` passed on that earlier publication head. An initial `corepack pnpm run build:all` invocation stopped before compilation because nested pnpm resolved a conflicting global version; retrying with direct `pnpm`, which resolves the repository's existing 11.10.0 pin, passed without source, configuration, or dependency changes.
- Fresh isolated precommit and committed-range Codex autoreviews found no actionable P0 defects. Review did not execute tests; the executions above are separate evidence.
- Real OpenClaw wrapper replay was repeated on the clean published ClawSweeper head `cb1fbbd0fa2856ad73555b29b15b6a95c9f233ff`: delayed default-summary proof passed in 43.371 s, the deliberately missing fast-test-name assertion was correctly rejected despite 11 passing tests, and explicit-verbose proof passed in 6.320 s. No heap, test timeout, execution budget, or cleanup limit changed.
- The first [hosted full check](https://github.com/openclaw/clawsweeper/actions/runs/33149101201) completed 3,951 tests: 3,942 passed, eight existing skips, and one obsolete prompt-example regex failed. The test-only follow-up removes that illustrative wording assertion, retaining schema/safety checks and the actual planning/execution regressions; both affected prompt suites then passed **72 tests**. The [corrected full CI run](https://github.com/openclaw/clawsweeper/actions/runs/33150101120) then passed: 3,943 passed, eight existing skips, zero failures. The [previous-head CI run](https://github.com/openclaw/clawsweeper/actions/runs/33152526775) passed 3,950 tests with eight existing skips and zero failures on the synthetic merge of `a2f044f819` and `ba73c412`; it covers the trusted-PTY-context correction and is historical continuity, not CI for the refreshed head.
- The prior full local `pnpm run check` did **not** pass: an untouched action-ledger opposing-parent-edge concurrency test stalled and the owned run was stopped. An independent helper-repair lane reproduced the same local stall. That same unchanged case passed in the hosted full check in 397 ms. The local hang remains separately owned; no ledger code, timeout, or assertion was changed here.

Previous publication validation targeted head `ba73c4126a46a5d91d009ebaeda85a4ff61c7919` on base `af8f89fe69e1e35009591a640c55d12a4a083cf9`. That earlier rebase was conflict-free and preserves the separate invalid-live-proof-artifact refresh on main. Follow-ups after the `cb1fbbd` real-wrapper replay remove one obsolete example assertion and add the trusted PTY planning fact with documentation/tests; production driver bytes still match the proof hash below. The PTY fact regression was run red before its producer fix; all **215 focused executor/context/policy tests**, builds, static checks, and lint then passed, as did fresh precommit review. The explicit-spec real-PTY command below passed on that previous head. Exact-head CI, fresh committed review, and the current ClawSweeper disposition control landing; no stale review or failed check is treated as a pass.

Current focused command:

```bash
node --test --test-reporter=spec test/live-proof.test.ts test/review-prompt-context.test.ts test/review-prompt-policy.test.ts test/live-proof-package-version.test.ts test/live-proof-report.test.ts
```

Earlier real PTY sibling command (not rerun in the publication pass):

```bash
node --test test/live-proof-review-environment.test.ts
```

## Real Behavior Proof

### Narrow hosted verification target

The [ClawSweeper code reviews](https://github.com/openclaw/clawsweeper/pull/1278#issuecomment-5449473844) found no code or security defects and judged the supplied process proof sufficient. The first automated probe nevertheless selected the entire multi-minute suite. The [next hosted probe](https://github.com/openclaw/clawsweeper/actions/runs/33151191770) selected the correct real-PTY case, which **passed in 2.991 seconds with a successful command exit**, but mixed a TAP-specific expectation with Node's normal spec-reporter output. That formatting mismatch is not a product or test failure.

This exposed one missing producer fact: the trusted planner context now explicitly supplies `terminalStdio: "pty"`, alongside the existing execution budget. Reporter defaults can differ from redirected logs, and wrappers can pipe their own child streams. The extended context regression first failed because this fact was absent and also rejects PR-authored claims that standard I/O is a pipe.

For a bounded hosted run, this exact command selects one **real production-driver, detached-child PTY case**, rather than every setup/environment fixture. It previously passed on head `ba73c4126a46a5d91d009ebaeda85a4ff61c7919`; the selected case took 11.291 seconds locally, after the build. The spec reporter is explicit. Use exactly these format-independent observations: `terminal proof preserves inherited PTY descriptors in a detached Node child` and `pass 1`, with `terminalCompletion: exit_zero`. Cosmetic reporter prefixes are not part of the assertions. No fake marker, repeat invocation, timeout increase, or proof override is needed.

```bash
pnpm run build:all && node --test --test-reporter=spec --test-name-pattern='terminal proof preserves inherited PTY descriptors in a detached Node child' test/live-proof-review-environment.test.ts
```

The same selected real-PTY command was rerun successfully on current head `d5780abb16ffebe2bea30da382f4a0d4354f95a6` with Node 24.20.0, taking 9.768 seconds overall. The recorded successful output contains the selected test name, `pass 1`, `fail 0`, and `skipped 0`; its decorative prefix is deliberately excluded from the expected substrings.

The test launches a real detached Node child through the production `driveTerminal` and `mediaProofCommandRunner`, verifies character-device/TTY stdin, stdout, and stderr plus clean child exit, observes real output, and checks process/capture cleanup. The delayed-output change itself additionally has the real 35-second before/after and real OpenClaw-wrapper evidence below. This addresses the review's request for after-fix terminal proof without asking the old outer driver to finish a multi-minute suite within its 30-second observation window.

### Completed terminal and wrapper proof

**Claim and surface:** the production terminal driver waits for a finite command's real completion and output, without turning successful exit alone into proof. Controlled local macOS execution used private tmux sockets, an isolated HOME/TMPDIR for the OpenClaw replay, no provider/channel credentials, and no recording or external media upload.

**Before/after fixture:** a harmless finite process emitted startup output, remained quiet for 35 seconds, then emitted its final summary and exited zero. The pre-fix production driver failed its 30-second expectation; the repaired driver passed in 40.804 seconds including supervision/cleanup, using the unchanged 90-second proof budget. The fixture bytes were identical before/after (SHA-256 `bd0f6fec467eae871c1bf18a50ecf879f7399b50f7f7e1bca0cf930c6a7507f7`).

**Real OpenClaw wrapper replay:** plans were parsed and executed through the production terminal driver/verifier from the clean published ClawSweeper head `cb1fbbd0fa2856ad73555b29b15b6a95c9f233ff`, against OpenClaw `9458d8b18105a9aa18ef334d50c6974c83f55acd`, Node 24.20.0, tmux 3.7c, and Vitest 4.1.11. Each command ran the real repository wrapper with its original test behavior:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/commands/doctor-format.test.ts --reporter=default
```

| Scenario | Observed result |
| --- | --- |
| Default reporter, with an explicit 35-second startup-delay fixture before the wrapper | 11 tests passed; final `Test Files`, `Tests`, and `[test] passed` assertions satisfied after process completion; whole proof 43.371 s |
| Default reporter, intentionally requesting a fast test's unprinted name | 11 tests passed, but the proof correctly failed as a proof-plan assertion mismatch; exit zero did not waive it |
| Explicit `--reporter=verbose`, requesting the emitted name plus final wrapper summary | 11 tests passed; both observations satisfied; whole proof 6.320 s |

Representative captured default-reporter result:

```text
Test Files  1 passed (1)
     Tests  11 passed (11)
[test] passed 1 Vitest shard in 3.59s
```

**Additional integration evidence:** a separate helper-repair lane replayed actual Codex-generated fast and 34-second delayed plans against this exact driver source (SHA-256 `2b8656cfdd824b1c82b27aa92be229e1e4ae4223aed3aa66202e941313c05cfb`). Both passed seven controls: generated success, duplicate invocation rejection, intentional rerun, exit 7, zero exit with missing output, finite deadline, and readiness timeout. That integration covers the driver, not this PR's updated planner prompt/runtime context; those have separate focused coverage. The helper changes are not included here.

**Limits:** this is real local process/PTY and wrapper proof, not a new migration, authenticated-provider, browser, media, or production-deployment test. Initial concurrent macOS PTY attempts hit the existing cleanup cap; serial replays passed without raising it. Raw host logs and agent transcripts are not published. Public execution evidence is the sanitized observations above; the existing terminal verification artifact schema is unchanged.
