### PR TITLE
fix(review): extend Telegram proof harness coverage

### DIFF
--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -555,7 +555,7 @@ expressly authorized production-path harnesses. Mocked transport clients and
 isolated unit tests remain `mock_only`; preserve existing browser-runtime, CSP,
 auth, and security safeguards.
 
-For PRs, always fill `telegramVisibleProof`. Use `status: "needed"` only when the PR touches Telegram behavior and the user-visible change can be demonstrated by the repository `telegram-e2e-userbot` skill, such as message formatting, slash-command output, reply text, attachments, reactions, threading, mentions, or other visible Telegram chat behavior. Use `status: "not_needed"` for non-Telegram PRs and for Telegram changes that are internal-only, test-only, docs-only, logging-only, retry/network reliability only, auth/secret plumbing only, or otherwise not meaningfully observable in a short Telegram Test Server run. A label, title, consumer, or example does not make internal shared retry/ordering work visible. For that work, set
+For PRs, always fill `telegramVisibleProof`. Use `status: "needed"` only when the PR changes user-visible Telegram behavior that Telegram's Test Server can observe, whether or not the repository `telegram-e2e-userbot` skill already covers that API path. Examples include message formatting, slash-command output, reply text, attachments, reactions, threading, mentions, and other visible Telegram chat behavior. Use `status: "not_needed"` for non-Telegram PRs and for Telegram changes that are internal-only, test-only, docs-only, logging-only, retry/network reliability only, auth/secret plumbing only, or otherwise not meaningfully observable in a short Telegram Test Server run. A label, title, consumer, or example does not make internal shared retry/ordering work visible. For that work, set
 `telegramVisibleProof.status: "not_needed"` and
 `mantisRecommendation.status: "not_recommended"`.
 
@@ -1075,7 +1075,8 @@ more tests or more security review are not enough.
 
 Always fill `telegramVisibleProof` using the changed-behavior classification
 above. The `proof: telegram-e2e` label tells the execution worker to use the
-repository `telegram-e2e-userbot` skill.
+repository `telegram-e2e-userbot` skill, exercise the exact changed behavior,
+and extend its harness or recipes when the current coverage cannot expose it.
 
 Always fill `liveProofPlan` with the fixed retired compatibility shape specified
 above. Do not derive commands, steps, or another demonstration plan from the

--- a/test/review-prompt-policy.test.ts
+++ b/test/review-prompt-policy.test.ts
@@ -691,6 +691,9 @@ test("review prompt classifies Telegram visible proof candidates", () => {
 
   assert.match(prompt, /telegramVisibleProof/);
   assert.match(prompt, /telegram-e2e-userbot/);
+  assert.match(prompt, /whether or not the repository/);
+  assert.match(prompt, /exercise the exact changed behavior/);
+  assert.match(prompt, /extend its harness or recipes/);
   assert.match(prompt, /message formatting/);
   assert.match(prompt, /retry\/network reliability only/);
   assert.match(prompt, /shared retry\/ordering work/);


### PR DESCRIPTION
## What Problem This Solves

ClawSweeper classified Telegram proof as needed only when the current repository skill could already demonstrate the behavior. That wording could skip a user-visible Telegram change when the harness lacked one Bot API action or recorder field.

## Why This Change Was Made

The review prompt now classifies from Telegram Test Server observability, not current harness coverage. The execution guidance tells the worker to exercise the exact changed behavior and extend the repository harness or recipes when needed.

This keeps the existing scope boundary: internal retries, logs, tests, credential plumbing, and other non-visible changes remain not needed.

Companion skill text: https://github.com/openclaw/openclaw/pull/132295

## User Impact

ClawSweeper requests Telegram proof only for user-visible Telegram changes. When it does, the worker must prove the changed behavior instead of stopping at a generic reply or an existing coverage gap.

OpenClaw Bay is not affected because this changes review and execution guidance only.

## Evidence

- Prompt-policy tests passed: 44/44.
- ClawSweeper builds, static checks, formatting, and lint passed.
- Fresh pre-commit and committed Codex reviews found no actionable defects.
- The exhaustive local check reached 13 terminal-proof tests that require tmux; this Mac does not have tmux. Those environment failures do not touch the changed prompt or focused test.


## Real Behavior Proof

Tested committed ClawSweeper head `bd67800269af2d6c55ccc42148e92081cd1fd3be` with the production local-review CLI against real OpenClaw PR [#131078](https://github.com/openclaw/openclaw/pull/131078) at `c4cd0d5acb618acceef6177b53afa9ce3fef7f36`. That pull request changes visible Telegram Markdown rendering and has no dedicated details-list recipe.

The after-fix review returned `telegram_visible_proof_status: needed`, included `proof: telegram-e2e` in its label plan, and routed the behavior to the repository Telegram Test Server userbot instead of Mantis. The run used `--local-only`; it did not comment, label, or mutate the target pull request.

This proves the changed runtime prompt classifies an uncovered but Telegram-observable path as needing the extensible repository skill. It does not claim that the target pull request itself was re-tested or changed by this run.

Exact command:

```bash
pnpm run review -- --local-only --target-repo openclaw/openclaw --item-number 131078 --target-dir <exact-pr-head-worktree> --artifact-dir <private-artifact-dir>
```

Observed terminal result:

```text
Review complete
elapsed: 5m 18s
decision: keep_open
confidence: high
action: kept_open
```

The 18,714-byte report had SHA-256 `8ed68110710e8b796e87c2536de353e8df5e42a1550d8af45f68faca0178624e`. Its relevant fields were:

```text
pull_head_sha: c4cd0d5acb618acceef6177b53afa9ce3fef7f36
telegram_visible_proof_status: needed
label plan: proof: telegram-e2e
Mantis recommendation: not_recommended
```

Crabbox provider, image, and lease are not applicable. The exercised owner is the local review CLI and its runtime-loaded prompt; a desktop container would not add another production boundary. The run used the configured Codex review provider and a clean exact-head OpenClaw worktree.
