### PR TITLE
fix(repair): prevent avoidable pnpm setup timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Removed redundant pnpm setup identity work by reusing the verified post-install identity without changing deadlines or mutation guards.
 - Guided package-version live proofs toward validated machine-readable output and exact resolution checks instead of guessed terminal formatting, while preserving literal expectations and successful-exit requirements.
 - Preserved empty-step live-proof plans through report rendering and inspection, with explicit JSON empty arrays and strict compatibility for existing solitary `- none` reports.
 - Added schema constraints and explicit prompt guidance for single-line live-proof commands and nonblank run steps while preserving strict parsing.

--- a/docs/proof/validation-identity-reuse/README.md
+++ b/docs/proof/validation-identity-reuse/README.md
@@ -1,0 +1,106 @@
+# Validation setup identity reuse
+
+- Status: historical proof recipe; not an operational runbook
+- Owner: ClawSweeper repair maintainers
+- Baseline: `5ada40c98ae6dcf31703cf7c3f01e35e8d23a13e`
+- Source: `src/repair/target-validation.ts`
+- Update when: the identity owner, fixture, toolchain, or recorded claim changes
+
+**Execution status: passed.** [Normalized observations](observations.json) bind
+the completed real-owner proof to this baseline plus the recorded production
+diff and recipe hashes. Node 24.20.0, Corepack 0.35.0, and pnpm 11.10.0 executed
+both allowed validations successfully, each with exit zero, a stdout marker,
+and no background processes. Runtime tampering and tracked-source tampering
+each rejected without another dispatch. The observer recorded no diagnostics
+and was restored. Setup took 43.553 seconds; this is one observed run, not a
+performance guarantee. Independent review, current-head CI, and landing gates
+remain outstanding.
+
+The claim is that successful pnpm setup retains its verified **post-install**
+identity without an immediate third capture, and still rejects stale runtime or
+source inputs before the next allowed validation command executes. Production
+budgets, source guards, containment policy, and permissions are unchanged.
+
+Build with the repository's pinned pnpm 11.10.0, then run from the repository
+root with Node 24 or newer and actual Corepack available on PATH:
+
+```sh
+corepack pnpm run build:all
+node docs/proof/validation-identity-reuse/run-proof.mjs /tmp/validation-identity-proof-new
+```
+
+Nested build scripts must also resolve pnpm 11.10.0. If needed, create Corepack
+shims in a task-local directory and prepend it to PATH; do not change global
+tools or bypass package-manager version checks.
+
+[The recipe](run-proof.mjs) calls the compiled production `prepareTargetToolchain`
+and `runAllowedValidationCommands` owners. It creates a tiny local package with
+one tracked local dependency, a local-only Git origin, and an isolated HOME.
+Actual Corepack/pnpm generate the lockfile, install the dependency, freeze the
+prepared runtime, and execute a script that checks the installed dependency and
+prints a unique stdout marker. That script writes no files. No target package
+is fetched from a registry; Corepack may download the pinned pnpm distribution.
+No account, credentials, real target repository, or GitHub action is involved.
+
+The Node test harness installs a **transparent `spawnSync` observer** after
+setup. Every call delegates the identical invocation to the original function
+and returns the exact original result. It observes only the production command
+runner's real `contained-command-worker.js` supervisor for the fixture's exact
+`verify` script. Actual returned JSON supplies exit status, signal, background
+process count, and stdout marker evidence; raw arguments, environment, stdout,
+and host paths are not copied into the normalized record. Malformed observation
+adds a diagnostic, returns the original result unchanged, and fails proof
+outside the production call. The observer and builtin ESM exports are restored
+in `finally`. No process, result, timeout, clock, or sandbox behavior is faked.
+
+The first allowed validation must return successfully and produce exactly one
+observed dispatch with exit zero, no background processes, and its stdout
+marker. Changing ignored `.modules.yaml` must produce the exact stale-runtime
+error with no additional dispatch or marker. Restoring its original bytes must
+permit a second real validation with the same successful receipt facts. A
+separate tracked-source mutation must reject with no third dispatch. These two
+positive controls establish that the observer actually sees executed scripts;
+the negative controls check that rejected scripts never reach the supervisor.
+
+The recipe uses real Git, filesystem state, subprocesses, final stdout I/O, and
+wall clock with default production budgets. Its outer watchdog remains 600
+seconds. The outer recipe launches Node's test runner with an allowlisted
+environment. On macOS this selects the existing process fallback in the
+production command runner. This is controlled production-owner behavior proof,
+**not** evidence of Linux namespace, network, or filesystem containment. No
+production gate is changed or bypassed for real repair work. Provider is
+`local-node-test-harness`; image and lease are not applicable. It is not a
+Crabbox lease or proof of an OpenClaw/native-app workload.
+
+`source.json` records the actual source HEAD, production diff digest, and
+source/build/recipe hashes. `supervisor-receipts.json` retains the normalized
+real transport observations even on failure. `observations.json` is written
+only after all allowed/rejected controls pass. Raw `driver.log` stays local.
+Rerun after source or recipe changes; an uncommitted run does not certify a
+later commit or branch head.
+
+## Retained earlier failures and separate regression
+
+Earlier attempts remain historical failures: an outer-watchdog expiry after a
+marker-file write, incomplete Corepack extraction during disk exhaustion, and
+a recovered-space run that completed setup but correctly rejected that marker
+write inside protected `node_modules`. The last was a proof-fixture defect,
+not a failure of the identity-reuse optimization. No production guard or tamper
+assertion was relaxed to repair the fixture.
+
+The accompanying unit regression is separate evidence: real Git and fake
+Corepack/pnpm processes use a virtual setup clock charging 250 ms per Git call.
+The original 15-second shared fixture budget is unchanged. Baseline fails at
+60 calls with `validation identity deadline exhausted during raw worktree head`;
+the patch completes setup in 51 calls / 12,750 charged ms. These charged times
+are not wall-clock performance measurements or actual pnpm install timings.
+
+Fresh 11-case focused coverage runs pass on both Node 24.20.0 and Node 26.7.0
+at the recorded baseline and patch. They cover the original real-clock refresh,
+stale setup, dependency/source mutation, workspace links, error precedence, and
+shared deadline/reserve behavior. Earlier failed runs remain local evidence;
+full macOS coverage was not repeated and exact-head CI remains required.
+
+Bay is unaffected: this change has no queue, publication, status, API, dashboard,
+or observer contract. The repair entry point and internal feature map remain
+accurate. Full exact-head CI and independent reviews remain landing gates.

