### PR TITLE
fix(observability): retain durable queue failure flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Retain only Cloudflare failure flags in queue transport logs so backend faults can be diagnosed without exposing exception details.
+
 - Hydrate review blobs from cached PR snapshots that store an absent previous filename as `null`, preventing repeat reviews from refusing otherwise available source.
 
 - Preserve Codex keep-open verdicts during publication instead of treating related PR links as independent supersession decisions.

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -4648,8 +4648,13 @@ async function exactReviewQueueRequest(env, path, request?: Request) {
       console.error("exact_review_queue_malformed_server_response");
       return json({ error: "exact_review_queue_unavailable" }, response.status);
     }
-  } catch {
-    console.error("exact_review_queue_request_failed");
+  } catch (error) {
+    const failure = objectValue(error);
+    console.error("exact_review_queue_request_failed", {
+      remote: failure.remote === true,
+      retryable: failure.retryable === true,
+      overloaded: failure.overloaded === true,
+    });
     return json({ error: "exact_review_queue_unavailable" }, 500);
   }
 }

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -30,6 +30,12 @@ CrabFleet action sessions, Codex steering, completion reasons, and dashboard
 rows, see
 [`steerable-repair-automation.md`](steerable-repair-automation.md).
 
+Queue transport failures keep the fixed public `exact_review_queue_unavailable`
+response. Server logs for `exact_review_queue_request_failed` retain only the
+Cloudflare `remote`, `retryable`, and `overloaded` boolean flags; exception text,
+stacks, request payloads, and credentials are excluded. These flags are diagnostic
+signals and do not change retry or publication policy.
+
 ## Deployment
 
 Cloudflare account:

--- a/test/dashboard-worker-durable-object-error.test.ts
+++ b/test/dashboard-worker-durable-object-error.test.ts
@@ -46,7 +46,7 @@ test("exact-review Durable Object rejects storage failures directly", async () =
   assert.equal((await queue.fetch(publicationsListRequest(100))).status, 200);
 });
 
