### PR TITLE
fix(review): stop retrying incomplete source revisions

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1300,6 +1300,11 @@ jobs:
           fi
           set -e
           echo "exit_code=$review_exit_code" >> "$GITHUB_OUTPUT"
+          # Keep 78 aligned with INCOMPLETE_AGENT_INPUT_SOURCE_EXIT_CODE. This
+          # unchanged source tuple is terminal, while the workflow stays red.
+          if [ "$review_exit_code" -eq 78 ]; then
+            echo "failure_reason=incomplete_source" >> "$GITHUB_OUTPUT"
+          fi
           if [ "$review_exit_code" -ne 0 ]; then
             exit "$review_exit_code"
           fi
@@ -1713,11 +1718,14 @@ jobs:
           REVIEW_SUPERSEDED: ${{ steps.review-exact-event-item.outputs.superseded || 'false' }}
           RESERVATION_STATUS: ${{ steps.reserve-exact-review-lease.outputs.status }}
           RETRY_AT: ${{ steps.reserve-exact-review-lease.outputs.retry_at || steps.review-exact-event-item.outputs.retry_at }}
+          REVIEW_FAILURE_REASON: ${{ steps.review-exact-event-item.outputs.failure_reason || '' }}
           CLAWSWEEPER_ACTION_LEDGER_DISABLED: "1"
         run: |
           state="Failed"
           detail="The exact review did not produce a publishable artifact. The durable queue will retry it."
-          if [ "$RESERVATION_STATUS" = "superseded" ] || [ "$REVIEW_SUPERSEDED" = "true" ]; then
+          if [ "$REVIEW_FAILURE_REASON" = "incomplete_source" ]; then
+            detail="The exact review could not verify the complete source. The durable queue will not retry this unchanged revision."
+          elif [ "$RESERVATION_STATUS" = "superseded" ] || [ "$REVIEW_SUPERSEDED" = "true" ]; then
             state="Waiting"
             detail="A newer exact-review queue owner superseded this run. This run completed as a no-op."
           elif [ "$RESERVATION_STATUS" = "held" ]; then
@@ -1804,6 +1812,7 @@ jobs:
           REQUEUE_LATEST: ${{ steps.exact-review-generation-result.outputs.requeue_latest }}
           RETRY_KIND: ${{ steps.exact-review-generation-result.outputs.retry_kind }}
           RETRY_AT: ${{ steps.exact-review-generation-result.outputs.retry_at }}
+          REVIEW_FAILURE_REASON: ${{ steps.review-exact-event-item.outputs.failure_reason || '' }}
           DIRECT_PUBLICATION_ACCEPTED: ${{ steps.direct-exact-review-publication.outputs.accepted }}
           DIRECT_PUBLICATION_SUPERSEDED: ${{ steps.direct-exact-review-publication.outputs.superseded }}
           DIRECT_LIFECYCLE_OUTCOME: ${{ steps.finalize-direct-exact-review-lifecycle.outcome }}
@@ -1866,6 +1875,9 @@ jobs:
                 : {}),
               ...(directLifecycleRequeue ? { direct_lifecycle_requeue: true } : {}),
               ...(retryAt ? { retry_at: retryAt } : {}),
+              ...(process.env.REVIEW_FAILURE_REASON
+                ? { review_failure_reason: process.env.REVIEW_FAILURE_REASON }
+                : {}),
             }));
           ')"
           response_file="$(mktemp)"

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -287,6 +287,7 @@ export type ExactReviewReviewRecoveryReason =
   | "workflow_cancelled"
   | "workflow_failed";
 type ExactReviewRetryKind = "coordination" | "throttle";
+type ExactReviewFailureReason = "incomplete_source";
 type ExactReviewPublicationFailureKind = "github_rate_limit" | "github_transient";
 type ExactReviewDispatchFailureClass =
   | "permanent_rejection"
@@ -2031,6 +2032,18 @@ export class ExactReviewQueue {
       }
       const outcome = exactReviewCompletionOutcome(body.outcome, "success");
       if (!outcome) return json({ error: "invalid_outcome" }, 400);