--- a/docs/proof/validation-identity-reuse/observations.json
+++ b/docs/proof/validation-identity-reuse/observations.json
@@ -1,0 +1,103 @@
+{
+  "status": "passed",
+  "source": {
+    "head": "5ada40c98ae6dcf31703cf7c3f01e35e8d23a13e",
+    "productionDiffSha256": "6efec1c03b094d1d1898f66e2e7951f8738f458fcacadac1f27a930e8c1522dc",
+    "sha256": {
+      "src/repair/target-validation.ts": "e6cbe74265e7e0d20ca6c37aa9a40a53257ec76e5009373e4759524a43a2bb8f",
+      "test/repair/target-validation.test.ts": "979acc9edca4b77b25d453d59703914fd8f4ad82712bf484fb571a0e6ce6fa54",
+      "dist/repair/target-validation.js": "4822598d005160e9df9c0d117a7e983e0f87ae790b255535289ee346439c7370",
+      "dist/repair/command-runner.js": "4f4332dfcb43868319cc2652687355144bffe142b45c9ea64833f112da696904",
+      "dist/repair/contained-command-worker.js": "50e7a4acde15948d0892bddc32a44a4477cebfdff790635fca520f9df948e813",
+      "docs/proof/validation-identity-reuse/run-proof.mjs": "9f25c70c2d203b000171e50f5ec4cd561256b30b61832103fd070ed59344dbb6"
+    }
+  },
+  "observations": {
+    "provider": "local-node-test-harness",
+    "image": null,
+    "lease": null,
+    "platform": "darwin",
+    "arch": "arm64",
+    "node": "v24.20.0",
+    "corepack": "0.35.0",
+    "pnpm": "11.10.0",
+    "pnpmEntrypointSha256": "ff3224d46b47fbb24a7e9fe15fededef7e00892d07d4e376b6762d4899906bfd",
+    "clock": "real",
+    "injectedToolProcesses": false,
+    "observer": "transparent spawnSync observer; identical invocation and original result, recording only real verify supervisor receipts",
+    "observerRestored": true,
+    "containment": "Node test-runner process fallback; Linux namespace containment not exercised",
+    "budgets": "unchanged production defaults; no setup/install/validation overrides",
+    "fixtureHead": "eadea593a852568704c5ebafda738ef063d646ce",
+    "fixtureHashes": {
+      ".gitignore": "4d56952b0fb13bf8f9b6c13a6d4c34a075bac3af447636a1df4335d7576e2f97",
+      "package.json": "5dc970ad2f4f16d270adb5ac2a236669bf4df0d71d09ee9a7c024a064b876b88",
+      "packages/dependency/index.js": "63d56dbe1a14e25040ed63ef6a4b190e15d6598049cac913c50c74477db6bbfe",
+      "packages/dependency/package.json": "92b2be7577308ab20a2cfcda99530276dd62cdd78af0977fe792e6e1a6c1922f",
+      "pnpm-lock.yaml": "35671f4d319a3d9d641c7f09d80473cb24b488fdce2df1345bb5f26f5118a4ec",
+      "pnpm-workspace.yaml": "d115dc6c83ba283a7d17146ad456056f3f70b003edb8c312a52880b48b034001",
+      "verify.cjs": "89c5665d56d3615f269339074064c569d0320e57e50746fa4976eaea6afbb4f6"
+    },
+    "setupWallMs": 43553,
+    "installedSha256": "63d56dbe1a14e25040ed63ef6a4b190e15d6598049cac913c50c74477db6bbfe",
+    "allowed": ["pnpm verify"],
+    "dispatches": 2,
+    "receipts": [
+      {
+        "supervisorStatus": 0,
+        "supervisorSignal": null,
+        "supervisorError": false,
+        "status": 0,
+        "signal": null,
+        "error": false,
+        "backgroundProcesses": 0,
+        "stdoutMarker": true,
+        "stdoutSha256": "496f929210abd61d2e4afe97d7dc56055220a8f0ba36d43fec7fd4a6a61dc660"
+      },
+      {
+        "supervisorStatus": 0,
+        "supervisorSignal": null,
+        "supervisorError": false,
+        "status": 0,
+        "signal": null,
+        "error": false,
+        "backgroundProcesses": 0,
+        "stdoutMarker": true,
+        "stdoutSha256": "496f929210abd61d2e4afe97d7dc56055220a8f0ba36d43fec7fd4a6a61dc660"
+      }
+    ],
+    "boundaries": [
+      {
+        "name": "allowed",
+        "dispatches": 1,
+        "stdoutMarkers": 1
+      },
+      {
+        "name": "runtime-tamper-rejected",
+        "dispatches": 1,
+        "stdoutMarkers": 1
+      },
+      {
+        "name": "restored-runtime-allowed",
+        "dispatches": 2,
+        "stdoutMarkers": 2
+      },
+      {
+        "name": "source-tamper-rejected",
+        "dispatches": 2,
+        "stdoutMarkers": 2
+      }
+    ],
+    "diagnostics": [],
+    "runtimeRejection": "prepared target pnpm toolchain is stale; refresh dependencies before validation: runtimeInputsSha256",
+    "restoredRuntimeAllowed": true,
+    "sourceRejection": "prepared target pnpm toolchain is stale; refresh dependencies before validation: contentTreeSha, status, worktreeSha256"
+  },
+  "limits": [
+    "Synthetic local package; actual production owners and actual tool processes.",
+    "Transparent spawnSync observer records actual supervisor results, without replacing calls or results.",
+    "Existing macOS Node test process fallback; not Linux namespace/network/filesystem containment or Windows proof.",
+    "Not a full OpenClaw install, native application, live repair, or GitHub mutation proof.",
+    "Uncommitted source/diff binding; parent must establish committed-head evidence before landing."
+  ]
+}

