### PR TITLE
feat: add OrcaRouter as a built-in OpenClaw provider

### DIFF
--- a/docs/repair/operations.md
+++ b/docs/repair/operations.md
@@ -248,12 +248,15 @@ otherwise ClawSweeper runs `openclaw` from `PATH`.
 Providers that are not bundled with OpenClaw can be supplied through
 `CLAWSWEEPER_OPENCLAW_PROVIDERS_JSON`, a JSON object merged into
 `models.providers`; referenced provider API-key environment variables must also
-be present. Three providers ship as built-in defaults and need only their API key
+be present. Four providers ship as built-in defaults and need only their API key
 in the environment: `kimi/…` (Kimi Code endpoint, `KIMI_API_KEY`; models
 `kimi-for-coding` and `k3`), `cerebras/…` (Cerebras Code plans,
 `CEREBRAS_API_KEY`; model `zai-glm-4.7` until Cerebras retires it on
-2026-08-17), and `zai/…` (Z.AI GLM Coding Plan endpoint, `ZAI_API_KEY`;
-model `glm-5.2` — plan keys only work on the coding endpoint). The subprocess environment is deny-by-default: only the base OS
+2026-08-17), `zai/…` (Z.AI GLM Coding Plan endpoint, `ZAI_API_KEY`;
+model `glm-5.2` — plan keys only work on the coding endpoint), and
+`orcarouter/…` (OrcaRouter OpenAI-compatible gateway, `ORCAROUTER_API_KEY`;
+model `orcarouter/auto`, written `orcarouter/orcarouter/auto` because the
+catalog id keeps the `orcarouter/` prefix). The subprocess environment is deny-by-default: only the base OS
 surface, `OPENCLAW_*` controls, proxy settings, and known provider API keys
 reach the agent. ClawSweeper gives OpenClaw a fresh state directory, a coding tool
 profile limited to the target workspace, and the lane's existing timeout and

--- a/src/openclaw-process.ts
+++ b/src/openclaw-process.ts
@@ -416,6 +416,7 @@ const OPENCLAW_CHILD_ENV_ALLOWLIST = [
   "ZAI_API_KEY",
   "DEEPSEEK_API_KEY",
   "MISTRAL_API_KEY",
+  "ORCAROUTER_API_KEY",
 ] as const;
 
 function pickEnv(env: NodeJS.ProcessEnv, names: readonly string[]): NodeJS.ProcessEnv {
@@ -464,6 +465,19 @@ const BUILTIN_PROVIDERS = {
     apiKey: "${ZAI_API_KEY}",
     api: "openai-completions",
     models: [{ id: "glm-5.2", name: "GLM-5.2", contextWindow: 1000000, maxTokens: 131072 }],
+  },
+  // OrcaRouter is an OpenAI-compatible gateway that auto-routes each request to
+  // a fitting upstream model; the `orcarouter/auto` virtual model picks the
+  // upstream on every call. Validated live 2026-08-30: chat/completions returns
+  // 200 with tool calls and maxTokens up to 131072. Catalog ids keep the
+  // `orcarouter/` prefix, so the ref is `orcarouter/orcarouter/auto`.
+  orcarouter: {
+    baseUrl: "https://api.orcarouter.ai/v1",
+    apiKey: "${ORCAROUTER_API_KEY}",
+    api: "openai-completions",
+    models: [
+      { id: "orcarouter/auto", name: "OrcaRouter Auto", contextWindow: 128000, maxTokens: 131072 },
+    ],
   },
 } as const;
 

--- a/test/openclaw-process.test.ts
+++ b/test/openclaw-process.test.ts
@@ -29,6 +29,7 @@ const record = {
     CLAWSWEEPER_APP_PRIVATE_KEY: process.env.CLAWSWEEPER_APP_PRIVATE_KEY ?? null,
     KIMI_API_KEY: process.env.KIMI_API_KEY ?? null,
     OPENAI_API_KEY: process.env.OPENAI_API_KEY ?? null,
+    ORCAROUTER_API_KEY: process.env.ORCAROUTER_API_KEY ?? null,
   },
 };
 fs.writeFileSync(process.env.OPENCLAW_TEST_RECORD, JSON.stringify(record));
@@ -560,6 +561,7 @@ test("OpenClaw subprocess env strips workflow credentials and keeps provider key
         CLAWSWEEPER_WEBHOOK_SECRET: "workflow-webhook",
         CLAWSWEEPER_APP_PRIVATE_KEY: "workflow-app",
         KIMI_API_KEY: "provider-kimi",
+        ORCAROUTER_API_KEY: "provider-orcarouter",
       },
       timeoutMs: 60_000,
     });
