### PR TITLE
fix(repair): trigger applicable Telegram E2E proof

### DIFF
--- a/src/repair/fix-prompt-builder.test.ts
+++ b/src/repair/fix-prompt-builder.test.ts
@@ -112,6 +112,26 @@ test("fix prompt makes Codex own the validation loop", () => {
   assert.match(prompt, /do not report validation as passed unless it passed after your last edit/);
 });
 
+test("fix prompt routes applicable Telegram behavior through the repository skill", () => {
+  const prompt = promptFor({
+    summary: "Repair a Telegram-visible reply regression.",
+    affected_surfaces: ["extensions/telegram"],
+    likely_files: ["extensions/telegram/src/bot-message.ts"],
+    changelog_required: false,
+  });
+
+  assert.match(
+    prompt,
+    /Telegram-visible behavior: when the changed behavior is observable on Telegram's Test Server/,
+  );
+  assert.match(
+    prompt,
+    /after base sync read and use `.agents\/skills\/telegram-e2e-userbot\/SKILL.md`/,
+  );
+  assert.match(prompt, /exercise the exact changed behavior/);
+  assert.match(prompt, /extend its harness or recipes when needed/);
+});
+
 test("automerge fix prompt makes Codex own PR repair, rebase, and CI discovery", () => {
   const prompt = buildFixPrompt({
     fixArtifact: {

--- a/src/repair/fix-prompt-builder.ts
+++ b/src/repair/fix-prompt-builder.ts
@@ -50,6 +50,7 @@ export function buildFixPrompt({
     "- address review-bot concerns named in the artifact;",
     "- resolve actionable human review comments, bot comments, and requested changes named in the artifact;",
     "- fix relevant failing CI/check output named in the artifact; do not leave known changed-surface CI failures for a later pass;",
+    "- Telegram-visible behavior: when the changed behavior is observable on Telegram's Test Server, after base sync read and use `.agents/skills/telegram-e2e-userbot/SKILL.md` to exercise the exact changed behavior; extend its harness or recipes when needed;",
     isAutomergeRepair ? renderAutomergeRepairGuidance() : "",
     renderChangelogRule(fixArtifact),
     "- prepare the PR so it can pass the ClawSweeper Repair merge_preflight gate;",


### PR DESCRIPTION
## Summary

- Tell writable repair agents to use the repository Telegram E2E skill only when the changed behavior is observable on Telegram's Test Server.
- Require the agent to exercise the exact changed behavior and extend the harness when needed.
- Add focused prompt regression coverage.

## Proof

- A local ClawSweeper repair prompt selected and read `telegram-e2e-userbot`.
- The Convex-backed doctor passed and released its lease.
- The agent ran a real Test Server direct-message turn, observed the expected reply and one provider request, then released its ports and lease.

## Validation

- Focused prompt tests: 13 passed.
- Full repository validation runs in CI.
