### PR TITLE
fix(review): bootstrap pinned local scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,11 +554,12 @@ bytes of the validated checkout. Clean text-converted checkouts retain both
 canonical Git and raw working bytes in scan coverage. The host never starts a target-bundled autoreview helper or second reviewer.
 
 Hosted Codex and OpenClaw setup share the checksum-pinned TruffleHog 3.97.1
-installer in `.github/actions/setup-review-tools/install.sh`. It supports Linux
-amd64 and fails on unsupported platforms. Local operators must install a trusted
-[TruffleHog executable](https://github.com/trufflesecurity/trufflehog#installation)
-on the host `PATH`, outside both checkouts; workers never
-install dependencies themselves. Missing tools, unclassified findings, scan errors, source
+installer in `.github/actions/setup-review-tools/install.sh`. For local review,
+ClawSweeper first uses a trusted host executable outside both checkouts; when it
+is absent, it bootstraps the exact checksum-pinned release asset into a
+user-owned cache outside both checkouts. The local bootstrap accepts no URL or
+version override, verifies the download and cached executable, and runs a clean
+environment version check before scanning. Missing tools, unclassified findings, scan errors, source
 drift, incomplete ancestry/objects, changed gitlinks, and LFS pointers refuse the
 review. The scan stages at most 256 MiB in private external temporary files and
 uses the remaining review deadline; it never silently truncates or bypasses.

--- a/docs/commit-sweeper.md
+++ b/docs/commit-sweeper.md
@@ -20,9 +20,13 @@ review engine in `src/commit-sweeper.ts`, used two ways:
 
 ## Usage
 
-Install a trusted TruffleHog executable on the host `PATH`, outside the source
-checkout and ClawSweeper checkout, before running either review command. Hosted
-setup pins version 3.97.1; local workers do not provision it. The mandatory scan
+Local review first uses a trusted TruffleHog executable on the host `PATH`,
+outside the source checkout and ClawSweeper checkout. If it is absent,
+ClawSweeper bootstraps the checksum-pinned 3.97.1 release asset into its
+user-owned cache outside both checkouts before it scans; run
+`pnpm setup:review-tools` to preflight that one-time cache setup. It accepts no
+scanner URL or version override and verifies both the downloaded archive and
+cached executable before a clean-environment version check. The mandatory scan
 covers the explicit initial payload and complete introduced before/after source
 bytes, independently of prompt truncation. See the [safety model](../README.md#safety-model)
 for refused inputs, the 256 MiB staging cap, deadline, and coverage limits.
@@ -36,12 +40,15 @@ pnpm local-review -- --base main
 
 It is GitHub-isolated by contract, not air-gapped: it still calls the configured
 Codex model service and requires model authentication and network connectivity.
-The review requires a clean checkout, uses a unique per-run output directory,
+On first use without a trusted host scanner, it also fetches the one pinned
+scanner release into the documented local cache before review admission. The
+review requires a clean checkout, uses a unique per-run output directory,
 withholds all GitHub token env vars, skips `gh` API commit-metadata hydration,
 points `GH_CONFIG_DIR` at an empty directory, disables Codex web search, and
 forbids other review-time network lookups. Repositories without a configured
 profile are rejected (no foreign-profile fallback). It never writes to GitHub;
-the local Markdown report is the only output.
+after its scanner cache is provisioned, the local Markdown report is the only
+review output.
 
 For `review --local-range`, per-file line counts come from complete Git numstat
 metadata for the resolved merge-base-to-HEAD range, independently of bounded

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "reserve-review-lease": "node dist/clawsweeper.js reserve-review-lease",
     "review": "node dist/clawsweeper.js review",
     "codex:local:check": "node scripts/check-local-codex.mjs",
+    "setup:review-tools": "node scripts/setup-review-tools.mjs",
     "e2e:automerge": "pnpm run build:repair && node scripts/e2e/automerge.mjs",
     "e2e:automerge:container": "node scripts/e2e/automerge-container.mjs",
     "retry-failed-reviews": "node dist/clawsweeper.js retry-failed-reviews",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "reserve-review-lease": "node dist/clawsweeper.js reserve-review-lease",
     "review": "node dist/clawsweeper.js review",
     "codex:local:check": "node scripts/check-local-codex.mjs",
-    "setup:review-tools": "node scripts/setup-review-tools.mjs",
+    "setup:review-tools": "pnpm run build && node scripts/setup-review-tools.mjs",
     "e2e:automerge": "pnpm run build:repair && node scripts/e2e/automerge.mjs",
     "e2e:automerge:container": "node scripts/e2e/automerge-container.mjs",
     "retry-failed-reviews": "node dist/clawsweeper.js retry-failed-reviews",

--- a/scripts/setup-review-tools.mjs
+++ b/scripts/setup-review-tools.mjs
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+import { ensureManagedTruffleHog } from "../dist/review-tool-bootstrap.js";
+
+const args = process.argv.slice(2);
+const index = args.indexOf("--timeout-ms");
+const timeoutMs = index === -1 ? 120_000 : Number(args[index + 1]);
+if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) process.exit(2);
+
+try {
+  const scanner = await ensureManagedTruffleHog({ timeoutMs });
+  process.stdout.write(`${scanner}\n`);
+} catch {
+  // Scanner diagnostics can include network or platform details. The admission
+  // boundary intentionally exposes only the fail-closed reason to callers.
+  process.exitCode = 1;
+}

--- a/scripts/setup-review-tools.mjs
+++ b/scripts/setup-review-tools.mjs
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
+import { realpathSync } from "node:fs";
 import { ensureManagedTruffleHog } from "../dist/review-tool-bootstrap.js";
+import { managedScannerCacheRoot } from "../dist/agent-input-scan.js";
 
 const args = process.argv.slice(2);
 const index = args.indexOf("--timeout-ms");
@@ -7,7 +9,12 @@ const timeoutMs = index === -1 ? 120_000 : Number(args[index + 1]);
 if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) process.exit(2);
 
 try {
-  const scanner = await ensureManagedTruffleHog({ timeoutMs });
+  const cwd = realpathSync(process.cwd());
+  const cacheRoot = managedScannerCacheRoot(process.env, cwd, process.cwd());
+  const scanner = await ensureManagedTruffleHog({
+    timeoutMs,
+    env: { ...process.env, CLAWSWEEPER_REVIEW_TOOLS_DIR: cacheRoot },
+  });
   process.stdout.write(`${scanner}\n`);
 } catch {
   // Scanner diagnostics can include network or platform details. The admission

--- a/src/agent-input-scan.ts
+++ b/src/agent-input-scan.ts
@@ -107,6 +107,47 @@ function trustedExecutable(name: string, cwd: string, lexicalCwd: string): strin
   throw new AgentInputScanError("scanner_unavailable");
 }
 
