### PR TITLE
fix(live-proof): avoid false failures on pnpm version output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Guided package-version live proofs toward validated machine-readable output and exact resolution checks instead of guessed terminal formatting, while preserving literal expectations and successful-exit requirements.
 - Added schema constraints and explicit prompt guidance for single-line live-proof commands and nonblank run steps while preserving strict parsing.
 - Scoped the `openclaw/openclaw` release-note review restriction to its repository profile so ClawSweeper and other targets follow their own policies without granting release-file edit permission.
 - Routed default apply's bounded source-drift refreshes through exact-event queue intake so full-repository hydration cannot fail before admission.

--- a/docs/live-proof.md
+++ b/docs/live-proof.md
@@ -2,12 +2,12 @@
 
 - Status: active
 - Owner: ClawSweeper review and publication maintainers
-- Source of truth: `src/live-proof/`, `.github/workflows/sweep.yml`,
-  `.github/workflows/exact-review-batch-publish.yml`, and repository `live_test`
-  profiles
+- Source of truth: `prompts/review-item.md`, `src/live-proof/`,
+  `.github/workflows/sweep.yml`, `.github/workflows/exact-review-batch-publish.yml`,
+  and repository `live_test` profiles
 - Last verified: `openclaw/clawsweeper@647503ec44b8e777dd172adf974a945367da0d19`
-- Update when: the plan schema, security boundary, execution gates, media
-  limits, storage path, or comment rendering changes
+- Update when: planner assertion guidance, the plan schema, security boundary,
+  execution gates, media limits, storage path, or comment rendering changes
 
 Live proof turns a review-time `liveProofPlan` into deterministic browser or
 terminal execution, with an optional recording when the behavior is worth
@@ -109,6 +109,35 @@ and terminal plans should assert stable output such as a header, flag, or error
 string rather than counts, timings, or run-dependent numbers. When no exact
 value is certain, the planner must choose a more stable assertion instead of
 inventing one.
