### PR TITLE
fix: stop ledger tests accumulating temporary files

### DIFF
--- a/test/action-ledger-runtime.test.ts
+++ b/test/action-ledger-runtime.test.ts
@@ -4,7 +4,7 @@ import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import test from "node:test";
+import test, { after } from "node:test";
 import { pathToFileURL } from "node:url";
 
 import {
@@ -46,9 +46,9 @@ import {
 } from "../dist/action-ledger-files.js";
 
 function tempRoot(): string {
-  return fs.realpathSync.native(
-    fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-action-runtime-")),
-  );
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-action-runtime-"));
+  after(() => fs.rmSync(root, { recursive: true, force: true }));
+  return fs.realpathSync.native(root);
 }
 
 function trustedChildRoot(root: string, name: string): string {
@@ -2924,46 +2924,54 @@ test("CrabFleet projection admission is fair across spool roots", async () => {
   const firstWaveResolvers: Array<(response: Response) => void> = [];
   const startOrder: string[] = [];
   let saturatedStarted = 0;
+  let releaseFirstWave = false;
   const saturatedFetch = (() => {
     saturatedStarted += 1;
     startOrder.push("saturated");
-    if (saturatedStarted <= CRABFLEET_PROJECTION_LIMITS.maxConcurrent) {
+    if (saturatedStarted <= CRABFLEET_PROJECTION_LIMITS.maxConcurrent && !releaseFirstWave) {
       return new Promise<Response>((resolve) => firstWaveResolvers.push(resolve));
     }
     return Promise.resolve(new Response(null, { status: 204 }));
   }) as typeof fetch;
   const saturatedTotal =
     CRABFLEET_PROJECTION_LIMITS.maxConcurrent + CRABFLEET_PROJECTION_LIMITS.maxQueued;
-  for (let index = 0; index < saturatedTotal; index += 1) {
-    assert.ok(recordReviewNumber(saturatedRoot, 100 + index, env, saturatedFetch));
-  }
-  assert.ok(
-    recordReviewNumber(independentRoot, 999, env, (async () => {
-      startOrder.push("independent");
-      return new Response(null, { status: 204 });
-    }) as typeof fetch),
-  );
-  await new Promise((resolve) => setImmediate(resolve));
-  assert.deepEqual(startOrder, Array(CRABFLEET_PROJECTION_LIMITS.maxConcurrent).fill("saturated"));
-
-  firstWaveResolvers.shift()!(new Response(null, { status: 204 }));
-  const fairnessDeadline = Date.now() + 500;
-  while (!startOrder.includes("independent")) {
-    if (Date.now() >= fairnessDeadline) {
-      throw new Error("independent root did not receive the next projection slot");
+  try {
+    for (let index = 0; index < saturatedTotal; index += 1) {
+      assert.ok(recordReviewNumber(saturatedRoot, 100 + index, env, saturatedFetch));
     }
-    await new Promise((resolve) => setTimeout(resolve, 5));
-  }
-  assert.deepEqual(startOrder.slice(0, 5), [
-    "saturated",
-    "saturated",
-    "saturated",
-    "saturated",
-    "independent",
-  ]);
+    assert.ok(
+      recordReviewNumber(independentRoot, 999, env, (async () => {
+        startOrder.push("independent");
+        return new Response(null, { status: 204 });
+      }) as typeof fetch),
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.deepEqual(
+      startOrder,
+      Array(CRABFLEET_PROJECTION_LIMITS.maxConcurrent).fill("saturated"),
+    );
 
-  for (const resolve of firstWaveResolvers) resolve(new Response(null, { status: 204 }));
-  await flushPendingCrabFleetPosts();
+    firstWaveResolvers.shift()!(new Response(null, { status: 204 }));
+    const fairnessDeadline = Date.now() + 500;
+    while (!startOrder.includes("independent")) {
+      if (Date.now() >= fairnessDeadline) {
+        throw new Error("independent root did not receive the next projection slot");
+      }
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    assert.deepEqual(startOrder.slice(0, 5), [
+      "saturated",
+      "saturated",
+      "saturated",
+      "saturated",
+      "independent",
+    ]);
+  } finally {
+    // Release held slots on failure so later tests do not inherit a starved pool.
+    releaseFirstWave = true;
+    for (const resolve of firstWaveResolvers) resolve(new Response(null, { status: 204 }));
+    await flushPendingCrabFleetPosts();
+  }
   assert.equal(startOrder.filter((entry) => entry === "saturated").length, saturatedTotal);
 });
 

--- a/test/action-ledger.test.ts
+++ b/test/action-ledger.test.ts
@@ -4,7 +4,7 @@ import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import test from "node:test";
+import test, { after } from "node:test";
 import { pathToFileURL } from "node:url";
 
 import {
@@ -70,9 +70,9 @@ const attemptId = actionAttemptId(operationId, {
 });
 
 function tempRoot(): string {
-  return fs.realpathSync.native(
-    fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-action-ledger-")),
-  );
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-action-ledger-"));
+  after(() => fs.rmSync(root, { recursive: true, force: true }));
+  return fs.realpathSync.native(root);
 }
 
 function createDirectoryLink(target: string, link: string): void {


### PR DESCRIPTION
Related: https://github.com/openclaw/clawsweeper/pull/1099

## What Problem This Solves

Resolves a problem where repeated action-ledger tests accumulate temporary files on long-lived development and validation hosts, even when the tests pass. One existing aggregate-limit case leaves nine 2 MiB shards per run. A fairness-test assertion failure can also leave mock requests occupying every projection slot and cause subsequent tests to fail or hang.

## Why This Change Was Made

Each test fixture now registers cleanup as soon as it creates its root, before path canonicalization can fail. Cleanup belongs to the active Node test and removes only that fixture's directory. The fairness fixture releases held requests and drains their work in `finally`, including callbacks arriving after cleanup starts. The existing timeouts and fairness assertions are unchanged.

This complements #1099's broader test-runner isolation and stale-run cleanup. These helpers must also clean up during direct `node --test` invocations and between individual tests; the changes do not overlap that PR.

## User Impact

Repeated narrow ledger tests no longer leave their temporary data behind after normal completion or assertion failure. A failed fairness assertion no longer strands the following tests. There is no production behavior, configuration, schema, or dependency change. Hard process termination can still bypass Node test hooks.

## OpenClaw Bay Impact

None. Only local test-fixture lifetime changes; production queues, action history, publication, and dashboard data are unchanged.

## Documentation Impact

Reviewed `CONTRIBUTING.md` and `docs/action-ledger.md`. Their validation and ledger contracts remain accurate; no documentation change is needed for this test-only repair.

## Evidence

Eight existing focused cases pass: aggregate byte limits, idempotent writes, exported projection concurrency, both import-race child cleanup cases, symlink defenses, and parent-chain swap detection. A fresh temporary directory contains zero retained fixture roots afterward. Formatting, `git diff --check`, and pre-commit and committed-branch Codex autoreviews pass. Production LOC delta is zero; test LOC is net +8, primarily cleanup scope and `try/finally` structure.

## Real Behavior Proof

**Claim and exercised surface:** action-ledger test fixtures release their real filesystem directories and held projection requests when their owning test finishes or fails.

**Environment:** macOS, Node v24.20.0; isolated source at base `db14db010bf3044be85f25fe40a587a5ca77523a`. The reviewed patch is commit `0efc0e7d2ada1f665e5b2c00ad41c5c3d078c65a`. Required runtime modules were emitted from that source with Node's built-in TypeScript stripping. Each comparison used an isolated temporary directory; no live channel or remote projection endpoint was contacted.

**Scenario and command:** execute the existing disk-producing tests before and after the patch, then count directories and actual retained file bytes under the isolated `TMPDIR`:

```sh
node --test --test-name-pattern='state shard imports enforce aggregate byte limits before publication|action event writes are create-only and replay-idempotent' test/action-ledger-runtime.test.ts test/action-ledger.test.ts
```

**Observed filesystem trace:**

| Scenario | Before | After |
| --- | --- | --- |
| Two successful existing tests | 2 roots, 10 files, 18,875,955 bytes retained | 0 roots, 0 files, 0 bytes retained |
| Injected error immediately after the aggregate fixture's first disk write | Original error plus 1 root / 2,097,152 bytes retained | Same original error; 0 roots / 0 bytes retained |
| Injected fairness assertion failure after four requests started, followed by the existing exported-concurrency test | Following test failed `0 !== 4`; process remained pending | Original failure remains visible; following test passes; process exits in 4.3 seconds with no roots retained |
| Final eight-case focused run | — | 8 passed, 0 failed; 0 retained roots / bytes |

**Limits:** the attempted full two-file macOS run exceeded the fairness fixture's unchanged 60-second request timeout while writing its 68 durability-backed events. That run was stopped and is not claimed green. The exact-head Linux `pnpm check` suite subsequently passed, along with Windows launcher, sparse-build, and CodeQL checks ([CI run](https://github.com/openclaw/clawsweeper/actions/runs/33261660352)). No timeout was raised or assertion weakened. All temporary data from the deliberate failure and stopped proof runs was removed.

## Native Review Admission

The pre-provider scanner blocker was repaired at its owner in https://github.com/openclaw/clawsweeper/pull/1296, merged as `0a46047ef6a6be7182babb6e33ed6d08df374d0a`. That change retains complete scanning and classifies only the exact existing synthetic fixture; it includes native admission/refusal proof and passed the normal review and CI gates. This cleanup PR remains unchanged at `0efc0e7d2ada1f665e5b2c00ad41c5c3d078c65a`, so the cleanup proof above remains applicable. A fresh committed-branch Codex autoreview also passed. The current native re-review can now use the repaired owner on main.
