### PR TITLE
fix(webhook): abort hung GitHub API fetches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Bound standalone webhook GitHub requests to 15 seconds, including response bodies, so stalled calls return a retryable response. Thanks @SebTardif.
 - Completed obsolete exact-review publications when apply verifies a strictly newer durable review for the same revision, preserving retry behavior for unproven results. Thanks @vincentkoc. (#1249)
 
 - Preserved owed source-drift reviews when completion callbacks are lost, and distinguished queue-completion failures from review failures. Thanks @yetval. (#1251)

--- a/docs/repair/operations.md
+++ b/docs/repair/operations.md
@@ -356,6 +356,14 @@ The target workflow remains a compatibility fallback when the webhook service
 is down or not installed for a repository; its direct event is bridged into the
 same queue.
 
+The standalone `repair:comment-webhook` listener limits each GitHub REST request,
+including reading its response body, to 15 seconds. A stalled request returns
+HTTP 503 with `retryable: true`; successful requests keep the existing response.
+This per-request deadline does not bound the total duration of a command that
+makes several GitHub requests. GitHub does not automatically redeliver failed
+webhooks; its delivery response window is 10 seconds, so this deadline bounds
+listener resources rather than guaranteeing delivery acknowledgment.
+
 Supported triggers:
 
 ```text

--- a/src/repair/comment-webhook.ts
+++ b/src/repair/comment-webhook.ts
@@ -21,6 +21,7 @@ import { directReReviewIntake } from "./direct-re-review-admission.js";
 import { postExactReviewCommandIntake } from "./exact-review-command-queue.js";
 
 const DEFAULT_PORT = 8787;
+const GITHUB_FETCH_TIMEOUT_MS = 15_000;
 const REVIEW_REPO = "openclaw/clawsweeper";
 const COMMAND_PATTERN =
   /(^|[ \t\r\n])@(?:clawsweeper|openclaw-clawsweeper)\b(?:\[bot\])?|(^|[ \t\r\n])\/(?:clawsweeper|review|re-review|rerun[ -]?review|status|explain|fix|build|implement|create[ -]?pr|fix[ -]?issue|autofix|auto[ -]?fix|automerge|auto[ -]?merge|approve|stop|autoclose)\b/i;
@@ -899,6 +900,7 @@ async function githubFetch({
       "user-agent": "clawsweeper-comment-webhook",
       "x-github-api-version": "2022-11-28",
     },
+    signal: AbortSignal.timeout(GITHUB_FETCH_TIMEOUT_MS),
   };
   if (body !== undefined) init.body = JSON.stringify(body);
   const response = await fetch(`https://api.github.com${path}`, init);

--- a/test/repair/comment-webhook.test.ts
+++ b/test/repair/comment-webhook.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import crypto from "node:crypto";
+import http from "node:http";
 import test from "node:test";
 
 import {
@@ -769,7 +770,7 @@ test("concurrent duplicate command webhooks converge on one fast ack comment", a
   const dispatchBodies: Array<Record<string, unknown>> = [];
   process.env.CLAWSWEEPER_APP_ID = "12345";
   delete process.env.CLAWSWEEPER_APP_CLIENT_ID;
-  process.env.CLAWSWEEPER_FAST_ACK_SETTLE_DELAYS_MS = "0,0,0";
+  process.env.CLAWSWEEPER_FAST_ACK_SETTLE_DELAYS_MS = "0";
   process.env.CLAWSWEEPER_APP_PRIVATE_KEY = privateKey
     .export({ type: "pkcs1", format: "pem" })
     .toString();
@@ -884,6 +885,7 @@ test("comment webhook settles duplicate fast ack comments after dispatch", async
   const previousAppId = process.env.CLAWSWEEPER_APP_ID;
   const previousClientId = process.env.CLAWSWEEPER_APP_CLIENT_ID;
   const previousPrivateKey = process.env.CLAWSWEEPER_APP_PRIVATE_KEY;
+  const previousSettleDelays = process.env.CLAWSWEEPER_FAST_ACK_SETTLE_DELAYS_MS;
   const { privateKey } = crypto.generateKeyPairSync("rsa", { modulusLength: 2048 });
   let commentLookups = 0;
   let deletedAck = 0;
@@ -893,6 +895,7 @@ test("comment webhook settles duplicate fast ack comments after dispatch", async
   });
   process.env.CLAWSWEEPER_APP_ID = "12345";
   delete process.env.CLAWSWEEPER_APP_CLIENT_ID;
+  process.env.CLAWSWEEPER_FAST_ACK_SETTLE_DELAYS_MS = "0";
   process.env.CLAWSWEEPER_APP_PRIVATE_KEY = privateKey
     .export({ type: "pkcs1", format: "pem" })
     .toString();
@@ -912,7 +915,7 @@ test("comment webhook settles duplicate fast ack comments after dispatch", async
     }
     if (path.startsWith("/repos/openclaw/openclaw/issues/71898/comments?") && method === "GET") {
       commentLookups += 1;
-      if (commentLookups <= 2) {
+      if (commentLookups === 1) {
         return jsonResponse([
           {
             id: 9001,
@@ -979,12 +982,15 @@ test("comment webhook settles duplicate fast ack comments after dispatch", async
 
     assert.deepEqual(result, { statusCode: 202, body: { ok: true, status_comment_id: 9001 } });
     await deleted;
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(commentLookups, 2);
     assert.equal(deletedAck, 9001);
   } finally {
     globalThis.fetch = previousFetch;
     restoreEnv("CLAWSWEEPER_APP_ID", previousAppId);
     restoreEnv("CLAWSWEEPER_APP_CLIENT_ID", previousClientId);
     restoreEnv("CLAWSWEEPER_APP_PRIVATE_KEY", previousPrivateKey);
+    restoreEnv("CLAWSWEEPER_FAST_ACK_SETTLE_DELAYS_MS", previousSettleDelays);
   }
 });
 
@@ -998,6 +1004,99 @@ test("webhook signature verification uses sha256 body hmac", () => {
     () => verifyGitHubSignature({ secret, signature: "sha256=bad", body }),
     /invalid GitHub webhook signature/,
   );
+});
+
+test("webhook GitHub requests have a deadline through the response body", async (t) => {
+  const previousFetch = globalThis.fetch;
+  const previousTimeout = AbortSignal.timeout;
+  for (const name of [
+    "CLAWSWEEPER_APP_ID",
+    "CLAWSWEEPER_APP_CLIENT_ID",
+    "CLAWSWEEPER_APP_PRIVATE_KEY",
+  ]) {
+    const previous = process.env[name];
+    t.after(() => restoreEnv(name, previous));
+  }
+  process.env.CLAWSWEEPER_APP_ID = "12345";
+  delete process.env.CLAWSWEEPER_APP_CLIENT_ID;
+  process.env.CLAWSWEEPER_APP_PRIVATE_KEY = crypto
+    .generateKeyPairSync("rsa", { modulusLength: 2048 })
+    .privateKey.export({ type: "pkcs1", format: "pem" })
+    .toString();
+
+  let mode = "success";
+  let calls = 0;
+  const server = http.createServer((request, response) => {
+    calls++;
+    if (mode === "headers") return;
+    response.writeHead(200, { "content-type": "application/json" });
+    if (mode === "body") {
+      response.write('{"id":');
+      return;
+    }
+    response.end(
+      JSON.stringify(
+        request.url?.endsWith("/installation")
+          ? { id: 999 }
+          : request.url?.endsWith("/access_tokens")
+            ? { token: "synthetic-token" }
+            : {},
+      ),
+    );
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  t.after(
+    () =>
+      new Promise<void>((resolve) => {
+        server.closeAllConnections();
+        server.close(() => resolve());
+      }),
+  );
+  const address = server.address();
+  assert.ok(address && typeof address !== "string");
+  t.mock.method(globalThis, "fetch", (input: string | URL | Request, init?: RequestInit) => {
+    const url = new URL(String(input));
+    assert.equal(url.origin, "https://api.github.com");
+    return previousFetch(`http://127.0.0.1:${address.port}${url.pathname}`, init);
+  });
+  t.mock.method(AbortSignal, "timeout", (ms: number) => {
+    assert.equal(ms, 15_000);
+    return previousTimeout(mode === "success" ? 2_000 : 50);
+  });
+
+  for (mode of ["success", "headers", "body"]) {
+    await t.test(mode, { timeout: 3_000 }, async () => {
+      calls = 0;
+      const result = handleGitHubWebhook({
+        event: "pull_request",
+        payload: {
+          action: "opened",
+          repository: {
+            full_name: "openclaw/openclaw",
+            default_branch: "main",
+            private: false,
+            archived: false,
+            fork: false,
+            has_issues: true,
+          },
+          pull_request: { number: 91095, head: { sha: "e".repeat(40) } },
+          installation: { id: 123 },
+        },
+      });
+      if (mode === "success") {
+        assert.deepEqual(await result, {
+          statusCode: 202,
+          body: { ok: true, dispatched: "clawsweeper_item" },
+        });
+        assert.equal(calls, 3);
+      } else {
+        await assert.rejects(result, (error: Error) =>
+          /^(AbortError|TimeoutError)$/.test(error.name),
+        );
+        assert.equal(calls, 1);
+      }
+    });
+  }
 });
 
 function jsonResponse(value: unknown) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the standalone `repair:comment-webhook` listener keeps a GitHub REST request open without an application deadline when the upstream connection or response body stalls.

## Why This Change Was Made

The shared GitHub REST wrapper now uses `AbortSignal.timeout(15_000)`, including while it reads the response body. Node owns cancellation; the existing HTTP error handler returns `{ "ok": false, "retryable": true }` with status 503. No custom retry or timer-management layer is added.

The native HTTP regression cases share one fixture. Adjacent fast-ack tests now finish one explicit cleanup pass before restoring their fetch mocks, eliminating background requests that were leaking into later tests.

Provenance: the unbounded wrapper was added in [09d81b5f3e](https://github.com/openclaw/clawsweeper/commit/09d81b5f3e), verified against its raw parent `42a9511db6eb5e9d3e0919a7d050b39772e6942b`. Thanks @SebTardif for the original centralized fix.

## User Impact

Each standalone-listener GitHub REST call releases stalled work after 15 seconds. Normal installation lookup, token creation, and dispatch keep their 202 success behavior. This is a per-request resource bound, not a total webhook deadline.

GitHub allows 10 seconds for a delivery response and does not automatically redeliver failed deliveries. This fix does not promise automatic redelivery or acknowledgment within that window; existing recovery producers remain responsible for missed intake. [GitHub delivery documentation](https://docs.github.com/en/webhooks/using-webhooks/handling-failed-webhook-deliveries)

## OpenClaw Bay Impact

Unaffected: this changes the standalone Node webhook listener, not the dashboard Worker's webhook ingress or Bay's observer-only projection. It does not change the Durable Object queue or address its intermittent backend 500s.

## Documentation Impact

Updated the active `docs/repair/operations.md` runbook with the per-request deadline, response-body coverage, and delivery limits. Added a changelog entry with contributor credit.

## Evidence

The focused suite passed all 31 tests, and `pnpm run check` passed on the exact candidate tree `5a1a28cd10de22d0eca36bad8bf0121d651537a9` (commit `252ab4dff5ce89fdf8dbbd1f4fc75fdb7988bef9`). Codex pre-commit review found no actionable findings at the required P0 scope.

A controlled native HTTP proof exercised the compiled production server through signed `POST /github/webhook` requests. Only the GitHub origin was redirected to a local fixture; native fetch, AbortSignal, streaming response reads, and the real 15-second deadline remained unchanged.

## Real Behavior Proof

- **Environment:** secretless AWS Crabbox `cbx_609258d19be1`, Linux, Node 24.18.1, pinned pnpm 11.10.0. No instance role, Tailscale, hydration, live GitHub credentials, or GitHub mutations.
- **Base:** `ddc75603add72a4b8dcd1a23d2497b1c8f1d178b`. The same fixture still had an outstanding upstream request when the external client watchdog stopped waiting at 17,002 ms.
- **Candidate:** a header stall returned 503 in 15,004 ms; a partial-body stall returned 503 in 15,003 ms. Both closed the upstream connection. A normal signed request returned 202 with exactly three fixture calls after each failure. Invalid HMAC returned 400 without an upstream call.
- **Commands:** `pnpm run build:all`; `node /tmp/clawsweeper-webhook-proof.mjs "$PWD" baseline` on the base; the same command with `candidate` after applying the patch; `node --test test/repair/comment-webhook.test.ts`; `pnpm run check`.
- **Limits:** controlled failure injection, not a live GitHub outage. The standalone webhook service was not deployed by this proof. Windows and automatic redelivery are not claimed.

The complete standalone driver below can be saved as `/tmp/clawsweeper-webhook-proof.mjs` and run against a built checkout. The unit regression compresses the deadline for speed; the HTTP proof above does not.

<details>
<summary>Reproducible native HTTP proof driver</summary>

```js
import assert from 'node:assert/strict';
import crypto from 'node:crypto';
import http from 'node:http';
import { spawn } from 'node:child_process';
import { once } from 'node:events';
import fs from 'node:fs/promises';
import os from 'node:os';
import path from 'node:path';
import { setTimeout as delay } from 'node:timers/promises';

const [checkout, variant] = process.argv.slice(2);
assert.ok(checkout && ['baseline', 'candidate', 'merged'].includes(variant));
const scratch = await fs.mkdtemp(path.join(os.tmpdir(), 'webhook-deadline-'));
let mode = 'success', calls = [], aborted = 0;
const fixture = http.createServer((req, res) => {
  calls.push(`${req.method} ${req.url}`);
  res.on('close', () => { if (!res.writableFinished) aborted++; });
  if (mode === 'headers') return;
  res.writeHead(200, {'content-type': 'application/json'});
  if (mode === 'body') { res.write('{"id":'); return; }
  const payload = req.url === '/repos/openclaw/clawsweeper/installation' ? {id: 999}
    : req.url === '/app/installations/999/access_tokens' ? {token: 'synthetic-dispatch-token'}
    : req.url === '/repos/openclaw/clawsweeper/dispatches' ? {} : null;
  assert.notEqual(payload, null, `unexpected fixture URL ${req.url}`);
  res.end(JSON.stringify(payload));
});
fixture.listen(0, '127.0.0.1'); await once(fixture, 'listening');
const probe = http.createServer(); probe.listen(0, '127.0.0.1'); await once(probe, 'listening');
const port = probe.address().port; await new Promise(r => probe.close(r));
const preload = path.join(scratch, 'redirect.mjs');
await fs.writeFile(preload, `const nativeFetch=globalThis.fetch; globalThis.fetch=(input,init)=>{const url=new URL(String(input));if(url.origin!=="https://api.github.com")throw new Error("unexpected outbound origin");url.protocol="http:";url.hostname="127.0.0.1";url.port="${fixture.address().port}";return nativeFetch(url,init)};`);
const {privateKey} = crypto.generateKeyPairSync('rsa', {modulusLength: 2048});
const secret = 'synthetic-webhook-proof-secret';
const child = spawn(process.execPath, ['--import', preload, path.join(checkout, 'dist/repair/comment-webhook.js')], {
  cwd: checkout, env: {PATH: process.env.PATH, HOME: scratch, PORT: String(port),
    CLAWSWEEPER_WEBHOOK_SECRET: secret, CLAWSWEEPER_APP_ID: '12345',
    CLAWSWEEPER_APP_PRIVATE_KEY: privateKey.export({type: 'pkcs1', format: 'pem'}).toString()},
  stdio: ['ignore', 'pipe', 'pipe'],
});
let output = ''; child.stdout.on('data', chunk => output += chunk); child.stderr.on('data', () => {});
const payload = JSON.stringify({action: 'opened', repository: {full_name: 'openclaw/openclaw', default_branch: 'main', private: false, archived: false, fork: false, has_issues: true}, pull_request: {number: 91095, head: {sha: 'e'.repeat(40)}}, installation: {id: 123}});
const signature = 'sha256=' + crypto.createHmac('sha256', secret).update(payload).digest('hex');
async function request(signatureValue = signature, budget = 23000) {
  return fetch(`http://127.0.0.1:${port}/github/webhook`, {method: 'POST', headers: {'x-github-event': 'pull_request', 'x-hub-signature-256': signatureValue}, body: payload, signal: AbortSignal.timeout(budget)});
}
async function success() {
  mode = 'success'; calls = [];
  const response = await request(); assert.equal(response.status, 202);
  assert.deepEqual(await response.json(), {ok: true, dispatched: 'clawsweeper_item'});
  assert.deepEqual(calls, ['GET /repos/openclaw/clawsweeper/installation', 'POST /app/installations/999/access_tokens', 'POST /repos/openclaw/clawsweeper/dispatches']);
}
const evidence = {variant, node: process.version, assertions: []};
try {
  for (let i = 0; i < 100 && !output.includes('listening on'); i++) await delay(50);
  assert.match(output, /listening on/);
  await success(); evidence.assertions.push({case: 'success', status: 202, upstreamCalls: 3});
  calls = [];
  const invalid = await request('sha256=' + '0'.repeat(64)); assert.equal(invalid.status, 400); await invalid.text(); assert.equal(calls.length, 0);
  evidence.assertions.push({case: 'invalid-signature', status: 400, upstreamCalls: 0});
  for (const stall of variant === 'baseline' ? ['headers'] : ['headers', 'body']) {
    mode = stall; calls = []; const beforeAbort = aborted, started = performance.now();
    if (variant === 'baseline') {
      await assert.rejects(request(signature, 17000), {name: 'TimeoutError'});
      assert.equal(aborted, beforeAbort); assert.equal(calls.length, 1);
      evidence.assertions.push({case: stall, result: 'still pending at external watchdog', elapsedMs: Math.round(performance.now() - started)});
    } else {
      const response = await request(); const elapsedMs = Math.round(performance.now() - started);
      assert.equal(response.status, 503); assert.deepEqual(await response.json(), {ok: false, retryable: true});
      assert.ok(elapsedMs >= 14500 && elapsedMs < 21000, `unexpected deadline ${elapsedMs}`);
      for (let i = 0; i < 40 && aborted === beforeAbort; i++) await delay(25);
      assert.equal(aborted, beforeAbort + 1); assert.equal(calls.length, 1);
      evidence.assertions.push({case: stall, status: 503, elapsedMs, upstreamClosed: true});
      await success(); evidence.assertions.push({case: `recovery-after-${stall}`, status: 202, upstreamCalls: 3});
    }
  }
  console.log(JSON.stringify(evidence));
} finally {
  child.kill('SIGTERM'); await once(child, 'exit');
  fixture.closeAllConnections(); await new Promise(r => fixture.close(r));
  await fs.rm(scratch, {recursive: true, force: true});
}
```

</details>
