### PR TITLE
fix(tests): clean up paused imports after race setup failures

### DIFF
--- a/test/action-ledger-runtime.test.ts
+++ b/test/action-ledger-runtime.test.ts
@@ -4168,6 +4168,162 @@ test("state shard imports retain global event identity and causal acyclicity", (
   assert.equal(fs.existsSync(path.join(cycleDestination, secondShard.relativePath)), false);
 });
 
+async function withImportRaceChildren(
+  run: (own: (child: ChildProcess) => ReturnType<typeof childResult>) => Promise<void>,
+): Promise<void> {
+  const children: { child: ChildProcess; closed: Promise<number | null> }[] = [];
+  let failure: { error: unknown } | undefined;
+  let cleanupErrors: unknown[] = [];
+  try {
+    await run((child) => {
+      const closed = new Promise<number | null>((resolve) => child.once("close", resolve));
+      children.push({ child, closed });
+      let error: Error | undefined;
+      child.on("error", (cause) => {
+        error ??= cause;
+      });
+      let stdout = "";
+      let stderr = "";
+      child.stdout?.setEncoding("utf8");
+      child.stderr?.setEncoding("utf8");
+      child.stdout?.on("data", (chunk) => {
+        stdout += String(chunk);
+      });
+      child.stderr?.on("data", (chunk) => {
+        stderr += String(chunk);
+      });
+      const result = closed.then((code) => {
+        if (error) throw error;
+        return { code, stdout, stderr };
+      });
+      // A readiness failure may prevent the caller from ever awaiting this result.
+      void result.catch(() => {});
+      return result;
+    });
+  } catch (error) {
+    failure = { error };
+  } finally {
+    const cleanup = await Promise.allSettled(
+      children.map(async ({ child, closed }) => {
+        // These disposable fixtures can be blocked in Atomics.wait indefinitely.
+        if (child.pid !== undefined && child.exitCode === null && child.signalCode === null) {
+          child.kill("SIGKILL");
+        }
+        let timer: NodeJS.Timeout | undefined;
+        try {
+          await Promise.race([
+            closed,
+            new Promise<never>((_resolve, reject) => {
+              timer = setTimeout(() => reject(new Error("import race child did not close")), 2_000);
+            }),
+          ]);
+        } finally {
+          clearTimeout(timer);
+        }
+      }),
+    );
+    cleanupErrors = cleanup.flatMap((result) =>
+      result.status === "rejected" ? [result.reason] : [],
+    );
+  }
+  if (cleanupErrors.length > 0) {
+    throw new AggregateError(
+      [...(failure ? [failure.error] : []), ...cleanupErrors],
+      "import race child cleanup failed",
+      failure ? { cause: failure.error } : undefined,
+    );
+  }
+  if (failure) throw failure.error;
+}
+
+test("import race child ownership closes held children on pre-release failures", async () => {
+  for (const stage of ["readiness", "second-spawn"]) {
+    const root = tempRoot();
+    const children: ChildProcess[] = [];
+    const closed: ChildProcess[] = [];
+    const releasePath = path.join(root, "release");
+    const failure = new Error("injected failure after second spawn");
+    await assert.rejects(
+      withImportRaceChildren(async (own) => {
+        const startHeldChild = (readyPath: string) => {
+          const child = spawn(
+            process.execPath,
+            [
+              "--input-type=module",
+              "-e",
+              `import fs from "node:fs";
+process.on("SIGTERM", () => {});
+fs.writeFileSync(process.argv[1], "ready");
+Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);`,
+              readyPath,
+            ],
+            { stdio: ["ignore", "pipe", "pipe"] },
+          );
+          own(child);
+          children.push(child);
+          child.once("close", () => closed.push(child));
+        };
+        const readyPath = path.join(root, "ready");
+        startHeldChild(readyPath);
+        await waitForPath(readyPath);
+        assert.equal(children[0].exitCode, null);
+        assert.equal(children[0].signalCode, null);
+        if (stage === "readiness") {
+          // Reject readiness deterministically while the first fixture is still held.
+          await waitForPath(path.join(root, "unobserved-ready"));
+        } else {
+          startHeldChild(path.join(root, "second-ready"));
+          throw failure;
+        }
+        fs.writeFileSync(releasePath, "release");
+      }),
+      (error) => {
+        if (stage === "readiness") {
+          assert.equal(
+            String(error),
+            `Error: timed out waiting for ${path.join(root, "unobserved-ready")}`,
+          );
+        } else {
+          assert.equal(error, failure);
+        }
+        return true;
+      },
+    );
+    assert.equal(fs.existsSync(releasePath), false);
+    assert.equal(children.length, stage === "readiness" ? 1 : 2);
+    assert.deepEqual(new Set(closed), new Set(children));
+    for (const child of children) {
+      assert.equal(child.signalCode, "SIGKILL");
+      assert.equal(child.stdout?.closed, true);
+      assert.equal(child.stderr?.closed, true);
+    }
+  }
+});
+
+test("import race child ownership observes spawn rejection before awaiting results", async () => {
+  const root = tempRoot();
+  let child: ChildProcess | undefined;
+  const failure = new Error("injected failure after spawn rejection");
+  await assert.rejects(
+    withImportRaceChildren(async (own) => {
+      child = spawn(process.execPath, ["-e", ""], {
+        cwd: path.join(root, "missing"),
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      const result = own(child);
+      await new Promise<void>((resolve) => child!.once("close", () => resolve()));
+      // Cross an event-loop turn before consuming the already rejected result.
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      await assert.rejects(result, { code: "ENOENT" });
+      throw failure;
+    }),
+    (error) => error === failure,
+  );
+  assert.equal(child?.pid, undefined);
+  assert.equal(child?.stdout?.closed, true);
+  assert.equal(child?.stderr?.closed, true);
+});
+
 test("destination import transactions prevent concurrent opposing parent edges", async () => {
   const root = tempRoot();
   const base = recordReview(root);
@@ -4220,28 +4376,40 @@ importActionEventShards(process.argv[1], process.argv[2]);`;
     moduleUrl,
   )});
 importActionEventShards(process.argv[1], process.argv[2]);`;
-  const firstChild = spawn(
-    process.execPath,
-    ["--input-type=module", "-e", firstScript, firstSource, destination, readyPath, releasePath],
-    { stdio: ["ignore", "pipe", "pipe"] },
-  );
-  const firstDone = childResult(firstChild);
-  await waitForPath(readyPath);
-  const secondChild = spawn(
-    process.execPath,
-    ["--input-type=module", "-e", importScript, secondSource, destination],
-    { stdio: ["ignore", "pipe", "pipe"] },
-  );
-  const secondDone = childResult(secondChild);
-  await new Promise((resolve) => setTimeout(resolve, 100));
-  fs.writeFileSync(releasePath, "release\n");
+  await withImportRaceChildren(async (own) => {
+    const firstDone = own(
+      spawn(
+        process.execPath,
+        [
+          "--input-type=module",
+          "-e",
+          firstScript,
+          firstSource,
+          destination,
+          readyPath,
+          releasePath,
+        ],
+        { stdio: ["ignore", "pipe", "pipe"] },
+      ),
+    );
+    await waitForPath(readyPath);
+    const secondDone = own(
+      spawn(
+        process.execPath,
+        ["--input-type=module", "-e", importScript, secondSource, destination],
+        { stdio: ["ignore", "pipe", "pipe"] },
+      ),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    fs.writeFileSync(releasePath, "release\n");
 
-  const [firstResult, secondResult] = await Promise.all([firstDone, secondDone]);
-  assert.equal(firstResult.code, 0, firstResult.stderr || firstResult.stdout);
-  assert.notEqual(secondResult.code, 0, secondResult.stdout);
-  assert.match(secondResult.stderr, /causal cycle/);
-  assert.equal(fs.existsSync(path.join(destination, firstShard.relativePath)), true);
-  assert.equal(fs.existsSync(path.join(destination, secondShard.relativePath)), false);
+    const [firstResult, secondResult] = await Promise.all([firstDone, secondDone]);
+    assert.equal(firstResult.code, 0, firstResult.stderr || firstResult.stdout);
+    assert.notEqual(secondResult.code, 0, secondResult.stdout);
+    assert.match(secondResult.stderr, /causal cycle/);
+    assert.equal(fs.existsSync(path.join(destination, firstShard.relativePath)), true);
+    assert.equal(fs.existsSync(path.join(destination, secondShard.relativePath)), false);
+  });
 });
 
 test("state shard imports reject noncanonical trusted root spellings", async () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the ledger import race test leaves a paused child alive after a readiness failure or an error following the second spawn, preventing the test process from finishing. Deterministic fault injection confirmed this cleanup gap; the triggering failure behind the original historical hang remains unproven.

## Why This Change Was Made

The test now owns each child immediately, observes spawn rejection, and waits for child close and stdout/stderr closure. Cleanup force-kills disposable held fixtures and preserves the original error. Real-child regressions cover readiness failure, failure after the second spawn, and ENOENT before the spawn result is awaited.

Only `test/action-ledger-runtime.test.ts` changes. The existing two-second readiness budget, 100ms release delay, child scripts, cycle assertions, runner flags, and production locking, storage, and schema are unchanged. No timer/state or infrastructure root cause is asserted.

## User Impact

No production or user-visible behavior changes. Developers get cleanup of test-owned children when this fixture fails, while retaining the original failure and opposing-parent-edge assertions.

## OpenClaw Bay Impact

Bay is unaffected: no lifecycle publication, workflow, queue, status, telemetry, dashboard, or data-contract change.

## Documentation Impact

Reviewed `AGENTS.md`, `CONTRIBUTING.md`, `README.md`, `VISION.md`, `docs/README.md`, `docs/action-ledger.md`, and the PR template. Existing contracts remain accurate; this test-only cleanup needs no documentation or changelog edit.

## Evidence

Base: `566889b0dc5a0756e8ad7d2a36402e8ea84ac175`. Head: `34797a15a52c768c9f3c4c7a65379afaaf0d34a5`. The one-file patch is byte-identical after rebase. Test source SHA-256: `39b8ca0ea3a44dc5263a51afe807be24a9dc9d43bc5fbb35e0435e2b67c841d2`.

On this head, macOS arm64 / Node 26.7.0 / package-pinned pnpm 11.10.0: a fresh `pnpm run build:node`, the focused command below, focused oxfmt and oxlint, and `git diff --check` all passed. The focused run passed 3/3 with no watchdog intervention or remaining owned children. GitHub checks separately report current-head CI.

**Historical local full-check failure is preserved, not relabeled green.** The original supplied check failed/interrupted. A later `pnpm run check` at `af8f89fe69e1e35009591a640c55d12a4a083cf9` with this same patch completed normally in 3260.899s with exit 1: **3949 tests, 3933 pass, 7 fail, 9 skip, 0 cancelled**. The cleanup regressions, real opposing-edge race, and 4097-event import all passed in full-file order. Failures outside the changed code were:

| Area | Observed failure |
| --- | --- |
| CrabFleet projection fairness | Actual 4, expected 68 |
| Live-proof package-manager echo | ENOTEMPTY during fixture cleanup |
| Live-proof original terminal pane | Cleanup did not finish within 10 seconds |
| Live-proof output/final-exit ordering | Assertion index −1 |
| Target-validation pinned-base checkout | Existing <2000ms assertion failed |
| Target-validation prepared pnpm | Identity deadline exhausted during `bin` |
| Target-validation Knip/offline cache | Identity deadline exhausted during helper-cache traversal |

Their causes were not established and are not dismissed as environment flakes. Upstream changed live-proof code before this rebase, but the historical failures have not been revalidated by a new macOS full check. Unfiltered pre-fix file attempts were interrupted rather than green; the longer attempt progressed through the race. Narrow coverage commands passed their assertions but missed the unchanged whole-suite branch threshold.

## Real Behavior Proof

**Claim and surface:** test-process ownership and failure cleanup, exercised through actual Node spawn, close, and pipe behavior in disposable fixtures—not production storage behavior or a live deployment.

**Scenario and environment:** local macOS arm64, Node 26.7.0, pnpm 11.10.0, the exact head above, freshly built `dist`. The tests hold a real child in `Atomics.wait`, reject readiness before release, fail after spawning child two, observe an ENOENT spawn rejection, and run the unchanged real filesystem opposing-parent-edge race. Provider: local processes; no container image or lease applies.

**Executed command:** after `pnpm run build:node`, an external owned-process watchdog ran this exact child command with a unique TMPDIR and a 60-second outer deadline. Existing test timing and assertions were not relaxed.

```bash
node --test --test-concurrency=16 '--test-name-pattern=^(import race child ownership|destination import transactions prevent concurrent opposing parent edges)' test/action-ledger-runtime.test.ts
```

**Observed current result / terminal trace:**

```text
✔ import race child ownership closes held children on pre-release failures (2389.322541ms)
✔ import race child ownership observes spawn rejection before awaiting results (11.863708ms)
✔ destination import transactions prevent concurrent opposing parent edges (9152.618916ms)
ℹ tests 3
ℹ pass 3
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ duration_ms 11832.564875
watchdog: exit=0, effective_exit=0, timed_out=false
watchdog cleanup signals: []
remaining owned processes: []
```

The failure regressions require the original error, no release marker, all owned close events, SIGKILL for held fixtures, and closed stdout/stderr. The ENOENT regression crosses an event-loop turn before consuming the rejected result. The race still requires only the first shard to publish and the opposing import to reject a causal cycle.

**Before/after provenance:** preserved instrumented probes were derived from the original race at `af8f89fe69e1e35009591a640c55d12a4a083cf9` and this byte-identical cleanup helper, before commit/rebase. These were deliberately injected faults, not natural recurrences. The readiness probe first observed the real ready marker and then awaited a missing observation; the second-spawn probe threw before release. Both old-path probes failed their close assertion (0/1 and 0/2 closed) and required watchdog cleanup, effective exit 124. Both patched probes passed with original errors preserved, closed streams, no watchdog signals, and zero survivors. A patched uncaught-readiness probe exited 1 normally with the original error after closing its child and pipes. The new current-head run above independently exercises the shared ownership helper and the original race.

**Artifacts and cleanup:** the current terminal trace is included above. Local command/result receipts and process/fixture traces were preserved; this body does not claim they have been uploaded. An independent audit across 21 receipts found zero remaining owned processes using process groups, PID/start identities, and detached command/cwd matches against run-owned TMPDIR paths. A detached shell/sleep from the older live-proof failure was separately cleaned and audited. No new cleanup signals were needed for the current proof.

**Limits:** no proof of the original historical trigger, production storage or infrastructure diagnosis, hostile-process containment, cross-platform proof, or green macOS full-suite claim. Successful forced termination and stream closure are exercised; OS refusal to kill or close is not simulated. No screenshot or video is needed for these process assertions.
