### PR TITLE
fix(review): hosted pull request reviews fail closed before Codex runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Recover hosted PR reviews that refused `incomplete_source` by fetching reviewed-head history before the bounded base/head fallback, preserving merge-base verification and secret-scanning gates. Thanks @masatohoshino. ([#1308](https://github.com/openclaw/clawsweeper/pull/1308))
 - Stopped treating pane-local runtime state as stored data while retaining warnings for explicit persistence changes and incomplete storage patches.
 - Corrected retained terminal-proof cleanup for independent process-exit and PTY-close events, preserving the original wrapper failure and draining dead-pane capture only after verified cleanup.
 - Prevented rejected model inputs from surviving in generated prompt artifacts; retained diagnostics now follow admission with owner-only access, and unused prompt copies are no longer written.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,8 +64,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
-- Recover hosted PR reviews that refused `incomplete_source` by fetching reviewed-head history before the bounded base/head fallback, preserving merge-base verification and secret-scanning gates. Thanks @masatohoshino. ([#1308](https://github.com/openclaw/clawsweeper/pull/1308))
 - Stopped treating pane-local runtime state as stored data while retaining warnings for explicit persistence changes and incomplete storage patches.
+- Recover hosted PR reviews that refused `incomplete_source` by fetching reviewed-head history before the bounded base/head fallback, preserving merge-base verification and secret-scanning gates. Thanks @masatohoshino. ([#1308](https://github.com/openclaw/clawsweeper/pull/1308))
 - Corrected retained terminal-proof cleanup for independent process-exit and PTY-close events, preserving the original wrapper failure and draining dead-pane capture only after verified cleanup.
 - Prevented rejected model inputs from surviving in generated prompt artifacts; retained diagnostics now follow admission with owner-only access, and unused prompt copies are no longer written.
 - Provisioned pinned TruffleHog for hosted reviews and enforced complete host-owned input scans before native review or cache reuse, preserving read-only workers, proxy authentication, and redacted fail-closed errors.

--- a/src/clawsweeper-review-blobs.ts
+++ b/src/clawsweeper-review-blobs.ts
@@ -93,6 +93,30 @@ export function ensurePullRequestReviewHead({
   );
 }
 
+const REVIEW_HISTORY_DEPTH = 256;
+
+function deepenReviewHistory(targetDir: string, revisions: readonly string[]): void {
+  spawnSync(
+    "git",
+    [
+      "fetch",
+      "--filter=blob:none",
+      "--no-tags",
+      "--no-write-fetch-head",
+      "--recurse-submodules=no",
+      `--depth=${REVIEW_HISTORY_DEPTH}`,
+      "origin",
+      ...revisions,
+    ],
+    {
+      cwd: targetDir,
+      env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" },
+      stdio: "ignore",
+      timeout: 30_000,
+    },
+  );
+}
+
 export function hydratePullRequestReviewHistory(options: {
   targetDir: string;
   baseSha: string;
@@ -111,26 +135,18 @@ export function hydratePullRequestReviewHistory(options: {
   if (reviewMergeBase(targetDir, baseSha, headSha).status === "unavailable") {
     // Existing tree hydration may have fetched only the PR tip. Bound history, not
     // the reviewed identity; failure remains explicit in the local evidence reader.
-    spawnSync(
-      "git",
-      [
-        "fetch",
-        "--filter=blob:none",
-        "--no-tags",
-        "--no-write-fetch-head",
-        "--recurse-submodules=no",
-        "--depth=256",
-        "origin",
-        baseSha,
-        headSha,
-      ],
-      {
-        cwd: targetDir,
-        env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" },
-        stdio: "ignore",
-        timeout: 30_000,
-      },
-    );
+    //
+    // Deepen the reviewed head on its own first. A depth-limited fetch re-bounds the
+    // ancestry of every revision it names, so naming the pinned base here as well
+    // truncates a base branch whose history the checkout already had -- the very
+    // ancestry a merge base is found in. Only deepen the base when the head alone did
+    // not establish one, which is the case where the base is itself shallow.
+    deepenReviewHistory(targetDir, [headSha]);
+    if (reviewMergeBase(targetDir, baseSha, headSha).status === "unavailable") {
+      // Unchanged fallback: the same fetch this function has always issued, for the case
+      // where the base is itself shallow and has to be deepened to reach an ancestor.
+      deepenReviewHistory(targetDir, [baseSha, headSha]);
+    }
   }
   if (testMergeSha && GIT_OBJECT_ID.test(testMergeSha)) {
     ensureReviewTreeCommit({

--- a/test/review-blob-hydration.test.ts
+++ b/test/review-blob-hydration.test.ts
@@ -9,9 +9,11 @@ import {
   ensurePullRequestReviewHead,
   githubReviewBlobSizes,
   hydratePullRequestReviewBlobs,
+  hydratePullRequestReviewHistory,
   materializePullRequestReviewTree,
   removePullRequestReviewTree,
 } from "../dist/clawsweeper-review-blobs.js";
+import { reviewMergeBase } from "../dist/pr-review-evidence.js";
 
 function git(cwd: string, ...args: string[]): string {
   return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
@@ -103,6 +105,247 @@ function objectExistsOffline(cwd: string, sha: string): boolean {
     }).status === 0
   );
 }
+
+// A review target is a single-branch, blobless clone of the base branch, so the reviewed
+// head arrives shallow and history hydration has to reach a merge base. A depth-limited
+// fetch re-bounds every revision it names, so hydration must not name a base branch whose
+// ancestry the checkout already holds.
+function reviewHistoryFixture({
+  commitsBeforeBranch,
+  commitsAfterBranch,
+  commitsOnBranch = 0,
+  commitsPastBase = 0,
+  cloneDepth,
+  baseRefreshDepth = 50,
+  publishPullRef = true,
+}: {
+  commitsBeforeBranch: number;
+  commitsAfterBranch: number;
+  commitsOnBranch?: number;
+  commitsPastBase?: number;
+  cloneDepth?: number;
+  baseRefreshDepth?: number;
+  publishPullRef?: boolean;
+}) {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-review-history-"));
+  const origin = join(root, "origin.git");
+  const source = join(root, "source");
+  const target = join(root, "target");
+  mkdirSync(source);
+  git(root, "init", "--bare", "-q", origin);
+  git(origin, "config", "uploadpack.allowFilter", "true");
+  git(origin, "config", "uploadpack.allowAnySHA1InWant", "true");
+  git(source, "init", "-q", "-b", "main");
+  git(source, "config", "user.name", "ClawSweeper Review Test");
+  git(source, "config", "user.email", "review-test@example.com");
+  git(source, "config", "commit.gpgsign", "false");
+  const commit = (name: string) => {
+    writeFileSync(join(source, "history.txt"), `${name}\n`);
+    git(source, "add", "-A");
+    git(source, "commit", "-qm", name);
+  };
+  commit("root");
+  for (let index = 0; index < commitsBeforeBranch; index += 1) commit(`history ${index}`);
+  const branchPoint = git(source, "rev-parse", "HEAD");
+  git(source, "checkout", "-qb", "feature");
+  writeFileSync(join(source, "feature.txt"), "feature\n");
+  git(source, "add", "-A");
+  git(source, "commit", "-qm", "feature");
+  for (let index = 0; index < commitsOnBranch; index += 1) {
+    writeFileSync(join(source, "feature.txt"), `feature ${index}\n`);
+    git(source, "commit", "-qam", `feature ${index}`);
+  }
+  const headSha = git(source, "rev-parse", "HEAD");
+  git(source, "checkout", "-q", "main");
+  for (let index = 0; index < commitsAfterBranch; index += 1) commit(`base ${index}`);
+  // A pull request pins the base branch where it stood when the request was opened, so the
+  // branch usually moves on past it. Commits past that point put the pinned base behind the
+  // depth-limited refresh boundary, exactly as it sits in a hosted review.
+  const baseSha = git(source, "rev-parse", "HEAD");
+  for (let index = 0; index < commitsPastBase; index += 1) commit(`past base ${index}`);
+  git(source, "remote", "add", "origin", origin);
+  git(source, "push", "-q", "origin", "main");
+  if (publishPullRef) git(source, "push", "-q", "origin", "feature:refs/pull/982/head");
+
+  git(
+    root,
+    "clone",
+    "-q",
+    "--filter=blob:none",
+    "--branch",
+    "main",
+    "--single-branch",
+    ...(cloneDepth ? [`--depth=${cloneDepth}`] : []),
+    `file://${origin}`,
+    target,
+  );
+  // The review runtime refreshes the base branch with a depth-limited fetch before reviewing.
+  git(
+    target,
+    "fetch",
+    "-q",
+    "origin",
+    "refs/heads/main:refs/remotes/origin/main",
+    `--depth=${baseRefreshDepth}`,
+  );
+  return { root, target, baseSha, headSha, branchPoint };
+}
+
+function reachable(target: string, sha: string): number {
+  const count = spawnSync("git", ["rev-list", "--count", sha], {
+    cwd: target,
+    encoding: "utf8",
+    env: { ...process.env, GIT_NO_LAZY_FETCH: "1" },
+  });
+  return count.status === 0 ? Number(count.stdout.trim()) : -1;
+}
+
+test("review history hydration keeps base ancestry the checkout already had", () => {
+  // The base branch's history is present and deeper than the bounded deepening, and the
+  // merge base is two commits behind the reviewed head but further behind the pinned base
+  // than the bound reaches. Naming the base in that fetch re-bounds ancestry the checkout
+  // already had and loses the merge base with it; deepening the head alone finds it.
+  const fixture = reviewHistoryFixture({
+    commitsBeforeBranch: 300,
+    commitsAfterBranch: 300,
+    commitsPastBase: 100,
+  });
+  try {
+    assert.ok(
+      ensurePullRequestReviewHead({
+        targetDir: fixture.target,
+        itemNumber: 982,
+        headSha: fixture.headSha,
+      }),
+    );
+    const before = reachable(fixture.target, fixture.baseSha);
+    assert.ok(before > 256, `expected deep base ancestry, saw ${before}`);
+    assert.equal(
+      reviewMergeBase(fixture.target, fixture.baseSha, fixture.headSha).status,
+      "unavailable",
+    );
+
+    assert.equal(
+      hydratePullRequestReviewHistory({
+        targetDir: fixture.target,
+        baseSha: fixture.baseSha,
+        headSha: fixture.headSha,
+        itemNumber: 982,
+      }),
+      fixture.branchPoint,
+    );
+
+    assert.equal(
+      reviewMergeBase(fixture.target, fixture.baseSha, fixture.headSha).status,
+      "verified",
+    );
+    assert.ok(
+      reachable(fixture.target, fixture.baseSha) > 256,
+      "hydration must not re-bound base ancestry to the fetch depth",
+    );
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("review history hydration still deepens a base branch that is itself shallow", () => {
+  // Shallow clone: the pinned base arrives with no ancestry, so reaching a merge base needs
+  // the base deepened too. Deepening only the head must not be the whole story.
+  const fixture = reviewHistoryFixture({
+    commitsBeforeBranch: 10,
+    commitsAfterBranch: 20,
+    cloneDepth: 1,
+    baseRefreshDepth: 1,
+  });
+  try {
+    assert.ok(
+      ensurePullRequestReviewHead({
+        targetDir: fixture.target,
+        itemNumber: 982,
+        headSha: fixture.headSha,
+      }),
+    );
+    assert.equal(reachable(fixture.target, fixture.baseSha), 1);
+
+    assert.equal(
+      hydratePullRequestReviewHistory({
+        targetDir: fixture.target,
+        baseSha: fixture.baseSha,
+        headSha: fixture.headSha,
+        itemNumber: 982,
+      }),
+      fixture.branchPoint,
+    );
+    assert.equal(
+      reviewMergeBase(fixture.target, fixture.baseSha, fixture.headSha).status,
+      "verified",
+    );
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("review history hydration stays fail-closed when the bounded deepening cannot reach", () => {
+  // The merge base is further from the reviewed head than the bounded deepening reaches.
+  // That is the documented bound doing its job, not the defect above: no merge base is
+  // reported and the caller keeps refusing.
+  const fixture = reviewHistoryFixture({
+    commitsBeforeBranch: 5,
+    commitsAfterBranch: 400,
+    cloneDepth: 1,
+    baseRefreshDepth: 1,
+  });
+  try {
+    assert.ok(
+      ensurePullRequestReviewHead({
+        targetDir: fixture.target,
+        itemNumber: 982,
+        headSha: fixture.headSha,
+      }),
+    );
+    assert.equal(
+      hydratePullRequestReviewHistory({
+        targetDir: fixture.target,
+        baseSha: fixture.baseSha,
+        headSha: fixture.headSha,
+        itemNumber: 982,
+      }),
+      null,
+    );
+    assert.equal(
+      reviewMergeBase(fixture.target, fixture.baseSha, fixture.headSha).status,
+      "unavailable",
+    );
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("review history hydration reports no merge base when the pull ref is unreachable", () => {
+  const fixture = reviewHistoryFixture({
+    commitsBeforeBranch: 5,
+    commitsAfterBranch: 5,
+    publishPullRef: false,
+  });
+  try {
+    rmSync(join(fixture.root, "origin.git"), { recursive: true, force: true });
+    assert.equal(
+      hydratePullRequestReviewHistory({
+        targetDir: fixture.target,
+        baseSha: fixture.baseSha,
+        headSha: fixture.headSha,
+        itemNumber: 982,
+      }),
+      null,
+    );
+    assert.equal(
+      reviewMergeBase(fixture.target, fixture.baseSha, fixture.headSha).status,
+      "unavailable",
+    );
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
 
 test("restricted PR review can inspect changed blobs from a genuine blobless clone offline", () => {
   const fixture = partialCloneFixture();


### PR DESCRIPTION
Closes #1307

## What Problem This Solves

Addresses hosted ClawSweeper reviews of `openclaw/openclaw` pull requests that stop before
Codex runs and publish no verdict. The run fails with
`AgentInputScanError: Agent input scan refused: incomplete_source`, the durable queue
re-leases the item, and every retry fails the same way, so the pull request keeps its
"ClawSweeper picked this up" acknowledgement and looks unreviewed to its author. [The companion issue](https://github.com/openclaw/clawsweeper/issues/1307) carries the public
run evidence and the timing across
[the pull request that introduced host-owned secret scanning](https://github.com/openclaw/clawsweeper/pull/1293), which made a verified merge base a
precondition of the host-owned input scan.

## Why This Change Was Made

This PR changes how review-history hydration deepens: which revisions its bounded fetch names,
and in what order. When the merge base is unavailable, `hydratePullRequestReviewHistory` deepens with one
bounded fetch that names **both** the pinned base and the reviewed head. A depth-limited fetch
re-bounds the ancestry of every revision it names, so naming the base truncates history the
checkout already had. In case A of the proof below, the commits reachable from the pinned base
drop from 84,773 to 256 across that single call, taking the merge base with them; hydration
then returns `null` and the scan refuses before any agent runs.

The head is the revision that actually needs deepening — tree hydration fetched it at depth 1.
Deepening from the head keeps the merge base inside the window the fetch retains; naming the
base as well moves that window's origin to the base and drops the merge base out of it.

So: deepen the head on its own first. If that does not establish a merge base, fall back to the
fetch this function already issued — both revisions, same depth, same flags, same timeout —
which is what the case of a genuinely shallow base still needs. The fallback issues the same arguments today's single fetch
issues — the head-only fetch has run first, so the repository state it starts from is not
identical, but the request is. In the four cases exercised below the change either recovers a
review that fails today (A/B) or leaves the outcome unchanged (C/D); that is the tested range,
not a claim about every input.

What changes, precisely: where the function issued one depth-limited fetch naming the pinned
base and the reviewed head, it now issues that fetch on the head alone and, only if no merge
base results, repeats the original fetch unchanged. So the fetch count is one or two rather
than always one, the ordering is new, and the head-only fetch touches the shared checkout's
shallow state before the fallback would. Not in scope: everything else. The admission
predicate itself is the unmodified `reviewMergeBase` — what changes is that the ancestry it
needs is still present when it runs, so a review that was refused for a merge base this
function had truncated can now reach one. History that cannot be reached
within the bound still reports no merge base and still refuses — the `stays fail-closed when the bounded deepening cannot reach` test. It does
not try to rescue every pull request whose merge
base lies beyond the bound. And the fallback still re-bounds the base exactly as the
current single fetch does, which matters because a review checkout is shared across a shard.
That is pre-existing behaviour on a path that only runs when the review would otherwise fail,
so on that path the request is what it is today; in the four tested cases nothing that recovers
today stops recovering, and reading the code that holds generally — but the tests are the four.
This change does not narrow that behaviour either.

I tried to narrow it and backed out twice, which is worth recording. Both attempts gated the
fallback on a proxy for "is the base shallow": first on the base's ancestry ending at a
shallow boundary, then on its reachable commit count being below the fetch depth. Each was
carried by the fixtures in `test/review-blob-hydration.test.ts` for the cases it was designed
for and failed the others — the boundary form cannot tell a shallow base that already reaches
deeper than the bound from one that does not, and the count form is inflated by side history
in a merge-heavy base, so each turns a case that recovers today into one that fails closed. A
predicate that inspects the ancestry path to the merge base rather than a proxy would work,
but it needs its own change and its own tests. `gitInfo()`'s depth-limited base-branch refresh, the
`--depth=1` tree fetches, TruffleHog provisioning, `GIT_NO_LAZY_FETCH=1` and
`protocol.allow=never` are untouched. The separate observability gap —
[`reviewMergeBase`](https://github.com/openclaw/clawsweeper/blob/c179a466606f782ae73404357a0c94e6bead5807/src/pr-review-evidence.ts#L164-L215)
distinguishes five failure reasons and
[the gate in `scanAgentInput`](https://github.com/openclaw/clawsweeper/blob/c179a466606f782ae73404357a0c94e6bead5807/src/agent-input-scan.ts#L169)
collapses them into `incomplete_source` — is left for its own change.

## User Impact

For pull requests whose merge base was lost to that truncation, the merge base now resolves, so
the scan's precondition can be met where it previously could not be. Whether the
review then completes and publishes is downstream of this change.

Measured cost is comparable, on one run per case. In the proof below all four cases — both pull requests, both
builds — are single runs that took 4.6–5.1s and ended at 188–190 MiB of `.git` disk usage,
with no case standing apart from the others. That is four runs on one host and one network
path, so it supports "no case is an outlier here", not a performance comparison. The change can issue one extra bounded
fetch, and only when the first left no merge base; on the subject pull request the head-only
fetch replaces the failing one rather than adding to it. Wall-clock and disk are what was
measured — not fetch count or bytes on the wire.

## OpenClaw Bay Impact

No Bay change is needed. The production half of the diff is confined to
`src/clawsweeper-review-blobs.ts`; the other file is a test. Review publication, the queue,
status, telemetry and dashboard data contracts are untouched, and no field or state Bay reads
is added or changed.

## Documentation Impact

No documented contract changes. `docs/review-cache.md` and `docs/repair/README.md` describe
review inputs, caching and the restricted checkout; neither states which revisions the
deepening fetch names, and the depth bound, its timeout and the scan's admission rules are
unchanged. This corrects which revisions that existing fetch is asked to bound.

## Evidence

Tests added: four focused tests in `test/review-blob-hydration.test.ts`, over real git fixtures
served from a `file://` origin; the merge-base status is never mocked. Run them with
`pnpm run build && node --test --test-name-pattern "review history hydration" test/review-blob-hydration.test.ts`:

- **keeps base ancestry the checkout already had** — deep base history, merge base two commits
  behind the head but further behind the pinned base than the bound reaches. What it asserts is
  that the merge base verifies **and** that more than the bound's worth of base ancestry
  survives: the retained count still falls (in the live proof, 84,773 to 770), so read the name
  as "keeps enough of it to reach the merge base", not "leaves it untouched".
- **still deepens a base branch that is itself shallow** — shallow clone where the pinned base
  arrives with no ancestry, so the second stage has to run. This is the case that makes
  "deepen only the head" wrong on its own.
- **stays fail-closed when the bounded deepening cannot reach** — merge base beyond the bound:
  hydration reports `null` and the merge base stays `unavailable`. The bound doing its job.
- **reports no merge base when the pull ref is unreachable** — origin removed; no throw, no
  merge base.

Negative control on the fix itself: dropping the head-only fetch, so the fallback runs alone and
the function behaves as it does today, fails `keeps base ancestry the checkout already had` and
leaves the other three passing. That is the only control run against this diff; earlier, larger
variants of the change carried further tests that went with them.

`pnpm run check` exits non-zero on this contributor host. Its static gates —
`check:active-surface`, `check:dashboard-queue-boundary`, `check:dashboard-strict`,
`check:docs`, `check:limits`, `format:check` and the typecheck — all pass; the non-zero exit
comes from 27 failing tests, all in `test/live-proof-review-environment.test.ts` and
`test/repair/target-validation.test.ts` — terminal-proof, container and dependency-setup cases
that need tooling this host does not provide. Restoring both changed files to their `c179a46660` versions and
running those two suites produces the same 27, and the two failing-test lists compare equal, so
they are not attributable to this change. CI will re-run the suite on its own runners.

### Real Behavior Proof

**Claim.** In the hosted checkout shape, hydration's single bounded fetch truncates the base
ancestry and returns no merge base for `openclaw/openclaw#133034` — a sufficient cause for the
refusal, since `scanAgentInput` gates on exactly that predicate. The proof exercises the
predicate, not the hosted refusal path itself. With this change the same call keeps that ancestry and resolves the merge
base, and a control pull request that already worked is unaffected in result and in cost.

**Exercised surface.** `hydratePullRequestReviewHistory` and `ensurePullRequestReviewHead`
through the built `dist/clawsweeper-review-blobs.js`, against the live
`https://github.com/openclaw/openclaw.git`. `reviewMergeBase` — the predicate `scanAgentInput`
gates on — is unmodified here and is the instrument in every case.

**Scenario / fixture.** Four independent checkouts, each built to model the hosted target
shape: `git clone --filter=blob:none --branch main --single-branch` (the hosted step adds
`--reference-if-able`, which changes where objects come from, not the single-branch scoping
this turns on), then the review runtime's
`git fetch origin refs/heads/main:refs/remotes/origin/main --depth=50`. All four pin the base
branch to one SHA captured before any clone. A/B run the subject pull request on the base
commit's build and on this branch; C/D do the same for control `#132716`.

**Command and environment.** Two builds of this repository are needed: one from the base
commit and one from this branch. Build the base commit in a separate worktree so its `HEAD`
really is that commit, `pnpm install && pnpm run build` in each, then run the four cases
against the live repository, loading one build per case. git 2.34.1, Node 24.18.0, branch head
`bdd681fd7e431aabc3a8fbe92b561ae597746f24`. The base commit for the baseline build is
`c179a466606f782ae73404357a0c94e6bead5807`. The harness that runs the four cases is
`run-proof.sh`, invoked as
`BUILD=<branch checkout> BASELINE=<baseline dist> BASE_COMMIT=c179a46660 ./run-proof.sh`; it
performs exactly the sequence described under Scenario and refuses to start unless the two builds differ in the expected direction and each
records its was built from.

**Assertions.** The script exits non-zero unless every case pinned the same base-branch SHA,
neither pull request's base or head moved while the cases ran (re-read and compared at the
end; both can also be pinned from outside via `EXPECT_*` variables),
case A reproduces the failure, cases B/C/D each verify a merge base, case A's base ancestry is
bounded at the fetch depth while case B's is not, and C and D agree once timing and size are
excluded. It also refuses to start unless the baseline dist lacks
`deepenReviewHistory` and the branch build does, and unless each build records the commit it
`BUILD`'s `HEAD` — a stale build was caught by that check while preparing this. Only a run
ending in `ALL ASSERTIONS PASSED` is a result.

**Observed result.**

| case | pull request | build | merge base after | reachable from base | elapsed | `.git` disk |
|---|---|---|---|---|---|---|
| A | [#133034](https://github.com/openclaw/openclaw/pull/133034) | base commit | **unavailable** | 84,773 -> **256** | 4.9s | 190 MiB |
| B | [#133034](https://github.com/openclaw/openclaw/pull/133034) | this branch | **verified** `61a75f5494` | 84,773 -> **770** | 5.1s | 188 MiB |
| C | [#132716](https://github.com/openclaw/openclaw/pull/132716) | base commit | verified `a7a2dacc7a` | 84,894 -> 309 | 4.7s | 189 MiB |
| D | [#132716](https://github.com/openclaw/openclaw/pull/132716) | this branch | verified `a7a2dacc7a` | 84,894 -> 309 | 4.6s | 189 MiB |

In each of these four runs the depth-limited fetch re-bounded ancestry — which is what
`--depth` is documented to do, setting retained depth from each named revision — which is visible here as the reachable count changing across the single
fetch in
[`hydratePullRequestReviewHistory`](https://github.com/openclaw/clawsweeper/blob/c179a466606f782ae73404357a0c94e6bead5807/src/clawsweeper-review-blobs.ts#L111-L134). The
difference the fix makes is *where* the retained window starts: from the base (A, 256 commits,
merge base lost) or from the head (B, 770 commits, merge base kept). C and D end identically. The script asserts the results and the
control equivalence, not which internal fetch produced them; C/D matching on both builds is
consistent with the fallback running on both sides, and that is how the code reads, but the
transcript does not prove it on its own.

```
## case A — subject, unmodified base commit
   merge base before:            unavailable | commits reachable from base: 84773
   after head, before hydration: unavailable | commits reachable from base: 84773
   hydrate history ->  null
   merge base after:             unavailable | commits reachable from base: 256
## case B — subject, this branch (independent checkout)
   after head, before hydration: unavailable | commits reachable from base: 84773
   hydrate history ->  61a75f549406a8c7e359c0e1243ab0adb42cd89d
   merge base after:             verified    | commits reachable from base: 770
# base ancestry retained: A=256 (bounded) vs B=770 (kept) — asserted
# control equivalence (C vs D, excluding timing and size): asserted equal
# ALL ASSERTIONS PASSED — a transcript without this line is not a valid result
```

The transcript above is an excerpt of the run's output, kept to the lines that carry the
result; the run also prints each case's clone tip, the pinned SHA it asserts, post-refresh
ancestry, shallow state and `.git` size, and ends with the `ALL ASSERTIONS PASSED` line quoted.
The authoritative complete output is what the harness prints when run — the excerpt omits
lines, it does not alter them.



The `after head, before hydration` line is the control that isolates the cause: with the
reviewed head installed and nothing deepened, base reachability is untouched at 84,773 and the
merge base is still unavailable. Only the hydration fetch that follows changes it.

**Limitations.** The proof reproduces the mechanism in a model of the hosted checkout, not a capture
from a runner, so it establishes a sufficient cause for the observed refusals rather than
proving it is the only one in production. It observes `reviewMergeBase`, the predicate the scan
gates on; it does not run TruffleHog or Codex, because the host-owned scanner is provisioned
inside the hosted runner by `.github/actions/setup-review-tools` and is not reproducible on a
contributor host — and the refusal being repaired happens before either runs. `main` moves
continuously, so ancestry counts differ between runs; the A/B asymmetry from a pinned starting
state and the C/D equivalence are the invariant parts.


## Maintainer verification — 2026-08-30

Current head: `f14ad532805d463ee09e9fcdaa3951fac31865f8`. The maintainer addition is one changelog entry thanking @masatohoshino. Production code, tests, scripts, workflows, and dependencies are byte-identical to the tested implementation head `bdd681fd7e431aabc3a8fbe92b561ae597746f24`.

`pnpm run check` passed on AWS Crabbox, lease `cbx_646cfbf7ff39`, run `run_d8090c339f9b`, Linux amd64 with Node 24.18.1. This includes the full coverage gate. A fresh isolated Codex autoreview of the implementation returned no accepted/actionable findings at its default P0 threshold.

An independent live Git/scanner replay also passed on that lease (run `run_690796422745`, Git 2.53.0, the repository-pinned TruffleHog 3.97.1). Four independent blobless, single-branch clones fetched the public OpenClaw Git remote, pinned the base-branch tip to `0594a100d9710a94cd8c80d72713a3565eefd2ff`, applied the depth-50 refresh, then called the actual baseline or patched history-hydration implementation. The scanner and merge-base predicate were unchanged between cases.

| Scenario | Baseline | Patched |
| --- | --- | --- |
| Affected https://github.com/openclaw/openclaw/pull/133034, pinned head `afd26c0259ddf10382d4165d7a2075c2dda445c1` | Base reachability 84,773 → 256; merge base unavailable; real scanner refused `incomplete_source` | Base reachability 84,773 → 770; merge base `61a75f549406a8c7e359c0e1243ab0adb42cd89d` verified; real scanner passed |
| Control https://github.com/openclaw/openclaw/pull/132716, pinned head `ab326763775abbf573eaee488fa0cf87b1773c3e` | Verified merge base `a7a2dacc7a43be0b8e88f74649b4b90cfc9e7cab`; 309 reachable commits after hydration | Same verified merge base and reachable count |

The controlled live harness ended with `ALL LIVE HISTORY AND SCANNER ASSERTIONS PASSED`. It scans the affected PR's real introduced before/after bytes with a synthetic prompt; it does not run inference or publish a review. The 128-file control tests history only, because it exceeds the existing 80-file blob-hydration bound. An initial harness attempted that broader control scan, hit this existing limit, and was corrected to keep the control scoped to ancestry; the affected-PR scanner assertions were retained unchanged.

Separately, [the manually dispatched hosted CI run](https://github.com/openclaw/clawsweeper/actions/runs/33330684459) passed, including the normally skipped **Hosted native review scan smoke**. Its `hosted-review-scan-proof` artifact records zero provider starts for four refusal scenarios and one successful real Codex structured response for a clean synthetic committed change, on Ubuntu 24 with the pinned scanner. This proves scanner/inference integration, not publication of a real target review.

No Bay change is needed: this PR changes history hydration and adds a changelog entry, without modifying queue, publication, or dashboard contracts. Terminal retry classification remains a separate follow-up; the scan continues to refuse genuinely incomplete ancestry.