+
+Package-version assertions should prefer machine-readable package-manager output
+after inspecting the target's pinned CLI version and supported schema. Capture
+the complete JSON from a separate subprocess's stdout, not terminal rendering or
+grep. Reject spawn errors, signals, nonzero exits, invalid/missing JSON, and
+unsupported shapes before emitting a stable marker. pnpm 11 `why --json` returns
+a top-level array of resolutions: it must be nonempty, and every resolution must
+have the exact requested package name and version. Nested `dependents` describe
+the dependency tree, not additional resolutions. One matching resolution must
+not hide wrong or mixed versions.
+
+The [review prompt](../prompts/review-item.md) owns a runnable single-line Node
+example using `spawnSync`, complete `JSON.parse`, and exact name/version checks.
+Run it once as `entry` or one `run` after safe setup, then assert its stable
+marker with the existing literal `expect_output` and `terminalCompletion:
+exit_zero`. Successful proof need not mirror the full child output. Never
+substitute exit success alone, `|| true`, a bare version substring, fuzzy matching,
+punctuation normalization, or a marker emitted before assertions. Without
+structured support, verify exact display and package/version boundaries instead
+of guessing `name version` versus `name@version`.
+
+This avoids the false failure in the
+[Crabline review](https://github.com/openclaw/crabline/pull/281#issuecomment-5447976937):
+`pnpm why postcss` printed `postcss@8.5.26`, but the generated plan expected
+`postcss 8.5.26`. The executor correctly rejected the absent literal despite exit
+zero. Version evidence does not establish runtime exposure, security, or
+compatibility; the incident's Vite/Vitest dependents were development-only.
+No executor, schema v1, lifecycle, or rendering contract changes are needed, so
+OpenClaw Bay is unaffected.
 
 The [review prompt](../prompts/review-item.md) and decision parser require
 `liveProofPlan.entry` and terminal `run.command` strings to contain no literal

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -605,6 +605,36 @@ not a count, timing, or number that varies per run. If you cannot name a value
 the run will certainly print or render, assert something more stable rather
 than inventing one.
 
+For dependency/package-version assertions, prefer the package manager's
+machine-readable output when supported. Inspect the target's pinned CLI version
+and supported schema first; do not guess human formatting such as `name version`
+versus `name@version`. Capture the complete JSON from an independent subprocess's
+stdout, not rendered terminal history or grep. Reject spawn errors, signals,
+nonzero exits, invalid JSON, missing output, and unsupported shapes before
+emitting a stable success marker. For pnpm 11 `why --json`, the top-level array
+contains resolved packages: require a nonempty array and EVERY resolution to
+have the exact requested name and version. Do not traverse `dependents` as
+resolutions or accept one correct version while wrong/mixed versions remain.
+
+Runnable pnpm 11 package-version example (adapt the package/version after
+inspection; these values are illustrative, not repository dependency policy):
+
+<!-- live-proof-pnpm11-package-version-example -->
+```bash
+node -e 'try { const result = require("node:child_process").spawnSync(process.argv[1], process.argv.slice(2), {encoding:"utf8"}); if (result.error || result.signal || result.status !== 0) throw new Error("pnpm why failed: " + (result.error?.message ?? result.signal ?? result.status)); const resolutions = JSON.parse(result.stdout); if (!Array.isArray(resolutions) || resolutions.length === 0 || !resolutions.every(p => p?.name === "postcss" && p?.version === "8.5.26")) throw new Error("unexpected package resolutions"); console.log("verified postcss@8.5.26"); } catch (error) { console.error(error.message); process.exitCode = 1; }' pnpm why postcss --json
+```
+
+Use this single-line command once as `entry` (or one `run` after safe setup),
+followed by `{"action":"expect_output","text":"verified postcss@8.5.26"}`
+and `terminalCompletion: "exit_zero"`; `static_text` is sufficient. The marker
+comes only after every assertion passes; successful proof need not mirror the
+full child output. Never use `|| true`, command exit alone, bare version
+substrings, punctuation normalization, fuzzy matching, or an unconditional/early
+marker. If structured output is unavailable, use only verified exact display
+with package/version boundaries, not guessed formatting. Version proof does
+not establish runtime exposure, security, or compatibility; development-only
+dependents remain development-only evidence.
+
 Judge whether the run has something worth watching, solely to choose its
 presentation. Choose `payoff.kind: "static_text"` when the whole demonstration
 is a short burst of plain text that a reader can understand better in a quoted

--- a/test/live-proof-package-version.test.ts
+++ b/test/live-proof-package-version.test.ts
@@ -1,0 +1,228 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import test, { type TestContext } from "node:test";
+
+import { mediaProofCommandRunner } from "../dist/clawsweeper-media-proof.js";
+import { driveTerminal } from "../dist/live-proof/drivers.js";
+
+const marker = "verified postcss@8.5.26";
+const examples = [
+  ...readFileSync(new URL("../prompts/review-item.md", import.meta.url), "utf8").matchAll(
+    /<!-- live-proof-pnpm11-package-version-example -->\r?\n```bash\r?\n([\s\S]*?)\r?\n```/g,
+  ),
+];
+assert.equal(examples.length, 1, "The production prompt must own one executable example.");
+const example = examples[0][1];
+assert.doesNotMatch(example, /[\r\n\u2028\u2029]/, "The terminal command must be single-line.");
+
+// Representative pnpm 11 resolution schema with a development-tool dependency tree.
+const resolution = {
+  name: "postcss",
+  version: "8.5.26",
+  path: "/fixture/node_modules/.pnpm/postcss@8.5.26/node_modules/postcss",
+  dependents: [
+    {
+      name: "vite",
+      version: "8.0.16",
+      dependents: [
+        {
+          name: "vitest",
+          version: "4.1.10",
+          dependents: [
+            { name: "@openclaw/crabline", version: "0.1.17", depField: "devDependencies" },
+          ],
+        },
+      ],
+    },
+  ],
+};
+const validJson = JSON.stringify([resolution], null, 2);
+
+type Response = {
+  stdout: string;
+  stderr?: string;
+  exitCode?: number;
+  signal?: string;
+  args?: string[];
+};
+
+function fixture(t: TestContext, response: Response, missingPnpm = false) {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-package-version-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const bin = join(root, "bin");
+  mkdirSync(bin);
+  symlinkSync(process.execPath, join(bin, "node"));
+  writeFileSync(join(root, "response.json"), JSON.stringify(response));
+  if (!missingPnpm) {
+    writeFileSync(
+      join(bin, "pnpm"),
+      [
+        "#!/usr/bin/env node",
+        'const {readFileSync, writeSync} = require("node:fs");',
+        'const response = JSON.parse(readFileSync(require("node:path").join(__dirname, "../response.json"), "utf8"));',
+        'require("node:assert/strict").deepEqual(process.argv.slice(2), response.args ?? ["why", "postcss", "--json"]);',
+        'writeSync(1, response.stdout); writeSync(2, response.stderr ?? "");',
+        "if (response.signal) process.kill(process.pid, response.signal);",
+        "else process.exit(response.exitCode ?? 0);",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+  }
+  return { root, bin };
+}
+
+function runExample(t: TestContext, response: Response, missingPnpm = false) {
+  const { root, bin } = fixture(t, response, missingPnpm);
+  const result = spawnSync("/bin/bash", ["--noprofile", "--norc", "-c", example], {
+    cwd: root,
+    // Only the fixture tools are available, so missing pnpm cannot fall back to a real install.
+    env: { ...process.env, PATH: bin },
+    encoding: "utf8",
+    timeout: 10_000,
+  });
+  assert.equal(result.error, undefined);
+  assert.equal(result.signal, null);
+  return result;
+}
+
+const cases = [
+  { name: "resolution with Vite/Vitest dependents", stdout: validJson, passes: true },
+  {
+    name: "two matching resolutions",
+    stdout: JSON.stringify([resolution, { ...resolution, path: "/second/postcss" }]),
+    passes: true,
+  },
+  {
+    name: "dependents are not resolutions",
+    stdout: JSON.stringify([
+      { ...resolution, dependents: [{ name: "postcss", version: "0.0.0" }] },
+    ]),
+    passes: true,
+  },
+  { name: "empty output", stdout: "" },
+  { name: "whitespace output", stdout: " \n\t" },
+  { name: "empty resolutions", stdout: "[]" },
+  { name: "missing name", stdout: JSON.stringify([{ version: "8.5.26" }]) },
+  { name: "missing version", stdout: JSON.stringify([{ name: "postcss" }]) },
+  { name: "null resolution", stdout: "[null]" },
+  { name: "string resolution", stdout: '["postcss@8.5.26"]' },
+  { name: "wrong name", stdout: JSON.stringify([{ ...resolution, name: "other-postcss" }]) },
+  ...["8.5.25", "8.5.260", "8.5.26-beta.1", "8.5.26+local"].map((version) => ({
+    name: `wrong exact version ${version}`,
+    stdout: JSON.stringify([{ ...resolution, version }]),
+  })),
+  ...[false, true].map((wrongFirst) => {
+    const mixed = [resolution, { ...resolution, version: "8.5.25" }];
+    return {
+      name: `mixed versions, wrong ${wrongFirst ? "first" : "last"}`,
+      stdout: JSON.stringify(wrongFirst ? mixed.reverse() : mixed),
+    };
+  }),
+  {
+    name: "correct dependent cannot rescue wrong resolution",
+    stdout: JSON.stringify([{ name: "vite", version: "7.0.0", dependents: [resolution] }]),
+  },
+  { name: "malformed JSON", stdout: "not JSON" },
+  { name: "truncated JSON", stdout: validJson.slice(0, -1) },
+  { name: "correct JSON followed by junk", stdout: `${validJson}\npostcss@8.5.26` },
+  { name: "unsupported object root", stdout: JSON.stringify(resolution) },
+  {
+    name: "unsupported importer schema",
+    stdout: JSON.stringify([{ name: "fixture", dependencies: { postcss: resolution } }]),
+  },
+  { name: "null root", stdout: "null" },
+  { name: "human display", stdout: "postcss@8.5.26\n" },
+];
+
+for (const scenario of cases) {
+  test(`prompt package-version example: ${scenario.name}`, (t) => {
+    const result = runExample(t, { stdout: scenario.stdout });
+    if ("passes" in scenario && scenario.passes) {
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(result.stdout, `${marker}\n`);
+      assert.equal(result.stderr, "");
+    } else {
+      assert.equal(result.status, 1);
+      assert.equal(result.stdout, "");
+      assert.ok(result.stderr.trim(), "Rejection must be visible.");
+      assert.ok(!result.stderr.includes(marker), "Failure must not echo a success marker.");
+    }
+  });
+}
+
+for (const failure of [
+  { name: "nonzero exit after valid JSON", exitCode: 7, diagnostic: /pnpm why failed: 7/ },
+  { name: "signal after valid JSON", signal: "SIGTERM", diagnostic: /pnpm why failed: SIGTERM/ },
+  { name: "spawn failure", missingPnpm: true, diagnostic: /ENOENT/ },
+]) {
+  test(`prompt package-version example rejects ${failure.name}`, (t) => {
+    const result = runExample(t, { stdout: validJson, ...failure }, "missingPnpm" in failure);
+    assert.equal(result.status, 1);
+    assert.equal(result.stdout, "");
+    assert.match(result.stderr, failure.diagnostic);
+    assert.ok(!result.stderr.includes(marker));
+  });
+}
+
+for (const scenario of [
+  {
+    name: "literal space-separated expectation rejects @ display despite exit zero",
+    entry: "pnpm why postcss",
+    expected: "postcss 8.5.26",
+    response: { stdout: "postcss@8.5.26\n", args: ["why", "postcss"] },
+    passes: false,
+  },
+  {
+    name: "exact prompt example verifies structured pnpm output",
+    entry: example,
+    expected: marker,
+    response: { stdout: validJson },
+    passes: true,
+  },
+  {
+    name: "exact prompt example rejects child failure after valid JSON",
+    entry: example,
+    expected: marker,
+    response: { stdout: validJson, exitCode: 7 },
+    passes: false,
+  },
+]) {
+  test(`terminal package-version proof: ${scenario.name}`, { timeout: 30_000 }, (t) => {
+    const { root, bin } = fixture(t, scenario.response);
+    const fixturePath = `${bin}${delimiter}${process.env.PATH ?? ""}`.replaceAll("'", "'\\''");
+    const result = driveTerminal({
+      plan: {
+        status: "recommended",
+        surface: "terminal",
+        terminalCompletion: "exit_zero",
+        reason: "Verify the resolved package version.",
+        payoff: { kind: "static_text", justification: "A version marker is sufficient." },
+        // Bind the fixture at the target command, independently of tmux's server environment.
+        entry: `PATH='${fixturePath}' ${scenario.entry}`,
+        steps: [{ action: "expect_output", text: scenario.expected }],
+      },
+      checkout: root,
+      rawVideoPath: join(root, "proof.webm"),
+      maxRecordingSeconds: 20,
+      recordMedia: false,
+      runner: mediaProofCommandRunner,
+    });
+    assert.equal(result.status, scenario.passes ? "completed" : "failed", JSON.stringify(result));
+    assert.equal(result.steps[0]?.satisfied, scenario.passes);
+    if (scenario.passes) {
+      assert.match(result.output, /verified postcss@8\.5\.26/);
+    } else if (scenario.entry === "pnpm why postcss") {
+      assert.match(result.output, /postcss@8\.5\.26/);
+      assert.match(
+        result.steps[0]?.detail ?? "",
+        /exited successfully before expected output appeared/,
+      );
+    } else {
+      assert.match(result.output, /pnpm why failed: 7/);
+      assert.match(result.steps[0]?.detail ?? "", /exit status 1/);
+    }
+  });
+}

--- a/test/live-proof.test.ts
+++ b/test/live-proof.test.ts
@@ -2354,7 +2354,9 @@ test("terminal wait steps cannot exceed the overall proof budget", () => {
   assert.equal(calls.includes("sleep 3"), false);
 });
 
-test("terminal recording holds the end state and enforces its minimum before finalizing", () => {
+test("terminal recording holds the end state and enforces its minimum before finalizing", (t) => {
+  // Fake sleeps must not consume real recording time under host load.
+  t.mock.method(Date, "now", () => 1_000_000);
   const calls: string[] = [];
   runTerminalFixture(
     terminalLifecycleRunner(calls, {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Resolves a problem where ClawSweeper could report correct package-version proof as failed because its generated terminal expectation guessed the package manager's human-readable formatting. In the [Crabline review](https://github.com/openclaw/crabline/pull/281#issuecomment-5447976937), pnpm 11.17.0 exited successfully and printed `postcss@8.5.26`, while the plan required the absent literal `postcss 8.5.26`.

Crabline's dependency update was handled separately by [the merged dependency refresh](https://github.com/openclaw/crabline/pull/282). This PR does not reopen that work or change Crabline's dependency policy.

## Why This Change Was Made

The terminal executor correctly enforced the literal expectation; the error belonged to the generated plan. The planner guidance now prefers supported machine-readable CLI output, checks the subprocess result and exact resolved package/version before emitting a stable success marker, and retains the existing `expect_output` plus `terminalCompletion: exit_zero` contract.

The pnpm 11 example accepts only a nonempty top-level resolution array whose every entry has the exact requested package name and version. It rejects missing, malformed, unsupported, wrong, or mixed resolutions, child errors/signals, and nonzero exits. Dependents remain dependency-tree metadata, not additional resolutions. The regression tests execute the actual command in the production prompt rather than maintaining a second implementation.

A separate test-only commit stabilizes an existing recording-hold test with a test-scoped `Date.now` mock. The fake command runner does not sleep, but elapsed host I/O time could reduce the calculated hold below the expected `sleep 6`. All existing ordering assertions remain intact; production clocks, recording minimums, deadlines, and budgets are unchanged.

## User Impact

Package-version proof planning no longer needs to guess whether the CLI displays `name version` or `name@version`. Incorrect versions and unsuccessful commands remain failures. This improves planner guidance; it does not make arbitrary model-generated plans infallible or relax proof requirements.

The terminal executor, plan schema, label policy, compatibility judgments, GitHub approval gates, dependency policy, and GHSA/advisory workflows are unchanged.

## OpenClaw Bay Impact

None. The existing schema-v1 plan, verification, lifecycle, and rendering contracts are unchanged.

## Documentation Impact

Updated the active `docs/live-proof.md` guide, owned by ClawSweeper review/publication maintainers, to document structured package-version assertions and their limits. The production review prompt owns the runnable example. Added the user-facing changelog entry.

## Evidence

Current-head direct subprocess proof is complete. The two failed macOS PTY cleanup reruns remain disclosed below; current-head Linux CI and fresh ClawSweeper terminal live verification remain required before merge.

- Fresh precommit Codex review: the complete five-file resolved candidate passed isolated local review with secret scanning against pinned main `a2f044f8197eecfe81cc3903971bcee4c60aed5b`, using default P0 reporting scope; no accepted/actionable findings, confidence 0.98. Earlier precommit reviews covered the original four-file patch and the subsequent test-only clock stabilization. This is not an all-priority review or the separate committed-branch pre-land review.
- Focused validation on the candidate: 257 passed, 0 failed/cancelled/skipped, including 31 new executable regression cases. Command: `node --test test/live-proof-package-version.test.ts test/live-proof.test.ts test/decision-parser.test.ts test/review-prompt-policy.test.ts test/pr-proof-automation.test.ts`. The first committed run had 238 passes and one recording-hold failure; after the scoped clock fix, the complete focused suite passed 239/239 in 89 seconds. After integrating main, those same five test files passed 257/257 in 63 seconds, including the added upstream cases, against the exact tree committed here.
- Builds, lint, formatting, and documentation checks: `pnpm run build:all`, `pnpm run check:static` (including formatting and docs), and `pnpm run lint` passed again on the exact integrated candidate tree with Node 24.20.0 and the repository-pinned pnpm 11.10.0. The earlier original-patch checks and updated-test lint also passed.
- The earlier local full check is **not claimed green**: it reached the full coverage suite and failed `destination import transactions prevent concurrent opposing parent edges` in unchanged `test/action-ledger-runtime.test.ts`, then was stopped during long-running unrelated ledger fixtures. The isolated recheck passed. No test gates, thresholds, or ledger code were changed. Attached CI checks report validation of this PR head separately. Baseline main `a2f044f8197eecfe81cc3903971bcee4c60aed5b` passed [CI run 33151672450](https://github.com/openclaw/clawsweeper/actions/runs/33151672450); that baseline result is context, not a substitute for this PR's exact-head CI.

## Review Disposition

The [old-head durable review](https://github.com/openclaw/clawsweeper/pull/1279#issuecomment-5449898262) covered `6108bfa1d44b1afb611ea39cc8a466a8d0948769` and found no actionable findings or security issues, with sufficient real proof. Its remaining blocker was the conflict with main and the required current-head proof/review refresh; no optional Rank-up moves were present.

Integrated pinned main `a2f044f8197eecfe81cc3903971bcee4c60aed5b` with a merge commit to preserve both published commits. The sole conflict was the first `Fixed` changelog insertion; both entries were retained unchanged. Relative to that base, this PR still changes only the prompt, active live-proof guide, changelog, package-version regression tests, and scoped recording-clock test. No authored workflow, policy, schema, dependency, label, security/advisory, or runtime-driver changes were added. A merge resolves the conflict without the review's suggested literal rebase or rewriting published history.

The combined-tree proof is reported below. A fresh review must bind the new head and this current body; old-head review and readiness labels are not used as landing evidence.

## Real Behavior Proof

**Claim and surface:** the executable production prompt example verifies the exact pnpm 11 package resolution without relying on human display punctuation, rejects the wrong version, and rejects a failed child command. The current-head proof exercises the actual Node/Bash/pnpm subprocess path. It does not claim to validate terminal-driver cleanup.

**Candidate:** `5a3c89a93d80c54f13c2f74a860d5dd8a47a87aa`; committed tree `f9be452d7a19b70da22d5b2ca4d00de48f810a3d`. The 257 focused tests and build/static/lint checks exercised this identical resolved tree before its merge commit. The direct subprocess proof below executed after commit on this exact head.

**Environment and fixture:** provider `local-process`, Node 24.20.0, Bash, actual pnpm 11.17.0, and macOS. The fixture contains only `package.json`, `pnpm-lock.yaml`, and `pnpm-workspace.yaml` from Crabline's reviewed head `021c5f46c4b38f6df544a30dd106f99ec3eededd`. No target dependencies were installed and no target application was executed.

**Commands:** run `pnpm why postcss` and execute the single-line command owned by [the production prompt](https://github.com/openclaw/clawsweeper/blob/5a3c89a93d80c54f13c2f74a860d5dd8a47a87aa/prompts/review-item.md#L621), identified by `live-proof-pnpm11-package-version-example`, through Bash. That command invokes actual `pnpm why postcss --json` and validates the complete subprocess result before emitting its marker. For the wrong-version case, change only the expected version comparison to `8.5.25`. For the child-failure case, a wrapper preserves real pnpm JSON stdout and then exits 7. The direct harness rejects spawn errors, signals, and timeouts. It does not use tmux.

**Current-head direct subprocess observations: all four checks passed.**

| Scenario | Exit | Actual stdout/stderr observation |
| --- | --- | --- |
| Actual pnpm human display | 0 | stdout contains `postcss@8.5.26` and does not contain `postcss 8.5.26`; stderr empty |
| Exact production-prompt structured command | 0 | stdout is only `verified postcss@8.5.26`; stderr empty |
| Structured command expecting `8.5.25` | 1 | stdout empty, no success marker; stderr `unexpected package resolutions` |
| Correct real JSON followed by child exit 7 | 1 | stdout empty, no success marker; stderr `pnpm why failed: 7` |

The human output identifies Vite 8.0.16 / Vitest 4.1.10 development-only dependents. JSON reports `name: postcss` and `version: 8.5.26`. The table is a sanitized observation trace; the retained `integrated-head-direct-pnpm-proof.json` binds the candidate, prompt hash, fixture hashes, and all four outcomes without publishing private host paths or raw session transcripts.

**Separate terminal-driver evidence and its limits:** before the merge commit, real PTY execution through `driveTerminal` on the exact tree `f9be452d7a19b70da22d5b2ca4d00de48f810a3d` produced all four expected outcomes with clean cleanup: the original guessed literal failed, the structured exact-version command passed, and both negative assertions failed. Two later post-commit macOS PTY reruns both failed with `terminal pane cleanup did not finish within 10 seconds`. Only the first negative scenario executed in those failed reruns; neither rerun passed. Source and generated-driver hashes were unchanged.

The changed planner command therefore has completed current-head direct real proof, while the repeated host cleanup failures remain failures. No runtime cleanup code, timeout, recording minimum, deadline, lease guard, or test gate was modified or bypassed. Current-head Linux CI and a fresh ClawSweeper terminal proof with `live_verification=passed` must independently validate the real terminal path before merge; old-head results or labels do not satisfy those gates. No further local PTY retries are claimed.

**Prompt SHA-256:** `1af48c8bbe2bad8a693c8fb20166a7e57373cfe87a3138ebd7d4727e2eb81150`.

**Fixture SHA-256:**

- `package.json`: `5fbbcb870eab9cd4d1ecddbdf1cd07377d8b35aa7ce94cc2f82008e400415bb2`
- `pnpm-lock.yaml`: `5ee255dde6b41e8167dcb5cefe9ce5829bed2d465377721546e166ea2a20a64b`
- `pnpm-workspace.yaml`: `2aacf727288936df9d9d1407d8a1e1c3dc93b79b9e99b37384752b53e6844785`

**Limits:** the direct proof establishes package-resolution and subprocess-assertion behavior, not terminal cleanup, an installed application, production deployment, runtime exposure, advisory remediation, or compatibility. It invoked no production review/apply/repair lane. The parser example is specifically for the inspected pnpm 11 `why --json` schema; other CLI versions or formats must be inspected rather than silently accepted.
