### PR TITLE
fix(webhook): bound request bodies before signature verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Bound standalone webhook bodies to 2 MiB before signature verification, preserving chunked deliveries and flushing rejection responses before closing oversized requests. Thanks @SebTardif.
 - Preserve committed lifecycle outcomes when later queue completions disagree, preventing terminal-state conflicts from failing completion callbacks and acknowledgement drivers.
 - Retain numeric queue failure source locations inside the Durable Object before remote transport discards the original stack, without logging private error text.
 - Bound shared repair GitHub CLI calls with native process deadlines and honor per-call timeout settings. Thanks @SebTardif.

--- a/docs/repair/operations.md
+++ b/docs/repair/operations.md
@@ -356,7 +356,12 @@ The target workflow remains a compatibility fallback when the webhook service
 is down or not installed for a repository; its direct event is bridged into the
 same queue.
 
-The standalone `repair:comment-webhook` listener limits each GitHub REST request,
+The standalone `repair:comment-webhook` listener bounds incoming bodies to 2 MiB
+before signature verification. It accepts declared-length and chunked bodies,
+rejects oversized declarations before reading, and checks streamed bytes as they
+arrive. An oversized body receives HTTP 400 before the connection closes.
+
+The listener limits each GitHub REST request,
 including reading its response body, to 15 seconds. A stalled request returns
 HTTP 503 with `retryable: true`; successful requests keep the existing response.
 This per-request deadline does not bound the total duration of a command that

--- a/docs/target-dispatcher.md
+++ b/docs/target-dispatcher.md
@@ -394,6 +394,11 @@ reviews per target repository. Keep the Actions
 dispatcher installed as a compatibility fallback; its legacy dispatch is
 bridged into the same queue before Codex starts.
 
+The standalone Node listener limits raw request bodies to 2 MiB before verifying
+their signature. Declared-length and chunked deliveries are supported. Oversized
+bodies receive HTTP 400 and a closed connection; Node owns HTTP framing and
+connection teardown.
+
 The receiver keeps the review lane proposal-only, then runs exact apply for the
 selected item with only immediate-safe close reasons enabled:
 `implemented_on_main` and `duplicate_or_superseded`. Normal scheduled apply

--- a/src/repair/comment-webhook.ts
+++ b/src/repair/comment-webhook.ts
@@ -21,6 +21,7 @@ import { directReReviewIntake } from "./direct-re-review-admission.js";
 import { postExactReviewCommandIntake } from "./exact-review-command-queue.js";
 
 const DEFAULT_PORT = 8787;
+export const WEBHOOK_MAX_BODY_BYTES = 2 * 1024 * 1024;
 const GITHUB_FETCH_TIMEOUT_MS = 15_000;
 const REVIEW_REPO = "openclaw/clawsweeper";
 const COMMAND_PATTERN =