-test("exact-review Worker projects rejected Durable Object calls to a fixed public error", async () => {
+test("exact-review Worker retains only platform flags from rejected Durable Object calls", async () => {
   const internalStack = [
     "Error: database pool internals",
     "at readQueue (file:///srv/clawsweeper-private/exact-review-queue.ts:91:4)",
@@ -57,19 +57,40 @@ test("exact-review Worker projects rejected Durable Object calls to a fixed publ
   const errors: unknown[][] = [];
   console.error = (...values: unknown[]) => errors.push(values);
   try {
-    const response = await worker.fetch(signedPublicationsListRequest(requestBody, secret), {
-      CLAWSWEEPER_WEBHOOK_SECRET: secret,
-      EXACT_REVIEW_QUEUE: new MemoryDurableNamespace({
-        async fetch() {
-          throw internalStack;
-        },
-      }),
-    });
+    for (const [failure, flags] of [
+      [internalStack, { remote: false, retryable: false, overloaded: false }],
+      [
+        Object.assign(new Error(internalStack), { remote: true }),
+        { remote: true, retryable: false, overloaded: false },
+      ],
+      [
+        Object.assign(new Error(internalStack), { retryable: true }),
+        { remote: false, retryable: true, overloaded: false },
+      ],
+      [
+        Object.assign(new Error(internalStack), { retryable: true, overloaded: true }),
+        { remote: false, retryable: true, overloaded: true },
+      ],
+      [
+        { message: internalStack, remote: "true", retryable: 1, overloaded: internalStack },
+        { remote: false, retryable: false, overloaded: false },
+      ],
+    ] as const) {
+      errors.length = 0;
+      const response = await worker.fetch(signedPublicationsListRequest(requestBody, secret), {
+        CLAWSWEEPER_WEBHOOK_SECRET: secret,
+        EXACT_REVIEW_QUEUE: new MemoryDurableNamespace({
+          async fetch() {
+            throw failure;
+          },
+        }),
+      });
 
-    assert.equal(response.status, 500);
-    assert.equal(response.headers.get("content-type"), "application/json; charset=utf-8");
-    assert.deepEqual(await response.json(), { error: "exact_review_queue_unavailable" });
-    assert.deepEqual(errors, [["exact_review_queue_request_failed"]]);
+      assert.equal(response.status, 500);
+      assert.equal(response.headers.get("content-type"), "application/json; charset=utf-8");
+      assert.deepEqual(await response.json(), { error: "exact_review_queue_unavailable" });
+      assert.deepEqual(errors, [["exact_review_queue_request_failed", flags]]);
+    }
   } finally {
     console.error = originalError;
   }

--- a/test/record-export-bounds.test.ts
+++ b/test/record-export-bounds.test.ts
@@ -560,8 +560,8 @@ test("signed record export hides missing and invalid logical byte metadata", asy
     assert.equal(invalidResponse.headers.get("content-type"), "application/json; charset=utf-8");
     assert.deepEqual(await invalidResponse.json(), { error: "exact_review_queue_unavailable" });
     assert.deepEqual(errors, [
-      ["exact_review_queue_request_failed"],
-      ["exact_review_queue_request_failed"],
+      ["exact_review_queue_request_failed", { remote: false, retryable: false, overloaded: false }],
+      ["exact_review_queue_request_failed", { remote: false, retryable: false, overloaded: false }],
     ]);
   } finally {
     console.error = originalError;


### PR DESCRIPTION
Intermittent canonical-record, publication-batch, and completion requests return HTTP 500 `exact_review_queue_unavailable`, but the Worker currently discards every property of the caught Durable Object exception. A filtered live trace captured two failed completion requests with only the generic `exact_review_queue_request_failed` log. That makes it impossible to distinguish platform overload, retryable infrastructure failure, and a remote exception from the application log.

The existing catch now logs only Cloudflare's documented `remote`, `retryable`, and `overloaded` boolean flags. Strict `=== true` checks prevent arbitrary thrown values from becoming log content. The public status/body and queue retry behavior stay unchanged. No exception message, stack, request payload, target identity, or credential is logged.

This is diagnostic instrumentation for the ongoing availability investigation; it does not claim to fix the underlying 500s. The public-error boundary introduced by https://github.com/openclaw/clawsweeper/pull/1263 is preserved. Cloudflare documents these flags and cautions against retrying overloaded objects: https://developers.cloudflare.com/durable-objects/best-practices/error-handling/.

## Real behavior proof

Candidate: `fe32ede4edba7a8f77465a3d422e4dad32008b2a`; baseline: `c377cfc04209464760ed5a1537fa693c71e77cf5`.

AWS Crabbox, lease `cbx_a1bfe9a2fb09`, image `ami-0461d919be7deb53c`, Node `v24.18.1`, pnpm `11.10.0`. The isolated checkout has no production credentials, instance role, or Tailscale. The production Worker code on the baseline is byte-identical to the current deployed Worker code from `9f343df8bfd7e852a7e10601a6a9ea7345af6f60`.

The production `dashboard/worker.ts` is bundled with the repository-pinned Wrangler 4.107.0 toolchain and executed in real workerd through Miniflare. A fixture Durable Object deliberately throws a private marker; the actual signed `/internal/exact-review/publications/list` request crosses the Durable Object boundary, and Cloudflare supplies the `remote` exception property. A fixture-only response header captures the Worker's console call without changing its response body or status.

```sh
node .artifacts/queue-failure-proof.mjs before
node .artifacts/queue-failure-proof.mjs after
```

Baseline output: HTTP 500, body `{ "error": "exact_review_queue_unavailable" }`, log `["exact_review_queue_request_failed"]`.

Candidate output: the same HTTP status/body, log `["exact_review_queue_request_failed", { "remote": true, "retryable": false, "overloaded": false }]`.

Both runs assert that the planted private marker is absent from the response and captured application log. The faulting Durable Object is controlled; workerd, the binding transport, signature validation, production Worker routing, and error catch are real. This proves diagnostic preservation and the privacy boundary, not a production outage reproduction. Retryable/overloaded variants are covered by the focused unit controls below.

The focused regression covers primitive errors, a remote exception, a retryable exception, overload with a retryable flag, and nonboolean properties. It checks the exact fixed response and exact allowed log fields, including exclusion of a planted private error marker.

Full `pnpm run check` passed: 4,145 passing tests, 8 skipped, plus the 13 static test cases. The initial full check identified an existing record-export log-shape assertion, which was aligned and then passed with the full suite. The privacy behavior itself remains unchanged.

The proof ran before commit; tree `669ef7ddfc2ee7b59b5f6d66ea0ef28d5ec6f0ca` is unchanged in the candidate commit. Runtime proof: `run_813448cd63cd`; final focused/full check: `run_706c563bed55`. Toolchain: Wrangler 4.107.0, Miniflare 4.20260701.0, workerd 1.20260701.1, esbuild 0.28.1.

Fresh pre-commit and committed-branch Codex Autoreview against the stated base both completed with no accepted/actionable P0 findings, the configured review scope.

OpenClaw Bay is unaffected: this changes only server-side diagnostic logging. No public schema, route, display, or browser action changes.

<details>
<summary>Standalone workerd reproduction driver</summary>

Install the repository-pinned proof toolchain with `npm install --prefix /tmp/clawsweeper-queue-proof-tools --no-audit --no-fund wrangler@4.107.0`. Save the following as `.artifacts/queue-failure-proof.mjs` and run the commands above from the baseline and candidate checkout respectively. The driver is included here so the runtime proof remains reproducible without adding one-off harness code to the product.

```js
import assert from 'node:assert/strict';
import {createRequire} from 'node:module';
import {createHmac} from 'node:crypto';
import {readFileSync,writeFileSync,mkdirSync} from 'node:fs';
import {execFileSync} from 'node:child_process';
import {resolve} from 'node:path';
const require=createRequire('/tmp/clawsweeper-queue-proof-tools/package.json');
const {build}=require('esbuild');
const {Miniflare,Log,LogLevel}=require('miniflare');
const phase=process.argv[2];
const output=resolve('.artifacts/queue-failure-'+phase+'.mjs');
mkdirSync('.artifacts',{recursive:true});
await build({stdin:{contents:`
import worker from './dashboard/worker.ts';
const events=[];
console.error=(...args)=>events.push(args);
export class FaultingQueue {
 async fetch(){throw new Error('synthetic-private-error-marker');}
}
export default {
 async fetch(request,env,ctx){
  const response=await worker.fetch(request,env,ctx);
  response.headers.set('x-proof-console',JSON.stringify(events.splice(0)));
  return response;
 }
};`,resolveDir:process.cwd(),sourcefile:'queue-failure-proof-entry.ts',loader:'ts'},bundle:true,format:'esm',platform:'neutral',target:'es2022',external:['cloudflare:workers'],outfile:output});
const mf=new Miniflare({modules:true,scriptPath:output,compatibilityDate:'2026-05-11',durableObjects:{EXACT_REVIEW_QUEUE:{className:'FaultingQueue',useSQLite:true}},bindings:{CLAWSWEEPER_WEBHOOK_SECRET:'synthetic-proof-secret'},log:new Log(LogLevel.NONE)});
try {
 const body=JSON.stringify({limit:100});
 const response=await mf.dispatchFetch('https://clawsweeper.openclaw.ai/internal/exact-review/publications/list',{method:'POST',headers:{'content-type':'application/json','x-clawsweeper-exact-review-signature':'sha256='+createHmac('sha256','synthetic-proof-secret').update(body).digest('hex')},body});
 const result={phase,head:execFileSync('git',['rev-parse','HEAD'],{encoding:'utf8'}).trim(),status:response.status,body:await response.json(),logs:JSON.parse(response.headers.get('x-proof-console'))};
 assert.equal(result.status,500);assert.deepEqual(result.body,{error:'exact_review_queue_unavailable'});
 const expected=phase==='before'?[['exact_review_queue_request_failed']]:[['exact_review_queue_request_failed',{remote:true,retryable:false,overloaded:false}]];
 assert.deepEqual(result.logs,expected);assert.ok(!JSON.stringify(result).includes('synthetic-private-error-marker'));
 writeFileSync('.artifacts/queue-failure-'+phase+'.json',JSON.stringify(result,null,2)+'\n');console.log(JSON.stringify(result));
} finally {await mf.dispose();}
```

</details>
