### PR TITLE
fix: prevent macOS terminal cleanup timeouts with descendants

### DIFF
--- a/docs/live-proof.md
+++ b/docs/live-proof.md
@@ -75,6 +75,13 @@ historical terminal records: cleanup is bound to the original pane, terminal,
 nonce, and lease, requires an exact zero-survivor receipt after the pane dies,
 and fails visibly for missing, stale, replaced, surviving-process, or timeout
 evidence. Target commands do not inherit `TMUX`, `TMUX_PANE`, or `TMUX_TMPDIR`.
+The watchdog sends TERM once with 150 ms total grace, then rediscovers and
+identity-checks survivors for KILL and requires two empty scans. It does not
+repeat the expensive macOS per-process lease checks in additional TERM sweeps.
+Up to eight independent signal workers run together, each revalidating the
+lease or original terminal immediately before signaling. Every worker is joined
+and its failure retained before the next scan. The controller's cleanup budget
+is unchanged.
 
 ## Historical artifact publication
 

--- a/src/live-proof/drivers.ts
+++ b/src/live-proof/drivers.ts
@@ -565,14 +565,25 @@ scan_bound_processes() {
   /usr/bin/sort -n -u -o "$scan_file" "$scan_file"
 }
 signal_bound_processes() {
+  local workers=() worker result=0
   while IFS= read -r candidate; do
     case "$candidate" in ""|*[!0-9]*) continue ;; esac
-    if ! holds_lease "$candidate"; then
-      on_bound_tty "$candidate" || continue
-      pane_owns_tty || continue
+    (
+      if ! holds_lease "$candidate"; then
+        on_bound_tty "$candidate" || exit 0
+        pane_owns_tty || exit 0
+      fi
+      /bin/kill "-$1" "$candidate" 2>/dev/null || [ "$?" -eq 1 ]
+    ) &
+    workers+=("$!")
+    # Bound independent Darwin lookups without caching identity across signals.
+    if [ "\${#workers[@]}" -ge 8 ]; then
+      wait "\${workers[0]}" || result=1
+      workers=("\${workers[@]:1}")
     fi
-    /bin/kill "-$1" "$candidate" 2>/dev/null || [ "$?" -eq 1 ] || return $?
   done <"$scan_file"
+  for worker in "\${workers[@]}"; do wait "$worker" || result=1; done
+  return "$result"
 }
 [ "$(lease_identity_now)" = "$lease_identity" ] || finish startup error:lease-identity 0 125
 pane_owns_tty || finish startup error:pane-identity 0 125
@@ -589,11 +600,11 @@ while [ -z "$trigger" ]; do
     sleep 0.05
   fi
 done
-for sweep in 1 2 3; do
-  scan_bound_processes || finish "$trigger" error:scan 0 125
-  signal_bound_processes TERM || finish "$trigger" error:term 0 125
-  sleep 0.05
-done
+# Repeating TERM multiplies Darwin's per-PID lease scans before escalation.
+# Keep the same total grace; the KILL phase rediscovers and verifies survivors.
+scan_bound_processes || finish "$trigger" error:scan 0 125
+signal_bound_processes TERM || finish "$trigger" error:term 0 125
+sleep 0.15
 stable_empty=0
 for ((sweep = 1; sweep <= 100; sweep += 1)); do
   scan_bound_processes || finish "$trigger" error:scan 0 125

