### PR TITLE
fix(review): stop rejecting the approved autoreview fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Classified the explicitly approved autoreview fixture only by its exact full-URI digest and canonical or vendored source path, preserving all scanner gates and value-free audits.
 - Stopped treating pane-local runtime state as stored data while retaining warnings for explicit persistence changes and incomplete storage patches.
 - Corrected retained terminal-proof cleanup for independent process-exit and PTY-close events, preserving the original wrapper failure and draining dead-pane capture only after verified cleanup.
 - Prevented rejected model inputs from surviving in generated prompt artifacts; retained diagnostics now follow admission with owner-only access, and unused prompt copies are no longer written.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
-- Classified the explicitly approved autoreview fixture only by its exact full-URI digest and canonical or vendored source path, preserving all scanner gates and value-free audits.
+- Classified the explicitly approved autoreview fixture only by its exact full-URI digest and canonical or vendored source path, enforcing the same digest/path/mode policy at every scanned endpoint for all reviewed fixtures while preserving scanner gates and value-free audits.
 - Stopped treating pane-local runtime state as stored data while retaining warnings for explicit persistence changes and incomplete storage patches.
 - Corrected retained terminal-proof cleanup for independent process-exit and PTY-close events, preserving the original wrapper failure and draining dead-pane capture only after verified cleanup.
 - Prevented rejected model inputs from surviving in generated prompt artifacts; retained diagnostics now follow admission with owner-only access, and unused prompt copies are no longer written.