--- a/docs/proof/validation-identity-reuse/run-proof.mjs
+++ b/docs/proof/validation-identity-reuse/run-proof.mjs
@@ -1,0 +1,340 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import childProcess, { execFileSync, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const recipe = fileURLToPath(import.meta.url);
+const root = path.resolve(path.dirname(recipe), "../../..");
+const hash = (bytes) => createHash("sha256").update(bytes).digest("hex");
+const command = (cwd, executable, args) =>
+  execFileSync(executable, args, {
+    cwd,
+    encoding: "utf8",
+    timeout: 120_000,
+    maxBuffer: 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+
+if (!process.env.VALIDATION_IDENTITY_PROOF_OUTPUT) {
+  assert.ok(process.argv[2], "usage: node run-proof.mjs <new-output-directory>");
+  const out = path.resolve(process.argv[2]);
+  fs.mkdirSync(out); // A new directory preserves prior observations.
+  for (const name of ["home", "tmp"]) fs.mkdirSync(path.join(out, name));
+  const paths = [
+    "src/repair/target-validation.ts",
+    "test/repair/target-validation.test.ts",
+    "dist/repair/target-validation.js",
+    "dist/repair/command-runner.js",
+    "dist/repair/contained-command-worker.js",
+    "docs/proof/validation-identity-reuse/run-proof.mjs",
+  ];
+  fs.writeFileSync(
+    path.join(out, "source.json"),
+    JSON.stringify(
+      {
+        head: command(root, "git", ["rev-parse", "HEAD"]),
+        productionDiffSha256: hash(
+          execFileSync(
+            "git",
+            ["diff", "--binary", "HEAD", "--", "src/repair/target-validation.ts"],
+            {
+              cwd: root,
+            },
+          ),
+        ),
+        sha256: Object.fromEntries(
+          paths.map((name) => [name, hash(fs.readFileSync(path.join(root, name)))]),
+        ),
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+  const child = spawnSync(process.execPath, ["--test", recipe], {
+    cwd: root,
+    env: {
+      PATH: process.env.PATH,
+      HOME: path.join(out, "home"),
+      TMPDIR: path.join(out, "tmp"),
+      LANG: "C",
+      CI: "1",
+      GIT_CONFIG_NOSYSTEM: "1",
+      GIT_CONFIG_GLOBAL: "/dev/null",
+      GIT_TERMINAL_PROMPT: "0",
+      VALIDATION_IDENTITY_PROOF_OUTPUT: out,
+    },
+    encoding: "utf8",
+    timeout: 600_000,
+    maxBuffer: 1024 * 1024,
+  });
+  fs.writeFileSync(path.join(out, "driver.log"), child.stdout + child.stderr);
+  assert.ifError(child.error);
+  assert.equal(child.status, 0, child.stdout + child.stderr);
+  process.stdout.write(fs.readFileSync(path.join(out, "observations.json"), "utf8"));
+} else {
+  const { default: test } = await import("node:test");
+  test("real pnpm setup binds installed runtime before allowed validation and tamper rejection", (t) => {
+    assert.ok(Number(process.versions.node.split(".")[0]) >= 24);
+    const out = process.env.VALIDATION_IDENTITY_PROOF_OUTPUT;
+    const phase = (name) =>
+      fs.appendFileSync(
+        path.join(out, "progress.jsonl"),
+        JSON.stringify({ phase: name, at: new Date().toISOString() }) + "\n",
+      );
+    phase("fixture-start");
+    const cwd = path.join(out, "package");
+    fs.mkdirSync(path.join(cwd, "packages", "dependency"), { recursive: true });
+    const write = (name, content) => fs.writeFileSync(path.join(cwd, name), content);
+    write(".gitignore", "node_modules/\n");
+    write(
+      "package.json",
+      JSON.stringify(
+        {
+          name: "validation-identity-proof",
+          private: true,
+          version: "1.0.0",
+          packageManager: "pnpm@11.10.0",
+          scripts: { verify: "node verify.cjs" },
+          dependencies: { "fixture-dependency": "file:packages/dependency" },
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    write("pnpm-workspace.yaml", "packages:\n  - packages/*\n");
+    write(
+      "packages/dependency/package.json",
+      JSON.stringify({
+        name: "fixture-dependency",
+        version: "1.0.0",
+        main: "index.js",
+      }) + "\n",
+    );
+    write("packages/dependency/index.js", 'module.exports = "installed";\n');
+    const stdoutMarker = "CLAWSWEEPER_IDENTITY_PROOF_DEPENDENCY_VERIFIED";
+    write(
+      "verify.cjs",
+      [
+        'const assert = require("node:assert/strict");',
+        'assert.equal(require("fixture-dependency"), "installed");',
+        `console.log(${JSON.stringify(stdoutMarker)});`,
+      ].join("\n") + "\n",
+    );
+    const git = (...args) => command(cwd, "git", args);
+    git("init", "-b", "main");
+    git("config", "user.name", "ClawSweeper Proof");
+    git("config", "user.email", "proof@example.invalid");
+    phase("fixture-git-ready");
+    const corepack = command(cwd, "corepack", ["--version"]);
+    const pnpm = command(cwd, "corepack", ["pnpm", "--version"]);
+    assert.equal(pnpm, "11.10.0");
+    const pnpmEntrypoint = path.join(
+      process.env.HOME,
+      ".cache/node/corepack/v1/pnpm/11.10.0/bin/pnpm.mjs",
+    );
+    assert.ok(fs.statSync(pnpmEntrypoint).isFile(), "fresh Corepack cache needs pnpm.mjs");
+    const pnpmEntrypointSha256 = hash(fs.readFileSync(pnpmEntrypoint));
+    phase("toolchain-verified");
+    // Generate only metadata with the actual package manager. Setup owns installation.
+    command(cwd, "corepack", [
+      "pnpm",
+      "install",
+      "--lockfile-only",
+      "--offline",
+      "--ignore-scripts",
+      "--ignore-pnpmfile",
+    ]);
+    assert.equal(fs.existsSync(path.join(cwd, "node_modules")), false);
+    git("add", ".");
+    git("commit", "-m", "fixture: local dependency validation");
+    const fixtureHead = git("rev-parse", "HEAD");
+    const fixtureFiles = git("ls-files").split("\n");
+    const fixtureHashes = Object.fromEntries(
+      fixtureFiles.map((name) => [name, hash(fs.readFileSync(path.join(cwd, name)))]),
+    );
+    const origin = path.join(out, "origin.git");
+    command(out, "git", ["init", "--bare", "--initial-branch=main", origin]);
+    git("remote", "add", "origin", origin);
+    git("push", "-u", "origin", "main:main"); // Task-owned local origin only.
+
+    return import(pathToFileURL(path.join(root, "dist/repair/target-validation.js")).href).then(
+      ({ prepareTargetToolchain, runAllowedValidationCommands }) => {
+        const options = {
+          targetRepo: "example/validation-identity-proof",
+          allowExpensiveValidation: false,
+          installTargetDeps: true,
+          strictTargetValidation: true,
+          pinnedBaseRemoteUrl: origin,
+          toolchain: { packageManager: "pnpm", baseValidationCommands: [], changedGate: null },
+        };
+        phase("setup-start");
+        const started = Date.now();
+        prepareTargetToolchain(cwd, options);
+        const setupWallMs = Date.now() - started;
+        phase("setup-complete");
+        assert.equal(git("status", "--porcelain"), "");
+        const installed = path.join(cwd, "node_modules", "fixture-dependency", "index.js");
+        assert.equal(fs.readFileSync(installed, "utf8"), 'module.exports = "installed";\n');
+        const installedSha256 = hash(fs.readFileSync(installed));
+        const supervisor = path.join(root, "dist/repair/contained-command-worker.js");
+        const receipts = [];
+        const diagnostics = [];
+        const boundaries = [];
+        let dispatches = 0;
+        const realSpawnSync = childProcess.spawnSync;
+        const observer = t.mock.method(childProcess, "spawnSync", function (...invocation) {
+          // Forward identical arguments and return the original result, including failures.
+          const result = Reflect.apply(realSpawnSync, this, invocation);
+          const [executable, args, spawnOptions] = invocation;
+          if (
+            executable !== process.execPath ||
+            args?.length !== 1 ||
+            args[0] !== supervisor ||
+            spawnOptions?.cwd !== cwd
+          )
+            return result;
+          try {
+            const input = JSON.parse(spawnOptions.input);
+            if (!Array.isArray(input.args)) throw new Error("invalid supervisor arguments");
+            if (input.cwd !== cwd || !input.args.includes("verify")) return result;
+            dispatches += 1;
+            const receipt = JSON.parse(result.stdout);
+            if (
+              typeof receipt.stdout !== "string" ||
+              !(receipt.status === null || Number.isInteger(receipt.status)) ||
+              !Number.isInteger(receipt.backgroundProcesses)
+            )
+              throw new Error("invalid supervisor result");
+            receipts.push({
+              supervisorStatus: result.status,
+              supervisorSignal: result.signal,
+              supervisorError: Boolean(result.error),
+              status: receipt.status,
+              signal: receipt.signal,
+              error: Boolean(receipt.error),
+              backgroundProcesses: receipt.backgroundProcesses,
+              stdoutMarker: receipt.stdout.split(/\r?\n/).includes(stdoutMarker),
+              stdoutSha256: hash(receipt.stdout),
+            });
+          } catch {
+            // Observation errors must never change the production call's outcome.
+            diagnostics.push("malformed fixture supervisor observation");
+          }
+          return result;
+        });
+        const observeBoundary = (name, expectedDispatches) => {
+          assert.deepEqual(diagnostics, []);
+          assert.equal(dispatches, expectedDispatches);
+          assert.equal(receipts.length, expectedDispatches);
+          for (const receipt of receipts) {
+            assert.equal(receipt.supervisorStatus, 0);
+            assert.equal(receipt.supervisorSignal, null);
+            assert.equal(receipt.supervisorError, false);
+            assert.equal(receipt.status, 0);
+            assert.equal(receipt.signal, null);
+            assert.equal(receipt.error, false);
+            assert.equal(receipt.backgroundProcesses, 0);
+            assert.equal(receipt.stdoutMarker, true);
+          }
+          boundaries.push({ name, dispatches, stdoutMarkers: receipts.length });
+        };
+        let runtimeRejection;
+        let sourceRejection;
+        let allowed;
+        try {
+          syncBuiltinESMExports();
+          phase("allowed-start");
+          allowed = runAllowedValidationCommands(["pnpm verify"], cwd, options);
+          assert.deepEqual(allowed, ["pnpm verify"]);
+          observeBoundary("allowed", 1);
+          phase("allowed-complete");
+          const metadata = path.join(cwd, "node_modules", ".modules.yaml");
+          const originalMetadata = fs.readFileSync(metadata);
+          fs.appendFileSync(metadata, "\n# controlled runtime tamper\n");
+          assert.equal(git("status", "--porcelain"), "");
+          assert.throws(
+            () => runAllowedValidationCommands(["pnpm verify"], cwd, options),
+            (error) => {
+              runtimeRejection = error.message;
+              return (
+                error.message ===
+                "prepared target pnpm toolchain is stale; refresh dependencies before validation: runtimeInputsSha256"
+              );
+            },
+          );
+          observeBoundary("runtime-tamper-rejected", 1);
+          phase("runtime-tamper-rejected");
+          fs.writeFileSync(metadata, originalMetadata);
+          assert.deepEqual(runAllowedValidationCommands(["pnpm verify"], cwd, options), [
+            "pnpm verify",
+          ]);
+          observeBoundary("restored-runtime-allowed", 2);
+          phase("restored-runtime-allowed");
+          fs.appendFileSync(
+            path.join(cwd, "verify.cjs"),
+            "\n// controlled tracked-source tamper\n",
+          );
+          assert.throws(
+            () => runAllowedValidationCommands(["pnpm verify"], cwd, options),
+            (error) => {
+              sourceRejection = error.message;
+              return error.message.startsWith(
+                "prepared target pnpm toolchain is stale; refresh dependencies before validation: ",
+              );
+            },
+          );
+          observeBoundary("source-tamper-rejected", 2);
+          phase("source-tamper-rejected");
+        } finally {
+          observer.mock.restore();
+          syncBuiltinESMExports();
+          fs.writeFileSync(
+            path.join(out, "supervisor-receipts.json"),
+            JSON.stringify({ dispatches, receipts, diagnostics, boundaries }, null, 2) + "\n",
+          );
+        }
+        assert.equal(childProcess.spawnSync, realSpawnSync);
+        assert.equal(spawnSync, realSpawnSync);
+        const observations = {
+          provider: "local-node-test-harness",
+          image: null,
+          lease: null,
+          platform: process.platform,
+          arch: process.arch,
+          node: process.version,
+          corepack,
+          pnpm,
+          pnpmEntrypointSha256,
+          clock: "real",
+          injectedToolProcesses: false,
+          observer:
+            "transparent spawnSync observer; identical invocation and original result, recording only real verify supervisor receipts",
+          observerRestored: true,
+          containment:
+            "Node test-runner process fallback; Linux namespace containment not exercised",
+          budgets: "unchanged production defaults; no setup/install/validation overrides",
+          fixtureHead,
+          fixtureHashes,
+          setupWallMs,
+          installedSha256,
+          allowed,
+          dispatches,
+          receipts,
+          boundaries,
+          diagnostics,
+          runtimeRejection,
+          restoredRuntimeAllowed: true,
+          sourceRejection,
+        };
+        fs.writeFileSync(
+          path.join(out, "observations.json"),
+          JSON.stringify(observations, null, 2) + "\n",
+        );
+      },
+    );
+  });
+}

--- a/src/repair/target-validation.ts
+++ b/src/repair/target-validation.ts
@@ -435,14 +435,15 @@ export function prepareTargetToolchain(
     } catch (error) {
       setupError = error as Error;
     }
+    let preparedSourceIdentity: ValidationSourceIdentity;
     try {
-      assertValidationSourceIdentity(cwd, sourceIdentity, deadlineAt);
+      preparedSourceIdentity = assertValidationSourceIdentity(cwd, sourceIdentity, deadlineAt);
     } catch (error) {
       if (!setupError || !isValidationIdentityDeadlineError(error)) throw error;
+      throw setupError;
     }
     if (setupError) throw setupError;
     if (preparedPnpmPackageManager) {
-      const preparedSourceIdentity = validationSourceIdentity(cwd, deadlineAt);
       storePreparedTargetPnpmRuntime({
         cwd,
         deadlineAt,
@@ -2748,6 +2749,7 @@ function assertValidationSourceIdentity(
       `target dependency setup mutated checkout identity: ${validationSourceIdentityMismatchFields(actual, expected, { ignoreRuntimeInputs: true }).join(", ")}`,
     );
   }
+  return actual;
 }
 
 function validationCheckoutIdentity(

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -4058,55 +4058,7 @@ test(
   "pnpm validation refreshes the prepared executable before every command",
   { skip: process.platform === "win32" },
   () => {
-    const cwd = gitPackageFixture({
-      first: 'node -e ""',
-      second: 'node -e ""',
-    });
-    git(cwd, "add", ".");
-    git(cwd, "commit", "-m", "initial");
-    attachOrigin(cwd);
-
-    const hostBin = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-pnpm-refresh-"));
-    const logPath = path.join(hostBin, "pnpm.log");
-    const maliciousMarker = path.join(hostBin, "malicious-ran");
-    const maliciousSource = `#!/usr/bin/env node
-require("node:fs").writeFileSync(${JSON.stringify(maliciousMarker)}, "ran");
-`;
-    const pnpmSource = `#!/usr/bin/env node
-const fs = require("node:fs");
-const args = process.argv.slice(2);
-fs.appendFileSync(${JSON.stringify(logPath)}, args.join(" ") + "\\n");
-if (args.includes("install")) fs.mkdirSync("node_modules", { recursive: true });
-if (args.includes("first")) {
-  fs.writeFileSync(process.argv[1], ${JSON.stringify(maliciousSource)}, { mode: 0o755 });
-}
-`;
-    writeNodeCommandShim(
-      hostBin,
-      "corepack",
-      `#!/usr/bin/env node
-const fs = require("node:fs");
-const path = require("node:path");
-const args = process.argv.slice(2);
-if (args[0] === "enable") {
-  const destination = args[args.indexOf("--install-directory") + 1];
-  fs.mkdirSync(destination, { recursive: true });
-  fs.writeFileSync(path.join(destination, "pnpm"), ${JSON.stringify(pnpmSource)}, { mode: 0o755 });
-}
-`,
-    );
-    const options = {
-      ...validationOptions("steipete/example", {
-        toolchain: {
-          packageManager: "pnpm",
-          baseValidationCommands: [],
-          changedGate: null,
-        },
-      }),
-      installTargetDeps: true,
-      installTimeoutMs: FAKE_TOOLCHAIN_TIMEOUT_MS,
-      setupTimeoutMs: FAKE_TOOLCHAIN_TIMEOUT_MS,
-    };
+    const { cwd, hostBin, logPath, maliciousMarker, options } = pnpmExecutableRefreshFixture();
 
     withCommandOverridesUnset(["corepack", "pnpm"], () =>
       withPathOnlyPrefix(hostBin, () => {
@@ -4126,6 +4078,140 @@ if (args[0] === "enable") {
     ]);
   },
 );
+
+test(
+  "pnpm validation refreshes the prepared executable within the shared setup identity budget",
+  { skip: process.platform === "win32" },
+  (t) => {
+    const { cwd, hostBin, logPath, maliciousMarker, dependencyPath, options } =
+      pnpmExecutableRefreshFixture();
+    const origin = git(cwd, "remote", "get-url", "origin");
+    try {
+      withCommandOverridesUnset(["corepack", "pnpm"], () =>
+        withPathOnlyPrefix(hostBin, () => {
+          assert.equal(fs.existsSync(dependencyPath), false);
+          let elapsedSetupMs = 0;
+          let completedGitCalls = 0;
+          const realSpawnSync = childProcess.spawnSync;
+          const clock = t.mock.method(Date, "now", () => 10_000 + elapsedSetupMs);
+          const spawn = t.mock.method(childProcess, "spawnSync", (command, args, spawnOptions) => {
+            if (path.basename(command).replace(/\.exe$/i, "") !== "git") {
+              return realSpawnSync(command, args, spawnOptions);
+            }
+            assert.ok(
+              spawnOptions.timeout > 0 && spawnOptions.timeout <= FAKE_TOOLCHAIN_TIMEOUT_MS,
+            );
+            // Real Git has its own watchdog; only completed Git calls charge the setup clock.
+            const result = realSpawnSync(command, args, {
+              ...spawnOptions,
+              timeout: FAKE_TOOLCHAIN_TIMEOUT_MS,
+              killSignal: "SIGKILL",
+            });
+            completedGitCalls += 1;
+            elapsedSetupMs += 250;
+            return result;
+          });
+          try {
+            syncBuiltinESMExports();
+            prepareTargetToolchain(cwd, options);
+          } finally {
+            spawn.mock.restore();
+            syncBuiltinESMExports();
+            clock.mock.restore();
+            t.diagnostic(
+              `setup: ${completedGitCalls} completed Git calls, ${elapsedSetupMs}ms charged`,
+            );
+          }
+          assert.ok(elapsedSetupMs > 0 && elapsedSetupMs < FAKE_TOOLCHAIN_TIMEOUT_MS);
+          assert.equal(fs.readFileSync(dependencyPath, "utf8"), "installed\n");
+          assert.deepEqual(
+            runAllowedValidationCommands(["pnpm first", "pnpm second"], cwd, options),
+            ["pnpm first", "pnpm second"],
+          );
+          const invocations = fs.readFileSync(logPath, "utf8").trim().split(/\r?\n/);
+          assert.equal(invocations.filter((line) => line.startsWith("install ")).length, 1);
+          assert.deepEqual(
+            invocations.slice(1).map((line) => line.split(" ").at(-1)),
+            ["first", "second"],
+          );
+          assert.equal(fs.existsSync(maliciousMarker), false);
+
+          // The prepared identity must bind installed ignored inputs, not the pre-install tree.
+          fs.writeFileSync(dependencyPath, "poisoned\n");
+          const logBeforePoisonedValidation = fs.readFileSync(logPath, "utf8");
+          assert.throws(
+            () => runAllowedValidationCommands(["pnpm second"], cwd, options),
+            /prepared target pnpm toolchain is stale/,
+          );
+          assert.equal(fs.readFileSync(logPath, "utf8"), logBeforePoisonedValidation);
+          assert.equal(fs.existsSync(maliciousMarker), false);
+        }),
+      );
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+      fs.rmSync(origin, { recursive: true, force: true });
+      fs.rmSync(hostBin, { recursive: true, force: true });
+    }
+  },
+);
+
+function pnpmExecutableRefreshFixture() {
+  const cwd = gitPackageFixture({
+    first: 'node -e ""',
+    second: 'node -e ""',
+  });
+  git(cwd, "add", ".");
+  git(cwd, "commit", "-m", "initial");
+  attachOrigin(cwd);
+
+  const hostBin = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-pnpm-refresh-"));
+  const logPath = path.join(hostBin, "pnpm.log");
+  const maliciousMarker = path.join(hostBin, "malicious-ran");
+  const dependencyPath = path.join(cwd, "node_modules", "fixture-dependency", "state.js");
+  const maliciousSource = `#!/usr/bin/env node
+require("node:fs").writeFileSync(${JSON.stringify(maliciousMarker)}, "ran");
+`;
+  const pnpmSource = `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(${JSON.stringify(logPath)}, args.join(" ") + "\\n");
+if (args.includes("install")) {
+  fs.mkdirSync("node_modules/fixture-dependency", { recursive: true });
+  fs.writeFileSync("node_modules/fixture-dependency/state.js", "installed\\n");
+}
+if (args.includes("first")) {
+  fs.writeFileSync(process.argv[1], ${JSON.stringify(maliciousSource)}, { mode: 0o755 });
+}
+`;
+  writeNodeCommandShim(
+    hostBin,
+    "corepack",
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const path = require("node:path");
+const args = process.argv.slice(2);
+if (args[0] === "enable") {
+  const destination = args[args.indexOf("--install-directory") + 1];
+  fs.mkdirSync(destination, { recursive: true });
+  fs.writeFileSync(path.join(destination, "pnpm"), ${JSON.stringify(pnpmSource)}, { mode: 0o755 });
+}
+`,
+  );
+  const options = {
+    ...validationOptions("steipete/example", {
+      toolchain: {
+        packageManager: "pnpm",
+        baseValidationCommands: [],
+        changedGate: null,
+      },
+    }),
+    installTargetDeps: true,
+    installTimeoutMs: FAKE_TOOLCHAIN_TIMEOUT_MS,
+    setupTimeoutMs: FAKE_TOOLCHAIN_TIMEOUT_MS,
+  };
+
+  return { cwd, hostBin, logPath, maliciousMarker, dependencyPath, options };
+}
 
 test("pnpm setup disables target pnpmfile hooks", { skip: process.platform === "win32" }, () => {
   const cwd = gitPackageFixture({ verify: 'node -e ""' });
@@ -8174,6 +8260,73 @@ fs.writeFileSync("pnpm-lock.yaml", "lockfileVersion: '9.0'\\n");
     !fs.existsSync(lockfilePath),
     "install-owned lockfile must not survive setup when the checkout started without one",
   );
+});
+
+test("target setup preserves post-install identity error precedence", (t) => {
+  const cwd = gitPackageFixture({ check: "node check.js" });
+  const sourcePath = path.join(cwd, "source.txt");
+  fs.writeFileSync(sourcePath, "original\n");
+  git(cwd, "add", ".");
+  git(cwd, "commit", "-m", "initial");
+
+  try {
+    for (const scenario of [
+      {
+        installFails: true,
+        mutate: true,
+        expire: false,
+        expected: /setup mutated checkout identity/,
+      },
+      { installFails: true, mutate: false, expire: false, expected: /^fixture install failed$/ },
+      { installFails: true, mutate: false, expire: true, expected: /^fixture install failed$/ },
+      {
+        installFails: false,
+        mutate: false,
+        expire: true,
+        expected: /validation identity deadline exhausted/,
+      },
+    ]) {
+      fs.writeFileSync(sourcePath, "original\n");
+      let now = 10_000;
+      let installed = false;
+      withVirtualDeadlineCommands(
+        t,
+        () => now,
+        ({ command, args, contained }) => {
+          if (command === "git") return;
+          if (command === "pnpm") {
+            assert.equal(contained, true);
+            assert.equal(args[0], "install");
+            installed = true;
+            if (scenario.mutate) fs.writeFileSync(sourcePath, "mutated\n");
+            if (scenario.expire) now += FAKE_TOOLCHAIN_TIMEOUT_MS;
+            if (scenario.installFails) return { status: 1, stderr: "fixture install failed" };
+          }
+          return { status: 0 };
+        },
+        () =>
+          assert.throws(
+            () =>
+              prepareTargetToolchain(cwd, {
+                ...validationOptions("steipete/example", {
+                  toolchain: {
+                    packageManager: "pnpm",
+                    baseValidationCommands: [],
+                    changedGate: null,
+                  },
+                }),
+                installTargetDeps: true,
+                installTimeoutMs: FAKE_TOOLCHAIN_TIMEOUT_MS,
+                setupTimeoutMs: FAKE_TOOLCHAIN_TIMEOUT_MS,
+              }),
+            { message: scenario.expected },
+          ),
+      );
+      assert.equal(installed, true);
+    }
+  } finally {
+    fs.rmSync(cwd, { recursive: true, force: true });
+  }
 });
 
 test("target setup shares one deadline across probes and installs", (t) => {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed. This is a same-repository branch and is already writable by repository maintainers; no maintainer-edit opt-out is used.

</details>

## What Problem This Solves

Resolves a problem where pnpm repair setup could exhaust its shared identity budget after a successful install, before validation began. The original failure was `validation identity deadline exhausted during raw worktree head`.

## Why This Change Was Made

Reuse the actual post-install identity that the source guard just checked, instead of immediately capturing it a third time. The pre-install identity is never reused for the prepared runtime: installed ignored dependencies remain bound to it. Mutation checks, setup-error precedence, executable refresh, production deadlines/reserves, containment, concurrency, and permissions stay unchanged.

## User Impact

Repair setup performs less redundant Git/filesystem work without extending its budget or allowing stale source/dependency state to validate. This is separate from the previously landed proof-classification follow-up at [PR 1286](https://github.com/openclaw/clawsweeper/pull/1286).

## OpenClaw Bay Impact

Unaffected. No queue, workflow, lifecycle/publication, status/telemetry, API, or dashboard contract changes.

## Documentation Impact

Reviewed the root contributor/vision guides, documentation index, repair entry point, and internal feature map. Existing repair guidance remains accurate because no operational contract changed. Added a historical proof recipe and compact normalized observations under `docs/proof/validation-identity-reuse/`, covered by the existing historical-proof lifecycle classification, plus one changelog entry. No root guide or operational runbook changes.

## Evidence

Tested committed head: [`6b4919e47d6f5e78c3a33f96bf1a7ae2526d29ab`](https://github.com/openclaw/clawsweeper/commit/6b4919e47d6f5e78c3a33f96bf1a7ae2526d29ab). The fresh committed-head production proof passed in **123.550 seconds**, with an empty production diff. All recorded source, test, compiled owner/supervisor, and recipe SHA256 values exactly match the reviewed candidate. The tracked observations deliberately remain a historical precommit snapshot at base `5ada40c98ae6dcf31703cf7c3f01e35e8d23a13e` plus its recorded production diff; they have not been relabeled as a committed-head run. The fresh head and normalized receipts are recorded below.

Fresh isolated Codex precommit review reported no accepted/actionable finding at its configured **P0 threshold**. This is not a claim of review at every severity. Committed-branch review, exact-head GitHub CI, and the current-head-and-body ClawSweeper review remain required before merge; no merge or automerge is requested by this publication.

The frozen source and test patch are unchanged. On the prior preparation base, the new regression against an isolated baseline compilation reproduced the exact original third-capture failure at 60 completed Git calls / 15,000 charged ms. The current baseline source/test are verified byte-identical. The patch completes setup at 51 calls / 12,750 charged ms; the ordinary successful fixture path removes 25 Git calls (76 to 51). These are virtual-clock charges, not measured install speed.

Fresh current-base coverage runs pass **11/11 on Node 24.20.0 and 11/11 on Node 26.7.0**, each with zero failures or skips. The set includes the new virtual-budget regression, original real-clock executable refresh, stale setup, ignored dependency poisoning, tracked source mutation, install-managed workspace links, setup-error precedence, shared deadlines, and validation reserves. Both new-regression runs report 51 Git calls / 12,750 charged ms. Node 24 was rerun rather than relying on old dependency fingerprints.

The pinned pnpm 11.10.0 build on this base passes; source/build/dependency input fingerprints remain unchanged through the fresh proof and tests. Final static checks, scoped source/test/proof formatting and lint, proof syntax, and documentation checks pass. The earlier documentation inventory included the untracked proof files; a fresh `check:static` run also passed against the exact staged six-file inventory before this commit. No full macOS coverage gate was repeated.

The earlier Node 26 11-case coverage attempt recorded 8 pass / 3 deadline failures in stale setup, executable refresh, and workspace-link fixtures during the disk-pressure period. The earlier preparation also passed the regression and original real-clock control separately on both Node 24 and Node 26, and the Node 24 covered 11-case set passed. These historical runs remain recorded; they are not relabeled as fresh current-head runs.

The separate peer full-coverage run on `468dab46ff57c65da3336e628482391c2896e4d6` reported 3,967 pass, 1 fail, and 9 skip. Its sole reported failure was the unchanged 129 MiB stdout fixture in `test/codex-review-runner.test.ts`, also failing isolated coverage against its 20-second budget. Full harness completion was lost/killed with exit 137, not a green full check. Full macOS coverage was deliberately not repeated during preparation. No unrelated fixture, deadline, concurrency, or coverage threshold changed; exact-head GitHub CI remains the full gate.

## Real Behavior Proof

**Claim and owner:** `prepareTargetToolchain` retains the checked post-install identity; `runAllowedValidationCommands` permits real validation and rejects ignored runtime or tracked-source tampering before another script dispatch.

**Scenario:** a task-owned local Git repository and local-only origin, one tracked local dependency, isolated HOME, actual Corepack/pnpm. The validation script checks the installed dependency and prints a unique stdout marker without writing files. The harness then changes ignored `.modules.yaml`, verifies rejection without dispatch, restores exact bytes and validates again, then changes tracked `verify.cjs` and verifies another rejection without dispatch.

**Commands:** with Node 24.20.0, Corepack 0.35.0, and task-local pnpm 11.10.0 shims on PATH, build the pinned repository sources:

```bash
corepack pnpm run build:all
```

Create the ignored artifact parent if needed:

```bash
mkdir -p .artifacts
```

Run the production proof into this new, concrete output directory (it must not already exist):

```bash
node docs/proof/validation-identity-reuse/run-proof.mjs .artifacts/validation-identity-reuse-6b4919e-20260828
```

Nested build commands must also resolve pnpm 11.10.0. The recorded committed run used this identical recipe with a fresh task-local output directory; private host paths and raw driver logs are intentionally omitted here.

**Environment and recording:** Node v24.20.0, Corepack 0.35.0, pnpm 11.10.0, macOS arm64, provider `local-node-test-harness`; no image or lease. The test harness installs a transparent `spawnSync` observer that delegates identical arguments/options to the original function and returns its exact original result. It records only the real production supervisor calls for the fixture's exact `verify` script and parses their actual JSON stdout/status/background-process receipts. Malformed observation leaves production outcomes unchanged and fails proof separately. The observer and builtin ESM exports are restored in `finally`. No tool process, result, timeout, clock, or sandbox behavior is replaced.

**Observed result:** the fresh committed-head proof passed in 123.550 seconds total. Setup took 56.062 seconds in this run (the historical precommit run took 43.553 seconds for setup). Both allowed calls returned `['pnpm verify']` and produced exit-zero receipts with the expected stdout marker and zero background processes. Total dispatch/marker counts were 1/1 after the first allowed call, stayed 1/1 after runtime rejection, became 2/2 after restoring metadata and validating again, and stayed 2/2 after tracked-source rejection. Runtime rejection specifically reported `runtimeInputsSha256`; tracked-source rejection reported `contentTreeSha, status, worktreeSha256`. No observer diagnostics; restoration confirmed.

**Artifacts:** immutable links to the [proof recipe](https://github.com/openclaw/clawsweeper/blob/6b4919e47d6f5e78c3a33f96bf1a7ae2526d29ab/docs/proof/validation-identity-reuse/run-proof.mjs), [proof README](https://github.com/openclaw/clawsweeper/blob/6b4919e47d6f5e78c3a33f96bf1a7ae2526d29ab/docs/proof/validation-identity-reuse/README.md), and [recorded precommit observations](https://github.com/openclaw/clawsweeper/blob/6b4919e47d6f5e78c3a33f96bf1a7ae2526d29ab/docs/proof/validation-identity-reuse/observations.json). The historical record binds its precommit head plus diff; the fresh committed run has `source.json.head = 6b4919e47d6f5e78c3a33f96bf1a7ae2526d29ab`, an empty production diff, and identical source/build/recipe hashes. Generated committed `source.json`, `observations.json`, `supervisor-receipts.json`, phase records, and raw driver logs are retained locally. The normalized committed receipt below exposes the relevant trace without raw stdout, environment, host paths, secrets, or agent transcripts.

**Earlier failed attempts:** an outer-watchdog expiry and incomplete Corepack extraction during disk exhaustion remain recorded. After disk recovery, the original marker-file recipe completed setup but correctly failed because writing inside protected `node_modules` violated the guard. Only that observation mechanism was repaired: stdout receipts replace file writes, while guard and tamper assertions remain intact. The corrected recipe completed under the existing 600-second outer watchdog.

**Limits:** this is real production-owner execution with genuine Corepack/pnpm, Git, filesystem, subprocesses, final stdout I/O, and real clock. The existing Node-test macOS process fallback is exercised, not Linux namespace/network/filesystem containment or Windows execution. It is not a full OpenClaw dependency install or native-app proof. The separate regression uses real Git plus fake Corepack/pnpm executables and a virtual setup clock. No live repair/apply, GitHub target action, registry credentials, deployment, or global tool change occurred.

<details>
<summary>Fresh committed-head proof receipt (normalized)</summary>

```json
{
  "head": "6b4919e47d6f5e78c3a33f96bf1a7ae2526d29ab",
  "elapsedSeconds": 123.55,
  "source": {
    "head": "6b4919e47d6f5e78c3a33f96bf1a7ae2526d29ab",
    "productionDiffSha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
    "sha256": {
      "src/repair/target-validation.ts": "e6cbe74265e7e0d20ca6c37aa9a40a53257ec76e5009373e4759524a43a2bb8f",
      "test/repair/target-validation.test.ts": "979acc9edca4b77b25d453d59703914fd8f4ad82712bf484fb571a0e6ce6fa54",
      "dist/repair/target-validation.js": "4822598d005160e9df9c0d117a7e983e0f87ae790b255535289ee346439c7370",
      "dist/repair/command-runner.js": "4f4332dfcb43868319cc2652687355144bffe142b45c9ea64833f112da696904",
      "dist/repair/contained-command-worker.js": "50e7a4acde15948d0892bddc32a44a4477cebfdff790635fca520f9df948e813",
      "docs/proof/validation-identity-reuse/run-proof.mjs": "9f25c70c2d203b000171e50f5ec4cd561256b30b61832103fd070ed59344dbb6"
    }
  },
  "observations": {
    "provider": "local-node-test-harness",
    "image": null,
    "lease": null,
    "platform": "darwin",
    "arch": "arm64",
    "node": "v24.20.0",
    "corepack": "0.35.0",
    "pnpm": "11.10.0",
    "pnpmEntrypointSha256": "ff3224d46b47fbb24a7e9fe15fededef7e00892d07d4e376b6762d4899906bfd",
    "clock": "real",
    "injectedToolProcesses": false,
    "observerRestored": true,
    "setupWallMs": 56062,
    "allowed": [
      "pnpm verify"
    ],
    "dispatches": 2,
    "receipts": [
      {
        "supervisorStatus": 0,
        "supervisorSignal": null,
        "supervisorError": false,
        "status": 0,
        "signal": null,
        "error": false,
        "backgroundProcesses": 0,
        "stdoutMarker": true,
        "stdoutSha256": "496f929210abd61d2e4afe97d7dc56055220a8f0ba36d43fec7fd4a6a61dc660"
      },
      {
        "supervisorStatus": 0,
        "supervisorSignal": null,
        "supervisorError": false,
        "status": 0,
        "signal": null,
        "error": false,
        "backgroundProcesses": 0,
        "stdoutMarker": true,
        "stdoutSha256": "496f929210abd61d2e4afe97d7dc56055220a8f0ba36d43fec7fd4a6a61dc660"
      }
    ],
    "boundaries": [
      {
        "name": "allowed",
        "dispatches": 1,
        "stdoutMarkers": 1
      },
      {
        "name": "runtime-tamper-rejected",
        "dispatches": 1,
        "stdoutMarkers": 1
      },
      {
        "name": "restored-runtime-allowed",
        "dispatches": 2,
        "stdoutMarkers": 2
      },
      {
        "name": "source-tamper-rejected",
        "dispatches": 2,
        "stdoutMarkers": 2
      }
    ],
    "diagnostics": [],
    "runtimeRejection": "prepared target pnpm toolchain is stale; refresh dependencies before validation: runtimeInputsSha256",
    "restoredRuntimeAllowed": true,
    "sourceRejection": "prepared target pnpm toolchain is stale; refresh dependencies before validation: contentTreeSha, status, worktreeSha256"
  }
}
```

</details>