--- a/test/live-proof-review-environment.test.ts
+++ b/test/live-proof-review-environment.test.ts
@@ -692,10 +692,12 @@ test(
 );
 
 test(
-  "terminal proof cleanup terminates a signal-resistant descendant in a distinct process group",
+  "terminal proof cleanup terminates signal-resistant descendants in distinct process groups",
   { timeout: 60_000 },
   () => {
     const root = mkdtempSync(join(tmpdir(), "clawsweeper-live-proof-cleanup-"));
+    const processToken = `clawsweeper-proof-child-${process.pid}-${Date.now()}`;
+    const childCount = 16;
     try {
       writeFileSync(
         join(root, "background.mjs"),
@@ -712,14 +714,17 @@ test(
         const pidPath = `${terminalCompletion}.pid`;
         const shellGroupPath = `${terminalCompletion}.shell-pgid`;
         const childGroupPath = `${terminalCompletion}.child-pgid`;
-        const processToken = `clawsweeper-proof-child-${terminalCompletion}-${process.pid}-${Date.now()}`;
         const entry = [
           "set -m",
-          `node background.mjs ${pidPath} ${processToken} >/dev/null 2>&1 &`,
-          "child=$!",
-          `while [ ! -s ${pidPath} ]; do sleep 0.01; done`,
           `/bin/ps -o pgid= -p "$$" | /usr/bin/tr -d '[:space:]' >${shellGroupPath}`,
-          `/bin/ps -o pgid= -p "$child" | /usr/bin/tr -d '[:space:]' >${childGroupPath}`,
+          `for ((index = 0; index < ${childCount}; index += 1)); do`,
+          `  node background.mjs ${pidPath}.$index ${processToken} >/dev/null 2>&1 &`,
+          "done",
+          `for ((index = 0; index < ${childCount}; index += 1)); do`,
+          `  while [ ! -s ${pidPath}.$index ]; do sleep 0.01; done`,
+          `  child=$(<${pidPath}.$index)`,
+          `  /bin/ps -o pgid= -p "$child" >>${childGroupPath}`,
+          "done",
           `printf 'cleanup-ready\\n%s\\n' '${softWrapLine}'`,
           ...(terminalCompletion === "ready_while_running" ? ["while :; do sleep 1; done"] : []),
         ].join("\n");
@@ -746,15 +751,13 @@ test(
         assert.equal(result.status, "completed", `${terminalCompletion}: ${result.output}`);
         assert.equal(result.steps[0]?.satisfied, true);
         assert.match(result.output, /peerD\nependencies host/);
-        const backgroundPid = Number.parseInt(readFileSync(join(root, pidPath), "utf8"), 10);
-        const shellGroup = readFileSync(join(root, shellGroupPath), "utf8");
-        const childGroup = readFileSync(join(root, childGroupPath), "utf8");
-        assert.equal(Number.isSafeInteger(backgroundPid), true);
-        assert.notEqual(
-          childGroup,
-          shellGroup,
-          `${terminalCompletion} did not create a distinct PGID`,
+        const backgroundPids = Array.from({ length: childCount }, (_, index) =>
+          Number.parseInt(readFileSync(join(root, `${pidPath}.${index}`), "utf8"), 10),
         );
+        const shellGroup = readFileSync(join(root, shellGroupPath), "utf8").trim();
+        const childGroups = readFileSync(join(root, childGroupPath), "utf8").trim().split(/\s+/);
+        assert.equal(new Set(childGroups).size, childCount);
+        assert.equal(childGroups.includes(shellGroup), false, terminalCompletion);
         let matches = processesContaining(processToken);
         const deadline = Date.now() + 2_000;
         while (matches.length > 0 && Date.now() < deadline) {
@@ -762,9 +765,15 @@ test(
           matches = processesContaining(processToken);
         }
         assert.deepEqual(matches, []);
-        assert.throws(() => process.kill(backgroundPid, 0), { code: "ESRCH" });
+        for (const pid of backgroundPids) {
+          assert.equal(Number.isSafeInteger(pid), true);
+          assert.throws(() => process.kill(pid, 0), { code: "ESRCH" });
+        }
       }
     } finally {
+      for (const processLine of processesContaining(processToken)) {
+        killProcess(Number.parseInt(processLine, 10));
+      }
       rmSync(root, { force: true, recursive: true });
     }
   },

--- a/test/live-proof.test.ts
+++ b/test/live-proof.test.ts
@@ -1650,7 +1650,7 @@ test("terminal cleanup requires the exact pane receipt and pane death", () => {
   );
   assert.match(
     cleanupScript,
-    /if ! holds_lease "\$candidate"; then\s+on_bound_tty "\$candidate" \|\| continue\s+pane_owns_tty \|\| continue\s+fi\s+\/bin\/kill/,
+    /if ! holds_lease "\$candidate"; then\s+on_bound_tty "\$candidate" \|\| exit 0\s+pane_owns_tty \|\| exit 0\s+fi\s+\/bin\/kill/,
   );
   assert.match(cleanupScript, /pane_owns_tty \|\| finish startup error:pane-identity/);
   assert.match(cleanupScript, /elif ! pane_owns_tty; then\s+trigger=pane-death/);
@@ -1716,6 +1716,70 @@ test("terminal cleanup requires the exact pane receipt and pane death", () => {
     }
   } finally {
     rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("terminal cleanup joins signal workers and retains early failures", () => {
+  let cleanupScript = "";
+  driveTerminal({
+    plan: {
+      ...recommendedPlan("terminal"),
+      entry: "demo",
+      steps: [{ action: "expect_output", text: "Ready" }],
+    },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 90,
+    recordMedia: false,
+    runner: terminalLifecycleRunner([], {
+      terminalCaptures: ["Ready\n"],
+      inspectCleanupScript: (script) => {
+        cleanupScript = script;
+      },
+    }),
+  });
+  const signalWorkers = cleanupScript.slice(
+    cleanupScript.indexOf("signal_bound_processes()"),
+    cleanupScript.indexOf('[ "$(lease_identity_now)"'),
+  );
+  assert.equal(signalWorkers.match(/\/bin\/kill/g)?.length, 1);
+  for (const fails of [false, true]) {
+    const root = mkdtempSync(join(tmpdir(), "clawsweeper-signal-workers-"));
+    try {
+      writeFileSync(
+        join(root, "scan"),
+        Array.from({ length: 12 }, (_, index) => `${index + 1}\n`).join(""),
+      );
+      const result = spawnSync(
+        "/bin/bash",
+        [
+          "--noprofile",
+          "--norc",
+          "-c",
+          [
+            'root=$1; fails=$2; scan_file="$root/scan"',
+            'holds_lease() { builtin printf "checked\\n" >>"$root/checked-$1"; }',
+            // Only signal delivery is replaced; execute the generated worker scheduler.
+            'signal_probe() { [ "$2" -ne 12 ] || sleep 0.05; builtin printf "%s\\n" "$1" >>"$root/signal-$2"; if [ "$fails" = yes ] && [ "$2" -eq 1 ]; then return 2; fi; return 0; }',
+            signalWorkers.replace("/bin/kill", "signal_probe"),
+            "signal_bound_processes TERM; code=$?",
+            'for ((index = 1; index <= 12; index += 1)); do [ -s "$root/signal-$index" ] || exit 99; done',
+            'exit "$code"',
+          ].join("\n"),
+          "clawsweeper-signal-workers",
+          root,
+          fails ? "yes" : "no",
+        ],
+        { encoding: "utf8" },
+      );
+      assert.equal(result.status, fails ? 1 : 0, result.stderr);
+      for (let index = 1; index <= 12; index += 1) {
+        assert.equal(readFileSync(join(root, `checked-${index}`), "utf8"), "checked\n");
+        assert.equal(readFileSync(join(root, `signal-${index}`), "utf8"), "-TERM\n");
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   }
 });
 


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This branch is in the same repository, so maintainers can edit it through existing repository permissions. GitHub's fork-collaboration toggle applies only to cross-repository pull requests.

</details>

## What Problem This Solves

Resolves a problem where retained terminal verification on macOS can fail with `terminal pane cleanup did not finish within 10 seconds` when a command leaves multiple signal-resistant descendants. The strengthened native fixture reproduces this timeout on current main. Fresh ordinary help baselines passed, so this PR does not attribute the historical help-only failures to a newer driver change.

## Why This Change Was Made

Send TERM once with the same cumulative 150 ms grace, and bound independent signal workers at eight so repeated, expensive Darwin per-process lease scans do not consume the cleanup budget before escalation. Each worker freshly checks the lease or original terminal immediately before signaling; every worker is joined and failures are retained before rescanning.

KILL escalation, two empty scans, exact pane/PID/TTY/nonce/lease binding, the zero-survivor receipt, pane death, and all existing budgets remain unchanged. The net **+11 runtime lines** pay for bounded workers and complete joining; tests are separately net +73 lines and documentation +7. Upstream soft-wrap behavior, finite-command completion, and detached Node PTY descriptors are preserved.

This is a throughput repair only. A real timeout or killed watchdog can still lose cleanup authority when final disposal destroys tmux and lease/control resources. Failure-disposal redesign remains a separate follow-up pending a decision about post-return cleanup ownership and unresolved recovery. This PR neither implements a recovery policy nor claims complete failure-path disposal.

## User Impact

Historical terminal verification can finish cleanup under the exercised descendant load without increasing timeouts or accepting weaker identity evidence. Automatic live-proof generation remains retired; no new execution lane or operator action is introduced.

## OpenClaw Bay Impact

Unaffected. The change is confined to the retained terminal executor and its tests; it changes no lifecycle publication, queue/workflow, status/telemetry, dashboard data contract, or observer UI. No Bay change or additional Bay proof is needed.

## Documentation Impact

Reviewed `AGENTS.md`, `CONTRIBUTING.md`, `VISION.md`, `docs/README.md`, and `docs/live-proof.md`. The compatibility-only `docs/live-proof.md` now describes one TERM pass, eight fresh-identity workers, complete joins, and the unchanged budget. No proof policy or automatic generation guidance changes.

## Evidence

- Refreshed mechanically onto main `5ada40c98ae6dcf31703cf7c3f01e35e8d23a13e`. The only overlap was the native fixture: retained upstream soft-wrapped output and result assertions alongside the sixteen-child loop and per-child ESRCH checks.
- `pnpm run build` passed. `node --test test/live-proof.test.ts test/live-proof-review-environment.test.ts` passed **168/168**, zero failures or skips, in 213.31 seconds. The actual invocation also loaded a PID-only local observer for safe fixture accounting. The strengthened native regression passed in 21.23 seconds.
- The generated-Bash scheduler test runs the real generated worker scheduler with signal delivery substituted and local identity probes; it covers an early worker error, joining every worker, and a delayed final worker. The native regression uses **16 resistant Node children in distinct PGIDs in each of both completion modes**, with ESRCH checks. Existing fake receipts alone cannot exercise this OS scheduling behavior.
- Immutable-main red provenance: a local Node `stripTypeScriptTypes`/load hook loaded `src/live-proof/drivers.ts` from main `5ada40c98ae6dcf31703cf7c3f01e35e8d23a13e`, without swapping source or build files. Running only `terminal proof cleanup terminates` failed naturally in 34.06 seconds, exit 1, with `AggregateError: terminal cleanup failed` containing the exact ten-second cleanup timeout. No added load or changed budgets. The fixture's failure cleanup does not count as driver success; no owned processes remained afterward and no manual emergency signaling was needed.
- Fresh isolated Codex autoreview passed before commit (`uncommitted`) and again on the committed branch against pinned main: both scoped-clean at the default **P0** threshold, with no accepted/actionable findings. This is not an all-priority audit; the reviewer did not independently run tests.
- `git diff --check` and `pnpm run check:docs` passed. The earlier full local `pnpm run check` belongs to original base `468dab46ff57c65da3336e628482391c2896e4d6` plus this repair: **3,967 passed, 9 Linux-only skips**, and **12 changed-coverage tests passed**. It is not represented as a full local check on the refreshed base. Exact-head hosted CI supplies the refreshed full-suite gate and must finish before landing.

## Real Behavior Proof

**Claim and surface:** the current compiled retained terminal driver completes identity-bound cleanup under the exercised macOS descendant load while preserving normal command completion. This exercises real private tmux PTYs, OS processes, lease/TTY checks, signal delivery, controller receipts, pane death, and resource disposal.

**Fixtures and environment:** native local macOS 27.0 arm64, tmux 3.7c, stock absolute `/bin/bash` 3.2.57. The original `pnpm openclaw --help` command runs in a harmless synthetic help-only package with Node 26.7.0. The standalone descendant trace runs **16 signal-resistant sleep helpers** with Node 24.20.0; these are distinct from the **16 Node children per mode** in the native regression. Node 24 is first on PATH for build/tests; Homebrew Bash 5 is available for helpers without changing the driver's absolute interpreter. No remote provider/container image was used; each run allocated a private fixture session and lease.

**Commands:** from the proved checkout, `pnpm run build`, then the two owner/native files above. The private local diagnostic invocation is `node "$LOCAL_TRACE_HARNESS" pnpm` on Node 26 and `node "$LOCAL_TRACE_HARNESS" descendants` on Node 24, with `TRACE_DRIVER_MODULE` unset. The baseline command is `node --import "$LOCAL_PID_OBSERVER" --import "$PINNED_MAIN_LOADER" --test --test-name-pattern 'terminal proof cleanup terminates' test/live-proof-review-environment.test.ts`. These variables stand for local diagnostic paths omitted from public text, not a new supported execution lane or a restored retired harness.

**Observed result and trace:** both standalone cases returned exit 0 and `completed`, satisfied the expected output assertion, and validated the exact request/ready/receipt binding plus the original pane identity. Sanitized observations from `trace.json` and `before-session-kill.json`:

```json
[
  {
    "case": "pnpm-help-node26",
    "status": "completed",
    "elapsedMs": 4505,
    "cleanupRequestToReceiptMs": 1458,
    "exactBindingValidated": true,
    "receipt": {"state": "done", "result": "ok", "survivors": 0},
    "originalPaneDead": true,
    "survivorCount": 0,
    "socketDirectoryRemains": false,
    "controlFilesRemain": false
  },
  {
    "case": "16-resistant-sleep-helpers-node24",
    "status": "completed",
    "elapsedMs": 6752,
    "cleanupRequestToReceiptMs": 4041,
    "exactBindingValidated": true,
    "receipt": {"state": "done", "result": "ok", "survivors": 0},
    "originalPaneDead": true,
    "survivorCount": 0,
    "socketDirectoryRemains": false,
    "controlFilesRemain": false
  }
]
```

**Artifact provenance:** proved commit `e80adfce1320d5fcc8dda88fe48130856b3da8bb` on main `5ada40c98ae6dcf31703cf7c3f01e35e8d23a13e`. Raw traces, before-disposal snapshots, immutable-main loader, failing baseline log, passing full-file log, source snapshots, and hashes are retained in ignored local landing evidence for maintainer inspection. Raw private artifacts and transcripts are not uploaded. The runtime source SHA-256 is `78cbf1e21b7dd853f7f8558539a003296fd8ebf50cca15efef22600310180ff4`; compiled driver SHA-256 is `b2e3008628a0cdeadb7cc956be01208dd570a2dfb0eb0bddd5732112705a31bf`. Commit/publication does not change those proved bytes.

**Limits:** timing depends on host load; these are the declared native scenarios, not an all-platform performance guarantee. The help trace is compatibility evidence, not proof of an unrelated behavior or a newly failing help baseline. Failure-path disposal remains unfixed as described above. CI and review support but do not replace this exercised runtime evidence.