--- a/README.md
+++ b/README.md
@@ -567,7 +567,10 @@ or its [vendored OpenClaw copy](https://github.com/openclaw/openclaw/blob/136eab
 as non-sensitive after a complete scan. Static host policy associates each
 exact full-URI SHA-256 with only its approved source paths, requiring a literal
 at the reported line of a host-staged Git blob from mode `100644`.
-Deduplicated blobs retain the approved paths that established their eligibility.
+Deduplicated blobs retain every scanned logical endpoint's path and Git mode,
+including mode-only transitions and shared-path aliases. Every captured reference
+must qualify under the same digest's exact path and mode `100644` policy before
+any source is eligible for classification or an audit notice.
 The policy does not trust checkout ignore rules, domain patterns, fixture words,
 test names, or unchanged-line inference; no nearby fixture is implicitly approved.
 Findings attributed to prompt, schema, diff, additional-input, other-path, or

--- a/README.md
+++ b/README.md
@@ -560,17 +560,30 @@ uses the remaining review deadline; it never silently truncates or bypasses.
 Diagnostics omit scanner output and source values. Restore prerequisites or
 remove sensitive input before retrying a refusal.
 
-The host classifies one reviewed synthetic malformed-configuration URI in
-`test/action-ledger-runtime.test.ts` as non-sensitive after a complete scan.
-Its policy binds the exact full finding bytes, detector contract, and literal
-line in a host-staged Git blob. It does not trust checkout ignore rules or
-domain patterns. Prompt, schema, diff, additional-input, and encoded-only
-occurrences remain blocking, as do other findings and incomplete scans.
+The host classifies the reviewed synthetic malformed-configuration URI in
+`test/action-ledger-runtime.test.ts` and the explicitly approved autoreview
+negative-test URI in the [canonical autoreview test](https://github.com/openclaw/agent-skills/blob/a8466c1d860588a083610fe41fd277c1d88b14e0/skills/autoreview/tests/test_autoreview_hardening.py)
+or its [vendored OpenClaw copy](https://github.com/openclaw/openclaw/blob/136eab023035dd5943818f791d3c3db7d92e4491/.agents/skills/autoreview/tests/test_autoreview_hardening.py)
+as non-sensitive after a complete scan. Static host policy associates each
+exact full-URI SHA-256 with only its approved source paths, requiring a literal
+at the reported line of a host-staged Git blob from mode `100644`.
+Deduplicated blobs retain the approved paths that established their eligibility.
+The policy does not trust checkout ignore rules, domain patterns, fixture words,
+test names, or unchanged-line inference; no nearby fixture is implicitly approved.
+Findings attributed to prompt, schema, diff, additional-input, other-path, or
+encoded-only occurrences remain blocking, as do other findings, verified findings,
+and incomplete scans. Unverified findings alone never qualify: every finding must
+match the exact bytes, source association, and strict detector contract. This
+classification does not expand TruffleHog's detection coverage.
 The classification is pinned to TruffleHog 3.97.1's output contract; scanner
 upgrades require requalification. See `src/agent-input-scan-fixtures.ts`.
-Every accepted classification emits a host-side structured stderr notice with
-the fixture digest, source blob, line, decoder, and occurrence count. Raw values
-and verification diagnostics never appear in that audit notice.
+After successful cleanup and final source fences, each accepted fixture/source
+pair emits a host-side structured stderr notice with `event`, `fixtureSha256`,
+`source`, `detector`, and `findings` entries containing `blob`, `line`, `decoder`,
+and `occurrences`. Counts are per source: a shared blob can appear in both source
+notices and those counts must not be summed across sources. A refused or drifted
+scan emits no success notice. Raw values and verification diagnostics never
+appear in that audit notice.
 
 Generated review and repair prompt diagnostics retire the previous attempt's
 copy before admission and persist only successfully scanned exact prompt bytes

--- a/src/agent-input-scan-fixtures.ts
+++ b/src/agent-input-scan-fixtures.ts
@@ -1,10 +1,35 @@
 import { createHash } from "node:crypto";
 import { basename } from "node:path";
 
-// Maintainer-reviewed malformed-config fixture introduced by d68b1861172120fc.
 // This is host policy, never an allowlist loaded from the reviewed checkout.
-export const REVIEWED_FIXTURE_SOURCE = "test/action-ledger-runtime.test.ts";
-const FIXTURE_SHA256 = "a728de5dbbef23b8aa5ef2d99060835f4f2fb5a0fa2abb9fe249d08aa09bd09e";
+const REVIEWED_FIXTURES = [
+  {
+    // Maintainer-reviewed malformed-config fixture introduced by d68b1861172120fc.
+    fixtureSha256: "a728de5dbbef23b8aa5ef2d99060835f4f2fb5a0fa2abb9fe249d08aa09bd09e",
+    sources: ["test/action-ledger-runtime.test.ts"],
+  },
+  {
+    // Explicitly approved autoreview negative-test fixture, including its vendored path.
+    fixtureSha256: "662a886a0fd7447dad0acda3aeccc9eb539fc90438b453de7e2f523ca7ee6c83",
+    sources: [
+      "skills/autoreview/tests/test_autoreview_hardening.py",
+      ".agents/skills/autoreview/tests/test_autoreview_hardening.py",
+    ],
+  },
+] as const;
+
+export function reviewedFixtureForSource(source: string, mode: string) {
+  const fixture =
+    mode === "100644"
+      ? REVIEWED_FIXTURES.find((entry) => entry.sources.some((path) => path === source))
+      : undefined;
+  return fixture ? { fixtureSha256: fixture.fixtureSha256, source } : undefined;
+}
+
+export interface ReviewedFixtureBlob {
+  bytes: Buffer;
+  sources: ReadonlySet<string>;
+}
 
 interface ClassifiedFinding {
   blob: string;
@@ -29,13 +54,13 @@ function records(bytes: Buffer): Record<string, unknown>[] {
     .map((line) => object(JSON.parse(line)));
 }
 
-/** Classify only complete native scans whose every finding is the reviewed fixture. */
+/** Classify only complete native scans whose every finding matches host fixture policy. */
 export function classifyReviewedFixtureScan(
   stdout: Buffer,
   stderr: Buffer,
-  sourceBlobs: ReadonlyMap<string, Buffer>,
+  sourceBlobs: ReadonlyMap<string, ReviewedFixtureBlob>,
 ):
-  | { fixtureSha256: string; source: string; detector: string; findings: ClassifiedFinding[] }
+  | { fixtureSha256: string; source: string; detector: string; findings: ClassifiedFinding[] }[]
   | undefined {
   try {
     const findings = records(stdout);
@@ -70,7 +95,10 @@ export function classifyReviewedFixtureScan(
     )
       return undefined;
 
-    const classified = new Map<string, ClassifiedFinding>();
+    const classified = new Map<
+      string,
+      { fixtureSha256: string; source: string; findings: Map<string, ClassifiedFinding> }
+    >();
     for (const finding of findings) {
       if (
         finding.DetectorType !== 17 ||
@@ -83,21 +111,25 @@ export function classifyReviewedFixtureScan(
         typeof finding.Raw !== "string" ||
         // URI Raw omits the path; RawV2 must match the complete reviewed value.
         finding.RawV2 !== finding.Raw ||
-        createHash("sha256").update(finding.Raw).digest("hex") !== FIXTURE_SHA256 ||
         finding.ExtraData !== null ||
         finding.StructuredData !== null
       )
         return undefined;
+      const digest = createHash("sha256").update(finding.Raw).digest("hex");
+      const fixture = REVIEWED_FIXTURES.find((entry) => entry.fixtureSha256 === digest);
+      if (!fixture) return undefined;
       const source = object(object(object(finding.SourceMetadata).Data).Filesystem);
-      const bytes = typeof source.file === "string" ? sourceBlobs.get(source.file) : undefined;
+      const staged = typeof source.file === "string" ? sourceBlobs.get(source.file) : undefined;
+      const sources = fixture.sources.filter((path) => staged?.sources.has(path));
       if (
-        !bytes ||
+        !staged ||
+        !sources.length ||
         typeof source.line !== "number" ||
         !Number.isSafeInteger(source.line) ||
         source.line <= 0
       )
         return undefined;
-      const line = new TextDecoder("utf-8", { fatal: true }).decode(bytes).split("\n")[
+      const line = new TextDecoder("utf-8", { fatal: true }).decode(staged.bytes).split("\n")[
         source.line - 1
       ];
       // HTML may rediscover an unchanged literal. Encoded-only occurrences,
@@ -114,22 +146,33 @@ export function classifyReviewedFixtureScan(
         return undefined;
       const blob = basename(source.file as string);
       const key = `${blob}:${source.line}:${finding.DecoderName}`;
-      const previous = classified.get(key);
-      classified.set(key, {
-        blob,
-        line: source.line,
-        decoder: finding.DecoderName,
-        occurrences: (previous?.occurrences ?? 0) + 1,
-      });
+      for (const path of sources) {
+        const groupKey = `${digest}:${path}`;
+        const group = classified.get(groupKey) ?? {
+          fixtureSha256: digest,
+          source: path,
+          findings: new Map<string, ClassifiedFinding>(),
+        };
+        const previous = group.findings.get(key);
+        group.findings.set(key, {
+          blob,
+          line: source.line,
+          decoder: finding.DecoderName,
+          occurrences: (previous?.occurrences ?? 0) + 1,
+        });
+        classified.set(groupKey, group);
+      }
     }
-    return {
-      fixtureSha256: FIXTURE_SHA256,
-      source: REVIEWED_FIXTURE_SOURCE,
-      detector: "URI",
-      findings: [...classified.entries()]
-        .sort(([a], [b]) => a.localeCompare(b))
-        .map(([, value]) => value),
-    };
+    return [...classified.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([, group]) => ({
+        fixtureSha256: group.fixtureSha256,
+        source: group.source,
+        detector: "URI",
+        findings: [...group.findings.entries()]
+          .sort(([a], [b]) => a.localeCompare(b))
+          .map(([, value]) => value),
+      }));
   } catch {
     // Scanner output includes credential-shaped bytes; never expose parse errors.
     return undefined;

--- a/src/agent-input-scan-fixtures.ts
+++ b/src/agent-input-scan-fixtures.ts
@@ -28,7 +28,7 @@ export function reviewedFixtureForSource(source: string, mode: string) {
 
 export interface ReviewedFixtureBlob {
   bytes: Buffer;
-  sources: ReadonlySet<string>;
+  references: readonly { source: string; mode: string }[];
 }
 
 interface ClassifiedFinding {
@@ -120,10 +120,13 @@ export function classifyReviewedFixtureScan(
       if (!fixture) return undefined;
       const source = object(object(object(finding.SourceMetadata).Data).Filesystem);
       const staged = typeof source.file === "string" ? sourceBlobs.get(source.file) : undefined;
-      const sources = fixture.sources.filter((path) => staged?.sources.has(path));
       if (
         !staged ||
-        !sources.length ||
+        !staged.references.length ||
+        staged.references.some(
+          ({ source, mode }) =>
+            reviewedFixtureForSource(source, mode)?.fixtureSha256 !== fixture.fixtureSha256,
+        ) ||
         typeof source.line !== "number" ||
         !Number.isSafeInteger(source.line) ||
         source.line <= 0
@@ -146,6 +149,7 @@ export function classifyReviewedFixtureScan(
         return undefined;
       const blob = basename(source.file as string);
       const key = `${blob}:${source.line}:${finding.DecoderName}`;
+      const sources = new Set(staged.references.map(({ source }) => source));
       for (const path of sources) {
         const groupKey = `${digest}:${path}`;
         const group = classified.get(groupKey) ?? {

--- a/src/agent-input-scan.ts
+++ b/src/agent-input-scan.ts
@@ -21,7 +21,8 @@ import { fileURLToPath } from "node:url";
 import { readReviewGit, reviewMergeBase, type ReviewGitReadOptions } from "./pr-review-evidence.js";
 import {
   classifyReviewedFixtureScan,
-  REVIEWED_FIXTURE_SOURCE,
+  reviewedFixtureForSource,
+  type ReviewedFixtureBlob,
 } from "./agent-input-scan-fixtures.js";
 
 export type AgentScanSource =
@@ -124,7 +125,7 @@ export function scanAgentInput(options: {
       throw new AgentInputScanError("unsafe_path");
     const inputDir = join(root, "input");
     mkdirSync(inputDir, { mode: 0o700 });
-    const reviewedFixtureBlobs = new Map<string, Buffer>();
+    const reviewedFixtureBlobs = new Map<string, ReviewedFixtureBlob>();
     let staged = 0;
     let ordinal = 0;
     const stage = (bytes: Buffer, name = String(ordinal++)) => {
@@ -338,7 +339,7 @@ export function scanAgentInput(options: {
       }
       assertCurrent();
       const blobs = new Set<string>();
-      const fixtureBlobs = new Set<string>();
+      const fixtureSources = new Map<string, Set<string>>();
       const endpoints =
         source.kind === "snapshot"
           ? [mergeBase.sha, source.headSha, source.indexTreeSha, source.treeSha]
@@ -384,7 +385,12 @@ export function scanAgentInput(options: {
               throw new AgentInputScanError("unsupported_content");
             if (!OBJECT_ID.test(oid!)) throw new AgentInputScanError("incomplete_source");
             blobs.add(oid!);
-            if (path === REVIEWED_FIXTURE_SOURCE && mode === "100644") fixtureBlobs.add(oid!);
+            const fixture = reviewedFixtureForSource(path, mode!);
+            if (fixture) {
+              const sources = fixtureSources.get(oid!) ?? new Set<string>();
+              sources.add(fixture.source);
+              fixtureSources.set(oid!, sources);
+            }
           }
         }
         stage(git([...args, "--patch", "--binary", "--full-index", "--"]));
@@ -405,7 +411,8 @@ export function scanAgentInput(options: {
           throw new AgentInputScanError("unsupported_content");
         // OID names preserve multiline bytes and make symlinks ordinary scan files.
         stage(bytes, oid);
-        if (fixtureBlobs.has(oid)) reviewedFixtureBlobs.set(join(inputDir, oid), bytes);
+        const sources = fixtureSources.get(oid);
+        if (sources) reviewedFixtureBlobs.set(join(inputDir, oid), { bytes, sources });
       }
     }
     const result = spawnSync(
@@ -466,12 +473,12 @@ export function scanAgentInput(options: {
   if (failure) throw failure;
   // Emit from the host after cleanup: successful callers can discard provider
   // stderr, but this classification must remain visible without exposing values.
-  if (classified)
+  for (const classification of classified ?? [])
     console.error(
       JSON.stringify({
         event: "agent_input_scan_classified",
         notice: "Reviewed synthetic fixture findings classified as non-sensitive.",
-        ...classified,
+        ...classification,
       }),
     );
 }

--- a/src/agent-input-scan.ts
+++ b/src/agent-input-scan.ts
@@ -21,7 +21,6 @@ import { fileURLToPath } from "node:url";
 import { readReviewGit, reviewMergeBase, type ReviewGitReadOptions } from "./pr-review-evidence.js";
 import {
   classifyReviewedFixtureScan,
-  reviewedFixtureForSource,
   type ReviewedFixtureBlob,
 } from "./agent-input-scan-fixtures.js";
 
@@ -338,8 +337,7 @@ export function scanAgentInput(options: {
         };
       }
       assertCurrent();
-      const blobs = new Set<string>();
-      const fixtureSources = new Map<string, Set<string>>();
+      const blobs = new Map<string, { source: string; mode: string }[]>();
       const endpoints =
         source.kind === "snapshot"
           ? [mergeBase.sha, source.headSha, source.indexTreeSha, source.treeSha]
@@ -384,13 +382,10 @@ export function scanAgentInput(options: {
             if (!["100644", "100755", "120000"].includes(mode!))
               throw new AgentInputScanError("unsupported_content");
             if (!OBJECT_ID.test(oid!)) throw new AgentInputScanError("incomplete_source");
-            blobs.add(oid!);
-            const fixture = reviewedFixtureForSource(path, mode!);
-            if (fixture) {
-              const sources = fixtureSources.get(oid!) ?? new Set<string>();
-              sources.add(fixture.source);
-              fixtureSources.set(oid!, sources);
-            }
+            // An OID identifies bytes, not each scanned endpoint's path/mode eligibility.
+            const references = blobs.get(oid!) ?? [];
+            references.push({ source: path, mode: mode! });
+            blobs.set(oid!, references);
           }
         }
         stage(git([...args, "--patch", "--binary", "--full-index", "--"]));
@@ -398,7 +393,7 @@ export function scanAgentInput(options: {
       // Only live committed checkouts need normalized raw files staged here;
       // snapshot objects were already captured and fenced before preparation.
       if (source.kind === "committed") assertCurrent();
-      for (const oid of blobs) {
+      for (const [oid, references] of blobs) {
         const size = Number(git(["cat-file", "-s", oid], 100).toString().trim());
         if (!Number.isSafeInteger(size) || size < 0)
           throw new AgentInputScanError("incomplete_source");
@@ -411,8 +406,7 @@ export function scanAgentInput(options: {
           throw new AgentInputScanError("unsupported_content");
         // OID names preserve multiline bytes and make symlinks ordinary scan files.
         stage(bytes, oid);
-        const sources = fixtureSources.get(oid);
-        if (sources) reviewedFixtureBlobs.set(join(inputDir, oid), { bytes, sources });
+        reviewedFixtureBlobs.set(join(inputDir, oid), { bytes, references });
       }
     }
     const result = spawnSync(

--- a/test/agent-input-scan.test.ts
+++ b/test/agent-input-scan.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
+  chmodSync,
   existsSync,
   copyFileSync,
   mkdirSync,
@@ -13,10 +14,11 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import test from "node:test";
 import { runAgentProcess, runAgentCheckoutInspection } from "../dist/agent-runner.js";
 import { AgentInputScanError, scanAgentInput } from "../dist/agent-input-scan.js";
+import { reviewedFixtureForSource } from "../dist/agent-input-scan-fixtures.js";
 import {
   captureTargetCheckoutBinding,
   withTargetReviewSnapshot,
@@ -425,23 +427,73 @@ test("repair scan binds raw bytes even when normalization leaves the same canoni
   assert.equal(existsSync(f.calls), false);
 });
 
+const ledgerSource = "test/action-ledger-runtime.test.ts";
+const autoreviewSources = [
+  "skills/autoreview/tests/test_autoreview_hardening.py",
+  ".agents/skills/autoreview/tests/test_autoreview_hardening.py",
+];
+
+test("reviewed fixture registry binds exact digests to exact regular-file source paths", () => {
+  for (const [source, digest] of [
+    [ledgerSource, "a728de5dbbef23b8aa5ef2d99060835f4f2fb5a0fa2abb9fe249d08aa09bd09e"],
+    ...autoreviewSources.map((source) => [
+      source,
+      "662a886a0fd7447dad0acda3aeccc9eb539fc90438b453de7e2f523ca7ee6c83",
+    ]),
+  ]) {
+    assert.deepEqual(reviewedFixtureForSource(source!, "100644"), {
+      fixtureSha256: digest,
+      source,
+    });
+    for (const mode of ["100755", "120000", "160000", "000000", "644"])
+      assert.equal(reviewedFixtureForSource(source!, mode), undefined);
+    for (const alias of [`./${source}`, `other/${source}`, `${source}.bak`, source!.toUpperCase()])
+      assert.equal(reviewedFixtureForSource(alias, "100644"), undefined);
+  }
+});
+
 for (const scenario of [
   "reviewed fixture",
+  "PLAIN duplicate",
   "HTML duplicate",
+  "shared approved path OIDs",
+  "shared endpoint OID",
+  "canonical autoreview path",
+  "vendored autoreview path",
+  "both autoreview paths",
+  "executable source",
   "changed raw",
   "changed full URI",
+  "changed matching raw values",
   "verified",
   "mixed findings",
+  "unapproved first",
   "wrong source",
   "wrong line",
   "other file",
   "prompt",
+  "schema",
+  "additional",
+  "diff",
   "decoded only",
+  "wrong detector",
+  "wrong source type",
+  "wrong decoder",
+  "missing verification error",
+  "unexpected extra data",
+  "unexpected structured data",
+  "wrong secret parts",
   "missing completion",
   "detector error",
+  "info error",
+  "info errors",
   "wrong count",
+  "verified count",
   "wrong version",
   "duplicate completion",
+  "trailing log",
+  "unterminated output",
+  "unterminated stderr",
   "malformed stderr",
   "malformed output",
   "unexpected successful output",
@@ -465,50 +517,118 @@ for (const scenario of [
       );
     assert.ok(uri, "reviewed synthetic fixture is present");
     const f = fixture(t, scenario === "prompt" ? uri : undefined);
-    const file = scenario === "other file" ? "other.test.ts" : "test/action-ledger-runtime.test.ts";
-    mkdirSync(join(f.cwd, "test"));
+    const files =
+      scenario === "shared approved path OIDs"
+        ? [...autoreviewSources, ledgerSource]
+        : scenario === "both autoreview paths"
+          ? autoreviewSources
+          : [
+              scenario === "canonical autoreview path"
+                ? autoreviewSources[0]!
+                : scenario === "vendored autoreview path"
+                  ? autoreviewSources[1]!
+                  : scenario === "other file"
+                    ? "other.test.ts"
+                    : ledgerSource,
+            ];
     const value = scenario === "decoded only" ? uri.replace(":", "&#58;") : uri;
     const contents = "// context\n".repeat(40) + JSON.stringify(value) + "\n";
-    writeFileSync(join(f.cwd, file), "// before\n" + contents);
+    for (const file of files) {
+      mkdirSync(dirname(join(f.cwd, file)), { recursive: true });
+      writeFileSync(
+        join(f.cwd, file),
+        scenario === "diff" ? "// before\n" : "// before\n" + contents,
+      );
+      if (scenario === "executable source") chmodSync(join(f.cwd, file), 0o755);
+    }
     const baseSha = f.commit();
-    writeFileSync(join(f.cwd, file), "// after\n" + contents);
+    for (const file of files) {
+      if (scenario === "shared endpoint OID") chmodSync(join(f.cwd, file), 0o755);
+      else writeFileSync(join(f.cwd, file), "// after\n" + contents);
+    }
     const headSha = f.commit();
+    const receipt = join(f.root, "scan-root");
+    const schemaPath = join(f.root, "schema.json");
+    if (scenario === "schema") writeFileSync(schemaPath, uri);
     useFakeScanner(
       t,
       String.raw`
 const uri = ${JSON.stringify(uri)};
 const scenario = ${JSON.stringify(scenario)};
+fs.writeFileSync(${JSON.stringify(receipt)}, path.dirname(inputDir));
 const parsed = new URL(uri);
-const findings = inputs.filter(({name}) => /^[a-f0-9]{40}$/.test(name) || (scenario === 'prompt' && name === 'prompt')).map(({name}) => ({
+const blobs = inputs.filter(({name}) => /^[a-f0-9]{40}$/.test(name));
+assert.equal(blobs.length, scenario === 'shared endpoint OID' ? 1 : 2);
+const findings = inputs.filter(({name, bytes}) =>
+  (/^[a-f0-9]{40}$/.test(name) && (scenario !== 'diff' || bytes.includes(uri))) ||
+  (scenario === 'prompt' && name === 'prompt') ||
+  (scenario === 'schema' && name === 'schema') ||
+  (scenario === 'additional' && name === '0') ||
+  (scenario === 'diff' && /^\d+$/.test(name) && bytes.includes(uri))
+).map(({name, bytes}) => ({
   SourceType: 15, DetectorType: 17, DetectorName: 'URI', DecoderName: 'PLAIN', Verified: false,
   VerificationError: 'synthetic verification error', Raw: uri, RawV2: uri,
-  SourceMetadata: {Data: {Filesystem: {file: path.join(inputDir, name), line: name === 'prompt' ? 1 : 42}}},
+  SourceMetadata: {Data: {Filesystem: {file: path.join(inputDir, name), line: /^[a-f0-9]{40}$/.test(name) ? 42 : bytes.toString().split('\n').findIndex(line => line.includes(uri)) + 1}}},
   SecretParts: {host: parsed.host, username: parsed.username, password: parsed.password},
   ExtraData: null, StructuredData: null,
 }));
+if (scenario === 'PLAIN duplicate') findings.push({...findings[0]});
 if (scenario === 'HTML duplicate') findings.push({...findings[0], DecoderName: 'HTML'});
 if (scenario === 'changed raw') findings[0].Raw += 'changed';
 if (scenario === 'changed full URI') findings[0].RawV2 += '/changed';
+if (scenario === 'changed matching raw values') findings[0].Raw = findings[0].RawV2 = uri + '/changed';
 if (scenario === 'verified') findings[0].Verified = true;
 if (scenario === 'mixed findings') findings.push({...findings[0], Raw: 'unreviewed', RawV2: 'unreviewed'});
+if (scenario === 'unapproved first') findings.unshift({...findings[0], Raw: 'unreviewed', RawV2: 'unreviewed'});
 if (scenario === 'wrong source') findings[0].SourceMetadata.Data.Filesystem.file = path.join(inputDir, 'prompt');
 if (scenario === 'wrong line') findings[0].SourceMetadata.Data.Filesystem.line++;
-if (scenario === 'source drift') fs.appendFileSync(${JSON.stringify(join(f.cwd, file))}, '// drift');
-process.stdout.write(findings.map(value => JSON.stringify(value)).join('\n') + '\n');
+if (scenario === 'wrong detector') findings[0].DetectorType = 18;
+if (scenario === 'wrong source type') findings[0].SourceType = 16;
+if (scenario === 'wrong decoder') findings[0].DecoderName = 'BASE64';
+if (scenario === 'missing verification error') findings[0].VerificationError = '';
+if (scenario === 'unexpected extra data') findings[0].ExtraData = {};
+if (scenario === 'unexpected structured data') findings[0].StructuredData = {};
+if (scenario === 'wrong secret parts') findings[0].SecretParts.host = 'mismatch';
+if (scenario === 'source drift') fs.appendFileSync(${JSON.stringify(join(f.cwd, files[0]!))}, '// drift');
+process.stdout.write(findings.map(value => JSON.stringify(value)).join('\n') + (scenario === 'unterminated output' ? '' : '\n'));
 if (scenario === 'malformed output') process.stdout.write('{');
 if (scenario === 'detector error') process.stderr.write(JSON.stringify({level:'error', logger:'trufflehog', msg:'error finding results in chunk'}) + '\n');
+if (scenario === 'info error') process.stderr.write(JSON.stringify({level:'info-0', logger:'trufflehog', msg:'detector failed', error:'synthetic'}) + '\n');
+if (scenario === 'info errors') process.stderr.write(JSON.stringify({level:'info-0', logger:'trufflehog', msg:'detector failed', errors:[]}) + '\n');
 const completion = JSON.stringify({
   level:'info-0', logger:'trufflehog', msg:'finished scanning', trufflehog_version:scenario === 'wrong version' ? 'changed' : '3.97.1',
-  chunks:2, bytes:1000, verified_secrets:0, unverified_secrets:findings.length + (scenario === 'wrong count' ? 1 : 0),
-}) + '\n';
+  chunks:2, bytes:1000, verified_secrets:scenario === 'verified count' ? 1 : 0, unverified_secrets:findings.length + (scenario === 'wrong count' ? 1 : 0),
+}) + (scenario === 'unterminated stderr' ? '' : '\n');
 if (scenario !== 'missing completion') process.stderr.write(completion);
 if (scenario === 'duplicate completion') process.stderr.write(completion);
+if (scenario === 'trailing log') process.stderr.write(JSON.stringify({level:'info-0', logger:'trufflehog', msg:'trailing'}) + '\n');
 if (scenario === 'malformed stderr') process.stderr.write('{');
 process.exit(scenario === 'unexpected successful output' ? 0 : 183);
 `,
     );
-    const run = () => f.run({ kind: "committed", baseSha, headSha });
-    if (scenario === "reviewed fixture" || scenario === "HTML duplicate") {
+    const run = () => {
+      const source = { kind: "committed" as const, baseSha, headSha };
+      if (scenario === "schema" || scenario === "additional") {
+        scanAgentInput({
+          cwd: f.cwd,
+          prompt: "Review the change.",
+          source,
+          timeoutMs: 30_000,
+          ...(scenario === "schema" ? { schemaPath } : { additionalBytes: [Buffer.from(uri)] }),
+        });
+        return { status: 0 };
+      }
+      return f.run(source);
+    };
+    if (
+      [
+        "reviewed fixture",
+        "PLAIN duplicate",
+        "HTML duplicate",
+        "shared approved path OIDs",
+        "shared endpoint OID",
+      ].includes(scenario)
+    ) {
       assert.equal(run().status, 0);
       assert.equal(readFileSync(f.calls, "utf8"), "called");
       assert.equal(notices.length, 1);
@@ -519,7 +639,11 @@ process.exit(scenario === 'unexpected successful output' ? 0 : 183);
       );
       const notice = JSON.parse(String(notices[0]![0]));
       assert.equal(notice.event, "agent_input_scan_classified");
-      assert.equal(notice.source, file);
+      assert.equal(notice.source, ledgerSource);
+      assert.equal(
+        notice.fixtureSha256,
+        reviewedFixtureForSource(ledgerSource, "100644")!.fixtureSha256,
+      );
       assert.equal(notice.detector, "URI");
       assert.match(notice.notice, /classified as non-sensitive/);
       assert.equal(
@@ -527,7 +651,11 @@ process.exit(scenario === 'unexpected successful output' ? 0 : 183);
           (sum: number, finding: { occurrences: number }) => sum + finding.occurrences,
           0,
         ),
-        scenario === "HTML duplicate" ? 3 : 2,
+        scenario === "shared endpoint OID" ? 1 : scenario.endsWith("duplicate") ? 3 : 2,
+      );
+      assert.equal(
+        notice.findings.length,
+        scenario === "shared endpoint OID" ? 1 : scenario === "HTML duplicate" ? 3 : 2,
       );
       for (const finding of notice.findings) {
         assert.match(finding.blob, /^[a-f0-9]{40}$/);
@@ -544,5 +672,6 @@ process.exit(scenario === 'unexpected successful output' ? 0 : 183);
       assert.equal(existsSync(f.diagnosticPromptPath), false);
       assert.deepEqual(notices, []);
     }
+    assert.equal(existsSync(readFileSync(receipt, "utf8")), false, "private staging is removed");
   });
 }

--- a/test/agent-input-scan.test.ts
+++ b/test/agent-input-scan.test.ts
@@ -457,7 +457,13 @@ for (const scenario of [
   "PLAIN duplicate",
   "HTML duplicate",
   "shared approved path OIDs",
-  "shared endpoint OID",
+  "shared approved and unapproved path OIDs",
+  "shared endpoint OID 644 to 755",
+  "shared endpoint OID 755 to 644",
+  "executable head snapshot",
+  "executable index snapshot",
+  "executable worktree snapshot",
+  "repeated regular snapshot OID",
   "canonical autoreview path",
   "vendored autoreview path",
   "both autoreview paths",
@@ -520,17 +526,19 @@ for (const scenario of [
     const files =
       scenario === "shared approved path OIDs"
         ? [...autoreviewSources, ledgerSource]
-        : scenario === "both autoreview paths"
-          ? autoreviewSources
-          : [
-              scenario === "canonical autoreview path"
-                ? autoreviewSources[0]!
-                : scenario === "vendored autoreview path"
-                  ? autoreviewSources[1]!
-                  : scenario === "other file"
-                    ? "other.test.ts"
-                    : ledgerSource,
-            ];
+        : scenario === "shared approved and unapproved path OIDs"
+          ? [ledgerSource, "other.test.ts"]
+          : scenario === "both autoreview paths"
+            ? autoreviewSources
+            : [
+                scenario === "canonical autoreview path"
+                  ? autoreviewSources[0]!
+                  : scenario === "vendored autoreview path"
+                    ? autoreviewSources[1]!
+                    : scenario === "other file"
+                      ? "other.test.ts"
+                      : ledgerSource,
+              ];
     const value = scenario === "decoded only" ? uri.replace(":", "&#58;") : uri;
     const contents = "// context\n".repeat(40) + JSON.stringify(value) + "\n";
     for (const file of files) {
@@ -539,14 +547,40 @@ for (const scenario of [
         join(f.cwd, file),
         scenario === "diff" ? "// before\n" : "// before\n" + contents,
       );
-      if (scenario === "executable source") chmodSync(join(f.cwd, file), 0o755);
+      if (scenario === "executable source" || scenario === "shared endpoint OID 755 to 644")
+        chmodSync(join(f.cwd, file), 0o755);
     }
     const baseSha = f.commit();
     for (const file of files) {
-      if (scenario === "shared endpoint OID") chmodSync(join(f.cwd, file), 0o755);
+      if (scenario === "shared endpoint OID 644 to 755" || scenario === "executable head snapshot")
+        chmodSync(join(f.cwd, file), 0o755);
+      else if (scenario === "shared endpoint OID 755 to 644") chmodSync(join(f.cwd, file), 0o644);
       else writeFileSync(join(f.cwd, file), "// after\n" + contents);
     }
     const headSha = f.commit();
+    const modeOnly =
+      scenario.startsWith("shared endpoint OID") || scenario === "executable head snapshot";
+    if (modeOnly) {
+      assert.equal(
+        f.git("rev-parse", `${baseSha}:${ledgerSource}`),
+        f.git("rev-parse", `${headSha}:${ledgerSource}`),
+      );
+      assert.equal(f.git("diff", baseSha, headSha, "--", ledgerSource).includes(uri), false);
+    }
+    if (scenario === "executable head snapshot") {
+      chmodSync(join(f.cwd, ledgerSource), 0o644);
+      f.git("add", "--", ledgerSource);
+    } else if (scenario === "executable index snapshot") {
+      chmodSync(join(f.cwd, ledgerSource), 0o755);
+      f.git("add", "--", ledgerSource);
+      chmodSync(join(f.cwd, ledgerSource), 0o644);
+    } else if (scenario === "executable worktree snapshot") {
+      chmodSync(join(f.cwd, ledgerSource), 0o755);
+    } else if (scenario === "repeated regular snapshot OID") {
+      writeFileSync(join(f.cwd, ledgerSource), "// before\n" + contents);
+      f.git("add", "--", ledgerSource);
+      writeFileSync(join(f.cwd, ledgerSource), "// after\n" + contents);
+    }
     const receipt = join(f.root, "scan-root");
     const schemaPath = join(f.root, "schema.json");
     if (scenario === "schema") writeFileSync(schemaPath, uri);
@@ -558,7 +592,7 @@ const scenario = ${JSON.stringify(scenario)};
 fs.writeFileSync(${JSON.stringify(receipt)}, path.dirname(inputDir));
 const parsed = new URL(uri);
 const blobs = inputs.filter(({name}) => /^[a-f0-9]{40}$/.test(name));
-assert.equal(blobs.length, scenario === 'shared endpoint OID' ? 1 : 2);
+assert.equal(blobs.length, ${modeOnly ? 1 : 2});
 const findings = inputs.filter(({name, bytes}) =>
   (/^[a-f0-9]{40}$/.test(name) && (scenario !== 'diff' || bytes.includes(uri))) ||
   (scenario === 'prompt' && name === 'prompt') ||
@@ -607,6 +641,13 @@ process.exit(scenario === 'unexpected successful output' ? 0 : 183);
 `,
     );
     const run = () => {
+      if (scenario.includes("snapshot")) {
+        const expected = captureTargetCheckoutBinding(f.cwd);
+        return withTargetReviewSnapshot(
+          { cwd: f.cwd, baseSha, expected, timeoutMs: 30_000 },
+          f.run,
+        );
+      }
       const source = { kind: "committed" as const, baseSha, headSha };
       if (scenario === "schema" || scenario === "additional") {
         scanAgentInput({
@@ -625,8 +666,7 @@ process.exit(scenario === 'unexpected successful output' ? 0 : 183);
         "reviewed fixture",
         "PLAIN duplicate",
         "HTML duplicate",
-        "shared approved path OIDs",
-        "shared endpoint OID",
+        "repeated regular snapshot OID",
       ].includes(scenario)
     ) {
       assert.equal(run().status, 0);
@@ -651,12 +691,9 @@ process.exit(scenario === 'unexpected successful output' ? 0 : 183);
           (sum: number, finding: { occurrences: number }) => sum + finding.occurrences,
           0,
         ),
-        scenario === "shared endpoint OID" ? 1 : scenario.endsWith("duplicate") ? 3 : 2,
+        scenario.endsWith("duplicate") ? 3 : 2,
       );
-      assert.equal(
-        notice.findings.length,
-        scenario === "shared endpoint OID" ? 1 : scenario === "HTML duplicate" ? 3 : 2,
-      );
+      assert.equal(notice.findings.length, scenario === "HTML duplicate" ? 3 : 2);
       for (const finding of notice.findings) {
         assert.match(finding.blob, /^[a-f0-9]{40}$/);
         assert.equal(finding.line, 42);


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where exact reviews stop before model execution when an unrelated edit touches the autoreview hardening test file containing an unchanged, reviewed synthetic credential-rejection fixture.

The confirmed example is [agent-skills PR205](https://github.com/openclaw/agent-skills/pull/205), with [exact-review job 99170200224](https://github.com/openclaw/clawsweeper/actions/runs/33278765964/job/99170200224) failing with `AgentInputScanError: findings` at host source `8d11c21558ba90ac6812b80b95efd0dd9b0aa936`. Complete before/after blob coverage includes that unchanged fixture even outside patch context; the clean independent exact-diff scan was not contradictory.

## Why This Change Was Made

Register the maintainer-approved full-URI digest `662a886a0fd7447dad0acda3aeccc9eb539fc90438b453de7e2f523ca7ee6c83` only for mode `100644` Git blobs at:

- `skills/autoreview/tests/test_autoreview_hardening.py`
- `.agents/skills/autoreview/tests/test_autoreview_hardening.py`

The existing action-ledger entry remains supported. Each staged OID retains **every scanned logical endpoint's path and mode**, including ineligible references. Every reference must satisfy the **same** digest/path/mode policy before classification; a valid base cannot authorize an executable head/index/worktree or an unapproved alias. Raw bytes remain staged once per OID. Unique audit sources are derived only after this validation.

This is not a domain, credential-word, test-name or unchanged-line exemption; no neighboring URI is implicitly approved. Full before/after/deleted/index/raw-worktree and prompt/schema/diff/additional coverage, scanner flags, budgets, strict output/version/verification/literal-line checks, source fences and cleanup remain intact. One unmatched finding refuses the whole scan, with no success notice. No original fixture literal was added to repository test sources, rewritten upstream, or obfuscated.

## Review Finding Disposition

Accepted and fixed the [P1 endpoint-mode finding](https://github.com/openclaw/clawsweeper/pull/1309#issuecomment-5469916359). Published head `e8dfeaf52a8fd6c29d5ced427c80a0ce1207df8b` inherited approval across a same-OID `100644→100755` transition because it retained only eligible references. Real TruffleHog reproduced that admission at both approved paths. The legacy classifier at production `8d11c21558` had the same inheritance pattern, so the repair consistently enforces the fence for both entries rather than adding a legacy exception.

All three rank-up requests were applied: retain complete endpoint eligibility context; add mode/alias/snapshot regressions; publish a redacted after-fix rejection trace. New hermetic regressions produced **75 passed / 7 failed** against the prior code, then **82 passed / 0 failed** after the repair. They cover both mode-transition directions, executable head/index/worktree snapshots, ineligible shared aliases, and valid repeated regular snapshot OIDs.

## User Impact

Reviews containing this exact approved fixture can proceed, while executable or otherwise ineligible source references remain blocking. TruffleHog findings are not hidden: accepted records emit digest/source/blob/line/decoder/count notices. Shared-blob counts are per-source references and must not be summed as unique findings.

## OpenClaw Bay Impact

Unaffected: no lifecycle, queue, workflow, publication, observer API or dashboard data-contract change. The raw-Git provenance repair and historical review comments are untouched.

## Documentation Impact

Updated the active README Safety Model and existing unreleased changelog entry. Documentation now states that every scanned endpoint association must qualify and distinguishes classification from detector coverage. No new documentation page or lifecycle category.

## Evidence

- Current head: `c8f03ea935473ee2702435f0bb6ca1f36e825918`.
- Required pre-commit Codex review, including P1 blockers: `scoped-clean`, no P0/P1 findings. The separate committed-base Codex review of the complete PR at this head is also `scoped-clean` with no findings.
- Fresh canonical validation: Node 24.20.0 / Bash 5.3.15 complete `pnpm run check` passed: **4,090 passed, zero failed, nine skipped**, plus all **13** changed-coverage tests; focused scanner/raw-Git suite **82 passed**. All coverage gates ran unchanged.
- CI and the committed-base review are checked separately against the exact head before landing; neither replaces runtime proof.

## Real Behavior Proof

**Surface:** the real `scanAgentInput` admission API and native TruffleHog. A counter immediately after admission is an inert downstream canary; no review model or target helper is invoked.

**Environment:** macOS, Node 24.20.0, external TruffleHog **3.97.1**, binary SHA-256 `f6899e5521ff060634a9599e02215195d29d330e9a902feb3f5322eedcb7ba21`. The original baseline scanner was extracted from production `8d11c21558ba90ac6812b80b95efd0dd9b0aa936`. A separate frozen copy of published head `e8dfeaf52a8fd6c29d5ced427c80a0ce1207df8b` establishes the endpoint bug before this repair.

Every run keeps the production flags:

```text
filesystem <private-input-dir> --results=verified,unknown --fail --fail-on-scan-errors --no-update --json --no-color
```

### Original false-positive regression

The pinned target range is `ae75f60e8d454f1cf44ec4613e10ec9ea7f2ade7..a8466c1d860588a083610fe41fd277c1d88b14e0`: five changed paths, ten complete before/after blobs, plus raw patch/metadata. The fixture and named test AST are unchanged; neither literal occurs in patch context.

| Case | Production baseline | Fixed candidate |
| --- | --- | --- |
| Full pinned candidate | `findings`, canary 0 | admitted, canary 1, audit |
| Exact blobs at vendored path | `findings`, canary 0 | admitted, canary 1, audit |
| Both approved paths share blobs | `findings`, canary 0 | admitted, two notices / two unique occurrences |
| Existing regular action-ledger fixture | admitted | admitted |
| Twelve negative source/surface cases | `findings`, canary 0 | `findings`, canary 0, no success notice |

The negatives cover wrong path, executable Git mode, altered password/host, mixed findings, prompt, schema, additional input, raw patch context, deleted bytes, the wrong digest at an otherwise approved path, and real Base64-decoded URI findings. All sixteen original scenarios were requalified; the production-before/current-after comparison preserves **32 matching admission assertions**.

Primary scans still report the same two URI findings and **112 chunks / 1,388,714 processed bytes**. The vendored source/path replay reports **53 chunks / 654,618 bytes**. Both findings are URI detector 17, filesystem source 15, PLAIN, unknown verification state, equal Raw/RawV2 matching the approved digest, null extras, and complete error-free scanner logs. Their value-free identities are:

```json
[
  {"blob":"3430fd935c089a5f4c5c1cc4b5422d1d43773778","line":3424,"occurrences":1},
  {"blob":"58dc0fbb4309a9b02a31be69bbcc65f7bddd244f","line":3563,"occurrences":1}
]
```

### Endpoint-boundary regression

The canonical/vendored mode fixtures reuse exact candidate blob `58dc0fbb4309a9b02a31be69bbcc65f7bddd244f`. The legacy case reuses its existing approved literal in a small fixture at its approved path. Each mode-only commit preserves its blob OID, and raw patches contain **no URI literal**, so rejection cannot be attributed to a patch finding.

| Case | Published head before repair | Fixed candidate |
| --- | --- | --- |
| Canonical `100644→100755`, same OID | admitted, canary 1 | `findings`, canary 0, no success notice |
| Vendored `100644→100755`, same OID | admitted, canary 1 | `findings`, canary 0, no success notice |
| Canonical `100755→100644`, same OID | admitted, canary 1 | `findings`, canary 0, no success notice |
| Legacy `100644→100755`, same OID | admitted, canary 1 | `findings`, canary 0, no success notice |
| Eligible and ineligible shared-path aliases | admitted, canary 1 | `findings`, canary 0, no success notice |
| Both approved aliases, all references regular | admitted | admitted |
| Ordinary regular-source control | admitted | admitted |

Each mode-transition case has one actual native URI finding. The normalized after-fix record for the canonical case is:

```json
{
  "source":"skills/autoreview/tests/test_autoreview_hardening.py",
  "fixtureSha256":"662a886a0fd7447dad0acda3aeccc9eb539fc90438b453de7e2f523ca7ee6c83",
  "endpointModes":["100644","100755"],
  "endpointBlobOids":["58dc0fbb4309a9b02a31be69bbcc65f7bddd244f","58dc0fbb4309a9b02a31be69bbcc65f7bddd244f"],
  "rawPatchContainsFixture":false,
  "nativeUriFindings":1,
  "outcome":"findings",
  "downstreamCanaryStarts":0,
  "successAuditNotices":0,
  "modelInvoked":false
}
```

**Current-head binding:** Re-executed against committed head `c8f03ea935473ee2702435f0bb6ca1f36e825918`: thirteen original admission cases, seven endpoint cases, the remaining three original cases, and the exact minimal replay below all met their stated outcomes. The numeric-HTML control remains separately recorded as unchanged nondetection, not refusal proof. Mode-transition findings reject with canary 0 and no success notice; ordinary canonical/vendored cases admit with the same native findings and audits. All five committed source fingerprints match the executed code. Compiled scanner dependency-closure SHA-256: `7957d23b1c0fb097dacc1db6db9264959ddf6b2894d042090393ce8a30c28e42`. No review model ran.

**Minimal replay:** after building either host scanner version, set `SCAN_MODULE` to its absolute compiled `agent-input-scan.js` path and `SCAN_TARGET_DIR` to the clean pinned agent-skills head with its base available. This command was executed for the candidate:

```bash
node --input-type=module <<'NODE'
import { pathToFileURL } from 'node:url';
const { scanAgentInput, AgentInputScanError } = await import(pathToFileURL(process.env.SCAN_MODULE));
let outcome = 'accepted';
let downstreamCanaryStarts = 0;
try {
  scanAgentInput({
    cwd: process.env.SCAN_TARGET_DIR,
    prompt: 'Controlled scanner admission proof; no review model.',
    source: {
      kind: 'committed',
      baseSha: 'ae75f60e8d454f1cf44ec4613e10ec9ea7f2ade7',
      headSha: 'a8466c1d860588a083610fe41fd277c1d88b14e0',
    },
    timeoutMs: 180000,
  });
  downstreamCanaryStarts++;
} catch (error) {
  outcome = error instanceof AgentInputScanError ? error.reason : 'unexpected_failure';
}
console.log(JSON.stringify({ outcome, downstreamCanaryStarts, modelInvoked: false }));
NODE
```

**Limits:** original production prompt/schema bytes were unavailable; replay uses harmless text with real source bytes. Vendored and mode-transition cases are controlled source/path replays, not a claimed full historical OpenClaw range. The local scanner binary is macOS, not the original Linux binary. A fully numeric-HTML-encoded Python-literal probe yields zero findings on both old and fixed code: that unsuccessful detection assumption is retained and **not** counted as refusal proof. Reported encoded findings still reject; real BASE64 URI findings matching the approved digest were observed and refused. No detector option, coverage check, or threshold was weakened. Raw URI values and verification diagnostics remain undisclosed; these normalized receipts are not agent transcripts.
