### PR TITLE
fix(review): hydrate blobs from cached PR snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Hydrate review blobs from cached PR snapshots that store an absent previous filename as `null`, preventing repeat reviews from refusing otherwise available source.
+
 - Preserve Codex keep-open verdicts during publication instead of treating related PR links as independent supersession decisions.
 
 - Let Codex own transport recovery within one review process; the durable queue owns fresh attempts. Batch publication now loads only reviewed item tuples and syncs their comments directly, removing full-repository hydration, source Git pulls, and a second comment-sync dispatch.

--- a/src/clawsweeper-review-blobs.ts
+++ b/src/clawsweeper-review-blobs.ts
@@ -250,7 +250,7 @@ export function hydratePullRequestReviewBlobs({
     const filename = safeReviewPath(file.filename);
     if (!filename) return { hydrated: false, blobs: 0 };
     const previous =
-      file.previous_filename === undefined ? filename : safeReviewPath(file.previous_filename);
+      file.previous_filename == null ? filename : safeReviewPath(file.previous_filename);
     if (!previous) return { hydrated: false, blobs: 0 };
     const status = typeof file.status === "string" ? file.status.toLowerCase() : "";
     if (status !== "added" && status !== "a") basePaths.add(previous);

--- a/test/review-blob-hydration.test.ts
+++ b/test/review-blob-hydration.test.ts
@@ -393,6 +393,30 @@ test("restricted PR review can inspect changed blobs from a genuine blobless clo
   }
 });
 