+      const reviewFailureReason =
+        body.review_failure_reason === undefined
+          ? undefined
+          : body.review_failure_reason === "incomplete_source"
+            ? (body.review_failure_reason as ExactReviewFailureReason)
+            : null;
+      if (body.review_failure_reason !== undefined && !reviewFailureReason) {
+        return json({ error: "invalid_review_failure_reason" }, 400);
+      }
+      if (reviewFailureReason && outcome !== "failure") {
+        return json({ error: "review_failure_reason_without_failure" }, 400);
+      }
       const failureKind =
         body.failure_kind === undefined
           ? undefined
@@ -2128,6 +2141,9 @@ export class ExactReviewQueue {
       if (retryKind && requestedRetryAt === null) {
         return json({ error: "retry_kind_without_retry_at" }, 400);
       }
+      if (reviewFailureReason && retryKind) {
+        return json({ error: "review_failure_reason_with_retry" }, 400);
+      }
       const state = this.readStateSync();
       const item = tupleCompletion ? state.items[itemKey] : exactReviewItemForLease(state, leaseId);
       if (
@@ -2181,6 +2197,9 @@ export class ExactReviewQueue {
       }
       if (retryKind && publicationItem) {
         return json({ error: "retry_kind_outside_regular_review" }, 400);
+      }
+      if (reviewFailureReason && publicationItem) {
+        return json({ error: "review_failure_reason_for_publication" }, 400);
       }
       const leasedDirectLifecycle = item.leaseDecision?.publication?.directLifecycle;
       const directLifecycleLeasePublication =
@@ -2293,9 +2312,10 @@ export class ExactReviewQueue {
                 requestedRetryAt ?? undefined,
                 requeueLatest,
                 retryKind,
+                reviewFailureReason,
                 this.random,
               ),
-              retried: outcome !== "success",
+              retried: outcome !== "success" && reviewFailureReason === undefined,
               refreshed: false,
               deadLetter: undefined,
             };
@@ -3492,6 +3512,7 @@ export class ExactReviewQueue {
           run.outcome,
           0,
           false,
+          undefined,
           undefined,
           this.random,
         );
@@ -12050,9 +12071,10 @@ function finishExactReviewQueueItem(
   requestedRetryAt = 0,
   requeueLatest = false,
   retryKind?: ExactReviewRetryKind,
+  reviewFailureReason?: ExactReviewFailureReason,
   random: () => number = Math.random,
 ) {
-  const retryingFailure = outcome !== "success";
+  const retryingFailure = outcome !== "success" && reviewFailureReason === undefined;
   const hasNewerRevision = item.revision > Number(item.leaseRevision || 0);
   if (
     !exactReviewQueueIsPublication(item) &&

--- a/src/agent-input-scan.ts
+++ b/src/agent-input-scan.ts
@@ -58,6 +58,14 @@ export class AgentInputScanError extends Error {
   }
 }
 
+export const INCOMPLETE_AGENT_INPUT_SOURCE_EXIT_CODE = 78;
+
+export function agentInputScanFailureExitCode(error: unknown): number | null {
+  return error instanceof AgentInputScanError && error.reason === "incomplete_source"
+    ? INCOMPLETE_AGENT_INPUT_SOURCE_EXIT_CODE
+    : null;
+}
+
 const MAX_SCAN_BYTES = 256 * 1024 * 1024;
 const OBJECT_ID = /^[0-9a-f]{40}(?:[0-9a-f]{24})?$/;
 const hostRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -2,6 +2,7 @@ import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { main } from "./clawsweeper-runtime.js";
+import { agentInputScanFailureExitCode } from "./agent-input-scan.js";
 import { isUserFacingCommandError } from "./command.js";
 
 export * from "./clawsweeper-runtime.js";
@@ -14,6 +15,6 @@ if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.ur
         ? error.stack || error.message
         : String(error);
     console.error(message);
-    process.exit(1);
+    process.exit(agentInputScanFailureExitCode(error) ?? 1);
   });
 }