@@ -118,6 +119,7 @@ async function handleRequest(request: http.IncomingMessage, response: http.Serve
     const retryable = /command intake failed \(HTTP (?:429|5\d\d)\)|aborted|timed out/i.test(
       message,
     );
+    if (!request.readableEnded) response.setHeader("connection", "close");
     response.writeHead(retryable ? 503 : 400, { "content-type": "application/json" });
     response.end(
       `${JSON.stringify(retryable ? { ok: false, retryable: true } : { ok: false, error: message })}\n`,
@@ -910,9 +912,21 @@ async function githubFetch({
   return text ? (JSON.parse(text) as LooseRecord) : {};
 }
 
-async function readBody(request: http.IncomingMessage) {
+export async function readBody(request: http.IncomingMessage) {
+  if (Number(request.headers["content-length"]) > WEBHOOK_MAX_BODY_BYTES) {
+    throw new Error(`request body exceeds ${WEBHOOK_MAX_BODY_BYTES} bytes`);
+  }
   const chunks: Buffer[] = [];
-  for await (const chunk of request) chunks.push(Buffer.from(chunk));
+  let received = 0;
+  // Let the HTTP response finish before Node closes an oversized request's connection.
+  for await (const chunk of request.iterator({ destroyOnReturn: false })) {
+    const next = Buffer.from(chunk);
+    received += next.length;
+    if (received > WEBHOOK_MAX_BODY_BYTES) {
+      throw new Error(`request body exceeds ${WEBHOOK_MAX_BODY_BYTES} bytes`);
+    }
+    chunks.push(next);
+  }
   return Buffer.concat(chunks).toString("utf8");
 }
 

--- a/test/repair/comment-webhook-body.test.ts
+++ b/test/repair/comment-webhook-body.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import type { IncomingMessage } from "node:http";
+import { Readable } from "node:stream";
+import test, { type TestContext } from "node:test";
+
+import { readBody, WEBHOOK_MAX_BODY_BYTES } from "../../dist/repair/comment-webhook.js";
+
+function requestBody(t: TestContext, chunks: Iterable<Buffer>, length?: number) {
+  const request = Object.assign(Readable.from(chunks), {
+    headers: length === undefined ? {} : { "content-length": String(length) },
+  }) as IncomingMessage;
+  t.after(() => request.destroy());
+  return request;
+}
+
+for (const declared of [true, false]) {
+  test(`webhook body accepts bounded UTF-8 input with ${declared ? "declared" : "streamed"} length`, async (t) => {
+    const body = Buffer.from("signed 🦞 delivery");
+    const request = requestBody(
+      t,
+      [body.subarray(0, 9), body.subarray(9)],
+      declared ? body.length : undefined,
+    );
+    assert.equal(await readBody(request), body.toString("utf8"));
+  });
+}
+
+test("webhook body rejects an oversized declaration without pulling input", async (t) => {
+  let pulled = false;
+  function* chunks() {
+    pulled = true;
+    yield Buffer.from("unread");
+  }
+  const request = requestBody(t, chunks(), WEBHOOK_MAX_BODY_BYTES + 1);
+  await assert.rejects(readBody(request), /request body exceeds/);
+  assert.equal(pulled, false);
+  assert.equal(request.destroyed, false);
+});
+
+test("webhook body accepts the exact byte limit", async (t) => {
+  const request = requestBody(t, [Buffer.alloc(WEBHOOK_MAX_BODY_BYTES, 120)]);
+  assert.equal(Buffer.byteLength(await readBody(request)), WEBHOOK_MAX_BODY_BYTES);
+});
+
+test("webhook body stops oversized streamed input while leaving the HTTP response usable", async (t) => {
+  const request = requestBody(t, [Buffer.alloc(WEBHOOK_MAX_BODY_BYTES, 120), Buffer.from("x")]);
+  await assert.rejects(readBody(request), /request body exceeds/);
+  assert.equal(request.destroyed, false);
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the standalone `repair:comment-webhook` listener buffers an unbounded POST body before checking its signature. A sender can omit a declared length and keep streaming, or declare an oversized body, tying up the listener before authentication.

## Why This Change Was Made

Bound incoming bytes to 2 MiB, reject an oversized declaration before reading, and let Node handle HTTP framing and connection teardown. Bounded chunked requests retain their existing behavior. When streaming exceeds the limit, preserve the request long enough to send the HTTP 400 response and ask Node to close the connection afterward.

The maintainer rewrite removes the custom Content-Length parser and missing-header rejection from the original proposal. Production code is +14 net lines versus +29 in the original PR. [Node's iterator contract](https://nodejs.org/api/stream.html#readableiteratoroptions) lets the reader exit without destroying the connection before the response can finish.

## User Impact

Oversized requests receive HTTP 400 and a closed connection. Valid bounded requests, including chunked bodies and the exact 2 MiB boundary, still reach signature verification and normal event classification. Bad signatures retain the existing rejection. This changes the standalone Node listener; it does not deploy a standalone service or change the hosted Worker ingress.

## OpenClaw Bay Impact

Bay is unaffected. This is the standalone Node listener's raw-body boundary; no queue, publication, lifecycle, public dashboard, or browser contract changes.

## Documentation Impact

Updated the active webhook runbooks in `docs/repair/operations.md` and `docs/target-dispatcher.md` to describe the byte cap, supported framing, and response/connection behavior. The standalone listener is the source of truth, repair/webhook operators own the runbooks, and cap/framing changes require an update. Added a changelog entry with contributor credit.

## Evidence

`pnpm run check` passed on Node 24.18.1: 4,165 unit tests passed, 8 skipped, and all 13 static checks passed. All 36 focused webhook tests passed. Both required Codex reviews found no actionable findings at their configured P0 scope.

## Real Behavior Proof

**Claim/surface:** the compiled standalone HTTP listener rejects oversized raw bodies before authentication while preserving bounded signed input and delivering an error response before connection teardown.

**Revision/environment:** candidate `f21af5110faaa5cf1b734c23d8901585d1c5119f`, tree `ea07fcd368c18c4412e6a91cabdae98273a50b9b`; compared with current main `b3e6adf72579bf69671e1034aeefc019449e3d63` and original PR head `c9d847890e65bb20f5ac382cd6c90c145806d6c1`. Crabbox provider **aws**, lease `cbx_214185e9c916`, run `run_389d104a9edb`, image `ami-0461d919be7deb53c`; Node 24.18.1 and pnpm 11.10.0. Fresh isolated lease, public network, no Tailscale, no hydration, no instance role (IMDS credential endpoint 404), only CI forwarded.

**Scenario:** start the actual compiled `dist/repair/comment-webhook.js` process and issue loopback HTTP requests using a keep-alive agent. Derive real HMAC signatures with a synthetic secret. Test ordinary and chunked bounded input, header-only oversize, an oversized chunked sender that never ends, exactly 2 MiB, one byte over, bad signature, and a successful request after rejection. The synthetic ping payload is deliberately ineligible for repository work, so the authenticated classifier returns 202 without any GitHub mutation.

**Observed original PR:** the ordinary signed request returned 202, but its equivalent chunked request returned 400 `missing Content-Length`.

**Observed main:** ordinary and chunked requests returned 202. A signed 2,097,167-byte body was accepted by the raw-body reader and reached the classifier. A sender held open after streaming 2,359,296 bytes still had no response at the 2.5-second fixture watchdog.

**Observed candidate:** header-only oversize returned 400 in 1 ms with zero body bytes sent; the client had not ended its request and the server closed the socket after the complete response. Chunked oversize returned 400 in 35 ms with the sender still open and the socket closed afterward. Normal and chunked signed input and the exact 2,097,152-byte boundary returned 202; one extra byte returned 400. Bad HMAC returned 400, a subsequent normal request returned 202, and the listener remained alive. The client advertised keep-alive, so these checks exercise server-owned connection closure.

**Commands/artifact:** the exact normalized trace and standalone proof driver are below. Save the driver as `/tmp/clawsweeper-webhook-body-cap-proof.mjs`, then run from the corresponding checkout:

```sh
pnpm install --frozen-lockfile
pnpm run build:repair
node /tmp/clawsweeper-webhook-body-cap-proof.mjs original # original PR
node /tmp/clawsweeper-webhook-body-cap-proof.mjs before   # main base
node /tmp/clawsweeper-webhook-body-cap-proof.mjs after    # candidate
```

**Limits:** real Node process and TCP/HTTP behavior with synthetic signatures and ignored repository work; not a delivery from GitHub or a hosted Worker test. This is a per-request buffering bound, not a global connection/admission limit or a slow-input policy. No production credentials or external GitHub mutations were used. The complete request signature is still checked after bounded buffering.

<details>
<summary>Native HTTP before/after observations</summary>

```json
{"phase":"original","normal":{"status":202,"body":{"accepted":false,"reason":"repository not eligible"},"connection":"keep-alive","ms":9,"sentBytes":35,"requestEnded":true},"chunked":{"status":400,"body":{"ok":false,"error":"missing Content-Length"},"connection":"keep-alive","ms":1,"sentBytes":35,"requestEnded":true}}
{"phase":"before","normal":{"status":202,"body":{"accepted":false,"reason":"repository not eligible"},"connection":"keep-alive","ms":8,"sentBytes":35,"requestEnded":true},"chunked":{"status":202,"body":{"accepted":false,"reason":"repository not eligible"},"connection":"keep-alive","ms":1,"sentBytes":35,"requestEnded":true},"oversizedSigned":{"status":202,"body":{"accepted":false,"reason":"repository not eligible"},"connection":"keep-alive","ms":15,"sentBytes":2097167,"requestEnded":true},"streaming":{"timeout":true,"ms":2503,"sentBytes":2359296,"requestEnded":false}}
{"phase":"after","normal":{"status":202,"body":{"accepted":false,"reason":"repository not eligible"},"connection":"keep-alive","ms":8,"sentBytes":35,"requestEnded":true},"chunked":{"status":202,"body":{"accepted":false,"reason":"repository not eligible"},"connection":"keep-alive","ms":1,"sentBytes":35,"requestEnded":true},"declared":{"status":400,"body":{"ok":false,"error":"request body exceeds 2097152 bytes"},"connection":"close","ms":1,"sentBytes":0,"requestEnded":false,"socketClosed":true},"streamed":{"status":400,"body":{"ok":false,"error":"request body exceeds 2097152 bytes"},"connection":"close","ms":35,"sentBytes":2228224,"requestEnded":false,"socketClosed":true},"boundary":{"status":202,"body":{"accepted":false,"reason":"repository not eligible"},"connection":"keep-alive","ms":15,"sentBytes":2097152,"requestEnded":true},"oversized":{"status":400,"body":{"ok":false,"error":"request body exceeds 2097152 bytes"},"connection":"close","ms":6,"sentBytes":2097153,"requestEnded":true},"badSignature":{"status":400,"body":{"ok":false,"error":"invalid GitHub webhook signature"},"connection":"keep-alive","ms":1,"sentBytes":35,"requestEnded":true},"recovery":{"status":202,"body":{"accepted":false,"reason":"repository not eligible"},"connection":"keep-alive","ms":1,"sentBytes":35,"requestEnded":true}}
```

</details>

<details>
<summary>Standalone native HTTP proof driver</summary>

```js
import assert from 'node:assert/strict';
import http from 'node:http';
import {spawn} from 'node:child_process';
import {createHmac} from 'node:crypto';
import {once} from 'node:events';
import {resolve} from 'node:path';
import {setTimeout as delay} from 'node:timers/promises';
const phase=process.argv[2];assert.ok(['original','before','after','merged'].includes(phase));
const cap=2*1024*1024,secret='synthetic-webhook-body-proof',port=18787;
const child=spawn(process.execPath,[resolve('dist/repair/comment-webhook.js')],{env:{PATH:process.env.PATH,HOME:process.env.HOME,PORT:String(port),CLAWSWEEPER_WEBHOOK_SECRET:secret},stdio:['ignore','pipe','pipe']});
let output='',errors='';child.stdout.on('data',x=>output+=x);child.stderr.on('data',x=>errors+=x);
async function post({body='{}',chunked=false,declared,open=false,badSignature=false,expectClose=false,stream=false}={}){
 const agent=new http.Agent({keepAlive:true,maxSockets:1});let timer,writer,socket,sent=0,closed=false;
 const started=performance.now();
 try{
  const result=await new Promise((resolveResult,reject)=>{
   let settled=false;
   const finish=(fn,value)=>{if(settled)return;settled=true;clearTimeout(timer);if(writer)clearInterval(writer);fn(value)};
   const signature='sha256='+createHmac('sha256',secret).update(body).digest('hex');
   const req=http.request({host:'127.0.0.1',port,path:'/github/webhook',method:'POST',agent,headers:{'content-type':'application/json','connection':'keep-alive','x-github-event':'ping','x-hub-signature-256':badSignature?'sha256='+'0'.repeat(64):signature,...(!chunked?{'content-length':String(declared??Buffer.byteLength(body))}:{'transfer-encoding':'chunked'})}},res=>{
    const chunks=[];res.on('data',x=>chunks.push(x));res.on('error',error=>finish(reject,error));res.on('end',()=>{
     const text=Buffer.concat(chunks).toString('utf8');let parsed;try{parsed=JSON.parse(text)}catch{parsed=text}
     finish(resolveResult,{status:res.statusCode,body:parsed,connection:res.headers.connection,ms:Math.round(performance.now()-started),sentBytes:sent,requestEnded:req.writableEnded});
    });
   });
   req.on('socket',value=>{socket=value;value.once('close',()=>{closed=true})});
   req.on('error',error=>finish(reject,error));
   timer=setTimeout(()=>{finish(resolveResult,{timeout:true,ms:Math.round(performance.now()-started),sentBytes:sent,requestEnded:req.writableEnded});req.destroy()},2500);
   if(stream){
    req.flushHeaders();const chunk=Buffer.alloc(65536,120);
    writer=setInterval(()=>{if(sent>=cap+262144){clearInterval(writer);return}req.write(chunk);sent+=chunk.length},1);
   }else if(open){req.flushHeaders()}
   else{sent=Buffer.byteLength(body);req.end(body)}
  });
  if(expectClose){
   for(let i=0;i<100&&!closed;i++)await delay(10);
   result.socketClosed=closed;
   assert.equal(result.connection,'close');assert.equal(closed,true,'server must close an unfinished body after its response');
  }
  return result;
 }finally{clearTimeout(timer);clearInterval(writer);agent.destroy();socket?.destroy()}
}
try{
 for(let i=0;i<200&&!output.includes('listening on');i++){if(child.exitCode!==null)throw new Error('listener exited: '+errors);await delay(10)}
 assert.ok(output.includes('listening on'),'listener did not start');
 const normal=JSON.stringify({zen:'synthetic signed delivery'});
 const normalResult=await post({body:normal});assert.equal(normalResult.status,202);
 const chunked=await post({body:normal,chunked:true});assert.equal(chunked.status,phase==='original'?400:202);
 if(phase==='original'){
  assert.match(chunked.body.error,/missing Content-Length/);
  console.log(JSON.stringify({phase,normal:normalResult,chunked}));
 }else if(phase==='before'){
  const large=await post({body:JSON.stringify({padding:'x'.repeat(cap+1)})});assert.equal(large.status,202);
  const streaming=await post({chunked:true,stream:true});assert.equal(streaming.timeout,true);
  console.log(JSON.stringify({phase,normal:normalResult,chunked,oversizedSigned:large,streaming}));
 }else{
  const declared=await post({declared:cap+1,open:true,expectClose:true});assert.equal(declared.status,400);assert.equal(declared.sentBytes,0);assert.equal(declared.requestEnded,false);
  const streamed=await post({chunked:true,stream:true,expectClose:true});assert.equal(streamed.status,400);assert.equal(streamed.requestEnded,false);
  const exact=JSON.stringify({pad:'x'.repeat(cap-10)});assert.equal(Buffer.byteLength(exact),cap);
  const boundary=await post({body:exact});assert.equal(boundary.status,202);
  const oversized=await post({body:exact+' '});assert.equal(oversized.status,400);
  const bad=await post({body:normal,badSignature:true});assert.equal(bad.status,400);assert.match(bad.body.error,/invalid GitHub webhook signature/);
  const recovery=await post({body:normal});assert.equal(recovery.status,202);assert.equal(child.exitCode,null);
  console.log(JSON.stringify({phase,normal:normalResult,chunked,declared,streamed,boundary,oversized,badSignature:bad,recovery}));
 }
}finally{
 child.kill('SIGTERM');const force=setTimeout(()=>child.kill('SIGKILL'),2000);await once(child,'exit');clearTimeout(force);
}
```

</details>
