### PR TITLE
fix(review): classify a reviewed synthetic URI fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,12 +553,24 @@ installer in `.github/actions/setup-review-tools/install.sh`. It supports Linux
 amd64 and fails on unsupported platforms. Local operators must install a trusted
 [TruffleHog executable](https://github.com/trufflesecurity/trufflehog#installation)
 on the host `PATH`, outside both checkouts; workers never
-install dependencies themselves. Missing tools, findings, scan errors, source
+install dependencies themselves. Missing tools, unclassified findings, scan errors, source
 drift, incomplete ancestry/objects, changed gitlinks, and LFS pointers refuse the
 review. The scan stages at most 256 MiB in private external temporary files and
 uses the remaining review deadline; it never silently truncates or bypasses.
 Diagnostics omit scanner output and source values. Restore prerequisites or
 remove sensitive input before retrying a refusal.
+
+The host classifies one reviewed synthetic malformed-configuration URI in
+`test/action-ledger-runtime.test.ts` as non-sensitive after a complete scan.
+Its policy binds the exact full finding bytes, detector contract, and literal
+line in a host-staged Git blob. It does not trust checkout ignore rules or
+domain patterns. Prompt, schema, diff, additional-input, and encoded-only
+occurrences remain blocking, as do other findings and incomplete scans.
+The classification is pinned to TruffleHog 3.97.1's output contract; scanner
+upgrades require requalification. See `src/agent-input-scan-fixtures.ts`.
+Every accepted classification emits a host-side structured stderr notice with
+the fixture digest, source blob, line, decoder, and occurrence count. Raw values
+and verification diagnostics never appear in that audit notice.
 
 Generated review and repair prompt diagnostics retire the previous attempt's
 copy before admission and persist only successfully scanned exact prompt bytes

--- a/src/agent-input-scan-fixtures.ts
+++ b/src/agent-input-scan-fixtures.ts
@@ -1,0 +1,137 @@
+import { createHash } from "node:crypto";
+import { basename } from "node:path";
+
+// Maintainer-reviewed malformed-config fixture introduced by d68b1861172120fc.
+// This is host policy, never an allowlist loaded from the reviewed checkout.
+export const REVIEWED_FIXTURE_SOURCE = "test/action-ledger-runtime.test.ts";
+const FIXTURE_SHA256 = "a728de5dbbef23b8aa5ef2d99060835f4f2fb5a0fa2abb9fe249d08aa09bd09e";
+
+interface ClassifiedFinding {
+  blob: string;
+  line: number;
+  decoder: string;
+  occurrences: number;
+}
+
+function object(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("invalid scanner object");
+  }
+  return value as Record<string, unknown>;
+}
+
+function records(bytes: Buffer): Record<string, unknown>[] {
+  const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  if (!text.endsWith("\n")) throw new Error("incomplete scanner output");
+  return text
+    .slice(0, -1)
+    .split("\n")
+    .map((line) => object(JSON.parse(line)));
+}
+
+/** Classify only complete native scans whose every finding is the reviewed fixture. */
+export function classifyReviewedFixtureScan(
+  stdout: Buffer,
+  stderr: Buffer,
+  sourceBlobs: ReadonlyMap<string, Buffer>,
+):
+  | { fixtureSha256: string; source: string; detector: string; findings: ClassifiedFinding[] }
+  | undefined {
+  try {
+    const findings = records(stdout);
+    const logs = records(stderr);
+    // TruffleHog can log detector failures and still exit 183. Its exit status
+    // alone therefore cannot establish that all detectors finished successfully.
+    if (
+      logs.some(
+        (entry) =>
+          entry.level !== "info-0" ||
+          typeof entry.logger !== "string" ||
+          typeof entry.msg !== "string" ||
+          entry.error !== undefined ||
+          entry.errors !== undefined,
+      ) ||
+      logs.filter((entry) => entry.msg === "finished scanning").length !== 1
+    )
+      return undefined;
+    const completion = logs.at(-1)!;
+    if (
+      completion.logger !== "trufflehog" ||
+      completion.msg !== "finished scanning" ||
+      completion.trufflehog_version !== "3.97.1" ||
+      typeof completion.chunks !== "number" ||
+      !Number.isSafeInteger(completion.chunks) ||
+      completion.chunks <= 0 ||
+      typeof completion.bytes !== "number" ||
+      !Number.isSafeInteger(completion.bytes) ||
+      completion.bytes <= 0 ||
+      completion.verified_secrets !== 0 ||
+      completion.unverified_secrets !== findings.length
+    )
+      return undefined;
+
+    const classified = new Map<string, ClassifiedFinding>();
+    for (const finding of findings) {
+      if (
+        finding.DetectorType !== 17 ||
+        finding.DetectorName !== "URI" ||
+        finding.SourceType !== 15 ||
+        finding.Verified !== false ||
+        (finding.DecoderName !== "PLAIN" && finding.DecoderName !== "HTML") ||
+        typeof finding.VerificationError !== "string" ||
+        !finding.VerificationError ||
+        typeof finding.Raw !== "string" ||
+        // URI Raw omits the path; RawV2 must match the complete reviewed value.
+        finding.RawV2 !== finding.Raw ||
+        createHash("sha256").update(finding.Raw).digest("hex") !== FIXTURE_SHA256 ||
+        finding.ExtraData !== null ||
+        finding.StructuredData !== null
+      )
+        return undefined;
+      const source = object(object(object(finding.SourceMetadata).Data).Filesystem);
+      const bytes = typeof source.file === "string" ? sourceBlobs.get(source.file) : undefined;
+      if (
+        !bytes ||
+        typeof source.line !== "number" ||
+        !Number.isSafeInteger(source.line) ||
+        source.line <= 0
+      )
+        return undefined;
+      const line = new TextDecoder("utf-8", { fatal: true }).decode(bytes).split("\n")[
+        source.line - 1
+      ];
+      // HTML may rediscover an unchanged literal. Encoded-only occurrences,
+      // numeric staging files (prompt/schema/diff), and forged paths never qualify.
+      if (!line?.includes(finding.Raw)) return undefined;
+      const uri = new URL(finding.Raw);
+      const parts = object(finding.SecretParts);
+      if (
+        Object.keys(parts).length !== 3 ||
+        parts.host !== uri.host ||
+        parts.username !== uri.username ||
+        parts.password !== uri.password
+      )
+        return undefined;
+      const blob = basename(source.file as string);
+      const key = `${blob}:${source.line}:${finding.DecoderName}`;
+      const previous = classified.get(key);
+      classified.set(key, {
+        blob,
+        line: source.line,
+        decoder: finding.DecoderName,
+        occurrences: (previous?.occurrences ?? 0) + 1,
+      });
+    }
+    return {
+      fixtureSha256: FIXTURE_SHA256,
+      source: REVIEWED_FIXTURE_SOURCE,
+      detector: "URI",
+      findings: [...classified.entries()]
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([, value]) => value),
+    };
+  } catch {
+    // Scanner output includes credential-shaped bytes; never expose parse errors.
+    return undefined;
+  }
+}