--- a/test/agent-input-scan.test.ts
+++ b/test/agent-input-scan.test.ts
@@ -17,13 +17,27 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
 import { runAgentProcess, runAgentCheckoutInspection } from "../dist/agent-runner.js";
-import { AgentInputScanError, scanAgentInput } from "../dist/agent-input-scan.js";
+import {
+  AgentInputScanError,
+  INCOMPLETE_AGENT_INPUT_SOURCE_EXIT_CODE,
+  agentInputScanFailureExitCode,
+  scanAgentInput,
+} from "../dist/agent-input-scan.js";
 import { reviewedFixtureForSource } from "../dist/agent-input-scan-fixtures.js";
 import {
   captureTargetCheckoutBinding,
   withTargetReviewSnapshot,
 } from "../dist/repair/target-validation.js";
 import { useFakeScanner } from "./agent-input-scan-helpers.ts";
+
+test("only incomplete source scan failures receive the terminal review exit code", () => {
+  assert.equal(
+    agentInputScanFailureExitCode(new AgentInputScanError("incomplete_source")),
+    INCOMPLETE_AGENT_INPUT_SOURCE_EXIT_CODE,
+  );
+  assert.equal(agentInputScanFailureExitCode(new AgentInputScanError("scanner_failed")), null);
+  assert.equal(agentInputScanFailureExitCode(new Error("review failed")), null);
+});
 
 function fixture(t: test.TestContext, prompt = "Review the change.") {
   const root = mkdtempSync(join(tmpdir(), "clawsweeper-input-test-"));

--- a/test/dashboard-worker-queue-runtime.test.ts
+++ b/test/dashboard-worker-queue-runtime.test.ts
@@ -9358,6 +9358,94 @@ for (const retryKind of ["coordination", "throttle"] as const) {
   });
 }
 
