### PR TITLE
fix(repair): stop stalled GitHub CLI requests blocking workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Bound shared repair GitHub CLI calls with native process deadlines and honor per-call timeout settings. Thanks @SebTardif.
 - Bound standalone webhook GitHub requests to 15 seconds, including response bodies, so stalled calls return a retryable response. Thanks @SebTardif.
 - Completed obsolete exact-review publications when apply verifies a strictly newer durable review for the same revision, preserving retry behavior for unproven results. Thanks @vincentkoc. (#1249)
 

--- a/docs/repair/README.md
+++ b/docs/repair/README.md
@@ -395,7 +395,10 @@ The workflow needs:
   request fails in time for the executor to write a blocked report and upload
   debug artifacts. `CLAWSWEEPER_GIT_NETWORK_TIMEOUT_MS` and
   `CLAWSWEEPER_GH_COMMAND_TIMEOUT_MS` can override the Git and GitHub CLI
-  portions separately.
+  portions separately. Shared repair GitHub CLI calls use the merged per-call
+  environment for these settings, default to two minutes, and enforce a
+  30-second minimum for environment-configured budgets. An explicit `timeoutMs`
+  call option takes precedence and may select a shorter positive deadline.
 - optional `CLAWSWEEPER_CODEX_REVIEW_ATTEMPTS` and `CLAWSWEEPER_RESOLVE_REVIEW_THREADS` variables for agentic merge-prep review loops; the review attempt default is `4`, with the last failed internal review converted into one final Codex review-fix pass when changed-surface validation can still prove the branch safe to push for exact-head review
 - optional `CLAWSWEEPER_MAX_REPAIRS_PER_PR` and
   `CLAWSWEEPER_MAX_REPAIRS_PER_HEAD` variables for trusted

--- a/src/repair/github-cli.ts
+++ b/src/repair/github-cli.ts
@@ -15,6 +15,7 @@ export type GhRunOptions = {
   cwd?: string;
   env?: NodeJS.ProcessEnv;
   input?: string;
+  timeoutMs?: number;
 };
 
 export type GhRetryOptions = GhRunOptions & {
@@ -164,6 +165,7 @@ export function ghText(ghArgs: string[], options: GhRunOptions = {}): string {
   const command = ghCommand(ghArgs, env);
   const text = execFileSync(command.command, command.args, {
     cwd: options.cwd ?? repoRoot(),
+    timeout: ghRunTimeoutMs(options, env),
     env,
     encoding: "utf8",
     input: options.input,
@@ -256,6 +258,7 @@ export async function ghTextAsync(ghArgs: string[], options: GhRunOptions = {}):
   const command = ghCommand(ghArgs, env);
   const { stdout } = await execFileAsync(command.command, command.args, {
     cwd: options.cwd ?? repoRoot(),
+    timeout: ghRunTimeoutMs(options, env),
     env,
     encoding: "utf8",
     maxBuffer: 64 * 1024 * 1024,
@@ -287,6 +290,7 @@ export function ghSpawn(ghArgs: string[], options: GhRunOptions = {}) {
   const command = ghCommand(ghArgs, env);
   return spawnSync(command.command, command.args, {
     cwd: options.cwd ?? repoRoot(),
+    timeout: ghRunTimeoutMs(options, env),
     encoding: "utf8",
     env,
     input: options.input,
@@ -374,6 +378,22 @@ export function ghStdoutFromError(error: unknown): string {
   return stripAnsi(
     bufferLikeToString(commandError.stdout ?? commandError.output?.[1] ?? ""),
   ).trim();
+}
+
+function ghRunTimeoutMs(options: GhRunOptions, env: NodeJS.ProcessEnv): number {
+  if (
+    options.timeoutMs !== undefined &&
+    Number.isFinite(options.timeoutMs) &&
+    options.timeoutMs > 0
+  ) {
+    return Math.max(1, Math.floor(options.timeoutMs));
+  }
+  const configured = Number(
+    env.CLAWSWEEPER_GH_COMMAND_TIMEOUT_MS ?? env.CLAWSWEEPER_NETWORK_COMMAND_TIMEOUT_MS,
+  );
+  return Number.isFinite(configured) && configured > 0
+    ? Math.max(30_000, Math.floor(configured))
+    : 120_000;
 }
 
 function resolveRetryOptions(options: GhRetryOptions | number): GhRetryOptions {

--- a/test/repair/github-cli.test.ts
+++ b/test/repair/github-cli.test.ts
@@ -1,3 +1,5 @@
+import childProcess from "node:child_process";
+import { syncBuiltinESMExports } from "node:module";
 import assert from "node:assert/strict";
 import test from "node:test";
 
@@ -6,6 +8,8 @@ import {
   ghJsonWithRetry,
   ghJsonWithRetryAsync,
   ghSpawn,
+  ghText,
+  ghTextAsync,
   githubLimitedPagePath,
   githubPaginatedPath,
 } from "../../dist/repair/github-cli.js";
@@ -181,5 +185,73 @@ test("public read throttles fall back once to the target App token", async () =>
       if (value === undefined) delete process.env[key];
       else process.env[key] = value;
     }
+  }
+});
+
+test("GitHub CLI deadlines stop stalled children and preserve successful output", async () => {
+  const env = {
+    GH_BIN: process.execPath,
+    GH_BIN_ARGS: JSON.stringify(["--eval", "setTimeout(() => {}, 10_000)", "--"]),
+  };
+  const options = { env, timeoutMs: 100 };
+  assert.throws(() => ghText(["api", "user"], options), { code: "ETIMEDOUT" });
+  await assert.rejects(ghTextAsync(["api", "user"], options), {
+    killed: true,
+    signal: "SIGTERM",
+  });
+  assert.equal(ghSpawn(["api", "user"], options).error?.code, "ETIMEDOUT");
+
+  env.GH_BIN_ARGS = JSON.stringify(["--eval", "process.stdout.write('ok')", "--"]);
+  assert.equal(ghText(["api", "user"], { env, timeoutMs: 2_000 }), "ok");
+  assert.equal(await ghTextAsync(["api", "user"], { env, timeoutMs: 2_000 }), "ok");
+  assert.equal(ghSpawn(["api", "user"], { env, timeoutMs: 2_000 }).stdout, "ok");
+});
+
+test("GitHub CLI deadline selection follows the child environment and explicit budget", (t) => {
+  let observedTimeout: number | undefined;
+  t.mock.method(childProcess, "spawnSync", (_file, _args, options) => {
+    observedTimeout = options.timeout;
+    return { status: 0, stdout: "", stderr: "" };
+  });
+  syncBuiltinESMExports();
+  t.after(() => {
+    t.mock.restoreAll();
+    syncBuiltinESMExports();
+  });
+  const previous = process.env.CLAWSWEEPER_GH_COMMAND_TIMEOUT_MS;
+  process.env.CLAWSWEEPER_GH_COMMAND_TIMEOUT_MS = "90000";
+  t.after(() => {
+    if (previous === undefined) delete process.env.CLAWSWEEPER_GH_COMMAND_TIMEOUT_MS;
+    else process.env.CLAWSWEEPER_GH_COMMAND_TIMEOUT_MS = previous;
+  });
+  const cases = [
+    { env: {}, expected: 90_000 },
+    { env: { CLAWSWEEPER_GH_COMMAND_TIMEOUT_MS: "45000" }, expected: 45_000 },
+    { env: { CLAWSWEEPER_GH_COMMAND_TIMEOUT_MS: "10" }, expected: 30_000 },
+    {
+      env: {
+        CLAWSWEEPER_GH_COMMAND_TIMEOUT_MS: undefined,
+        CLAWSWEEPER_NETWORK_COMMAND_TIMEOUT_MS: "60000",
+      },
+      expected: 60_000,
+    },
+    {
+      env: {
+        CLAWSWEEPER_GH_COMMAND_TIMEOUT_MS: undefined,
+        CLAWSWEEPER_NETWORK_COMMAND_TIMEOUT_MS: undefined,
+      },
+      expected: 120_000,
+    },
+    ...["", "invalid", "0", "-1", "Infinity"].map((value) => ({
+      env: { CLAWSWEEPER_GH_COMMAND_TIMEOUT_MS: value },
+      expected: 120_000,
+    })),
+    { timeoutMs: 250, env: {}, expected: 250 },
+    { timeoutMs: 0.5, env: {}, expected: 1 },
+    ...[0, -1, NaN, Infinity].map((timeoutMs) => ({ timeoutMs, env: {}, expected: 90_000 })),
+  ];
+  for (const { expected, ...options } of cases) {
+    ghSpawn(["api", "user"], { ...options, env: { ...options.env, GH_BIN: process.execPath } });
+    assert.equal(observedTimeout, expected);
   }
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes stalled GitHub CLI requests in the shared repair helpers. These calls previously had no application deadline, and the original proposal ignored timeout settings supplied through the existing per-call `env` option.

## Why This Change Was Made

`ghText`, `ghTextAsync`, and `ghSpawn` now pass a native timeout to Node using the same merged environment supplied to their child process. A positive explicit `timeoutMs` wins; otherwise the GitHub-specific environment setting takes precedence over the network fallback, with a two-minute default and 30-second minimum for configured values. A fractional positive explicit value is clamped to one millisecond so rounding cannot disable the deadline.

This resolves the current review's `options.env` finding without adding another environment merge or process supervisor. Native error/result shapes and existing mutation-ledger handling remain in place. The synchronous shared helper was added without a timeout in [62dd779eb1](https://github.com/openclaw/clawsweeper/commit/62dd779eb1), verified against its raw parent `8e77181d04da619f26005d8c7299e0b9b2aeb3c4`.

## User Impact

A stalled ordinary `gh` process is terminated at its selected deadline instead of holding the repair worker open. Per-call worker settings now take effect. Healthy commands preserve stdout, and ordinary command failures remain failures.

The deadline applies to each command attempt. Longer legitimate calls may require a larger configured budget. This does not bound the entire retry loop or add process-tree supervision; it retains Node's normal SIGTERM behavior.

## OpenClaw Bay Impact

Unaffected: this changes worker-side process execution, not Bay's observer-only surface or any queue/status data shape.

## Documentation Impact

Updated the active `docs/repair/README.md` reference with the shared-helper default, environment floor, and per-call precedence. Added a changelog entry with credit to @SebTardif.

## Evidence

The exact candidate tree `979970625147762dd98f60191387a8ce51724f2f` (commit `acb5b36df1e964e024fbe43462e11fe974599530`) passed `pnpm run check`: 4,151 tests passed, eight skipped, and all 13 static checks passed. The focused suite passed six tests. Codex pre-commit review found no actionable P0 findings.

The controlled proof uses the real `/usr/bin/gh` against a local HTTP fixture, through the compiled production helpers. It supplies only synthetic auth in an isolated home and config directory. It does not replace child-process execution with a mock.

## Real Behavior Proof

- **Environment:** secretless AWS Crabbox `cbx_500a9817fb0b`, Linux, Node 24.18.1, GitHub CLI 2.46.0 from the image, pinned pnpm 11.10.0. No instance role, Tailscale, hydration, or live GitHub credentials.
- **Original proposal:** `fbde9401b4148d95636ad895472f23b81677d49b` stayed pending past 31.5 seconds with a per-call 30-second GH budget and an ambient 90-second value. The separate watchdog stopped that deliberately stuck driver.
- **Current-main baseline:** `1b9086615d892ecc7c1fd4b681e8a1b1208dfa5c` ignored a 250 ms explicit budget and was still pending at the 1.2-second watchdog.
- **Candidate:** `ghText`, `ghTextAsync`, and `ghSpawn` terminated stalled real CLI requests in 254, 256, and 254 ms with an explicit 250 ms budget. Per-call GH and network settings terminated them in 30,012 and 30,011 ms despite ambient 90-second values. Every timed-out connection closed. Healthy requests after each helper returned `synthetic-user`, and a normal HTTP error retained native exit status 1.
- **Commands:** `pnpm run build:all`; `node /tmp/clawsweeper-github-cli-proof.mjs run "$PWD" original-env` on the original PR; `baseline` on the pinned main; `candidate` after the patch; `node --test test/repair/github-cli.test.ts`; `pnpm run check`.
- **Limits:** controlled local HTTP failures with a real CLI, not a live GitHub outage. No public mutations occurred. Windows and children that resist SIGTERM are not claimed. [Node's native timeout semantics](https://nodejs.org/api/child_process.html#child_processexecfilesyncfile-args-options) remain the contract.

The regression suite also checks merged-environment selection, the configured minimum, explicit precedence, invalid values, fractional rounding, and successful output. Environment-budget proof uses real 30-second timers without compression.

<details>
<summary>Standalone proof driver</summary>

Save as `/tmp/clawsweeper-github-cli-proof.mjs` and run against a built checkout on Linux with `/usr/bin/gh` installed.

```js
import assert from 'node:assert/strict';
import { fork } from 'node:child_process';
import fs from 'node:fs/promises';
import http from 'node:http';
import os from 'node:os';
import path from 'node:path';
import { fileURLToPath, pathToFileURL } from 'node:url';
import { once } from 'node:events';
import { setTimeout as delay } from 'node:timers/promises';
const self = fileURLToPath(import.meta.url);
const [mode, checkout, variant] = process.argv.slice(2);
if (mode === 'fixture') {
  const server = http.createServer((req,res) => {
    process.send({event:'request',path:req.url});
    res.on('close',()=>{if(!res.writableFinished)process.send({event:'aborted',path:req.url})});
    if(req.url === '/hang')return;
    res.writeHead(req.url === '/error' ? 503 : 200, {'content-type':'application/json'});
    res.end(JSON.stringify(req.url === '/error' ? {message:'synthetic failure'} : {login:'synthetic-user'}));
  });
  server.listen(0,'127.0.0.1',()=>process.send({event:'ready',port:server.address().port}));
} else if (mode === 'call') {
  const [method, optionsJson, endpoint] = process.argv.slice(4);
  const api = await import(pathToFileURL(path.join(checkout,'dist/repair/github-cli.js')));
  const options = {...JSON.parse(optionsJson),cwd:checkout};
  const started = performance.now();
  let result;
  try {
    const value = await api[method](['api',endpoint,'--jq','.login'],options);
    result = method === 'ghSpawn' ? {status:value.status,stdout:String(value.stdout).trim(),code:value.error?.code,signal:value.signal} : {stdout:value};
  } catch (error) {
    result = {code:error.code??null,status:error.status??null,killed:error.killed===true,signal:error.signal??null};
  }
  process.send({...result,elapsedMs:Math.round(performance.now()-started)},()=>process.exit(0));
} else {
  assert.equal(mode,'run');assert.ok(['baseline','original-env','candidate','merged'].includes(variant));
  const scratch = await fs.mkdtemp(path.join(os.tmpdir(),'gh-deadline-'));
  const env={PATH:process.env.PATH,HOME:scratch,GH_CONFIG_DIR:path.join(scratch,'gh'),GH_BIN:'/usr/bin/gh',GH_BIN_ARGS:'[]',GH_TOKEN:'synthetic-fixture-token',GH_PROMPT_DISABLED:'1',NO_COLOR:'1'};
  const fixture=fork(self,['fixture'],{env,stdio:['ignore','ignore','ignore','ipc']});
  let requests=0,aborted=0;
  fixture.on('message',m=>{if(m.event==='request')requests++;if(m.event==='aborted')aborted++});
  const [{port}]=await once(fixture,'message');
  const evidence={variant,node:process.version,gh:'/usr/bin/gh',cases:[]};
  const groups=[];
  async function call(method,options,route,ambient={},watchdog=5000,expectWatchdog=false) {
    const beforeRequests=requests,beforeAborted=aborted;
    const child=fork(self,['call',checkout,method,JSON.stringify(options),`http://127.0.0.1:${port}${route}`],{env:{...env,...ambient},detached:true,stdio:['ignore','ignore','pipe','ipc']});
    groups.push(child.pid);let stderr='';child.stderr.on('data',b=>stderr+=b);
    const result=await new Promise((resolve,reject)=>{
      const timer=setTimeout(()=>{
        try{process.kill(-child.pid,'SIGKILL')}catch{}
        expectWatchdog ? resolve({watchdog:true}) : reject(new Error(`external watchdog for ${method}: ${stderr}`));
      },watchdog);
      child.once('message',m=>{clearTimeout(timer);resolve(m)});
      child.once('error',e=>{clearTimeout(timer);reject(e)});
      child.once('exit',(code,signal)=>{if(code && signal!=='SIGKILL'){clearTimeout(timer);reject(new Error(`driver failed: ${stderr}`))}});
    });
    assert.equal(requests,beforeRequests+1,'real gh must reach the HTTP fixture exactly once');
    if(route==='/hang') {
      for(let i=0;i<80&&aborted===beforeAborted;i++)await delay(25);
      assert.equal(aborted,beforeAborted+1,'the upstream connection must close');
    }
    return {...result,upstreamClosed:route==='/hang'?true:undefined};
  }
  try {
    assert.equal((await call('ghText',{timeoutMs:2000},'/ok')).stdout,'synthetic-user');
    if(variant==='baseline') {
      const result=await call('ghText',{timeoutMs:250},'/hang',{},1200,true);
      assert.equal(result.watchdog,true);evidence.cases.push({method:'ghText',expectedMs:250,stillPendingAtMs:1200,...result});
    } else if(variant==='original-env') {
      const result=await call('ghTextAsync',{env:{CLAWSWEEPER_GH_COMMAND_TIMEOUT_MS:'30000'}},'/hang',{CLAWSWEEPER_GH_COMMAND_TIMEOUT_MS:'90000'},31500,true);
      assert.equal(result.watchdog,true);evidence.cases.push({case:'per-call-gh-env',expectedMs:30000,stillPendingAtMs:31500,...result});
    } else {
      for(const method of ['ghText','ghTextAsync','ghSpawn']) {
        const result=await call(method,{timeoutMs:250},'/hang');
        assert.ok(result.code==='ETIMEDOUT'||(result.killed&&result.signal==='SIGTERM'));
        assert.ok(result.elapsedMs>=200&&result.elapsedMs<2000);
        evidence.cases.push({method,...result});
        assert.equal((await call(method,{timeoutMs:2000},'/ok')).stdout,'synthetic-user');
      }
      for(const variable of ['CLAWSWEEPER_GH_COMMAND_TIMEOUT_MS','CLAWSWEEPER_NETWORK_COMMAND_TIMEOUT_MS']) {
        const result=await call('ghTextAsync',{env:{[variable]:'30000'}},'/hang',{[variable]:'90000'},35000);
        assert.equal(result.killed,true);assert.equal(result.signal,'SIGTERM');
        assert.ok(result.elapsedMs>=29500&&result.elapsedMs<34000);
        evidence.cases.push({case:variable,...result});
      }
      assert.equal((await call('ghText',{timeoutMs:2000},'/error')).status,1);
      evidence.cases.push({case:'http-error',status:1},{case:'healthy-after-each-helper',stdout:'synthetic-user'});
    }
    console.log(JSON.stringify(evidence));
  } finally {
    for(const pid of groups){try{process.kill(-pid,'SIGKILL')}catch{}}
    fixture.kill('SIGTERM');await once(fixture,'exit');
    await fs.rm(scratch,{recursive:true,force:true});
  }
}
```

</details>