--- a/src/agent-input-scan.ts
+++ b/src/agent-input-scan.ts
@@ -19,6 +19,10 @@ import { tmpdir } from "node:os";
 import { delimiter, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { readReviewGit, reviewMergeBase, type ReviewGitReadOptions } from "./pr-review-evidence.js";
+import {
+  classifyReviewedFixtureScan,
+  REVIEWED_FIXTURE_SOURCE,
+} from "./agent-input-scan-fixtures.js";
 
 export type AgentScanSource =
   | { kind: "prompt" }
@@ -111,6 +115,7 @@ export function scanAgentInput(options: {
   };
   let root: string | undefined;
   let failure: AgentInputScanError | undefined;
+  let classified: ReturnType<typeof classifyReviewedFixtureScan>;
   try {
     const cwd = realpathSync(options.cwd);
     const scanner = trustedExecutable("trufflehog", cwd, options.cwd);
@@ -119,6 +124,7 @@ export function scanAgentInput(options: {
       throw new AgentInputScanError("unsafe_path");
     const inputDir = join(root, "input");
     mkdirSync(inputDir, { mode: 0o700 });
+    const reviewedFixtureBlobs = new Map<string, Buffer>();
     let staged = 0;
     let ordinal = 0;
     const stage = (bytes: Buffer, name = String(ordinal++)) => {
@@ -332,6 +338,7 @@ export function scanAgentInput(options: {
       }
       assertCurrent();
       const blobs = new Set<string>();
+      const fixtureBlobs = new Set<string>();
       const endpoints =
         source.kind === "snapshot"
           ? [mergeBase.sha, source.headSha, source.indexTreeSha, source.treeSha]
@@ -377,6 +384,7 @@ export function scanAgentInput(options: {
               throw new AgentInputScanError("unsupported_content");
             if (!OBJECT_ID.test(oid!)) throw new AgentInputScanError("incomplete_source");
             blobs.add(oid!);
+            if (path === REVIEWED_FIXTURE_SOURCE && mode === "100644") fixtureBlobs.add(oid!);
           }
         }
         stage(git([...args, "--patch", "--binary", "--full-index", "--"]));
@@ -397,6 +405,7 @@ export function scanAgentInput(options: {
           throw new AgentInputScanError("unsupported_content");
         // OID names preserve multiline bytes and make symlinks ordinary scan files.
         stage(bytes, oid);
+        if (fixtureBlobs.has(oid)) reviewedFixtureBlobs.set(join(inputDir, oid), bytes);
       }
     }
     const result = spawnSync(
@@ -425,11 +434,19 @@ export function scanAgentInput(options: {
         maxBuffer: 1024 * 1024,
       },
     );
-    if (result.status === 183 || result.stdout?.length) throw new AgentInputScanError("findings");
     if ((result.error as NodeJS.ErrnoException | undefined)?.code === "ETIMEDOUT")
       throw new AgentInputScanError("deadline");
-    if (result.error || result.signal || result.status !== 0)
+    if (result.error || result.signal || (result.status !== 0 && result.status !== 183))
       throw new AgentInputScanError("scanner_failed");
+    if (result.status === 183 || result.stdout?.length) {
+      if (result.status === 183)
+        classified = classifyReviewedFixtureScan(
+          result.stdout,
+          result.stderr,
+          reviewedFixtureBlobs,
+        );
+      if (!classified) throw new AgentInputScanError("findings");
+    }
     remaining();
     assertCurrent();
     remaining();
@@ -447,4 +464,14 @@ export function scanAgentInput(options: {
     }
   }
   if (failure) throw failure;
+  // Emit from the host after cleanup: successful callers can discard provider
+  // stderr, but this classification must remain visible without exposing values.
+  if (classified)
+    console.error(
+      JSON.stringify({
+        event: "agent_input_scan_classified",
+        notice: "Reviewed synthetic fixture findings classified as non-sensitive.",
+        ...classified,
+      }),
+    );
 }

--- a/test/agent-input-scan.test.ts
+++ b/test/agent-input-scan.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
   existsSync,
   copyFileSync,
@@ -22,7 +23,7 @@ import {
 } from "../dist/repair/target-validation.js";
 import { useFakeScanner } from "./agent-input-scan-helpers.ts";
 
-function fixture(t: test.TestContext) {
+function fixture(t: test.TestContext, prompt = "Review the change.") {
   const root = mkdtempSync(join(tmpdir(), "clawsweeper-input-test-"));
   t.after(() => rmSync(root, { recursive: true, force: true }));
   const cwd = join(root, "target");
@@ -48,7 +49,7 @@ function fixture(t: test.TestContext) {
   const run = (source: Parameters<typeof scanAgentInput>[0]["source"]) =>
     runAgentProcess({
       label: "scan-fixture",
-      prompt: "Review the change.",
+      prompt,
       diagnosticPromptPath,
       scanSource: source,
       model: "internal",
@@ -423,3 +424,125 @@ test("repair scan binds raw bytes even when normalization leaves the same canoni
   );
   assert.equal(existsSync(f.calls), false);
 });
+
+for (const scenario of [
+  "reviewed fixture",
+  "HTML duplicate",
+  "changed raw",
+  "changed full URI",
+  "verified",
+  "mixed findings",
+  "wrong source",
+  "wrong line",
+  "other file",
+  "prompt",
+  "decoded only",
+  "missing completion",
+  "detector error",
+  "wrong count",
+  "wrong version",
+  "duplicate completion",
+  "malformed stderr",
+  "malformed output",
+  "unexpected successful output",
+  "source drift",
+]) {
+  test(`reviewed synthetic fixture admission: ${scenario}`, (t) => {
+    const notices: unknown[][] = [];
+    t.mock.method(console, "error", (...args: unknown[]) => notices.push(args));
+    // Read the existing malformed-configuration fixture without reproducing its
+    // credential-shaped bytes in another source file or assertion diagnostic.
+    const existing = readFileSync(
+      new URL("./action-ledger-runtime.test.ts", import.meta.url),
+      "utf8",
+    );
+    const uri = [...existing.matchAll(/"([^"\n]+)"/g)]
+      .map((match) => match[1]!)
+      .find(
+        (value) =>
+          createHash("sha256").update(value).digest("hex") ===
+          "a728de5dbbef23b8aa5ef2d99060835f4f2fb5a0fa2abb9fe249d08aa09bd09e",
+      );
+    assert.ok(uri, "reviewed synthetic fixture is present");
+    const f = fixture(t, scenario === "prompt" ? uri : undefined);
+    const file = scenario === "other file" ? "other.test.ts" : "test/action-ledger-runtime.test.ts";
+    mkdirSync(join(f.cwd, "test"));
+    const value = scenario === "decoded only" ? uri.replace(":", "&#58;") : uri;
+    const contents = "// context\n".repeat(40) + JSON.stringify(value) + "\n";
+    writeFileSync(join(f.cwd, file), "// before\n" + contents);
+    const baseSha = f.commit();
+    writeFileSync(join(f.cwd, file), "// after\n" + contents);
+    const headSha = f.commit();
+    useFakeScanner(
+      t,
+      String.raw`
+const uri = ${JSON.stringify(uri)};
+const scenario = ${JSON.stringify(scenario)};
+const parsed = new URL(uri);
+const findings = inputs.filter(({name}) => /^[a-f0-9]{40}$/.test(name) || (scenario === 'prompt' && name === 'prompt')).map(({name}) => ({
+  SourceType: 15, DetectorType: 17, DetectorName: 'URI', DecoderName: 'PLAIN', Verified: false,
+  VerificationError: 'synthetic verification error', Raw: uri, RawV2: uri,
+  SourceMetadata: {Data: {Filesystem: {file: path.join(inputDir, name), line: name === 'prompt' ? 1 : 42}}},
+  SecretParts: {host: parsed.host, username: parsed.username, password: parsed.password},
+  ExtraData: null, StructuredData: null,
+}));
+if (scenario === 'HTML duplicate') findings.push({...findings[0], DecoderName: 'HTML'});
+if (scenario === 'changed raw') findings[0].Raw += 'changed';
+if (scenario === 'changed full URI') findings[0].RawV2 += '/changed';
+if (scenario === 'verified') findings[0].Verified = true;
+if (scenario === 'mixed findings') findings.push({...findings[0], Raw: 'unreviewed', RawV2: 'unreviewed'});
+if (scenario === 'wrong source') findings[0].SourceMetadata.Data.Filesystem.file = path.join(inputDir, 'prompt');
+if (scenario === 'wrong line') findings[0].SourceMetadata.Data.Filesystem.line++;
+if (scenario === 'source drift') fs.appendFileSync(${JSON.stringify(join(f.cwd, file))}, '// drift');
+process.stdout.write(findings.map(value => JSON.stringify(value)).join('\n') + '\n');
+if (scenario === 'malformed output') process.stdout.write('{');
+if (scenario === 'detector error') process.stderr.write(JSON.stringify({level:'error', logger:'trufflehog', msg:'error finding results in chunk'}) + '\n');
+const completion = JSON.stringify({
+  level:'info-0', logger:'trufflehog', msg:'finished scanning', trufflehog_version:scenario === 'wrong version' ? 'changed' : '3.97.1',
+  chunks:2, bytes:1000, verified_secrets:0, unverified_secrets:findings.length + (scenario === 'wrong count' ? 1 : 0),
+}) + '\n';
+if (scenario !== 'missing completion') process.stderr.write(completion);
+if (scenario === 'duplicate completion') process.stderr.write(completion);
+if (scenario === 'malformed stderr') process.stderr.write('{');
+process.exit(scenario === 'unexpected successful output' ? 0 : 183);
+`,
+    );
+    const run = () => f.run({ kind: "committed", baseSha, headSha });
+    if (scenario === "reviewed fixture" || scenario === "HTML duplicate") {
+      assert.equal(run().status, 0);
+      assert.equal(readFileSync(f.calls, "utf8"), "called");
+      assert.equal(notices.length, 1);
+      assert.equal(
+        JSON.stringify(notices).includes(uri),
+        false,
+        "audit never exposes finding bytes",
+      );
+      const notice = JSON.parse(String(notices[0]![0]));
+      assert.equal(notice.event, "agent_input_scan_classified");
+      assert.equal(notice.source, file);
+      assert.equal(notice.detector, "URI");
+      assert.match(notice.notice, /classified as non-sensitive/);
+      assert.equal(
+        notice.findings.reduce(
+          (sum: number, finding: { occurrences: number }) => sum + finding.occurrences,
+          0,
+        ),
+        scenario === "HTML duplicate" ? 3 : 2,
+      );
+      for (const finding of notice.findings) {
+        assert.match(finding.blob, /^[a-f0-9]{40}$/);
+        assert.equal(finding.line, 42);
+      }
+    } else {
+      assert.throws(run, (error) => {
+        assert.ok(error instanceof AgentInputScanError);
+        assert.equal(error.reason, scenario === "source drift" ? "source_drift" : "findings");
+        assert.equal(String(error).includes(uri), false, "finding bytes stay private");
+        return true;
+      });
+      assert.equal(existsSync(f.calls), false);
+      assert.equal(existsSync(f.diagnosticPromptPath), false);
+      assert.deepEqual(notices, []);
+    }
+  });
+}


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the native review of https://github.com/openclaw/clawsweeper/pull/1294 repeatedly fails before provider invocation because TruffleHog finds the same existing 45-byte synthetic malformed-configuration URI (no path, query, or fragment) in the complete base and head versions of a changed test file. Removing it only from the new revision would still leave the base finding.

## Why This Change Was Made

Keep classification at the host-owned scan boundary. One reviewed fixture is identified by its exact full-value SHA-256, URI detector contract, and literal occurrence at the reported line of a host-staged Git blob for `test/action-ledger-runtime.test.ts`. The policy never comes from the reviewed checkout. All findings must qualify, and the native scanner must report complete, error-free output under the pinned 3.97.1 contract. Both `Raw` and `RawV2` are checked. **This exact approved URI has no path, query, or fragment, so native TruffleHog returns the same 45 bytes in both fields.** For a different URI with a path, the detector removes that path from `Raw` but preserves it in `RawV2`; that different full value must remain blocked.

The complete raw diffs, binary patches, before/head blobs, prompt, schema, and additional input still reach TruffleHog with the original flags. Changed values, mixed findings, prompt/schema/diff/additional-input occurrences, encoded-only occurrences, scan errors, and source drift still refuse admission. There are no ignore comments, excluded detectors or paths, new configuration, or fixture rewrites. A sanitized structured host stderr notice preserves each accepted source/blob/line/decoder/count without raw values or verification diagnostics; successful provider callers cannot hide it by discarding their stderr.

## User Impact

Reviews that encounter this existing synthetic fixture can proceed while unrelated sensitive findings remain blocking. The classification deliberately fails closed if the scanner output contract changes; a scanner upgrade requires requalification.

## OpenClaw Bay Impact

None. This changes pre-provider input admission and emits an operator log notice; it does not change queue, publication, dashboard, or observer data contracts.

## Documentation Impact

Updated the active README Safety Model at the scan owner to describe the exact classification, its limits, audit notice, and scanner-upgrade requirement. Reviewed `docs/commit-sweeper.md`; its complete-input scanning contract is unchanged.

## Evidence

- Corrected regression reproduction rejects the reviewed fixture on the previous owner with `AgentInputScanError: findings`, before provider invocation.
- `node --test test/agent-input-scan.test.ts`: 49/49 passed, including all 20 new classification/refusal/audit cases and the existing snapshot cases. `node --test test/agent-runner.test.ts`: 8/8 passed. The full admission run caught a test-helper callback-argument regression during development; the helper signature was restored and the original assertions then passed unchanged.
- Exact-head [hosted CI](https://github.com/openclaw/clawsweeper/actions/runs/33270946443) passed, including the full `pnpm run check`, sparse builds, and Windows launcher; CodeQL also passed.
- `pnpm run build:node`, `pnpm run check:static`, `pnpm run lint:src`, `pnpm run lint:scripts`, and `git diff --check` pass.
- Fresh isolated Codex autoreviews before commit and against the committed branch report no accepted/actionable P0 findings. Candidate head: `6e0e0a75a46bac1f656069e87e9a379642155450`.
- Direct dependency inspection: [URI detector](https://github.com/trufflesecurity/trufflehog/blob/v3.97.1/pkg/detectors/uri/uri.go), [JSON output](https://github.com/trufflesecurity/trufflehog/blob/v3.97.1/pkg/output/json.go), and [scan completion/exit ordering](https://github.com/trufflesecurity/trufflehog/blob/v3.97.1/main.go). Exit 183 alone is insufficient because detector errors can be logged while findings are returned.
- The fixture's introduction was verified from the raw parent and parent-to-commit patch of `d68b1861172120fc6429cb346aadce65a46ed5a2`, not blame alone. No credential-shaped value is copied into this PR.

## Real Behavior Proof

Claim: the actual host admission owner accepts the unchanged PR's reviewed fixture and continues refusing altered or additional findings with the native scanner.

Environment: macOS arm64, Node 24.20.0, TruffleHog 3.97.1; trusted compiled candidate modules outside an isolated, clean Git target. Target base `db14db010bf3044be85f25fe40a587a5ca77523a`, unchanged head `0efc0e7d2ada1f665e5b2c00ad41c5c3d078c65a`. The proof invokes `scanAgentInput({cwd, prompt, source: {kind: "committed", baseSha, headSha}, timeoutMs})` rather than manually selecting scan files. It stages both changed test files and all complete source inputs through the production owner with `--results=verified,unknown --fail --fail-on-scan-errors --no-update --json --no-color`.

Rebuilt and repeated against **clean committed candidate `6e0e0a75a46bac1f656069e87e9a379642155450`** at 2026-08-29 19:38:54 UTC. `git rev-parse HEAD` matched that commit and `git status --porcelain` was empty before rebuilding, before snapshotting the compiled owner, and after proof. The copied compiled owner matched the rebuild byte-for-byte; the committed source hashes were recorded alongside the compiled hashes. This distinguishes the **owner PR head (1296)** from the **input target PR head (1294)**.

| Native scenario | Result | Host audit | Target state |
| --- | --- | --- | --- |
| Exact unchanged PR 1294 | admitted, 8.2 seconds | one sanitized classification event | clean, exact head unchanged |
| Same target with fixture credential altered | refused: `findings`, 8.1 seconds | none | clean |
| Same target with a distinct additional finding | refused: `findings`, 6.0 seconds | none | clean |

Redacted native field trace, freshly observed 19:36:44 UTC on the complete base/head blobs:

| Source | Line | `Raw` bytes | `RawV2` bytes | Equal | Path / query / fragment present |
| --- | --- | --- | --- | --- | --- |
| Base blob `706a111e474d4ffff0ba27d49fade1c8c66e1c97` | 3484 | 45 | 45 | true | false / false / false |
| Head blob `a17ba3b4b08d5f4e0673321a1202d3d4d6525a91` | 3492 | 45 | 45 | true | false / false / false |

Both raw-field SHA-256 values in every record are `a728de5dbbef23b8aa5ef2d99060835f4f2fb5a0fa2abb9fe249d08aa09bd09e`. These are real TruffleHog 3.97.1 records, not the fake scanner fixture. Completion reported zero verified findings, two unknown findings, and no scan errors. Decoder duplication may vary between native runs; no fixed finding count is assumed by production.

A fourth native case at **19:42:00 UTC** exercises the review's distinct-field scenario directly. A real two-commit Git fixture contains the complete original test file at its canonical path, with only a path extension added to the URI in the second commit. Native TruffleHog reports `Raw` = 45 bytes with the approved digest, `RawV2` = 49 bytes with digest `b146c2ee0e8714569773e6c7113d97ae66bf3c2bd4e6170823d40796c9562a99`, equality `false`, and a path only in `RawV2`. The actual committed owner **refuses with `findings` and emits no classification notice**, as required. This bounded field-contract fixture is separate from the three whole-PR runs above. Local redacted receipt: `/tmp/clawsweeper-1296-committed-native-2mj7p_ww/path-negative-receipt.json`.

The successful owner event identifies only the fixture digest and Git blob/line/decoder/count metadata. Captured stdout/stderr were checked for absence of the URI, password, and hostname. Exact committed candidate fingerprints:

| File | SHA-256 |
| --- | --- |
| `src/agent-input-scan.ts` | `8538338d2cbfa1e475ebb34e68641ba6c76392b10a23891903ac4bf60723ff11` |
| `src/agent-input-scan-fixtures.ts` | `286fa5c7e024795915a99a13e724cd0e2f7ad866c9f8704a9af83fd52fca1d8d` |
| `dist/agent-input-scan.js` | `9a75c8dbdfdfed1a91d5197b16a8484a7e6309fca9a1404fd730b679ec316926` |
| `dist/agent-input-scan-fixtures.js` | `95a685771e73b978a68891900ea73cc9a72ccc5dbd8aa1bb9f761fee8845a268` |

Reproduction of the positive admission path from a clean checkout of this PR head, with the native scanner installed outside both checkouts:

```sh
pnpm install --frozen-lockfile
pnpm run build:node
scan_target=$(mktemp -d)
git clone --quiet --no-checkout https://github.com/openclaw/clawsweeper.git "$scan_target/target"
git -C "$scan_target/target" checkout --quiet --detach 0efc0e7d2ada1f665e5b2c00ad41c5c3d078c65a
SCAN_TARGET="$scan_target/target" node --input-type=module <<'JS'
import { scanAgentInput } from './dist/agent-input-scan.js';
scanAgentInput({
  cwd: process.env.SCAN_TARGET,
  prompt: 'Review the committed cleanup change.',
  source: {
    kind: 'committed',
    baseSha: 'db14db010bf3044be85f25fe40a587a5ca77523a',
    headSha: '0efc0e7d2ada1f665e5b2c00ad41c5c3d078c65a',
  },
  timeoutMs: 120000,
});
console.log('admission passed; no provider started');
JS
```

Local redacted receipts: `/tmp/clawsweeper-1296-committed-native-2mj7p_ww/receipt.json` and `/tmp/clawsweeper-1294-native-field-shape-rjzxdik5/receipt.json` (not hosted artifacts; their material results are reproduced above).

Limits: this is real scanner/admission proof, not a provider or hosted-review claim. The target PR remains unchanged and unmerged until this owner repair lands and its normal native review succeeds. No raw scanner findings or credentials are included in proof output.

## Review Finding Disposition

The 19:34 UTC review's P1 premise is not supported by the native output: the reviewed fixture has **no path**, so clearing its already-empty path leaves `Raw` equal to `RawV2`. I re-read the actual pinned detector (`uri.go:93–109`) and verified the fixture directly from this PR's committed source. A fresh native trace at 19:36:44 UTC reports both fields as 45 bytes, the same approved SHA-256, equality `true`, and path/query/fragment presence `false` for both base and head findings. Raw URI presence was measured without WHATWG normalization (which inserts a default slash).

The proposed general distinct-field admission is intentionally not adopted: this is one exact fixture classification, not permission for other full URIs sharing its abbreviated `Raw`. The existing `changed full URI` regression sets a different `RawV2` while keeping `Raw` and verifies refusal. Native distinct-field proof and the rebuilt committed-head binding are recorded above. This resolves the P1 premise and associated automation-risk claim without loosening the gate. The requested stronger proof is accepted and supplied; there is no functional source change.

## Scope and Risk

Production delta is +166/-2 lines; test delta is +125/-2 lines. The production growth is the new strict classification and audit boundary; the previous unconditional rejection remains for every unclassified finding. No configuration, dependency, database, workflow, provider, or review-policy changes. No broad false-positive heuristic or fallback was added.
