### PR TITLE
fix: terminal proof rejects soft-wrapped output

### DIFF
--- a/docs/live-proof.md
+++ b/docs/live-proof.md
@@ -66,6 +66,10 @@ assertion. Historical `ready_while_running` plans retain their bounded marker,
 stability, and liveness checks. Child standard I/O stays bound to the concrete
 PTY path so detached subprocesses can preserve their inherited descriptors.
 
+Retained terminal assertions join only tmux soft wraps, preserving hard newline
+boundaries and whitespace for literal matching. The final visual viewport keeps
+screen rows, including soft wraps.
+
 The retained verifier also preserves the final watchdog cleanup contract for
 historical terminal records: cleanup is bound to the original pane, terminal,
 nonce, and lease, requires an exact zero-survivor receipt after the pane dies,

--- a/src/live-proof/drivers.ts
+++ b/src/live-proof/drivers.ts
@@ -1820,12 +1820,13 @@ function terminalPrivateErrorMessage(error: unknown, privatePaths: readonly stri
   return message;
 }
 
+// Assertion captures join soft wraps; the final viewport keeps visual screen rows.
 function captureTerminalPane(
   runner: MediaProofCommandRunner,
   checkout: string,
   target: string,
 ): string {
-  const args = ["capture-pane", "-p", "-t", target, "-S", "-200"];
+  const args = ["capture-pane", "-p", "-J", "-t", target, "-S", "-200"];
   const capture = runner("tmux", args, { cwd: checkout });
   requireSuccess("tmux", args, capture);
   return normalizeTerminalOutput(String(capture.stdout ?? ""));
@@ -1836,7 +1837,7 @@ function captureTerminalHistory(
   checkout: string,
   target: string,
 ): string {
-  const args = ["capture-pane", "-p", "-t", target, "-S", `-${TERMINAL_HISTORY_LINES}`];
+  const args = ["capture-pane", "-p", "-J", "-t", target, "-S", `-${TERMINAL_HISTORY_LINES}`];
   const capture = runner("tmux", args, { cwd: checkout });
   requireSuccess("tmux", args, capture);
   return normalizeTerminalOutput(String(capture.stdout ?? ""));

--- a/test/live-proof-review-environment.test.ts
+++ b/test/live-proof-review-environment.test.ts
@@ -26,6 +26,10 @@ import { sanitizedLiveProofEnvironment } from "../dist/live-proof/environment.js
 import { parseLiveVerificationResult } from "../dist/live-proof/verification.js";
 import { repositoryProfileFor } from "../dist/repository-profiles.js";
 
+const softWrapMarker = "prepares pruned esm output with an actual peerDependencies host";
+// End peerD at the driver's existing 160-column boundary.
+const softWrapLine = " ".repeat(160 - softWrapMarker.indexOf("ependencies")) + softWrapMarker;
+
 test("review live proof composes inherited Go environment settings", () => {
   const profile = join("scratch", "profile");
   const environment = sanitizedLiveProofEnvironment({
@@ -716,7 +720,7 @@ test(
           `while [ ! -s ${pidPath} ]; do sleep 0.01; done`,
           `/bin/ps -o pgid= -p "$$" | /usr/bin/tr -d '[:space:]' >${shellGroupPath}`,
           `/bin/ps -o pgid= -p "$child" | /usr/bin/tr -d '[:space:]' >${childGroupPath}`,
-          "printf 'cleanup-ready\\n'",
+          `printf 'cleanup-ready\\n%s\\n' '${softWrapLine}'`,
           ...(terminalCompletion === "ready_while_running" ? ["while :; do sleep 1; done"] : []),
         ].join("\n");
         const result = driveTerminal({
@@ -730,7 +734,7 @@ test(
                 : "The command remains live after printing its readiness result.",
             payoff: { kind: "static_text", justification: "Text is sufficient." },
             entry,
-            steps: [{ action: "expect_output", text: "cleanup-ready" }],
+            steps: [{ action: "expect_output", text: softWrapMarker }],
           },
           checkout: root,
           rawVideoPath: join(root, `${terminalCompletion}.webm`),
@@ -740,6 +744,8 @@ test(
         });
 
         assert.equal(result.status, "completed", `${terminalCompletion}: ${result.output}`);
+        assert.equal(result.steps[0]?.satisfied, true);
+        assert.match(result.output, /peerD\nependencies host/);
         const backgroundPid = Number.parseInt(readFileSync(join(root, pidPath), "utf8"), 10);
         const shellGroup = readFileSync(join(root, shellGroupPath), "utf8");
         const childGroup = readFileSync(join(root, childGroupPath), "utf8");
@@ -1097,6 +1103,30 @@ test(
 test("terminal proof supervises consecutive commands in the same pane", { timeout: 30_000 }, () => {
   const root = mkdtempSync(join(tmpdir(), "clawsweeper-live-proof-consecutive-"));
   try {
+    writeFileSync(join(root, "initial.sh"), `printf '%s\\n' '${softWrapLine}'\n`);
+    const runner: MediaProofCommandRunner = (command, args, options = {}) => {
+      if (command === "tmux" && args[0] === "capture-pane" && args.at(-1) === "-200") {
+        const target = args[args.indexOf("-t") + 1]!;
+        const seed = mediaProofCommandRunner(
+          "tmux",
+          [
+            "send-keys",
+            "-t",
+            target,
+            "source ./initial.sh; tmux wait-for -S initial-ready",
+            "Enter",
+          ],
+          options,
+        );
+        assert.equal(seed.status, 0, String(seed.stderr));
+        const ready = mediaProofCommandRunner("tmux", ["wait-for", "initial-ready"], {
+          ...options,
+          timeoutMs: 5_000,
+        });
+        assert.equal(ready.status, 0, String(ready.stderr));
+      }
+      return mediaProofCommandRunner(command, args, options);
+    };
     const result = driveTerminal({
       plan: {
         status: "recommended",
@@ -1104,11 +1134,55 @@ test("terminal proof supervises consecutive commands in the same pane", { timeou
         terminalCompletion: "exit_zero",
         reason: "Each proof command must complete and preserve its own output.",
         payoff: { kind: "static_text", justification: "Text is sufficient." },
-        entry: "printf 'FIRST_OK\\n'",
+        entry: `printf 'FIRST_OK\\n%s\\n' '${softWrapLine}'`,
         steps: [
+          { action: "expect_output", text: softWrapMarker },
           { action: "expect_output", text: "FIRST_OK" },
-          { action: "run", command: "printf 'SECOND_OK\\n'" },
+          { action: "run", command: `printf 'SECOND_OK\\n%s\\n' '${softWrapLine}'` },
+          { action: "expect_output", text: softWrapMarker },
           { action: "expect_output", text: "SECOND_OK" },
+        ],
+      },
+      checkout: root,
+      rawVideoPath: join(root, "proof.webm"),
+      maxRecordingSeconds: 90,
+      recordMedia: false,
+      runner,
+    });
+
+    assert.equal(result.status, "completed", result.output);
+    assert.deepEqual(
+      result.steps.map((step) => step.status),
+      ["completed", "completed", "completed", "completed", "completed"],
+    );
+    for (const index of [0, 3]) {
+      assert.equal(result.steps[index]?.satisfied, true);
+      assert.equal(result.steps[index]?.presentAtStart, true);
+    }
+    assert.match(result.output, /peerD\nependencies host/);
+    assert.equal(result.output.includes(softWrapMarker), false);
+    assert.match(result.output, /SECOND_OK/);
+    assert.doesNotMatch(result.output, /FIRST_OK/);
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+test("terminal proof preserves hard newlines and exact whitespace", { timeout: 30_000 }, () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-live-proof-hard-lines-"));
+  const hardLineOutput = `${softWrapLine.replace("peerD", "peerD\n")}  \n`;
+  try {
+    const result = driveTerminal({
+      plan: {
+        status: "recommended",
+        surface: "terminal",
+        terminalCompletion: "exit_zero",
+        reason: "Only soft wraps may be joined; hard boundaries and whitespace remain literal.",
+        payoff: { kind: "static_text", justification: "Text is sufficient." },
+        entry: `printf '\\033[32m%s\\033[0m' '${hardLineOutput}'`,
+        steps: [
+          { action: "expect_output", text: hardLineOutput },
+          { action: "expect_output", text: softWrapMarker },
         ],
       },
       checkout: root,
@@ -1118,13 +1192,11 @@ test("terminal proof supervises consecutive commands in the same pane", { timeou
       runner: mediaProofCommandRunner,
     });
 
-    assert.equal(result.status, "completed", result.output);
-    assert.deepEqual(
-      result.steps.map((step) => step.status),
-      ["completed", "completed", "completed"],
-    );
-    assert.match(result.output, /SECOND_OK/);
-    assert.doesNotMatch(result.output, /FIRST_OK/);
+    assert.equal(result.status, "partial", result.output);
+    assert.equal(result.steps[0]?.satisfied, true);
+    assert.equal(result.steps[1]?.satisfied, false);
+    assert.match(result.steps[1]?.detail ?? "", /command exited successfully/);
+    assert.match(result.output, /peerD\nependencies host/);
   } finally {
     rmSync(root, { force: true, recursive: true });
   }
@@ -1143,10 +1215,10 @@ test(
           terminalCompletion: "exit_zero",
           reason: "Each command must satisfy assertions from its own rendered output.",
           payoff: { kind: "static_text", justification: "Text is sufficient." },
-          entry: "printf 'STALE_FROM_FIRST\\n'",
+          entry: `printf '%s\\n' '${softWrapLine}'`,
           steps: [
             { action: "run", command: "printf 'SECOND_ONLY\\n'" },
-            { action: "expect_output", text: "STALE_FROM_FIRST" },
+            { action: "expect_output", text: softWrapMarker },
           ],
         },
         checkout: root,
@@ -1159,7 +1231,8 @@ test(
       assert.equal(result.status, "partial", result.output);
       assert.equal(result.steps[1]?.satisfied, false);
       assert.match(result.output, /SECOND_ONLY/);
-      assert.match(result.output, /proof-plan assertion mismatch:.*"STALE_FROM_FIRST"/);
+      assert.match(result.output, /proof-plan assertion mismatch:/);
+      assert.ok(result.steps[1]?.detail.includes(JSON.stringify(softWrapMarker)));
     } finally {
       rmSync(root, { force: true, recursive: true });
     }


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the retained terminal verifier rejects successful output when an expected phrase crosses the terminal's 160-column soft-wrap boundary. The historical symptom was `peerD` / `ependencies` appearing on adjacent screen rows in [this review](https://github.com/openclaw/openclaw/pull/131615#issuecomment-5450273663), despite the command succeeding. That link is context, not a claim that the original OpenClaw tests were rerun here.

## Why This Change Was Made

Use tmux's wrap metadata (`capture-pane -J`) for assertion history and the initial `presentAtStart` snapshot, retaining literal `includes` matching, hard newline boundaries, whitespace, exit-status checks, and command isolation. Final viewport capture deliberately keeps physical screen rows.

This repairs the **retained verifier only**. Automatic generation remains retired by https://github.com/openclaw/clawsweeper/pull/1280; the intervening historical-proof classification and helper-retirement changes are included in the base. No automatic lane, policy gate, timeout/retry, dependency, schema, or OpenClaw product code changes.

## User Impact

Operators using retained terminal tooling can match phrases split only by terminal layout without accepting a true newline inside the phrase, a nonzero exit, or a marker left by a previous command. Visual output remains wrapped as rendered. Ordinary automatic reviews do not resume proof execution.

## OpenClaw Bay Impact

Unaffected: no observer fields, projections, routes, controls, lifecycle policy, or proof-credit rules change. Historical receipts remain diagnostic; this patch does not turn terminal PASS into behavioral-proof sufficiency.

## Documentation Impact

Reviewed `AGENTS.md`, `CONTRIBUTING.md`, `VISION.md`, `README.md`, and `docs/README.md`. Updated the compatibility-only `docs/live-proof.md` to distinguish logical assertion captures from visual viewport rows. Its existing maintainer owner and update triggers remain accurate. No changelog change.

## Evidence

Tested committed head: `c0eb630aa15632640695ba6d8497ca9d8f8470df`.
Base: `ccac077fea2f63570bd7d91969ee69abcca310e0`.
Diff: production +3/-2 (two flags and one comment), tests +82/-9, docs +4/-0; three files only.

- Final-head build and documentation checks passed: `pnpm run build`; `pnpm run check:docs`; `git diff origin/main..HEAD --check`.
- Final-head real-tmux regression checks: **5 passed, 0 failed, 0 skipped** (82.5 seconds), covering entry/subsequent commands and initial presence, actual hard newlines and exact whitespace, both completion modes with descendant cleanup, prior-command rejection, and the original package-manager-echo safeguard unchanged.
- Earlier wider focused run on `f72ea010c1d7fd134b1bd0826b3a707778c312bc` plus this patch: **173 passed, 0 failed, 0 skipped** for `node --test test/live-proof.test.ts test/live-proof-review-environment.test.ts test/live-proof-report.test.ts`. This is supporting pre-rebase evidence, not an exact-head full-suite claim.
- Codex autoreview: pre-commit uncommitted review passed; committed branch against `origin/main` passed. Both named gates used the helper's requested default P0 reporting scope, with no reported findings. No review transcripts are attached.

Full-check limitation: the earlier local `pnpm run check` passed static/docs, all builds, lint, and changed-surface coverage, then stopped making progress in the existing `test/action-ledger-runtime.test.ts` import-bindings pause subprocess. The owned run was stopped after more than 17 minutes. This does not establish a patch regression; the two corresponding main CI runs were green. No ledger changes or gate bypasses are included. Fresh exact-head hosted CI now passed: [CI run 33193117080](https://github.com/openclaw/clawsweeper/actions/runs/33193117080) completed successfully, including `pnpm check`, sparse repair build smoke, and Windows Codex launcher. [CodeQL run 33193117034](https://github.com/openclaw/clawsweeper/actions/runs/33193117034) also passed. These results close the local full-check validation gap without changing or bypassing the ledger tests.

Review disposition: [the first ClawSweeper review](https://github.com/openclaw/clawsweeper/pull/1285#issuecomment-5455508597) assessed the real behavior proof as sufficient and found no actionable correctness or security issue. Its two remaining checklist entries both concerned the then-pending broad CI check; the exact-head success above resolves them. No Rank-up moves were requested. The short three-case real-runtime proof was refreshed on the same unchanged head before requesting the updated review.

## Real Behavior Proof

**Claim and exercised surface:** compiled `driveTerminal` → real `mediaProofCommandRunner`/tmux PTY → `buildLiveVerificationResult` → `parseLiveVerificationResult`. This directly exercises the changed capture boundary and downstream PASS/FAIL interpretation, rather than substituting a mocked capture or treating a generic command exit as proof.

**Environment:** local macOS arm64, Node 24.20.0, pnpm 11.10.0, tmux 3.7c; native local execution, no Crabbox provider/image/lease. Media recording disabled. The tmux manual specifies that `-J` preserves trailing spaces and joins wrapped lines.

**Fixture:** `prepares pruned esm output with an actual peerDependencies host`, padded so `peerD` ends at column 160. The baseline real-PTY regression on pre-fix production code failed despite exit 0 and showed `peerD\nependencies`; the same test after the fix passed. The regression and negative controls are public in [`test/live-proof-review-environment.test.ts`](https://github.com/openclaw/clawsweeper/blob/c0eb630aa15632640695ba6d8497ca9d8f8470df/test/live-proof-review-environment.test.ts).

Run from the repository root with Node 24 and tmux installed:

```sh
pnpm run build
node --test --test-name-pattern='terminal proof (supervises consecutive commands in the same pane|preserves hard newlines and exact whitespace|does not satisfy a command from the previous pane state|cleanup terminates a signal-resistant descendant in a distinct process group|cannot pass from package-manager echo before a nonzero exit)' test/live-proof-review-environment.test.ts
node /tmp/terminal-soft-wrap-runtime.mjs
```

The standalone script is included below so the runtime reproduction does not depend on inaccessible local files. It records the actual Git HEAD in each receipt and asserts all three outcomes; only its generated fixture directories are removed.

**Observed final-head runtime trace** (all three expected outcomes verified):

```text
soft-wrap-exit-zero: overallPass=true, driveStatus=completed, satisfied=true, visualSoftWrap=true
hard-newline-exit-zero: overallPass=false, driveStatus=failed, satisfied=false; assertion mismatch despite successful command exit
soft-wrap-exit-seven: overallPass=false, driveStatus=failed, satisfied=false; terminal command failed with exit status 7
```

The passing case's returned viewport still contains `peerD\nependencies host` and does not contain the contiguous marker, while its assertion is satisfied. The hard-newline fixture separately proves exact whitespace can match without allowing the contiguous phrase. The package-manager test still uses an actual `pnpm run` echo followed by exit 7.

**Artifacts and limits:** the trace above and public regression source provide inspectable evidence; the standalone script writes timestamped, exact-head verification receipts to `/tmp/terminal-soft-wrap-runtime-receipts.json`. This is a controlled synthetic controller proof, not a rerun of the original OpenClaw 18 tests, a video, a live-channel run, or evidence of automatic proof execution. The fixture's `18 passed` line is synthetic text only. No foreign PR was mutated, and no historical receipt is being used to grant proof credit.

<details>
<summary>Standalone runtime reproduction — save as /tmp/terminal-soft-wrap-runtime.mjs</summary>

```js
import assert from 'node:assert/strict';
import { execFileSync } from 'node:child_process';
import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
import { join } from 'node:path';
import { pathToFileURL } from 'node:url';

const repo = process.cwd();
const { driveTerminal } = await import(pathToFileURL(join(repo, 'dist/live-proof/drivers.js')));
const { mediaProofCommandRunner } = await import(pathToFileURL(join(repo, 'dist/clawsweeper-media-proof.js')));
const { buildLiveVerificationResult, parseLiveVerificationResult } = await import(pathToFileURL(join(repo, 'dist/live-proof/verification.js')));
const headSha = execFileSync('git', ['-C', repo, 'rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
const marker = 'prepares pruned esm output with an actual peerDependencies host';
const line = ' '.repeat(160 - marker.indexOf('ependencies')) + marker;
const cases = [
  { name: 'soft-wrap-exit-zero', text: line + '\n18 passed\n', exit: 0, expectedPass: true },
  { name: 'hard-newline-exit-zero', text: line.replace('peerD', 'peerD\n') + '\n', exit: 0, expectedPass: false },
  { name: 'soft-wrap-exit-seven', text: line + '\n', exit: 7, expectedPass: false },
];
const receipts = [];
for (const scenario of cases) {
  const root = mkdtempSync('/tmp/clawsweeper-wrap-proof-');
  try {
    writeFileSync(join(root, 'emit.mjs'), `process.stdout.write(${JSON.stringify(scenario.text)}); process.exitCode = ${scenario.exit};\n`);
    const plan = {
      status: 'recommended', surface: 'terminal', terminalCompletion: 'exit_zero',
      reason: 'Local synthetic terminal capture verification; not an OpenClaw test rerun.',
      payoff: { kind: 'static_text', justification: 'Observe literal matching and physical screen rows without media.' },
      entry: 'node emit.mjs', steps: [{ action: 'expect_output', text: marker }],
    };
    const drive = driveTerminal({ plan, checkout: root, rawVideoPath: join(root, 'proof.webm'), maxRecordingSeconds: 90, recordMedia: false, runner: mediaProofCommandRunner });
    const result = parseLiveVerificationResult(buildLiveVerificationResult({ repo: 'example/terminal-soft-wrap', item: 1, headSha, plan, driveStatus: drive.status, stepLog: drive.steps, output: drive.output, verifiedAt: new Date().toISOString() }));
    assert.equal(result.overall_pass, scenario.expectedPass, JSON.stringify(result));
    if (scenario.expectedPass) {
      assert.ok(result.output.includes('peerD\nependencies host'), 'visual viewport lost soft wrap');
      assert.equal(result.output.includes(marker), false, 'viewport was incorrectly joined');
    } else {
      assert.match(result.failure.reason, scenario.exit === 7 ? /exit status 7/ : /assertion mismatch/);
    }
    receipts.push({ scenario: scenario.name, sourceHead: headSha, uncommittedPatch: false, synthetic: true, ...result });
    console.log(JSON.stringify({ scenario: scenario.name, overallPass: result.overall_pass, driveStatus: result.drive_status, satisfied: result.steps[0].satisfied, failure: result.failure?.reason, visualSoftWrap: result.output.includes('peerD\nependencies host') }));
  } finally {
    rmSync(root, { recursive: true, force: true });
  }
}
writeFileSync('/tmp/terminal-soft-wrap-runtime-receipts.json', JSON.stringify(receipts, null, 2) + '\n', { mode: 0o600 });
console.log('runtime-proof: all three expected outcomes verified; no publication');

```

</details>