+test("persisted snapshot null previous filenames still hydrate missing blobs", () => {
+  const fixture = partialCloneFixture();
+  try {
+    assert.equal(objectExistsOffline(fixture.target, fixture.addedBlobSha), false);
+    assert.equal(objectExistsOffline(fixture.target, fixture.changedBlobSha), false);
+    const result = hydratePullRequestReviewBlobs({
+      targetDir: fixture.target,
+      baseSha: fixture.baseSha,
+      headSha: fixture.headSha,
+      resolveBlobSizes: resolveFixtureBlobSizes(fixture.source),
+      files: [
+        { filename: "added.txt", previous_filename: null, status: "added" },
+        { filename: "changed.txt", previous_filename: null, status: "modified" },
+        { filename: "removed.txt", previous_filename: null, status: "removed" },
+      ],
+    });
+    assert.deepEqual(result, { hydrated: true, blobs: 4 });
+    assert.equal(objectExistsOffline(fixture.target, fixture.addedBlobSha), true);
+    assert.equal(objectExistsOffline(fixture.target, fixture.changedBlobSha), true);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
 test("restricted review materializes the exact pull request head before model execution", () => {
   const fixture = partialCloneFixture({ prefetchHead: false });
   const reviewTree = join(fixture.root, "review-tree");


### PR DESCRIPTION
Repeated reviews could refuse `incomplete_source` even after the ancestry fix in https://github.com/openclaw/clawsweeper/pull/1308. The PR hydration snapshot writer persists a missing `previous_filename` as `null`. Cache reuse feeds that file list to blob hydration, which recognized only `undefined` as absent and rejected `null` as an unsafe path before fetching any blobs. This is observable in the real cached artifact for https://github.com/openclaw/openclaw/pull/133034; a later hosted attempt failed after both blob-hydration warnings.

Treat null and undefined as the same absent previous filename. The existing path validation, file/byte limits, merge-base verification and TruffleHog admission stay intact. Add a real blobless-Git regression covering cached added, modified and removed files and verifying that the missing head blobs become available offline. This supports the existing persisted snapshot contract without adding another representation or retry path.

## Behavior proof

Source: 8ad2930f93f8e8668afc98a4395ee1fe700b18e8. AWS Crabbox `cbx_03440716e37d`, image `ami-0461d919be7deb53c`, Node 24.18.1 and pnpm 11.10.0.

The input comes from `review-shard-0/133034.md` in [successful hosted run 33336340171](https://github.com/openclaw/clawsweeper/actions/runs/33336340171), target head `afd26c0259ddf10382d4165d7a2075c2dda445c1`. Its persisted `pr_hydration_snapshot.files.items` contains four non-renamed files with `previous_filename: null`. Replay uses those exact path/status/previous-path values and public Git objects for the merge base `61a75f549406a8c7e359c0e1243ab0adb42cd89d`, base `85f24748b8df8bb1f0198a680e7c7f4fa68ccc9f` and unchanged head.

Calling the built production `hydratePullRequestReviewBlobs` for both merge-base→head and base→head gives:

| Source | Both results |
| --- | --- |
| Baseline | `{ hydrated: false, blobs: 0 }` |
| Candidate | `{ hydrated: true, blobs: 6 }` |

Receipts are `.artifacts/cached-hydration-before.json` and `.artifacts/cached-hydration-after.json`. Baseline replay: AWS run `run_0c06580269b8`; candidate replay and validation: `run_95ea47051f22`; committed-head replay: `run_8d0c523ac92b` on a clean working tree. The standalone replay retains the actual cached input; it does not substitute a successful hydration result. Those live Git objects had already been downloaded by the diagnostic probe, so the separate genuine blobless-Git regression starts with absent blobs and proves the fetch/offline-read boundary. That regression fails on the baseline and passes with the fix.

[Hosted run 33339690794](https://github.com/openclaw/clawsweeper/actions/runs/33339690794) is the observed failed follow-up: its review step exited 78 after two blob-hydration warnings and produced no new review artifact/comment, despite an overall green workflow. This replay establishes the cached-null defect; it does not claim every `incomplete_source` refusal has that cause. The current-head hosted proof below now covers real review and publication. No live closure mode is enabled.

### Hosted current-head proof

[Candidate run 33341157225](https://github.com/openclaw/clawsweeper/actions/runs/33341157225) ran `8ad2930f93f8e8668afc98a4395ee1fe700b18e8` against the same unchanged https://github.com/openclaw/openclaw/pull/133034 head. [Review job 99337059802](https://github.com/openclaw/clawsweeper/actions/runs/33341157225/job/99337059802) completed at 23:18:28Z with `reviewed=1`, `cache_hits=0`, `hydrations=1`, `decision=keep_open`, `action=kept_open`; there were no blob-hydration warnings or input-scan refusal. It uploaded `review-shard-0` (artifact 9740664050). This proves real scanner/Codex execution reached a review result, rather than relying on the workflow's aggregate status.

[Publisher job 99337783006](https://github.com/openclaw/clawsweeper/actions/runs/33341157225/job/99337783006) hydrated the selected tuple, applied one review artifact, published canonical state and completed the actual comment-sync path with `closed=0/0`, `processed=1` and `review_comment_synced=1`. The [existing durable comment](https://github.com/openclaw/openclaw/pull/133034#issuecomment-5470996527) was updated in place at 23:20:13Z. Its marker binds head `afd26c0259ddf10382d4165d7a2075c2dda445c1`, reviewed time `2026-08-30T23:18:28.818Z`, and owner `github-run-33341157225-1`. Artifact download was rate-limited on the operator account; the job logs and live durable marker were inspected directly.

The earlier current-head ClawSweeper review found no actionable defect and accepted the captured-snapshot replay as sufficient proof; this hosted trace adds the real scanner, Codex, canonical-state and GitHub publication boundaries. [Hosted CI 33341149708](https://github.com/openclaw/clawsweeper/actions/runs/33341149708) also passed.

Validation: 22 focused hydration/snapshot tests pass, including path and byte-limit rejection. Full `pnpm check` passed: 4,136 tests passed and eight skipped. Independent Codex review found no actionable P0 defects.

OpenClaw Bay needs no change: the snapshot/record schema, lifecycle states and observer-only controls are unchanged.