+test("exact-review queue terminates incomplete source only for the unchanged revision", async () => {
+  const storage = new MemoryDurableStorage();
+  const terminal = leasedExactReviewQueueItem(709, "7090");
+  const transient = leasedExactReviewQueueItem(710, "7100");
+  const newer = leasedExactReviewQueueItem(711, "7110");
+  newer.revision = 2;
+  newer.decision = { ...newer.decision, sourceAction: "synchronize" };
+  await storage.put("exact-review-queue", {
+    deliveries: {},
+    items: {
+      "openclaw/openclaw#709": terminal,
+      "openclaw/openclaw#710": transient,
+      "openclaw/openclaw#711": newer,
+    },
+  });
+  const queue = new ExactReviewQueue({ storage }, {});
+  const complete = (itemNumber: number, runId: string, reviewFailureReason?: string) =>
+    queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/complete", {
+        method: "POST",
+        body: JSON.stringify({
+          lease_id: `lease-${itemNumber}`,
+          item_key: `openclaw/openclaw#${itemNumber}`,
+          lease_revision: 1,
+          claim_generation: 1,
+          run_id: runId,
+          run_attempt: 1,
+          outcome: "failure",
+          ...(reviewFailureReason ? { review_failure_reason: reviewFailureReason } : {}),
+        }),
+      }),
+    );
+
+  const terminalResponse = await complete(709, "7090", "incomplete_source");
+  assert.equal(terminalResponse.status, 200);
+  assert.deepEqual(await terminalResponse.json(), { ok: true, requeued: false });
+
+  const transientResponse = await complete(710, "7100");
+  assert.equal(transientResponse.status, 200);
+  assert.deepEqual(await transientResponse.json(), { ok: true, requeued: true });
+
+  const newerResponse = await complete(711, "7110", "incomplete_source");
+  assert.equal(newerResponse.status, 200);
+  assert.deepEqual(await newerResponse.json(), { ok: true, requeued: true });
+
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<string, Record<string, unknown>>;
+  };
+  assert.equal(state.items["openclaw/openclaw#709"], undefined);
+  assert.equal(state.items["openclaw/openclaw#710"].state, "pending");
+  assert.equal(state.items["openclaw/openclaw#710"].reviewFailureAttempts, 1);
+  assert.equal(state.items["openclaw/openclaw#711"].state, "pending");
+  assert.equal(state.items["openclaw/openclaw#711"].revision, 2);
+  assert.equal(state.items["openclaw/openclaw#711"].reviewFailureAttempts, 0);
+});
+
+test("exact-review queue validates terminal review failure reasons", async () => {
+  const queue = new ExactReviewQueue({ storage: new MemoryDurableStorage() }, {});
+  for (const [body, error] of [
+    [
+      { outcome: "failure", review_failure_reason: "scanner_failed" },
+      "invalid_review_failure_reason",
+    ],
+    [
+      { outcome: "success", review_failure_reason: "incomplete_source" },
+      "review_failure_reason_without_failure",
+    ],
+    [
+      {
+        outcome: "failure",
+        review_failure_reason: "incomplete_source",
+        retry_kind: "coordination",
+        retry_at: new Date(Date.now() + 60_000).toISOString(),
+      },
+      "review_failure_reason_with_retry",
+    ],
+  ] as const) {
+    const response = await queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/complete", {
+        method: "POST",
+        body: JSON.stringify({ lease_id: "lease-1", run_id: "1", ...body }),
+      }),
+    );
+    assert.equal(response.status, 400);
+    assert.deepEqual(await response.json(), { error });
+  }
+});
+
 test("exact-review queue spends review attempts for an untyped retry deadline", async () => {
   const storage = new MemoryDurableStorage();
   const retryAt = Date.now() + 45 * 60_000;

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -899,6 +899,10 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
   assert.match(step(reviewer, "Review exact event item").run ?? "", /source_head_sha/);
   assert.match(
     step(reviewer, "Review exact event item").run ?? "",
+    /review_exit_code.*-eq 78[\s\S]*failure_reason=incomplete_source/,
+  );
+  assert.match(
+    step(reviewer, "Review exact event item").run ?? "",
     /kill -TERM -- "-\$review_pgid"/,
   );
   assert.match(step(reviewer, "Review exact event item").run ?? "", /sleep 60/);
@@ -926,6 +930,7 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
   const deferHeldReview = step(reviewer, "Defer exact review while same-head lease is held");
   const failGeneration = step(reviewer, "Fail unsuccessful exact review generation");
   const releaseGeneration = step(reviewer, "Release unsuccessful workflow-owned review lease");
+  const markUnsuccessful = step(reviewer, "Mark unsuccessful re-review");
   assert.match(create.if ?? "", /review-exact-event-item\.outcome == 'success'/);
   assert.match(create.if ?? "", /review-exact-event-item\.outputs\.retry_at == ''/);
   assert.match(create.if ?? "", /review-exact-event-item\.outputs\.superseded != 'true'/);
@@ -1134,7 +1139,12 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
     complete.env?.RETRY_KIND,
     "${{ steps.exact-review-generation-result.outputs.retry_kind }}",
   );
+  assert.equal(
+    complete.env?.REVIEW_FAILURE_REASON,
+    "${{ steps.review-exact-event-item.outputs.failure_reason || '' }}",
+  );
   assert.match(complete.run ?? "", /retry_kind: retryKind/);
+  assert.match(complete.run ?? "", /review_failure_reason: process\.env\.REVIEW_FAILURE_REASON/);
   assert.match(complete.run ?? "", /requeue_latest: true/);
   assert.match(deferHeldReview.if ?? "", /reserve-exact-review-lease\.outputs\.status == 'held'/);
   assert.match(deferHeldReview.run ?? "", /retry deferred/);
@@ -1145,6 +1155,14 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
   );
   assert.match(failGeneration.if ?? "", /review-exact-event-item\.outputs\.superseded != 'true'/);
   assert.match(failGeneration.if ?? "", /complete-exact-review-queue\.outcome != 'success'/);