@@ -570,6 +572,7 @@ test("OpenClaw subprocess env strips workflow credentials and keeps provider key
     assert.equal(record.env.CLAWSWEEPER_WEBHOOK_SECRET, null);
     assert.equal(record.env.CLAWSWEEPER_APP_PRIVATE_KEY, null);
     assert.equal(record.env.KIMI_API_KEY, "provider-kimi");
+    assert.equal(record.env.ORCAROUTER_API_KEY, "provider-orcarouter");
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -641,6 +644,49 @@ test("OpenClaw zai models get built-in Coding Plan endpoint defaults", () => {
           apiKey: "${ZAI_API_KEY}",
           api: "openai-completions",
           models: [{ id: "glm-5.2", name: "GLM-5.2", contextWindow: 1000000, maxTokens: 131072 }],
+        },
+      },
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("OpenClaw orcarouter models get built-in gateway defaults", () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-openclaw-test-"));
+  const recordPath = join(root, "record.json");
+  const binary = fakeOpenclaw(root);
+  try {
+    const result = runOpenclawProcess({
+      label: "orcarouter-defaults",
+      prompt: "hi",
+      model: "orcarouter/orcarouter/auto",
+      cwd: root,
+      env: {
+        ...process.env,
+        CLAWSWEEPER_OPENCLAW_BIN: binary,
+        CLAWSWEEPER_OPENCLAW_MODEL: "orcarouter/orcarouter/auto",
+        OPENCLAW_TEST_RECORD: recordPath,
+      },
+      timeoutMs: 60_000,
+    });
+    assert.equal(result.status, 0, result.stderr);
+    const record = JSON.parse(readFileSync(recordPath, "utf8"));
+    assert.deepEqual(record.config.models, {
+      mode: "merge",
+      providers: {
+        orcarouter: {
+          baseUrl: "https://api.orcarouter.ai/v1",
+          apiKey: "${ORCAROUTER_API_KEY}",
+          api: "openai-completions",
+          models: [
+            {
+              id: "orcarouter/auto",
+              name: "OrcaRouter Auto",
+              contextWindow: 128000,
+              maxTokens: 131072,
+            },
+          ],
         },
       },
     });


### PR DESCRIPTION
## What Problem This Solves

ClawSweeper's `openclaw` agent lane ships built-in provider defaults for the
providers its maintainers want to reach without a custom
`CLAWSWEEPER_OPENCLAW_PROVIDERS_JSON`. Today those are `kimi/…`, `cerebras/…`,
and `zai/…`. An operator who wants to route review/repair inference through the
[OrcaRouter](https://www.orcarouter.ai) gateway has to hand-write a provider
block and wire the key through the OpenClaw child environment. That is exactly
the gap the existing built-in defaults close for other gateways.

## Why This Change Was Made

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents.
Like OpenRouter, it exposes a provider/model namespace across many models — but
it also combines adaptive routing, automatic failover, zero-markup inference,
observability, guardrails, and agent-tool governance behind the same endpoint.
Adding `orcarouter` as a first-class provider mirrors the existing `zai`/
`cerebras`/`kimi` built-in blocks in `src/openclaw-process.ts`, so ClawSweeper
operators can use that stack directly instead of treating OrcaRouter as an
anonymous custom base URL.

It also runs gateway-level, zero-trust security for AI agents on the same
endpoint — screening every prompt/response and governing every tool call on a
default-deny basis, with no application code changes.

Changes:

- Add an `orcarouter` entry to `BUILTIN_PROVIDERS` in `src/openclaw-process.ts`
  (`baseUrl https://api.orcarouter.ai/v1`, `api: "openai-completions"`, model
  `orcarouter/auto`), exactly parallel to the existing built-in provider blocks.
- Add `ORCAROUTER_API_KEY` to the OpenClaw child environment allowlist so the
  key reaches the embedded agent like the other provider keys.
- Add a unit test asserting the generated `models.providers.orcarouter` block
  and the key pass-through, plus the key in the fake-CLI env record.
- Update `docs/repair/operations.md` to list OrcaRouter as the fourth built-in
  default with its `orcarouter/orcarouter/auto` model reference.

Why `orcarouter/orcarouter/auto`: OrcaRouter's catalog ids keep the
`orcarouter/` prefix (for example `orcarouter/auto`, `orcarouter/fusion`), and
OpenClaw sends the model row `id` as the API `model` field, so the built-in id
is `orcarouter/auto` and the ref is the vendor-nested `orcarouter/orcarouter/auto`
— the same shape OpenClaw already supports for NVIDIA's nested ids.

## User Impact

Operators of the OpenClaw runner can set `CLAWSWEEPER_OPENCLAW_MODEL=orcarouter/orcarouter/auto`,
define an `ORCAROUTER_API_KEY` secret, and use the gateway with no
`CLAWSWEEPER_OPENCLAW_PROVIDERS_JSON` — matching the experience of the other
built-in providers. No behavior changes when the model is not `orcarouter/…`.

## Evidence

- `tsc` build, `oxlint src`, `oxfmt --check`, and `check:docs` all pass.
- `node --test test/openclaw-process.test.ts` → 13/13 pass, including the new
  `OpenClaw orcarouter models get built-in gateway defaults` and the updated
  env-allowlist assertion.
- Full `test:unit`: 2743/2766 pass; the 22 failures are environment-only
  (`tmux`/`rsync`/Crabbox missing in the container), present on the base branch
  and unrelated to this change.
- Live proof (L3): drove ClawSweeper's own `runOpenclawProcess` config path,
  confirmed the generated provider block and the `ORCAROUTER_API_KEY` env
  pass-through, then issued a real `chat/completions` request to
  `https://api.orcarouter.ai/v1` with model `orcarouter/auto` and
  `max_tokens: 131072` → HTTP 200. Request id
  `chatcmpl-20260830053229365813198268d9d6Mo6QSEIL` (redacted API key).

---

I'm an engineer on the OrcaRouter team. Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter