### PR TITLE
fix(review): support Git null device on Windows

### DIFF
--- a/src/pr-review-evidence.ts
+++ b/src/pr-review-evidence.ts
@@ -7,6 +7,9 @@ import type { ItemContext } from "./clawsweeper-types.js";
 const OBJECT_ID = /^[0-9a-f]{40}(?:[0-9a-f]{24})?$/;
 const MAX_FILES = 80;
 const MAX_PATCH_CHARS = 24_000;
+// Git for Windows accepts the DOS device spelling but rejects Node's `\\\\.\\nul`
+// spelling when it is supplied through GIT_CONFIG_GLOBAL.
+const gitNullDevice = process.platform === "win32" ? "NUL" : devNull;
 
 type MergeBase =
   | { status: "verified"; sha: string }
@@ -88,7 +91,7 @@ export function readReviewGit(
       "-c",
       "core.fsmonitor=false",
       "-c",
-      "core.hooksPath=" + devNull,
+      "core.hooksPath=" + gitNullDevice,
       "-c",
       "diff.external=",
       ...args,
@@ -111,14 +114,14 @@ export function readReviewGit(
             }
           : {
               GIT_CONFIG_NOSYSTEM: "1",
-              GIT_CONFIG_GLOBAL: devNull,
+              GIT_CONFIG_GLOBAL: gitNullDevice,
               GIT_ATTR_NOSYSTEM: "1",
             }),
         GIT_NO_LAZY_FETCH: "1",
         GIT_OPTIONAL_LOCKS: "0",
         GIT_NO_REPLACE_OBJECTS: "1",
         // Legacy graft files alter ancestry independently of replacement refs.
-        GIT_GRAFT_FILE: devNull,
+        GIT_GRAFT_FILE: gitNullDevice,
         GIT_TERMINAL_PROMPT: "0",
         GIT_LFS_SKIP_SMUDGE: "1",
       },

--- a/test/pr-review-evidence.test.ts
+++ b/test/pr-review-evidence.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { readReviewGit } from "../dist/pr-review-evidence.js";
+
+test("readReviewGit keeps raw reads isolated with a Git-compatible null device", () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-review-git-"));
+  const repo = join(root, "repo");
+  const malformedGlobalConfig = join(root, "malformed-global.gitconfig");
+  const previousGlobalConfig = process.env.GIT_CONFIG_GLOBAL;
+  try {
+    execFileSync("git", ["init", "-q", repo], { stdio: "pipe" });
+    writeFileSync(malformedGlobalConfig, "[broken\n");
+    process.env.GIT_CONFIG_GLOBAL = malformedGlobalConfig;
+
+    const output = readReviewGit(repo, ["rev-parse", "--is-inside-work-tree"]);
+
+    assert.equal(output?.toString("utf8").trim(), "true");
+    assert.equal(process.env.GIT_CONFIG_GLOBAL, malformedGlobalConfig);
+  } finally {
+    if (previousGlobalConfig === undefined) delete process.env.GIT_CONFIG_GLOBAL;
+    else process.env.GIT_CONFIG_GLOBAL = previousGlobalConfig;
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Fixes native Windows local committed-range review after hardened Git reads were introduced. The hardened reader now uses Git-for-Windows' `NUL` device spelling on Windows and retains Node's `os.devNull` value on POSIX.

## Problem

Node 24 reports `os.devNull` as `\\\\.\\nul` on Windows. Git for Windows 2.52 rejects that spelling when it is supplied through `GIT_CONFIG_GLOBAL`, so `readReviewGit` failed before the trusted-input scanner could infer the local range.

## Implementation

- Add one platform-aware `gitNullDevice` value in `src/pr-review-evidence.ts`.
- Use it for the hardened reader's existing `core.hooksPath`, `GIT_CONFIG_GLOBAL`, and `GIT_GRAFT_FILE` null-device targets.
- Preserve every existing isolation flag, scanner path, hosted workflow, and platform policy.
- Add a focused regression test that supplies a malformed inherited global config, verifies the child raw Git read still succeeds, and confirms the parent environment is unchanged.

## Platform classification

This is a category-1 product/runtime defect in native Windows local review only. It is not a hosted-workflow or repository-wide cross-platform CI change. POSIX keeps its previous `/dev/null` behavior.

## Validation

- Native Windows (Node v24.13.0, Git for Windows 2.52.0): `pnpm run build`, `node --test test/pr-review-evidence.test.ts`, and an independent raw `readReviewGit` invocation passed. Direct Git reproduction showed `GIT_CONFIG_GLOBAL=NUL` succeeds while `GIT_CONFIG_GLOBAL=\\\\.\\nul` fails with `fatal: unable to access '\\\\.\\nul': Invalid argument`.
- `pnpm run build:all` passed.
- `pnpm exec oxlint src/pr-review-evidence.ts --tsconfig tsconfig.json --type-aware --deny-warnings --report-unused-disable-directives -D correctness -D preserve-caught-error` passed.
- `pnpm exec oxlint test/pr-review-evidence.test.ts --deny-warnings --report-unused-disable-directives -D correctness -D preserve-caught-error` passed.
- `pnpm exec oxfmt --check src/pr-review-evidence.ts test/pr-review-evidence.test.ts` and `git diff --check origin/main...HEAD` passed.
- `pnpm run review -- --local-range --target-repo openclaw/clawsweeper --base origin/main` completed locally for the one committed range: `decision=keep_open`, `confidence=high`.
- Codex dirty-patch review and committed-range review against `origin/main` found no actionable issues.

## Real Behavior Proof

Claim: hardened raw Git reads work on native Windows without weakening isolation, and POSIX retains its null-device behavior.

Surface/scenario: a malformed inherited `GIT_CONFIG_GLOBAL` would normally make Git fail; the reader must provide its own compatible null device for raw reads. The focused test creates a temporary Git repository, sets a malformed parent global config, calls `readReviewGit(..., ["rev-parse", "--is-inside-work-tree"])`, and checks both successful output and parent-env preservation.

Native trace: Windows Node v24.13.0 / Git for Windows 2.52.0 ran the focused test successfully. Independent device experiment: `GIT_CONFIG_GLOBAL=NUL` returned `true` with exit 0; `GIT_CONFIG_GLOBAL=\\\\.\\nul` exited 128 with Git's invalid-argument error.

Hosted POSIX trace: Crabbox AWS/Linux run `run_1a8c9178a38a`, lease `cbx_8b6e29cb4336` (`crimson-shrimp`), c7a.8xlarge, promoted AMI `ami-0461d919be7deb53c` in eu-west-1. The exact two-file dirty worktree was synced (`dirty_delta=2`) with `--no-hydrate`; remote command was `corepack enable && pnpm install --frozen-lockfile`, `pnpm run build`, then `node --test test/pr-review-evidence.test.ts`. Exit 0; frozen install, build, and the one POSIX test passed. Timing JSON: lease 58.289s, sync 18.281s, command 11.278s, total 31.590s, end-to-end 90.854s. Crabbox reported `leaseStopped=true`; a subsequent lease listing did not contain `cbx_8b6e29cb4336`.

Limits: the hosted run proves retained POSIX behavior, while the focused native test and direct Git experiment prove the Windows device contract. The broader native unit fixtures still contain unrelated direct uses of Node's Windows null-device spelling; this change intentionally does not expand into those separate surfaces.

## Risk and rollout

Low risk: the patch changes only the spelling passed to the already-hardened reader on Windows. It does not alter source validation, network isolation, scanner behavior, hosted workflows, or platform policy. User-visible outcome is that local committed-range review can progress to the scanner/model phases on native Windows.

Related: CSW-143 and CSW-145 were blocked by this independent local-review regression.
