### PR TITLE
fix(state): bound record export candidates

### DIFF
--- a/dashboard/exact-review-direct-publication.ts
+++ b/dashboard/exact-review-direct-publication.ts
@@ -355,6 +355,11 @@ export class ExactReviewDirectPublicationStore {
          (repo_slug, store_revision, section, record_id)`,
     );
     this.storage.sql.exec(
+      `CREATE INDEX IF NOT EXISTS exact_review_record_export_by_repo_section_revision
+         ON ${EXACT_REVIEW_RECORD_EXPORT_INDEX_TABLE}
+         (repo_slug, section, store_revision)`,
+    );
+    this.storage.sql.exec(
       `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_RECORD_BACKFILL_TABLE} (
          repo_slug TEXT NOT NULL,
          section TEXT NOT NULL CHECK (
@@ -814,6 +819,9 @@ export class ExactReviewDirectPublicationStore {
     maxRecords: number;
   }): { records: RecordExportEntry[]; nextCursor: number | null; watermark: number } {
     const placeholders = options.sections.map(() => "?").join(", ");
+    // The preflight joins source metadata before reconstruction. It must not
+    // scan more candidates than the reconstruction bound can ever consume.
+    const rowLimit = Math.min(options.limit, options.maxRecords);
     const rows = Array.from(
       this.storage.sql.exec(
         `SELECT export.repo_slug, export.section, export.record_id, export.digest,
@@ -849,7 +857,7 @@ export class ExactReviewDirectPublicationStore {
         ...options.sections,
         options.sinceRevision,
         options.cursor,
-        options.limit,
+        rowLimit,
       ),
     );
     const selectedRows: Record<string, unknown>[] = [];
@@ -874,12 +882,28 @@ export class ExactReviewDirectPublicationStore {
     }
     const watermark = this.currentExportRevisionSync();
     const lastRevision = records.at(-1)?.storeRevision ?? null;
+    const hasMore =
+      lastRevision !== null && records.length === rows.length && rows.length === rowLimit
+        ? Array.from(
+            this.storage.sql.exec(
+              `SELECT 1
+                 FROM ${EXACT_REVIEW_RECORD_EXPORT_INDEX_TABLE} export
+                WHERE export.repo_slug = ?
+                  AND export.section IN (${placeholders})
+                  AND export.store_revision > ?
+                  AND export.store_revision > ?
+                LIMIT 1`,
+              options.repoSlug,
+              ...options.sections,
+              options.sinceRevision,
+              lastRevision,
+            ),
+          ).length > 0
+        : false;
     return {
       records,
       nextCursor:
-        lastRevision !== null && (records.length < rows.length || rows.length === options.limit)
-          ? lastRevision
-          : null,
+        lastRevision !== null && (records.length < rows.length || hasMore) ? lastRevision : null,
       watermark,
     };
   }

--- a/test/dashboard-worker-bay-records-routes.test.ts
+++ b/test/dashboard-worker-bay-records-routes.test.ts
@@ -4459,19 +4459,7 @@ test("canonical commit records and tuples export with one monotonic revision", a
     )
   ).json();
   assert.equal(pageTwo.records.length, 1);
-  assert.equal(pageTwo.nextCursor, 2);
-  const terminalPage = await (
-    await worker.fetch(
-      signedStateAppendRequest(
-        exportPath,
-        { ...pageOnePayload, cursor: pageTwo.nextCursor },
-        secret,
-      ),
-      env,
-    )
-  ).json();
-  assert.deepEqual(terminalPage.records, []);
-  assert.equal(terminalPage.nextCursor, null);
+  assert.equal(pageTwo.nextCursor, null);
   assert.deepEqual(pageTwo.records[0], {
     section: "items",
     id: "711",

--- a/test/record-export-bounds.test.ts
+++ b/test/record-export-bounds.test.ts
@@ -289,6 +289,9 @@ test("signed record export bounds reconstruction work and source bytes while pag
     const cursor = nextCursor;
     storage.sql.resetQueryHistory();
     const page = await exportPage(env, cursor);
+    const candidateQueries = storage.sql.queriesMatching(/SELECT export\.repo_slug/);
+    assert.equal(candidateQueries.length, 1);
+    assert.equal(candidateQueries[0]?.bindings.at(-1), EXPECTED_RECORD_WORK_BUDGET);
     const reconstructed = reconstructedRecords(storage, recordsByIdentity);
     const reconstructedBytes = reconstructed.reduce((sum, record) => sum + record.byteLength, 0);
     assert.ok(reconstructed.length <= EXPECTED_RECORD_WORK_BUDGET);
@@ -326,6 +329,60 @@ test("signed record export bounds reconstruction work and source bytes while pag
   behaviorProof.expectedManifest = manifest(fixtures);
   behaviorProof.materializedManifest = manifest(received);
   behaviorProof.manifestParity = true;
+});
+
+test("signed record export does not advertise an empty page at the record boundary", async () => {
+  const { env, storage } = await exportHarness();
+  for (let index = 1; index <= EXPECTED_RECORD_WORK_BUDGET; index += 1) {
+    seedFixtureRecord(
+      storage,
+      fixtureRecord({
+        source: "canonical",
+        section: "items",
+        id: String(index),
+        content: `record-${index}:`.padEnd(1024, String(index % 10)),
+        storeRevision: index,
+      }),
+    );
+  }
+
+  for (let index = EXPECTED_RECORD_WORK_BUDGET + 1; index <= 150; index += 1) {
+    seedFixtureRecord(
+      storage,
+      fixtureRecord({
+        source: "canonical",
+        section: "closed",
+        id: String(index),
+        content: `closed-${index}:`.padEnd(1024, String(index % 10)),
+        storeRevision: index,
+      }),
+    );
+  }
+
+  const page = await exportPage(env, 0, ["items"]);
+
+  assert.equal(page.records.length, EXPECTED_RECORD_WORK_BUDGET);
+  assert.equal(page.nextCursor, null);
+  const candidateQueries = storage.sql.queriesMatching(/SELECT export\.repo_slug/);
+  assert.equal(candidateQueries.length, 1);
+  assert.equal(candidateQueries[0]?.bindings.at(-1), EXPECTED_RECORD_WORK_BUDGET);
+  assert.equal(
+    storage.sql.queriesMatching(/SELECT 1\s+FROM exact_review_record_export_index/).length,
+    1,
+  );
+  const plan = Array.from(
+    storage.sql.exec(
+      `EXPLAIN QUERY PLAN
+       SELECT 1 FROM ${EXACT_REVIEW_RECORD_EXPORT_INDEX_TABLE}
+        WHERE repo_slug = ? AND section IN (?) AND store_revision > ?
+        LIMIT 1`,
+      REPO_SLUG,
+      "items",
+      EXPECTED_RECORD_WORK_BUDGET,
+    ),
+    (row) => String(row.detail),
+  ).join("\n");
+  assert.match(plan, /exact_review_record_export_by_repo_section_revision/);
 });
 
 test("signed record export preserves historical backfill items and canonical tombstones", async () => {


### PR DESCRIPTION
## Summary

Bound canonical record-export preflight work to the same 50-record budget used
for reconstruction. Preserve pagination with a bounded terminal lookahead.

## Incident

Two scheduled canonical Worker runs failed during `hydrateState` while exporting
`openclaw-openclaw` records. The Worker correctly failed closed with the public
`500 exact_review_queue_unavailable` response; no incomplete dispatch occurred.

The live Durable Object exception is intentionally redacted, so this change does
not claim a verified lower-level Cloudflare error. It fixes a verified
availability/correctness problem in the export path: source-byte preflight joined
up to the request limit (100) even though reconstruction cannot consume more than
50 records.

## Implementation

- Cap the metadata-joining candidate query at `min(limit, maxRecords)`.
- Probe for a continuation only after a full materialized page.
- Add `(repo_slug, section, store_revision)` for the section-filtered lookahead,
  so it cannot scan unrelated later sections.
- Cover the candidate cap, multi-page manifest parity, terminal boundary, and
  SQLite query plan.

This remains fail-closed: it does not add retries, suppress notifications, alter
workflows/gates, or permit dispatch with incomplete state.

## Real Behavior Proof

Claim: the signed Worker-to-Durable-Object records export remains bounded to 50
source/reconstruction candidates, advances when more records exist, and does not
advertise an empty terminal page.

Exercised surface: local Worker route `/internal/state/records/export` with the
SQLite-backed `ExactReviewQueue` Durable Object harness.

Scenario and fixture: 58 canonical/backfill records, including source-byte and
serialized-size boundaries, materialized over pages `[50, 6, 1, 1]` with exact
manifest parity; a separate 50-item terminal page followed by 100 later `closed`
records proves the lookahead is section-indexed and returns `nextCursor: null`.

Commands and observed result:

```text
pnpm run build:dashboard
pnpm run build:node
node --test test/record-export-bounds.test.ts test/dashboard-worker-durable-object-error.test.ts
pnpm run lint:dashboard
git diff --check
```

All passed: 10 focused Worker/DO/export tests and dashboard lint.

Docker-backed proof: fresh Crabbox local-container lease
`cbx_3a943b51e1a0`, image `mcr.microsoft.com/playwright:v1.60.0-noble`, ran the
same dashboard/node builds and 10 focused tests successfully; the lease was then
released. The controlled proof has no production Cloudflare CPU claim.

## Review

- Dirty-patch Codex review: clean after correcting terminal continuation and
  bounding the section-filtered lookahead.
- Committed-range Codex review against `origin/main`: clean at
  `41ca5f74b4fc135ad7d68eadf4543f1c98b8dd4d`.
- Local ClawSweeper committed-range review was invoked with
  `pnpm run review -- --local-range --target-repo openclaw/clawsweeper --base origin/main`.
  It fails before model inference with `AgentInputScanError: scanner_unavailable`
  because trusted `trufflehog` is not installed. Martin explicitly authorized
  CSW-144 to ignore this unavailable local prerequisite only; no scanner,
  workflow, or security policy was changed. CSW-145 was created to address the
  underlying local-review dependency.

## Platform Scope

Category 3 Worker/Durable Object SQLite runtime. No Windows source, CI, or
repository-wide platform-policy change.

## OpenClaw Bay impact

Unaffected. This changes the private authenticated canonical-record hydration
export only; it does not change Bay observer routes, lifecycle telemetry,
projection semantics, or its public data contract.

## Risk and rollout

The change adds one idempotent SQLite index during normal schema initialization
and makes the export page boundary exact. It should reduce request work; it does
not prove the redacted production exception's lower-level cause. After an
authorized deployment, monitor the scheduled canonical Worker export for the
same `exact_review_queue_unavailable` boundary before treating the incident as
resolved.