+  assert.equal(
+    markUnsuccessful.env?.REVIEW_FAILURE_REASON,
+    "${{ steps.review-exact-event-item.outputs.failure_reason || '' }}",
+  );
+  assert.match(
+    markUnsuccessful.run ?? "",
+    /incomplete_source[\s\S]*will not retry this unchanged revision/,
+  );
   assert.match(
     failGeneration.if ?? "",
     /exact-review-generation-result\.outputs\.retry_kind == ''/,


### PR DESCRIPTION
## Summary

- classify `AgentInputScanError: incomplete_source` as a distinct terminal review failure
- consume only the failed unchanged revision instead of sending it through the generic retry/recovery loop
- preserve any newer queued revision and keep the workflow red/operator-visible
- retain the existing retry behavior for every unclassified failure and older completion client

## Root cause

The scanner already marks `incomplete_source` non-retryable, but the CLI flattened every review failure to exit code 1. The workflow and exact-review queue therefore received an indistinguishable generic failure and repeatedly retried/recovered the same immutable head.

This change carries one narrow reason across the existing boundaries: CLI exit code `78` -> workflow `failure_reason` -> exact-queue `review_failure_reason`. The queue consumes that leased revision only when the reason is `incomplete_source`; a newer revision remains pending.

## Behavior proof

**Claim:** an unchanged review revision rejected as `incomplete_source` is terminal, while transient failures still retry and a newer revision is preserved.

**Exercised surface:** signed HTTP enqueue -> production Worker routing -> SQLite-backed `ExactReviewQueue` Durable Object -> dispatch -> claim -> complete.

**Exact-head runtime:** Crabbox `0.47.0-46-gfeadcdcc`, Podman-backed `provider=local-container`, image `node:24-bookworm`, lease `cbx_bfcbce5344e3`, run `run_34e2b681ae4b`, head `98b0d7683d2eae06b54dca650e786f7f5beda2f1`. Wrangler `4.107.0` ran the real Worker with Miniflare SQLite Durable Object storage; the GitHub API boundary was a loopback deterministic stub so no GitHub mutation occurred.

**Observed result:** the unchanged terminal completion returned 200 `{ "ok": true, "requeued": false }` and its dispatch count stayed at one after settling. The generic-failure control returned `{ "requeued": true }` and produced a second revision-1 dispatch. When revision 2 arrived during a revision-1 lease, the old completion was fenced with `409 lease_superseded` and the next dispatch carried `lease_revision: 2`.

**Artifact/trace:** [full redacted proof transcript](https://github.com/openclaw/clawsweeper/pull/1311#issuecomment-5471058199). Crabbox required and collected `proof/pr-1311-runtime.json`; the 968-byte artifact tar SHA-256 is `f5ed83b6b79e35a5e6e4445328cbb5891942ae710191bc6613980a7e6edf061d`. Crabbox exited 0 and automatically stopped the lease.

**Commands:**

```text
pnpm run build:all
node --test --test-name-pattern='only incomplete source scan failures' test/agent-input-scan.test.ts
node --test --test-name-pattern='exact event review publishes directly' test/sweep-workflow.test.ts
node --test --test-name-pattern='exact-review queue terminates incomplete source|exact-review queue validates terminal review failure reasons' test/dashboard-worker-queue-runtime.test.ts
pnpm exec oxfmt --check .github/workflows/sweep.yml dashboard/exact-review-queue.ts src/agent-input-scan.ts src/clawsweeper.ts test/agent-input-scan.test.ts test/dashboard-worker-queue-runtime.test.ts test/sweep-workflow.test.ts
git diff --check
```

All passed at `98b0d7683d`.

**Limits:** this is the actual local Worker and SQLite Durable Object, not the deployed Cloudflare account. GitHub App/token/workflow/item/dispatch calls were served by the loopback stub. The scanner itself was intentionally not invoked on this machine; proof begins at the typed workflow-to-queue failure contract changed by this PR.

## Compatibility and operations

- no persistence or schema change
- completion field is additive and optional; omission preserves generic retries
- invalid reason combinations fail closed
- workflow remains red so the hydration failure stays visible
- no OpenClaw Bay UI/display change; this only changes exact-review queue retry semantics

## Review note

Local hosted-agent review was not run because this machine must not execute the repository's local scanner dependency. GitHub ClawSweeper review is expected on the established PR.