+function trustedScanner(cwd: string, lexicalCwd: string, timeoutMs: number): string {
+  try {
+    return trustedExecutable("trufflehog", cwd, lexicalCwd);
+  } catch (error) {
+    if (!(error instanceof AgentInputScanError) || error.reason !== "scanner_unavailable")
+      throw error;
+  }
+  const installer = join(hostRoot, "scripts", "setup-review-tools.mjs");
+  const result = spawnSync(process.execPath, [installer, "--timeout-ms", String(timeoutMs)], {
+    encoding: "utf8",
+    env: {
+      SystemRoot: process.env.SystemRoot,
+      HOME: process.env.HOME,
+      USERPROFILE: process.env.USERPROFILE,
+      LOCALAPPDATA: process.env.LOCALAPPDATA,
+      CLAWSWEEPER_REVIEW_TOOLS_DIR: process.env.CLAWSWEEPER_REVIEW_TOOLS_DIR,
+    },
+    timeout: timeoutMs,
+    maxBuffer: 4096,
+    windowsHide: true,
+  });
+  const path = result.status === 0 ? result.stdout.trim() : "";
+  if (!path || !isAbsolute(path) || path.includes("\0"))
+    throw new AgentInputScanError("scanner_unavailable");
+  let actual: string;
+  try {
+    actual = realpathSync(path);
+    const stat = lstatSync(actual);
+    if (!stat.isFile() || stat.isSymbolicLink()) throw new Error("unsafe scanner cache entry");
+  } catch {
+    throw new AgentInputScanError("scanner_unavailable");
+  }
+  if (
+    [cwd, resolve(lexicalCwd), hostRoot, realpathSync(hostRoot)].some((root) =>
+      within(root, actual),
+    )
+  )
+    throw new AgentInputScanError("unsafe_path");
+  return actual;
+}
+
 export function scanAgentInput(options: {
   cwd: string;
   prompt: string;
@@ -126,7 +167,7 @@ export function scanAgentInput(options: {
   let classified: ReturnType<typeof classifyReviewedFixtureScan>;
   try {
     const cwd = realpathSync(options.cwd);
-    const scanner = trustedExecutable("trufflehog", cwd, options.cwd);
+    const scanner = trustedScanner(cwd, options.cwd, remaining());
     root = mkdtempSync(join(realpathSync(tmpdir()), "clawsweeper-input-scan-"));
     if (within(cwd, root) || within(realpathSync(hostRoot), root))
       throw new AgentInputScanError("unsafe_path");

--- a/src/agent-input-scan.ts
+++ b/src/agent-input-scan.ts
@@ -70,6 +70,20 @@ export function agentInputScanFailureExitCode(error: unknown): number | null {
 const MAX_SCAN_BYTES = 256 * 1024 * 1024;
 const OBJECT_ID = /^[0-9a-f]{40}(?:[0-9a-f]{24})?$/;
 const hostRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const REVIEW_TOOL_BOOTSTRAP_ENV = [
+  "SystemRoot",
+  "HOME",
+  "USERPROFILE",
+  "LOCALAPPDATA",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "NO_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "no_proxy",
+  "NODE_USE_ENV_PROXY",
+  "NODE_EXTRA_CA_CERTS",
+] as const;
 
 function within(root: string, candidate: string): boolean {
   const rel = relative(root, candidate);
@@ -164,6 +178,15 @@ export function managedScannerCacheRoot(
   return root;
 }
 
+export function reviewToolBootstrapEnvironment(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const child: NodeJS.ProcessEnv = {};
+  for (const name of REVIEW_TOOL_BOOTSTRAP_ENV) {
+    const value = env[name];
+    if (value !== undefined) child[name] = value;
+  }
+  return child;
+}
+
 function trustedScanner(cwd: string, lexicalCwd: string, timeoutMs: number): string {
   try {
     return trustedExecutable("trufflehog", cwd, lexicalCwd);
@@ -176,10 +199,7 @@ function trustedScanner(cwd: string, lexicalCwd: string, timeoutMs: number): str
   const result = spawnSync(process.execPath, [installer, "--timeout-ms", String(timeoutMs)], {
     encoding: "utf8",
     env: {
-      SystemRoot: process.env.SystemRoot,
-      HOME: process.env.HOME,
-      USERPROFILE: process.env.USERPROFILE,
-      LOCALAPPDATA: process.env.LOCALAPPDATA,
+      ...reviewToolBootstrapEnvironment(process.env),
       // The child receives only the parent-validated absolute location, so it
       // cannot create a managed cache inside either checkout before refusal.
       CLAWSWEEPER_REVIEW_TOOLS_DIR: cacheRoot,

--- a/src/agent-input-scan.ts
+++ b/src/agent-input-scan.ts
@@ -16,8 +16,9 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { delimiter, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { basename, delimiter, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
+import { reviewToolCacheRoot } from "./review-tool-bootstrap.js";
 import { readReviewGit, reviewMergeBase, type ReviewGitReadOptions } from "./pr-review-evidence.js";
 import {
   classifyReviewedFixtureScan,
@@ -107,6 +108,62 @@ function trustedExecutable(name: string, cwd: string, lexicalCwd: string): strin
   throw new AgentInputScanError("scanner_unavailable");
 }
 
+function realpathWithMissingTail(path: string): string {
+  const tail: string[] = [];
+  const seenLinks = new Set<string>();
+  let current = path;
+  for (;;) {
+    try {
+      if (lstatSync(current).isSymbolicLink()) {
+        if (seenLinks.has(current)) throw new Error("Scanner cache symlink cycle.");
+        seenLinks.add(current);
+        // A cache below an external alias such as macOS /tmp is safe when its
+        // canonical location is outside the checkouts. Resolve the link and
+        // let the caller apply that canonical boundary check.
+        current = resolve(dirname(current), readlinkSync(current));
+        continue;
+      }
+      return resolve(realpathSync(current), ...tail);
+    } catch (error) {
+      if (error instanceof AgentInputScanError) throw error;
+      const parent = dirname(current);
+      if (parent === current)
+        throw new Error("Could not resolve scanner cache location.", { cause: error });
+      tail.unshift(basename(current));
+      current = parent;
+    }
+  }
+}
+
+export function managedScannerCacheRoot(
+  env: NodeJS.ProcessEnv,
+  cwd: string,
+  lexicalCwd: string,
+): string {
+  let root: string;
+  try {
+    root = reviewToolCacheRoot(env);
+  } catch (error) {
+    if (error instanceof AgentInputScanError) throw error;
+    throw new AgentInputScanError("scanner_unavailable");
+  }
+  const protectedRoots = [cwd, resolve(lexicalCwd), hostRoot, realpathSync(hostRoot)];
+  let resolvedRoot: string;
+  try {
+    resolvedRoot = realpathWithMissingTail(root);
+  } catch (error) {
+    if (error instanceof AgentInputScanError) throw error;
+    throw new AgentInputScanError("scanner_unavailable");
+  }
+  if (
+    protectedRoots.some(
+      (protectedRoot) => within(protectedRoot, root) || within(protectedRoot, resolvedRoot),
+    )
+  )
+    throw new AgentInputScanError("unsafe_path");
+  return root;
+}
+
 function trustedScanner(cwd: string, lexicalCwd: string, timeoutMs: number): string {
   try {
     return trustedExecutable("trufflehog", cwd, lexicalCwd);
@@ -114,6 +171,7 @@ function trustedScanner(cwd: string, lexicalCwd: string, timeoutMs: number): str
     if (!(error instanceof AgentInputScanError) || error.reason !== "scanner_unavailable")
       throw error;
   }
+  const cacheRoot = managedScannerCacheRoot(process.env, cwd, lexicalCwd);
   const installer = join(hostRoot, "scripts", "setup-review-tools.mjs");
   const result = spawnSync(process.execPath, [installer, "--timeout-ms", String(timeoutMs)], {
     encoding: "utf8",
@@ -122,7 +180,9 @@ function trustedScanner(cwd: string, lexicalCwd: string, timeoutMs: number): str
       HOME: process.env.HOME,
       USERPROFILE: process.env.USERPROFILE,
       LOCALAPPDATA: process.env.LOCALAPPDATA,
-      CLAWSWEEPER_REVIEW_TOOLS_DIR: process.env.CLAWSWEEPER_REVIEW_TOOLS_DIR,
+      // The child receives only the parent-validated absolute location, so it
+      // cannot create a managed cache inside either checkout before refusal.
+      CLAWSWEEPER_REVIEW_TOOLS_DIR: cacheRoot,
     },
     timeout: timeoutMs,
     maxBuffer: 4096,

--- a/src/review-tool-bootstrap.ts
+++ b/src/review-tool-bootstrap.ts
@@ -1,0 +1,233 @@
+import { spawnSync } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import { lstatSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { arch, platform } from "node:process";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import { gunzipSync } from "node:zlib";
+
+export const TRUFFLEHOG_VERSION = "3.97.1";
+const MAX_ARCHIVE_BYTES = 256 * 1024 * 1024;
+const MAX_TAR_BYTES = 512 * 1024 * 1024;
+
+export type ReviewToolArtifact = {
+  platform: string;
+  executable: string;
+  url: string;
+  sha256: string;
+};
+
+const ARTIFACTS: Readonly<Record<string, ReviewToolArtifact>> = {
+  "darwin-arm64": {
+    platform: "darwin-arm64",
+    executable: "trufflehog",
+    url: "https://github.com/trufflesecurity/trufflehog/releases/download/v3.97.1/trufflehog_3.97.1_darwin_arm64.tar.gz",
+    sha256: "1af86cf30c1cc5c1735ec6af9292b399ec9bed3ff1b30be13fcbfd4a30ab449a",
+  },
+  "darwin-x64": {
+    platform: "darwin-x64",
+    executable: "trufflehog",
+    url: "https://github.com/trufflesecurity/trufflehog/releases/download/v3.97.1/trufflehog_3.97.1_darwin_amd64.tar.gz",
+    sha256: "1515710bb16be5653ca9986c27ecd1a0e7536fc6e53ad46f7100992692f6a05f",
+  },
+  "linux-arm64": {
+    platform: "linux-arm64",
+    executable: "trufflehog",
+    url: "https://github.com/trufflesecurity/trufflehog/releases/download/v3.97.1/trufflehog_3.97.1_linux_arm64.tar.gz",
+    sha256: "57bfcc0988aae3f2ef97e74abe1138cf37a8fbd84dd26299062c77a6a6b125dd",
+  },
+  "linux-x64": {
+    platform: "linux-x64",
+    executable: "trufflehog",
+    url: "https://github.com/trufflesecurity/trufflehog/releases/download/v3.97.1/trufflehog_3.97.1_linux_amd64.tar.gz",
+    sha256: "f863ea3a8d786f7d097870496c977944cce7372a2fe1e56707d965016e543ece",
+  },
+  "win32-arm64": {
+    platform: "win32-arm64",
+    executable: "trufflehog.exe",
+    url: "https://github.com/trufflesecurity/trufflehog/releases/download/v3.97.1/trufflehog_3.97.1_windows_arm64.tar.gz",
+    sha256: "7b87a1f1590c66bf45045de29a354d8a1386d5ce094205bcb371e1ae805cb4ee",
+  },
+  "win32-x64": {
+    platform: "win32-x64",
+    executable: "trufflehog.exe",
+    url: "https://github.com/trufflesecurity/trufflehog/releases/download/v3.97.1/trufflehog_3.97.1_windows_amd64.tar.gz",
+    sha256: "dc1759892a41d64ee0d46cd5d4391dad7f916f54257154aa1b0732f9c50901b2",
+  },
+};
+
+function sha256(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function tarString(bytes: Buffer): string {
+  const end = bytes.indexOf(0);
+  return bytes.subarray(0, end === -1 ? bytes.length : end).toString("utf8");
+}
+
+function tarSize(bytes: Buffer): number {
+  const value = tarString(bytes).trim();
+  if (!/^[0-7]+$/.test(value)) throw new Error("Trusted scanner archive has an invalid size.");
+  const size = Number.parseInt(value, 8);
+  if (!Number.isSafeInteger(size) || size < 0)
+    throw new Error("Trusted scanner archive has an invalid size.");
+  return size;
+}
+
+export function extractTarExecutable(archive: Buffer, executable: string): Buffer {
+  let tar: Buffer;
+  try {
+    tar = gunzipSync(archive, { maxOutputLength: MAX_TAR_BYTES });
+  } catch {
+    throw new Error("Trusted scanner archive could not be decompressed.");
+  }
+  let offset = 0;
+  while (offset + 512 <= tar.length) {
+    const header = tar.subarray(offset, offset + 512);
+    if (header.every((byte) => byte === 0)) break;
+    const prefix = tarString(header.subarray(345, 500));
+    const name = tarString(header.subarray(0, 100));
+    const path = prefix ? `${prefix}/${name}` : name;
+    const size = tarSize(header.subarray(124, 136));
+    const dataStart = offset + 512;
+    const dataEnd = dataStart + size;
+    if (dataEnd > tar.length) throw new Error("Trusted scanner archive is truncated.");
+    if (path === executable) {
+      if (!["\0", "0"].includes(String.fromCharCode(header[156]!)))
+        throw new Error("Trusted scanner archive has an unsafe executable entry.");
+      return Buffer.from(tar.subarray(dataStart, dataEnd));
+    }
+    offset = dataEnd + ((512 - (size % 512)) % 512);
+  }
+  throw new Error("Trusted scanner archive does not contain the expected executable.");
+}
+
+export function reviewToolArtifact(
+  runtimePlatform: string = platform,
+  runtimeArch: string = arch,
+): ReviewToolArtifact | undefined {
+  return ARTIFACTS[`${runtimePlatform}-${runtimeArch}`];
+}
+
+function cacheRoot(env: NodeJS.ProcessEnv): string {
+  const configured = env.CLAWSWEEPER_REVIEW_TOOLS_DIR?.trim();
+  if (configured) {
+    if (!isAbsolute(configured)) throw new Error("CLAWSWEEPER_REVIEW_TOOLS_DIR must be absolute.");
+    return resolve(configured);
+  }
+  return join(homedir(), ".clawsweeper-review-tools");
+}
+
+function validCachedArchive(path: string, expectedHash: string): boolean {
+  try {
+    const stat = lstatSync(path);
+    if (!stat.isFile() || stat.isSymbolicLink() || stat.size <= 0 || stat.size > MAX_ARCHIVE_BYTES)
+      return false;
+    return sha256(readFileSync(path)) === expectedHash;
+  } catch {
+    return false;
+  }
+}
+
+function cachedBinaryMatches(path: string, expected: Buffer): boolean {
+  try {
+    const stat = lstatSync(path);
+    return stat.isFile() && !stat.isSymbolicLink() && readFileSync(path).equals(expected);
+  } catch {
+    return false;
+  }
+}
+
+function assertVersion(path: string): void {
+  const result = spawnSync(path, ["--version"], {
+    encoding: "utf8",
+    env: {
+      SystemRoot: process.env.SystemRoot,
+      HOME: dirname(path),
+      TMP: dirname(path),
+      TEMP: dirname(path),
+    },
+    timeout: 30_000,
+    maxBuffer: 4096,
+    windowsHide: true,
+  });
+  if (
+    result.error ||
+    result.status !== 0 ||
+    `${result.stdout ?? ""}${result.stderr ?? ""}`.trim() !== `trufflehog ${TRUFFLEHOG_VERSION}`
+  )
+    throw new Error("Trusted scanner version check failed.");
+}
+
+export async function ensureManagedTruffleHog(options: {
+  timeoutMs: number;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof fetch;
+  runtimePlatform?: string;
+  runtimeArch?: string;
+}): Promise<string> {
+  const env = options.env ?? process.env;
+  const artifact = reviewToolArtifact(
+    options.runtimePlatform ?? platform,
+    options.runtimeArch ?? arch,
+  );
+  if (!artifact)
+    throw new Error("No checksum-pinned trusted scanner is available for this platform.");
+  const root = cacheRoot(env);
+  const cacheDir = join(root, "trufflehog", `v${TRUFFLEHOG_VERSION}`, artifact.platform);
+  const archivePath = join(cacheDir, "archive.tar.gz");
+  const binary = join(cacheDir, artifact.executable);
+  let archive: Buffer;
+  if (validCachedArchive(archivePath, artifact.sha256)) {
+    archive = readFileSync(archivePath);
+  } else {
+    const fetchImpl = options.fetchImpl ?? fetch;
+    const response = await fetchImpl(artifact.url, {
+      signal: AbortSignal.timeout(Math.max(1, options.timeoutMs)),
+    });
+    if (!response.ok) throw new Error("Trusted scanner download failed.");
+    archive = Buffer.from(await response.arrayBuffer());
+    if (
+      archive.length === 0 ||
+      archive.length > MAX_ARCHIVE_BYTES ||
+      sha256(archive) !== artifact.sha256
+    )
+      throw new Error("Trusted scanner download checksum did not match.");
+    mkdirSync(cacheDir, { recursive: true, mode: 0o700 });
+    const temporaryArchive = `${archivePath}.${randomUUID()}.tmp`;
+    try {
+      writeFileSync(temporaryArchive, archive, { mode: 0o600, flag: "wx" });
+      rmSync(archivePath, { force: true });
+      renameSync(temporaryArchive, archivePath);
+    } finally {
+      rmSync(temporaryArchive, { force: true });
+    }
+  }
+  const executable = extractTarExecutable(archive, artifact.executable);
+  if (executable.length === 0 || executable.length > MAX_ARCHIVE_BYTES)
+    throw new Error("Trusted scanner executable is invalid.");
+  if (!cachedBinaryMatches(binary, executable)) {
+    mkdirSync(dirname(binary), { recursive: true, mode: 0o700 });
+    const temporary = `${binary}.${randomUUID()}.tmp`;
+    try {
+      writeFileSync(temporary, executable, { mode: 0o700, flag: "wx" });
+      rmSync(binary, { force: true });
+      renameSync(temporary, binary);
+    } finally {
+      rmSync(temporary, { force: true });
+    }
+  }
+  try {
+    if (!cachedBinaryMatches(binary, executable))
+      throw new Error("Trusted scanner cache verification failed.");
+    assertVersion(binary);
+    return binary;
+  } catch (error) {
+    try {
+      rmSync(binary, { force: true });
+    } catch {
+      // The failure remains fail-closed even if a corrupted cache file cannot be removed.
+    }
+    throw error;
+  }
+}

--- a/src/review-tool-bootstrap.ts
+++ b/src/review-tool-bootstrap.ts
@@ -60,6 +60,29 @@ function sha256(bytes: Uint8Array): string {
   return createHash("sha256").update(bytes).digest("hex");
 }
 
+async function boundedResponseBytes(response: Response): Promise<Buffer> {
+  const contentLength = response.headers.get("content-length");
+  if (contentLength && /^\d+$/.test(contentLength) && Number(contentLength) > MAX_ARCHIVE_BYTES)
+    throw new Error("Trusted scanner download exceeds the archive limit.");
+  if (!response.body) throw new Error("Trusted scanner download has no body.");
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      size += value.byteLength;
+      if (size > MAX_ARCHIVE_BYTES)
+        throw new Error("Trusted scanner download exceeds the archive limit.");
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return Buffer.concat(chunks, size);
+}
+
 function tarString(bytes: Buffer): string {
   const end = bytes.indexOf(0);
   return bytes.subarray(0, end === -1 ? bytes.length : end).toString("utf8");
@@ -186,7 +209,7 @@ export async function ensureManagedTruffleHog(options: {
       signal: AbortSignal.timeout(Math.max(1, options.timeoutMs)),
     });
     if (!response.ok) throw new Error("Trusted scanner download failed.");
-    archive = Buffer.from(await response.arrayBuffer());
+    archive = await boundedResponseBytes(response);
     if (
       archive.length === 0 ||
       archive.length > MAX_ARCHIVE_BYTES ||

--- a/src/review-tool-bootstrap.ts
+++ b/src/review-tool-bootstrap.ts
@@ -1,14 +1,72 @@
 import { spawnSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
-import { lstatSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import {
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { arch, platform } from "node:process";
-import { dirname, isAbsolute, join, resolve } from "node:path";
+import { basename, dirname, isAbsolute, join, parse, relative, resolve } from "node:path";
 import { gunzipSync } from "node:zlib";
 
 export const TRUFFLEHOG_VERSION = "3.97.1";
 const MAX_ARCHIVE_BYTES = 256 * 1024 * 1024;
 const MAX_TAR_BYTES = 512 * 1024 * 1024;
+const PRIVATE_CACHE_MODE = 0o077;
+const DARWIN_SAFE_ACL_PERMISSIONS = new Set([
+  "directory_inherit",
+  "execute",
+  "file_inherit",
+  "limit_inherit",
+  "list",
+  "only_inherit",
+  "read",
+  "readattr",
+  "readextattr",
+  "readsecurity",
+  "search",
+  "synchronize",
+]);
+const WINDOWS_CACHE_AUTHORITY_SCRIPT = String.raw`
+$ErrorActionPreference = 'Stop'
+$target = $env:CLAWSWEEPER_CACHE_AUTHORITY_PATH
+$check = $env:CLAWSWEEPER_CACHE_AUTHORITY_CHECK
+if ([string]::IsNullOrWhiteSpace($target)) { exit 20 }
+$identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+$currentSid = $identity.User.Value
+$allowed = [Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+[void]$allowed.Add($currentSid)
+[void]$allowed.Add('S-1-5-18')
+[void]$allowed.Add('S-1-5-32-544')
+[void]$allowed.Add('S-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464')
+$acl = Get-Acl -LiteralPath $target
+$owner = $acl.GetOwner([Security.Principal.SecurityIdentifier]).Value
+if ($check -eq 'private' -and $owner -ne $currentSid) { exit 21 }
+if ($check -ne 'private' -and -not $allowed.Contains($owner)) { exit 21 }
+$dangerous = [int64]([Security.AccessControl.FileSystemRights]::Write -bor
+  [Security.AccessControl.FileSystemRights]::Modify -bor
+  [Security.AccessControl.FileSystemRights]::DeleteSubdirectoriesAndFiles -bor
+  [Security.AccessControl.FileSystemRights]::ChangePermissions -bor
+  [Security.AccessControl.FileSystemRights]::TakeOwnership)
+$replaceChild = [int64]([Security.AccessControl.FileSystemRights]::DeleteSubdirectoriesAndFiles -bor
+  [Security.AccessControl.FileSystemRights]::ChangePermissions -bor
+  [Security.AccessControl.FileSystemRights]::TakeOwnership)
+$mask = if ($check -eq 'ancestor') { $replaceChild } else { $dangerous }
+$rules = $acl.GetAccessRules($true, $true, [Security.Principal.SecurityIdentifier])
+foreach ($rule in $rules) {
+  if ($rule.AccessControlType -ne [Security.AccessControl.AccessControlType]::Allow) { continue }
+  if (($rule.PropagationFlags -band [Security.AccessControl.PropagationFlags]::InheritOnly) -ne 0) { continue }
+  $sid = $rule.IdentityReference.Value
+  if ($allowed.Contains($sid)) { continue }
+  if (([int64]$rule.FileSystemRights -band $mask) -ne 0) { exit 22 }
+}
+exit 0
+`;
 
 export type ReviewToolArtifact = {
   platform: string;
@@ -135,17 +193,217 @@ export function reviewToolArtifact(
 export function reviewToolCacheRoot(env: NodeJS.ProcessEnv): string {
   const configured = env.CLAWSWEEPER_REVIEW_TOOLS_DIR?.trim();
   if (configured) {
-    if (!isAbsolute(configured)) throw new Error("CLAWSWEEPER_REVIEW_TOOLS_DIR must be absolute.");
+    if (!isAbsolute(configured) || configured.split("").some((value) => value.charCodeAt(0) < 32))
+      throw new Error("CLAWSWEEPER_REVIEW_TOOLS_DIR must be a safe absolute path.");
     return resolve(configured);
   }
   return join(homedir(), ".clawsweeper-review-tools");
 }
 
+function pathChain(path: string): string[] {
+  const absolute = resolve(path);
+  const root = parse(absolute).root;
+  const tail = relative(root, absolute);
+  const chain = [root];
+  let current = root;
+  for (const segment of tail.split(/[\\/]/).filter(Boolean)) {
+    current = join(current, segment);
+    chain.push(current);
+  }
+  return chain;
+}
+
+function canonicalCacheRoot(root: string): string {
+  const tail: string[] = [basename(root)];
+  let current = dirname(root);
+  for (;;) {
+    try {
+      return resolve(realpathSync(current), ...tail);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      const parent = dirname(current);
+      if (parent === current)
+        throw new Error("Trusted scanner cache authority could not be verified.", { cause: error });
+      tail.unshift(basename(current));
+      current = parent;
+    }
+  }
+}
+
+function assertWindowsCacheAuthority(path: string, check: "private" | "parent" | "ancestor"): void {
+  const systemRoot = process.env.SystemRoot;
+  if (!systemRoot || !isAbsolute(systemRoot))
+    throw new Error("Trusted scanner cache authority could not be verified.");
+  const canonicalSystemRoot = realpathSync(systemRoot);
+  const powershell = realpathSync(
+    join(canonicalSystemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe"),
+  );
+  const executableRelative = relative(canonicalSystemRoot, powershell);
+  const executableStat = lstatSync(powershell);
+  if (
+    !executableStat.isFile() ||
+    executableStat.isSymbolicLink() ||
+    executableRelative.startsWith("..") ||
+    isAbsolute(executableRelative)
+  )
+    throw new Error("Trusted scanner cache authority could not be verified.");
+  const result = spawnSync(
+    powershell,
+    ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", WINDOWS_CACHE_AUTHORITY_SCRIPT],
+    {
+      encoding: "utf8",
+      env: {
+        SystemRoot: canonicalSystemRoot,
+        CLAWSWEEPER_CACHE_AUTHORITY_PATH: path,
+        CLAWSWEEPER_CACHE_AUTHORITY_CHECK: check,
+      },
+      timeout: 30_000,
+      maxBuffer: 4096,
+      windowsHide: true,
+    },
+  );
+  if (result.error || result.status !== 0)
+    throw new Error("Trusted scanner cache is not private to the current user.");
+}
+
+function currentPosixUid(): number {
+  if (typeof process.getuid !== "function")
+    throw new Error("Trusted scanner cache authority could not be verified.");
+  return process.getuid();
+}
+
+export function darwinAclAllowsUnsafeWriter(output: string, currentUser: string): boolean {
+  const lines = output.split(/\r?\n/);
+  const aclMarked = /^\S*\+/.test(lines[0] ?? "");
+  let sawAclEntry = false;
+  for (const line of lines.slice(1)) {
+    if (!line) continue;
+    const match = /^\s*\d+:\s+(.+?)\s+(allow|deny)\s+(.+)$/.exec(line);
+    if (!match) return true;
+    sawAclEntry = true;
+    if (match[2] === "deny") continue;
+    const principal = match[1]!.trim().split(/\s+/)[0]!.toLowerCase();
+    if (
+      new Set([`user:${currentUser.toLowerCase()}`, "user:root", "group:admin", "group:wheel"]).has(
+        principal,
+      )
+    )
+      continue;
+    const permissions = match[3]!
+      .toLowerCase()
+      .split(",")
+      .map((value) => value.trim())
+      .filter(Boolean);
+    if (permissions.some((permission) => !DARWIN_SAFE_ACL_PERMISSIONS.has(permission))) return true;
+  }
+  return aclMarked && !sawAclEntry;
+}
+
+function assertDarwinCacheAuthority(path: string): void {
+  const ls = "/bin/ls";
+  const id = "/usr/bin/id";
+  for (const executable of [ls, id]) {
+    const stat = lstatSync(executable);
+    if (!stat.isFile() || stat.isSymbolicLink())
+      throw new Error("Trusted scanner cache authority could not be verified.");
+  }
+  const options = {
+    encoding: "utf8" as const,
+    env: { LANG: "C", LC_ALL: "C", PATH: "/usr/bin:/bin" },
+    timeout: 30_000,
+    maxBuffer: 64 * 1024,
+  };
+  const identity = spawnSync(id, ["-un"], options);
+  const currentUser = identity.stdout.trim();
+  if (identity.error || identity.status !== 0 || !currentUser || /[\r\n:]/.test(currentUser))
+    throw new Error("Trusted scanner cache authority could not be verified.");
+  const acl = spawnSync(ls, ["-lde", path], options);
+  if (acl.error || acl.status !== 0 || darwinAclAllowsUnsafeWriter(acl.stdout, currentUser))
+    throw new Error("Trusted scanner cache is not private to the current user.");
+}
+
+function assertPrivateCacheEntry(path: string, kind: "directory" | "file"): void {
+  const stat = lstatSync(path);
+  if (
+    stat.isSymbolicLink() ||
+    (kind === "directory" ? !stat.isDirectory() : !stat.isFile() || stat.nlink !== 1)
+  )
+    throw new Error(`Trusted scanner cache has an unsafe ${kind} entry.`);
+  if (platform === "win32") {
+    assertWindowsCacheAuthority(path, "private");
+    return;
+  }
+  if (stat.uid !== currentPosixUid() || (stat.mode & PRIVATE_CACHE_MODE) !== 0)
+    throw new Error("Trusted scanner cache is not private to the current user.");
+  if (platform === "darwin") assertDarwinCacheAuthority(path);
+}
+
+function assertCacheAncestor(path: string, check: "parent" | "ancestor"): void {
+  const stat = lstatSync(path);
+  if (!stat.isDirectory() || stat.isSymbolicLink())
+    throw new Error("Trusted scanner cache has an unsafe directory ancestor.");
+  if (platform === "win32") {
+    assertWindowsCacheAuthority(path, check);
+    return;
+  }
+  if (posixCacheAncestorIsUnsafe(stat.uid, currentPosixUid(), stat.mode))
+    throw new Error("Trusted scanner cache has an unsafe directory ancestor.");
+  if (platform === "darwin") assertDarwinCacheAuthority(path);
+}
+
+export function posixCacheAncestorIsUnsafe(
+  ownerUid: number,
+  currentUid: number,
+  mode: number,
+): boolean {
+  const trustedOwner = ownerUid === 0 || ownerUid === currentUid;
+  const writableByOtherPrincipal = (mode & 0o022) !== 0;
+  const replacementProtected = (mode & 0o1000) !== 0;
+  return !trustedOwner || (writableByOtherPrincipal && !replacementProtected);
+}
+
+function ensurePrivateCacheRoot(root: string): string {
+  root = canonicalCacheRoot(root);
+  const chain = pathChain(root);
+  let existing = chain.length - 1;
+  for (let index = 0; index < chain.length; index += 1) {
+    try {
+      const stat = lstatSync(chain[index]!);
+      if (!stat.isDirectory() || stat.isSymbolicLink())
+        throw new Error("Trusted scanner cache has an unsafe directory ancestor.");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      existing = index - 1;
+      break;
+    }
+  }
+  if (existing < 0) throw new Error("Trusted scanner cache authority could not be verified.");
+  if (existing === chain.length - 1) {
+    assertPrivateCacheEntry(root, "directory");
+    for (let index = existing - 1; index >= 0; index -= 1)
+      assertCacheAncestor(chain[index]!, "ancestor");
+    return root;
+  }
+  assertCacheAncestor(chain[existing]!, "parent");
+  for (let index = existing - 1; index >= 0; index -= 1)
+    assertCacheAncestor(chain[index]!, "ancestor");
+  for (let index = existing + 1; index < chain.length; index += 1) {
+    const path = chain[index]!;
+    try {
+      mkdirSync(path, { mode: 0o700 });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+    }
+    assertPrivateCacheEntry(path, "directory");
+  }
+  return root;
+}
+
 function validCachedArchive(path: string, expectedHash: string): boolean {
   try {
+    assertPrivateCacheEntry(path, "file");
     const stat = lstatSync(path);
-    if (!stat.isFile() || stat.isSymbolicLink() || stat.size <= 0 || stat.size > MAX_ARCHIVE_BYTES)
-      return false;
+    if (stat.size <= 0 || stat.size > MAX_ARCHIVE_BYTES) return false;
     return sha256(readFileSync(path)) === expectedHash;
   } catch {
     return false;
@@ -154,40 +412,23 @@ function validCachedArchive(path: string, expectedHash: string): boolean {
 
 function cachedBinaryMatches(path: string, expected: Buffer): boolean {
   try {
-    const stat = lstatSync(path);
-    return stat.isFile() && !stat.isSymbolicLink() && readFileSync(path).equals(expected);
+    assertPrivateCacheEntry(path, "file");
+    return readFileSync(path).equals(expected);
   } catch {
     return false;
   }
 }
 
-function assertSafeCacheDirectory(path: string): void {
-  const stat = lstatSync(path);
-  if (!stat.isDirectory() || stat.isSymbolicLink())
-    throw new Error("Trusted scanner cache has an unsafe directory entry.");
-}
-
-function ensureSafeCacheDirectory(path: string, recursive: boolean): void {
-  try {
-    assertSafeCacheDirectory(path);
-    return;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-    try {
-      mkdirSync(path, { recursive, mode: 0o700 });
-    } catch (createError) {
-      if ((createError as NodeJS.ErrnoException).code !== "EEXIST") throw createError;
-    }
-  }
-  assertSafeCacheDirectory(path);
-}
-
 function ensureManagedCacheDirectory(root: string, segments: readonly string[]): string {
-  ensureSafeCacheDirectory(root, true);
-  let current = root;
+  let current = ensurePrivateCacheRoot(root);
   for (const segment of segments) {
     current = join(current, segment);
-    ensureSafeCacheDirectory(current, false);
+    try {
+      mkdirSync(current, { mode: 0o700 });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+    }
+    assertPrivateCacheEntry(current, "directory");
   }
   return current;
 }

--- a/src/review-tool-bootstrap.ts
+++ b/src/review-tool-bootstrap.ts
@@ -109,7 +109,7 @@ export function reviewToolArtifact(
   return ARTIFACTS[`${runtimePlatform}-${runtimeArch}`];
 }
 
-function cacheRoot(env: NodeJS.ProcessEnv): string {
+export function reviewToolCacheRoot(env: NodeJS.ProcessEnv): string {
   const configured = env.CLAWSWEEPER_REVIEW_TOOLS_DIR?.trim();
   if (configured) {
     if (!isAbsolute(configured)) throw new Error("CLAWSWEEPER_REVIEW_TOOLS_DIR must be absolute.");
@@ -173,7 +173,7 @@ export async function ensureManagedTruffleHog(options: {
   );
   if (!artifact)
     throw new Error("No checksum-pinned trusted scanner is available for this platform.");
-  const root = cacheRoot(env);
+  const root = reviewToolCacheRoot(env);
   const cacheDir = join(root, "trufflehog", `v${TRUFFLEHOG_VERSION}`, artifact.platform);
   const archivePath = join(cacheDir, "archive.tar.gz");
   const binary = join(cacheDir, artifact.executable);

--- a/src/review-tool-bootstrap.ts
+++ b/src/review-tool-bootstrap.ts
@@ -48,12 +48,16 @@ $acl = Get-Acl -LiteralPath $target
 $owner = $acl.GetOwner([Security.Principal.SecurityIdentifier]).Value
 if ($check -eq 'private' -and $owner -ne $currentSid) { exit 21 }
 if ($check -ne 'private' -and -not $allowed.Contains($owner)) { exit 21 }
-$dangerous = [int64]([Security.AccessControl.FileSystemRights]::Write -bor
-  [Security.AccessControl.FileSystemRights]::Modify -bor
+$dangerous = [int64]([Security.AccessControl.FileSystemRights]::CreateFiles -bor
+  [Security.AccessControl.FileSystemRights]::CreateDirectories -bor
+  [Security.AccessControl.FileSystemRights]::WriteExtendedAttributes -bor
+  [Security.AccessControl.FileSystemRights]::WriteAttributes -bor
   [Security.AccessControl.FileSystemRights]::DeleteSubdirectoriesAndFiles -bor
+  [Security.AccessControl.FileSystemRights]::Delete -bor
   [Security.AccessControl.FileSystemRights]::ChangePermissions -bor
   [Security.AccessControl.FileSystemRights]::TakeOwnership)
 $replaceChild = [int64]([Security.AccessControl.FileSystemRights]::DeleteSubdirectoriesAndFiles -bor
+  [Security.AccessControl.FileSystemRights]::Delete -bor
   [Security.AccessControl.FileSystemRights]::ChangePermissions -bor
   [Security.AccessControl.FileSystemRights]::TakeOwnership)
 $mask = if ($check -eq 'ancestor') { $replaceChild } else { $dangerous }

--- a/src/review-tool-bootstrap.ts
+++ b/src/review-tool-bootstrap.ts
@@ -161,6 +161,37 @@ function cachedBinaryMatches(path: string, expected: Buffer): boolean {
   }
 }
 
+function assertSafeCacheDirectory(path: string): void {
+  const stat = lstatSync(path);
+  if (!stat.isDirectory() || stat.isSymbolicLink())
+    throw new Error("Trusted scanner cache has an unsafe directory entry.");
+}
+
+function ensureSafeCacheDirectory(path: string, recursive: boolean): void {
+  try {
+    assertSafeCacheDirectory(path);
+    return;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    try {
+      mkdirSync(path, { recursive, mode: 0o700 });
+    } catch (createError) {
+      if ((createError as NodeJS.ErrnoException).code !== "EEXIST") throw createError;
+    }
+  }
+  assertSafeCacheDirectory(path);
+}
+
+function ensureManagedCacheDirectory(root: string, segments: readonly string[]): string {
+  ensureSafeCacheDirectory(root, true);
+  let current = root;
+  for (const segment of segments) {
+    current = join(current, segment);
+    ensureSafeCacheDirectory(current, false);
+  }
+  return current;
+}
+
 function assertVersion(path: string): void {
   const result = spawnSync(path, ["--version"], {
     encoding: "utf8",
@@ -197,7 +228,11 @@ export async function ensureManagedTruffleHog(options: {
   if (!artifact)
     throw new Error("No checksum-pinned trusted scanner is available for this platform.");
   const root = reviewToolCacheRoot(env);
-  const cacheDir = join(root, "trufflehog", `v${TRUFFLEHOG_VERSION}`, artifact.platform);
+  const cacheDir = ensureManagedCacheDirectory(root, [
+    "trufflehog",
+    `v${TRUFFLEHOG_VERSION}`,
+    artifact.platform,
+  ]);
   const archivePath = join(cacheDir, "archive.tar.gz");
   const binary = join(cacheDir, artifact.executable);
   let archive: Buffer;
@@ -216,7 +251,6 @@ export async function ensureManagedTruffleHog(options: {
       sha256(archive) !== artifact.sha256
     )
       throw new Error("Trusted scanner download checksum did not match.");
-    mkdirSync(cacheDir, { recursive: true, mode: 0o700 });
     const temporaryArchive = `${archivePath}.${randomUUID()}.tmp`;
     try {
       writeFileSync(temporaryArchive, archive, { mode: 0o600, flag: "wx" });
@@ -230,7 +264,6 @@ export async function ensureManagedTruffleHog(options: {
   if (executable.length === 0 || executable.length > MAX_ARCHIVE_BYTES)
     throw new Error("Trusted scanner executable is invalid.");
   if (!cachedBinaryMatches(binary, executable)) {
-    mkdirSync(dirname(binary), { recursive: true, mode: 0o700 });
     const temporary = `${binary}.${randomUUID()}.tmp`;
     try {
       writeFileSync(temporary, executable, { mode: 0o700, flag: "wx" });

--- a/test/agent-input-scan.test.ts
+++ b/test/agent-input-scan.test.ts
@@ -21,6 +21,7 @@ import {
   AgentInputScanError,
   INCOMPLETE_AGENT_INPUT_SOURCE_EXIT_CODE,
   agentInputScanFailureExitCode,
+  managedScannerCacheRoot,
   scanAgentInput,
 } from "../dist/agent-input-scan.js";
 import { reviewedFixtureForSource } from "../dist/agent-input-scan-fixtures.js";
@@ -233,6 +234,54 @@ test("checkout-controlled scanner is never executed", (t) => {
   assert.throws(() => f.run({ kind: "prompt" }), /scanner_unavailable/);
   assert.equal(existsSync(f.calls), false);
 });
+
+test("managed scanner cache roots inside either checkout refuse before bootstrap writes", (t) => {
+  const f = fixture(t);
+  for (const root of [
+    join(f.cwd, "managed-scanner-cache"),
+    join(process.cwd(), `.managed-scanner-cache-${Date.now()}`),
+  ]) {
+    assert.throws(
+      () => managedScannerCacheRoot({ CLAWSWEEPER_REVIEW_TOOLS_DIR: root }, f.cwd, f.cwd),
+      /unsafe_path/,
+    );
+    assert.equal(existsSync(root), false, "rejected cache roots must not be created");
+  }
+});
+
+test(
+  "managed scanner cache symlinks refuse before bootstrap writes",
+  { skip: process.platform === "win32" },
+  (t) => {
+    const f = fixture(t);
+    const cacheRoot = join(f.root, "managed-scanner-cache-link");
+    const target = join(f.cwd, "managed-scanner-cache");
+    symlinkSync(target, cacheRoot);
+    assert.throws(
+      () => managedScannerCacheRoot({ CLAWSWEEPER_REVIEW_TOOLS_DIR: cacheRoot }, f.cwd, f.cwd),
+      /unsafe_path/,
+    );
+    assert.equal(existsSync(target), false, "rejected cache symlinks must not create their target");
+  },
+);
+
+test(
+  "managed scanner cache may sit below an external symlinked ancestor",
+  { skip: process.platform === "win32" },
+  (t) => {
+    const f = fixture(t);
+    const external = join(f.root, "external-cache-parent");
+    const alias = join(f.root, "external-cache-alias");
+    mkdirSync(external);
+    symlinkSync(external, alias);
+    const cacheRoot = join(alias, "managed-scanner-cache");
+    assert.equal(
+      managedScannerCacheRoot({ CLAWSWEEPER_REVIEW_TOOLS_DIR: cacheRoot }, f.cwd, f.cwd),
+      cacheRoot,
+    );
+    assert.equal(existsSync(cacheRoot), false, "validation must not create an external cache");
+  },
+);
 
 for (const location of ["bin", "..tools", "..tools-copy"]) {
   test(`checkout scanner trust rejects ${location} even with an external symlink`, (t) => {

--- a/test/agent-input-scan.test.ts
+++ b/test/agent-input-scan.test.ts
@@ -22,6 +22,7 @@ import {
   INCOMPLETE_AGENT_INPUT_SOURCE_EXIT_CODE,
   agentInputScanFailureExitCode,
   managedScannerCacheRoot,
+  reviewToolBootstrapEnvironment,
   scanAgentInput,
 } from "../dist/agent-input-scan.js";
 import { reviewedFixtureForSource } from "../dist/agent-input-scan-fixtures.js";
@@ -38,6 +39,27 @@ test("only incomplete source scan failures receive the terminal review exit code
   );
   assert.equal(agentInputScanFailureExitCode(new AgentInputScanError("scanner_failed")), null);
   assert.equal(agentInputScanFailureExitCode(new Error("review failed")), null);
+});
+
+test("managed scanner bootstrap forwards only required proxy and CA configuration", () => {
+  assert.deepEqual(
+    reviewToolBootstrapEnvironment({
+      SystemRoot: "C:\\Windows",
+      HTTPS_PROXY: "http://proxy.example",
+      no_proxy: "localhost",
+      NODE_USE_ENV_PROXY: "1",
+      NODE_EXTRA_CA_CERTS: "C:\\certs\\corp.pem",
+      NODE_TLS_REJECT_UNAUTHORIZED: "0",
+      CLAWSWEEPER_TOKEN: "secret",
+    }),
+    {
+      SystemRoot: "C:\\Windows",
+      HTTPS_PROXY: "http://proxy.example",
+      no_proxy: "localhost",
+      NODE_USE_ENV_PROXY: "1",
+      NODE_EXTRA_CA_CERTS: "C:\\certs\\corp.pem",
+    },
+  );
 });
 
 function fixture(t: test.TestContext, prompt = "Review the change.") {

--- a/test/agent-input-scan.test.ts
+++ b/test/agent-input-scan.test.ts
@@ -76,6 +76,18 @@ function fixture(t: test.TestContext, prompt = "Review the change.") {
   return { root, cwd, git, commit, calls, diagnosticPromptPath, run };
 }
 
+function disableManagedScanner(t: test.TestContext) {
+  const previous = process.env.CLAWSWEEPER_REVIEW_TOOLS_DIR;
+  // A relative cache root is rejected before download. These tests exercise the
+  // fail-closed branch where no trusted host scanner and no usable managed
+  // cache are available, while keeping checkout-controlled executables inert.
+  process.env.CLAWSWEEPER_REVIEW_TOOLS_DIR = "relative-managed-scanner-cache";
+  t.after(() => {
+    if (previous === undefined) delete process.env.CLAWSWEEPER_REVIEW_TOOLS_DIR;
+    else process.env.CLAWSWEEPER_REVIEW_TOOLS_DIR = previous;
+  });
+}
+
 for (const scenario of ["deletion", "multiline", "past-display-limits", "comment-only"]) {
   test(`raw admission catches ${scenario} input before dispatch`, (t) => {
     const f = fixture(t);
@@ -207,6 +219,7 @@ test("OpenClaw inspection cannot launch a provider on scan refusal", (t) => {
 
 test("checkout-controlled scanner is never executed", (t) => {
   const f = fixture(t);
+  disableManagedScanner(t);
   const previousPath = process.env.PATH;
   process.env.PATH = f.cwd;
   t.after(() => {
@@ -224,6 +237,7 @@ test("checkout-controlled scanner is never executed", (t) => {
 for (const location of ["bin", "..tools", "..tools-copy"]) {
   test(`checkout scanner trust rejects ${location} even with an external symlink`, (t) => {
     const f = fixture(t);
+    disableManagedScanner(t);
     const bin = join(f.cwd, location);
     mkdirSync(bin);
     if (location === "..tools-copy") copyFileSync("/usr/bin/true", join(bin, "trufflehog"));
@@ -345,6 +359,7 @@ ${failure === "signal" ? "process.kill(process.pid, 'SIGTERM');" : failure === "
     if (failure === "missing") {
       rmSync(join(bin, "trufflehog"));
       process.env.PATH = bin;
+      disableManagedScanner(t);
     }
     writeFileSync(f.diagnosticPromptPath, "stale-sensitive-diagnostic");
     const schema = join(f.root, "schema");

--- a/test/review-tool-bootstrap.test.ts
+++ b/test/review-tool-bootstrap.test.ts
@@ -1,6 +1,16 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdirSync, mkdtempSync, readdirSync, rmSync, symlinkSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import test from "node:test";
@@ -8,7 +18,9 @@ import { gzipSync } from "node:zlib";
 
 import {
   extractTarExecutable,
+  darwinAclAllowsUnsafeWriter,
   ensureManagedTruffleHog,
+  posixCacheAncestorIsUnsafe,
   reviewToolCacheRoot,
   reviewToolArtifact,
   TRUFFLEHOG_VERSION,
@@ -23,6 +35,68 @@ function tarEntry(name: string, contents: Buffer): Buffer {
   const padding = Buffer.alloc((512 - (contents.length % 512)) % 512);
   return Buffer.concat([header, contents, padding]);
 }
+
+function allowOtherPrincipalWrites(path: string): void {
+  if (process.platform === "darwin") {
+    const result = spawnSync(
+      "/bin/chmod",
+      ["+a", "everyone allow write,delete,append,writeattr,writeextattr,writesecurity,chown", path],
+      { encoding: "utf8" },
+    );
+    assert.equal(result.status, 0, `${result.stdout}${result.stderr}`);
+    return;
+  }
+  if (process.platform !== "win32") {
+    chmodSync(path, 0o777);
+    return;
+  }
+  const systemRoot = process.env.SystemRoot;
+  assert.ok(systemRoot, "Windows cache-authority tests require SystemRoot");
+  const result = spawnSync(
+    join(systemRoot, "System32", "icacls.exe"),
+    [path, "/grant", "*S-1-1-0:(OI)(CI)F"],
+    { encoding: "utf8", windowsHide: true },
+  );
+  assert.equal(result.status, 0, `${result.stdout}${result.stderr}`);
+}
+
+test("review-tool bootstrap rejects dangerous Darwin allow ACLs", () => {
+  assert.equal(
+    darwinAclAllowsUnsafeWriter(
+      "drwx------+ 4 owner staff 128 Aug 31 12:00 cache\n 0: group:everyone deny delete\n",
+      "owner",
+    ),
+    false,
+  );
+  assert.equal(
+    darwinAclAllowsUnsafeWriter(
+      "drwx------+ 4 owner staff 128 Aug 31 12:00 cache\n 0: user:other allow read,write,delete\n",
+      "owner",
+    ),
+    true,
+  );
+  assert.equal(
+    darwinAclAllowsUnsafeWriter(
+      "drwx------+ 4 owner staff 128 Aug 31 12:00 cache\n 0: user:owner allow read,write,delete\n",
+      "owner",
+    ),
+    false,
+  );
+  assert.equal(
+    darwinAclAllowsUnsafeWriter(
+      "drwx------+ 4 owner staff 128 Aug 31 12:00 cache\n unparseable acl entry\n",
+      "owner",
+    ),
+    true,
+  );
+});
+
+test("review-tool bootstrap rejects ancestors controlled by another POSIX user", () => {
+  assert.equal(posixCacheAncestorIsUnsafe(1001, 1000, 0o755), true);
+  assert.equal(posixCacheAncestorIsUnsafe(1000, 1000, 0o755), false);
+  assert.equal(posixCacheAncestorIsUnsafe(0, 1000, 0o1777), false);
+  assert.equal(posixCacheAncestorIsUnsafe(0, 1000, 0o777), true);
+});
 
 test("review-tool bootstrap pins the official Windows archive", () => {
   const artifact = reviewToolArtifact("win32", "x64");
@@ -39,7 +113,7 @@ test("review-tool bootstrap requires an absolute configured cache root", () => {
   assert.equal(reviewToolCacheRoot({ CLAWSWEEPER_REVIEW_TOOLS_DIR: absolute }), absolute);
   assert.throws(
     () => reviewToolCacheRoot({ CLAWSWEEPER_REVIEW_TOOLS_DIR: "relative-review-tools" }),
-    /must be absolute/,
+    /must be a safe absolute/,
   );
 });
 
@@ -126,8 +200,68 @@ test("review-tool bootstrap refuses a symlinked cache root before download", asy
       runtimePlatform: "linux",
       runtimeArch: "x64",
     }),
-    /unsafe directory entry/,
+    /unsafe directory (?:entry|ancestor)/,
   );
   assert.equal(fetched, false);
   assert.deepEqual(readdirSync(target), []);
+});
+
+test(
+  "review-tool bootstrap permits a cache below an external symlinked ancestor",
+  { skip: process.platform === "win32" },
+  async (t) => {
+    const base = mkdtempSync(join(tmpdir(), "clawsweeper-review-tools-alias-"));
+    const target = join(base, "target");
+    const alias = join(base, "alias");
+    mkdirSync(target, { mode: 0o700 });
+    symlinkSync(target, alias, "dir");
+    t.after(() => rmSync(base, { recursive: true, force: true }));
+    const root = join(alias, "cache");
+    const response = new Response("unread", {
+      status: 200,
+      headers: { "content-length": String(256 * 1024 * 1024 + 1) },
+    });
+    await assert.rejects(
+      ensureManagedTruffleHog({
+        timeoutMs: 30_000,
+        env: { CLAWSWEEPER_REVIEW_TOOLS_DIR: root },
+        fetchImpl: async () => response,
+        runtimePlatform: "linux",
+        runtimeArch: "x64",
+      }),
+      /exceeds the archive limit/,
+    );
+    assert.equal(existsSync(join(target, "cache")), true);
+  },
+);
+
+test("review-tool bootstrap refuses a cache root writable by another principal", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "clawsweeper-review-tools-authority-"));
+  const root = join(base, "cache");
+  const marker = join(base, "scanner-executed");
+  const binaryDir = join(root, "trufflehog", `v${TRUFFLEHOG_VERSION}`, "linux-x64");
+  mkdirSync(binaryDir, { recursive: true, mode: 0o700 });
+  writeFileSync(
+    join(binaryDir, "trufflehog"),
+    `#!${process.execPath}\nrequire("node:fs").writeFileSync(${JSON.stringify(marker)}, "bad");`,
+    { mode: 0o700 },
+  );
+  allowOtherPrincipalWrites(root);
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+  let fetched = false;
+  await assert.rejects(
+    ensureManagedTruffleHog({
+      timeoutMs: 30_000,
+      env: { CLAWSWEEPER_REVIEW_TOOLS_DIR: root },
+      fetchImpl: async () => {
+        fetched = true;
+        return new Response("unreachable");
+      },
+      runtimePlatform: "linux",
+      runtimeArch: "x64",
+    }),
+    /not private to the current user/,
+  );
+  assert.equal(fetched, false);
+  assert.equal(existsSync(marker), false);
 });

--- a/test/review-tool-bootstrap.test.ts
+++ b/test/review-tool-bootstrap.test.ts
@@ -1,11 +1,14 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { resolve } from "node:path";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import test from "node:test";
 import { gzipSync } from "node:zlib";
 
 import {
   extractTarExecutable,
+  ensureManagedTruffleHog,
   reviewToolCacheRoot,
   reviewToolArtifact,
   TRUFFLEHOG_VERSION,
@@ -55,4 +58,22 @@ test("review-tool bootstrap extracts only the exact regular executable", () => {
   tampered[0] ^= 0xff;
   assert.throws(() => extractTarExecutable(tampered, "trufflehog.exe"), /decompressed/);
   assert.equal(createHash("sha256").update(executable).digest("hex").length, 64);
+});
+
+test("review-tool bootstrap rejects an oversized response before reading its body", async (t) => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-review-tools-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const response = new Response("unread", {
+    headers: { "content-length": String(256 * 1024 * 1024 + 1) },
+  });
+  await assert.rejects(
+    ensureManagedTruffleHog({
+      timeoutMs: 30_000,
+      env: { CLAWSWEEPER_REVIEW_TOOLS_DIR: root },
+      fetchImpl: async () => response,
+      runtimePlatform: "linux",
+      runtimeArch: "x64",
+    }),
+    /exceeds the archive limit/,
+  );
 });

--- a/test/review-tool-bootstrap.test.ts
+++ b/test/review-tool-bootstrap.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readdirSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import test from "node:test";
@@ -76,4 +76,58 @@ test("review-tool bootstrap rejects an oversized response before reading its bod
     }),
     /exceeds the archive limit/,
   );
+});
+
+test("review-tool bootstrap refuses symlinked managed-cache directories before download", async (t) => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-review-tools-"));
+  const target = mkdtempSync(join(tmpdir(), "clawsweeper-review-tools-target-"));
+  t.after(() => {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(target, { recursive: true, force: true });
+  });
+  mkdirSync(root, { recursive: true });
+  symlinkSync(target, join(root, "trufflehog"), process.platform === "win32" ? "junction" : "dir");
+  let fetched = false;
+  await assert.rejects(
+    ensureManagedTruffleHog({
+      timeoutMs: 30_000,
+      env: { CLAWSWEEPER_REVIEW_TOOLS_DIR: root },
+      fetchImpl: async () => {
+        fetched = true;
+        return new Response("unreachable");
+      },
+      runtimePlatform: "linux",
+      runtimeArch: "x64",
+    }),
+    /unsafe directory entry/,
+  );
+  assert.equal(fetched, false);
+  assert.deepEqual(readdirSync(target), []);
+});
+
+test("review-tool bootstrap refuses a symlinked cache root before download", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "clawsweeper-review-tools-base-"));
+  const target = mkdtempSync(join(tmpdir(), "clawsweeper-review-tools-target-"));
+  t.after(() => {
+    rmSync(base, { recursive: true, force: true });
+    rmSync(target, { recursive: true, force: true });
+  });
+  const root = join(base, "cache");
+  symlinkSync(target, root, process.platform === "win32" ? "junction" : "dir");
+  let fetched = false;
+  await assert.rejects(
+    ensureManagedTruffleHog({
+      timeoutMs: 30_000,
+      env: { CLAWSWEEPER_REVIEW_TOOLS_DIR: root },
+      fetchImpl: async () => {
+        fetched = true;
+        return new Response("unreachable");
+      },
+      runtimePlatform: "linux",
+      runtimeArch: "x64",
+    }),
+    /unsafe directory entry/,
+  );
+  assert.equal(fetched, false);
+  assert.deepEqual(readdirSync(target), []);
 });

--- a/test/review-tool-bootstrap.test.ts
+++ b/test/review-tool-bootstrap.test.ts
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
+import { resolve } from "node:path";
 import test from "node:test";
 import { gzipSync } from "node:zlib";
 
 import {
   extractTarExecutable,
+  reviewToolCacheRoot,
   reviewToolArtifact,
   TRUFFLEHOG_VERSION,
 } from "../dist/review-tool-bootstrap.js";
@@ -27,6 +29,15 @@ test("review-tool bootstrap pins the official Windows archive", () => {
     url: `https://github.com/trufflesecurity/trufflehog/releases/download/v${TRUFFLEHOG_VERSION}/trufflehog_${TRUFFLEHOG_VERSION}_windows_amd64.tar.gz`,
     sha256: "dc1759892a41d64ee0d46cd5d4391dad7f916f54257154aa1b0732f9c50901b2",
   });
+});
+
+test("review-tool bootstrap requires an absolute configured cache root", () => {
+  const absolute = resolve("review-tools");
+  assert.equal(reviewToolCacheRoot({ CLAWSWEEPER_REVIEW_TOOLS_DIR: absolute }), absolute);
+  assert.throws(
+    () => reviewToolCacheRoot({ CLAWSWEEPER_REVIEW_TOOLS_DIR: "relative-review-tools" }),
+    /must be absolute/,
+  );
 });
 
 test("review-tool bootstrap extracts only the exact regular executable", () => {

--- a/test/review-tool-bootstrap.test.ts
+++ b/test/review-tool-bootstrap.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import test from "node:test";
+import { gzipSync } from "node:zlib";
+
+import {
+  extractTarExecutable,
+  reviewToolArtifact,
+  TRUFFLEHOG_VERSION,
+} from "../dist/review-tool-bootstrap.js";
+
+function tarEntry(name: string, contents: Buffer): Buffer {
+  const header = Buffer.alloc(512);
+  header.write(name, 0, "utf8");
+  header.write(contents.length.toString(8).padStart(11, "0") + "\0", 124, "ascii");
+  header.write("0000755\0", 100, "ascii");
+  header.write("0", 156, "ascii");
+  const padding = Buffer.alloc((512 - (contents.length % 512)) % 512);
+  return Buffer.concat([header, contents, padding]);
+}
+
+test("review-tool bootstrap pins the official Windows archive", () => {
+  const artifact = reviewToolArtifact("win32", "x64");
+  assert.deepEqual(artifact, {
+    platform: "win32-x64",
+    executable: "trufflehog.exe",
+    url: `https://github.com/trufflesecurity/trufflehog/releases/download/v${TRUFFLEHOG_VERSION}/trufflehog_${TRUFFLEHOG_VERSION}_windows_amd64.tar.gz`,
+    sha256: "dc1759892a41d64ee0d46cd5d4391dad7f916f54257154aa1b0732f9c50901b2",
+  });
+});
+
+test("review-tool bootstrap extracts only the exact regular executable", () => {
+  const executable = Buffer.from("trusted scanner bytes");
+  const archive = gzipSync(
+    Buffer.concat([
+      tarEntry("README.md", Buffer.from("ignored")),
+      tarEntry("trufflehog.exe", executable),
+      Buffer.alloc(1024),
+    ]),
+  );
+  assert.deepEqual(extractTarExecutable(archive, "trufflehog.exe"), executable);
+  assert.throws(() => extractTarExecutable(archive, "other.exe"), /expected executable/);
+  const tampered = Buffer.from(archive);
+  tampered[0] ^= 0xff;
+  assert.throws(() => extractTarExecutable(tampered, "trufflehog.exe"), /decompressed/);
+  assert.equal(createHash("sha256").update(executable).digest("hex").length, 64);
+});


### PR DESCRIPTION
## Summary

Local ClawSweeper review currently stops before inference when no trusted host-owned `trufflehog` is available on `PATH`. This PR preserves the mandatory input-admission scan and adds a checksum-pinned managed scanner fallback for that missing-tool case.

The current task direction is to bring this managed fallback to maintainer review. That direction does not pre-approve merge, automerge, deployment, gate changes, or workflow changes.

## Problem

Requiring a separately installed scanner makes an otherwise isolated local review fail with `scanner_unavailable`. Removing or bypassing the scan is not acceptable: prompts, schemas, raw before/after blobs, diffs, and snapshots must still be scanned before any provider invocation.

## Implementation

- Add a fixed TruffleHog `v3.97.1` asset map for Windows, macOS, and Linux on x64/arm64.
- Download only the platform's official fixed asset, enforce response and archive size bounds, verify the pinned SHA-256 before extraction, extract only the exact regular executable, and validate the cached executable and version on every use.
- Use a current-user-owned cache outside both the ClawSweeper checkout and the reviewed checkout; reject checkout-contained, relative, malformed, symlinked, or independently writable managed-cache paths before any download or write.
- Keep trusted host `PATH` discovery as the first choice. Invoke managed provisioning only after that path reports `scanner_unavailable`.
- Preserve the existing private staging, 256 MiB admission cap, timeout budget, scanner flags, classified-fixture handling, and fail-closed outcomes.
- Add `pnpm setup:review-tools`, focused regression coverage, and operator documentation. Hosted setup/actions are unchanged.
- Forward only the proxy, no-proxy, custom-CA, and platform location variables required for the pinned bootstrap; arbitrary credentials and TLS-disable controls are not inherited.

## Security contract

- No URL, version, checksum, or archive-entry override exists.
- Bootstrap/download/extract/cache/version failures remain `scanner_unavailable`; scan failures, findings, deadlines, incomplete input, source drift, unsupported content, and unsafe paths still refuse review before inference.
- The configured cache root and every managed directory component are checked with `lstat`; symlinks and non-directories are rejected. A concurrent creator is accepted only for `mkdir`'s `EEXIST`, followed by the same validation.
- Existing cache entries must be private and current-user-owned. POSIX ownership/mode, macOS extended ACLs, and Windows owner/DACL authority are checked fail closed; read-only principals are tolerated, but any untrusted principal able to create, replace, delete, or retake control is rejected.
- Checkout-controlled scanners are never executed, and rejected checkout/symlink cache roots remain no-write paths.

## Real Behavior Proof

### Claim

On the exact PR head, a production `scanAgentInput` call with no TruffleHog on `PATH` provisions the fixed verified scanner in an external cache and completes a harmless scan. Checkout-contained, symlinked, and independently writable cache roots fail closed before writing or executing an attacker-controlled scanner.

### Exercised surface

`scanAgentInput` -> trusted scanner discovery -> `scripts/setup-review-tools.mjs` -> `ensureManagedTruffleHog` -> real TruffleHog scan.

### Scenario and environment

- Head: `48b2d0d22994a7e079490c5cbea4fd17d1e65956`
- Base: `206fe726bbadaae32dcb9822a2511a351a5c9317` (`main`)
- Provider: Crabbox `local-container`
- Image: `mcr.microsoft.com/playwright:v1.60.0-noble`
- Run: `run_23c6b52c00d9`
- Lease: `cbx_7c6256496dda` / `crimson-crab` (stopped cleanly)
- Runtime: Linux x86_64, Node `v24.15.0`, pnpm `11.10.0`
- Scanner discovery PATH: `/usr/bin:/bin` (no TruffleHog present)

### Observed result and inspectable redacted trace

```text
proof_head=48b2d0d22994a7e079490c5cbea4fd17d1e65956
proof_base=206fe726bbadaae32dcb9822a2511a351a5c9317
proof_platform=Linux-x86_64
tests 96; pass 96; fail 0; skipped 0
pathless_managed_scan=clean_pass
trufflehog 3.97.1
scanner_sha256=591136c64476b0f3545f5863aa96c2b3a3406c1348d53a8065baf694e7a36829
managed_cache_files:
trufflehog/v3.97.1/linux-x64/archive.tar.gz
trufflehog/v3.97.1/linux-x64/trufflehog
checkout_cache_refusal=unsafe_path_no_write
symlink_cache_refusal=scanner_unavailable_no_write
shared_cache_refusal=scanner_unavailable_no_execution
lint:src: Found 0 warnings and 0 errors.
lint:repair: Found 0 warnings and 0 errors.
lint:scripts: Found 0 warnings and 0 errors.
lint:dashboard: Found 0 warnings and 0 errors.
Documentation checks passed.
proof_result=pass
runStatus=succeeded exitCode=0
leaseStopped=true
```

The run downloaded and verified the fixed Linux x64 archive SHA-256 `f863ea3a8d786f7d097870496c977944cce7372a2fe1e56707d965016e543ece`. The committed Codex review also compared all six pinned archive digests with the official `v3.97.1` GitHub release metadata.

### Proof limits

- The live production-path receipt is Linux x64. Windows x64 bootstrap tests and build pass on the host; other platform mappings are deterministic and digest-pinned but were not live-executed in this closeout.
- Crabbox `--no-hydrate` raw sync from Windows converts the synchronized tree to CRLF, so repository-wide formatting and workflow-fixture tests are not valid in that transport. Broad lint/static checks ran in the container; native-checkout GitHub CI is the authoritative full-format/full-suite gate.
- This proof does not exercise a secret finding; deterministic tests cover findings and every refusal class without exposing real credentials.

## Validation

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm run build:all`
- `node --test test/review-tool-bootstrap.test.ts test/agent-input-scan.test.ts` - 96 passed, 0 failed in local-container proof.
- `corepack pnpm run lint` - all source, repair, script/test, and dashboard lint groups clean in local-container proof.
- `corepack pnpm run check:active-surface`
- `corepack pnpm run check:dashboard-queue-boundary`
- `corepack pnpm run check:dashboard-strict`
- `corepack pnpm run check:docs`
- `corepack pnpm run check:limits`
- `git diff --check origin/main...HEAD`
- Native Windows focused bootstrap suite - 9 passed, 0 failed, 1 platform-specific skip; `pnpm setup:review-tools` resolved and validated TruffleHog 3.97.1 with the host's existing read-only sandbox ACL.
- GitHub [CI run 33393067093](https://github.com/openclaw/clawsweeper/actions/runs/33393067093) on exact head `48b2d0d229` - `pnpm check` passed in 9m12s; Windows Codex launcher and sparse repair build smoke passed; hosted native review smoke was inapplicable/skipped.
- GitHub [CodeQL run 33393067010](https://github.com/openclaw/clawsweeper/actions/runs/33393067010) - JavaScript/TypeScript and Actions analyses passed.
- GitHub [repair containment run 33393067133](https://github.com/openclaw/clawsweeper/actions/runs/33393067133) - both samples passed.
- GitHub [production automerge-flow run 33393067063](https://github.com/openclaw/clawsweeper/actions/runs/33393067063) - passed in 9m42s.

## Review closeout

- Dirty-patch Codex review findings were accepted and fixed for exact-root and managed-component symlinks, the concurrent cold-cache `mkdir` race, cache ownership/ACL authority, macOS ACL parsing, safe external ancestor aliases, ancestor ownership, proxy/custom-CA forwarding, and Windows composite rights. Review was repeated after each accepted fix until clean.
- `codex review --base origin/main` on the committed exact head: no actionable defects identified; focused build and scanner/bootstrap tests completed successfully.
- Local ClawSweeper committed-range review: `decision=keep_open confidence=high action=kept_open`.

## Maintainer direction

Martin, the repository maintainer and task owner, directed CSW-145A to own and finish the hardened managed fallback through maintainer-ready review. The selected direction is to harden the managed fallback rather than remove or bypass scanning. This authorizes updating and reviewing this PR, but does not authorize merge, automerge, deployment, gate changes, or workflow dispatch.

## Risks and rollout

This intentionally adds a network fetch and executable cache to the local review admission boundary. The fixed upstream release must be deliberately requalified before any version update. Cache validation is repeated on reuse, and every provisioning failure remains fail closed. No GitHub workflow, hosted scanner setup, release gate, merge gate, or production runtime is changed.

## Release-note context

Local review can now provision its pinned scanner when a trusted host scanner is absent, while retaining the same mandatory fail-closed input scan.
