### PR TITLE
fix(observability): retain queue failure source locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Retain numeric queue failure source locations inside the Durable Object before remote transport discards the original stack, without logging private error text.
 - Bound shared repair GitHub CLI calls with native process deadlines and honor per-call timeout settings. Thanks @SebTardif.
 - Bound standalone webhook GitHub requests to 15 seconds, including response bodies, so stalled calls return a retryable response. Thanks @SebTardif.
 - Completed obsolete exact-review publications when apply verifies a strictly newer durable review for the same revision, preserving retry behavior for unproven results. Thanks @vincentkoc. (#1249)

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -731,6 +731,22 @@ function exactReviewPublicBayRepositories(env): Set<string> {
   return new Set(repositories);
 }
 
+function rethrowQueueFailure(error: unknown, phase: "initialize" | "fetch"): never {
+  const stack = objectValue(error).stack;
+  // Remote error text may contain private data; retain only deployed source coordinates.
+  const frame =
+    typeof stack === "string"
+      ? /^[ \t]+at (?:[^\r\n]*[/ (])?worker\.js:([1-9]\d{0,5}):([1-9]\d{0,5})\)?[ \t]*\r?$/m.exec(
+          stack,
+        )
+      : null;
+  console.error("exact_review_queue_handler_failed", {
+    phase,
+    location: frame ? [Number(frame[1]), Number(frame[2])] : null,
+  });
+  throw error;
+}
+
 export class ExactReviewQueue {
   private state;
   private storage;
@@ -789,20 +805,34 @@ export class ExactReviewQueue {
     if (typeof state.blockConcurrencyWhile === "function") {
       this.lifecycleProjectionReady = Promise.resolve(
         state.blockConcurrencyWhile(async () => {
-          this.lifecycleProjectionStore.ensureSchemaSync();
-          this.lifecycleTelemetryStore.ensureSchemaSync();
-          this.lifecycleTelemetryStore.syncBayRepositoryScope(
-            exactReviewPublicBayRepositories(this.env),
-          );
+          try {
+            this.lifecycleProjectionStore.ensureSchemaSync();
+            this.lifecycleTelemetryStore.ensureSchemaSync();
+            this.lifecycleTelemetryStore.syncBayRepositoryScope(
+              exactReviewPublicBayRepositories(this.env),
+            );
+          } catch (error) {
+            rethrowQueueFailure(error, "initialize");
+          }
         }),
       );
     } else {
-      this.ready = this.initializeStorage();
+      this.ready = this.initializeStorage().catch((error) =>
+        rethrowQueueFailure(error, "initialize"),
+      );
       this.lifecycleProjectionReady = this.ready;
     }
   }
 
   async fetch(request: Request) {
+    try {
+      return await this.handleFetch(request);
+    } catch (error) {
+      rethrowQueueFailure(error, "fetch");
+    }
+  }
+
+  private async handleFetch(request: Request) {
     const url = new URL(request.url);
     // This is deliberately the only route that may observe lifecycle rows
     // before full queue initialization. Its constructor-managed schema barrier
@@ -4679,7 +4709,8 @@ export class ExactReviewQueue {
 
   private ensureReady() {
     if (this.ready) return this.ready;
-    const initialize = () => this.initializeStorage();
+    const initialize = () =>
+      this.initializeStorage().catch((error) => rethrowQueueFailure(error, "initialize"));
     this.ready =
       typeof this.state.blockConcurrencyWhile === "function"
         ? Promise.resolve(this.state.blockConcurrencyWhile(initialize))

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -34,7 +34,12 @@ Queue transport failures keep the fixed public `exact_review_queue_unavailable`
 response. Server logs for `exact_review_queue_request_failed` retain only the
 Cloudflare `remote`, `retryable`, and `overloaded` boolean flags; exception text,
 stacks, request payloads, and credentials are excluded. These flags are diagnostic
-signals and do not change retry or publication policy.
+signals and do not change retry or publication policy. Inside the Durable Object,
+`exact_review_queue_handler_failed` additionally records `initialize` or `fetch`
+and the first numeric `[line, column]` location in the deployed `worker.js` module
+(or `null` when unavailable). Match coordinates to that deployment’s bundle;
+remote transport replaces the original stack before the outer Worker sees it.
+These logs exclude error messages, SQL, private paths, and raw stacks.
 
 ## Deployment
 

--- a/test/dashboard-worker-durable-object-error.test.ts
+++ b/test/dashboard-worker-durable-object-error.test.ts
@@ -36,14 +36,57 @@ function signedPublicationsListRequest(body: string, secret: string) {
   });
 }
 
-test("exact-review Durable Object rejects storage failures directly", async () => {
+test("exact-review Durable Object logs only source coordinates and rethrows storage failures", async (t) => {
   const storage = new MemoryDurableStorage();
   const queue = newQueue(storage);
   assert.equal((await queue.fetch(publicationsListRequest(100))).status, 200);
+  const errors: unknown[][] = [];
+  t.mock.method(console, "error", (...values: unknown[]) => errors.push(values));
+  for (const [stack, location] of [
+    ["Error: private marker\n    at query (worker.js:91:4)", [91, 4]],
+    [
+      "Error: private marker\r\n    at query (file:///private-path/worker.js:123:7)\r\n    at caller (worker.js:234:8)",
+      [123, 7],
+    ],
+    ["Error: private marker worker.js:91:4", null],
+    ["Error: private marker\n    at query (private-worker.js:91:4)", null],
+    ["Error: private marker\n    at query (worker.js:0:4)", null],
+    ["Error: private marker\n    at query (worker.js:1234567:4)", null],
+    [undefined, null],
+  ] as const) {
+    const failure = new Error("private marker");
+    failure.stack = stack;
+    errors.length = 0;
+    storage.failNextSql(/SELECT item_key, item_json/, failure);
+    await assert.rejects(queue.fetch(publicationsListRequest(100)), (error) => error === failure);
+    assert.deepEqual(errors, [["exact_review_queue_handler_failed", { phase: "fetch", location }]]);
+    assert.equal((await queue.fetch(publicationsListRequest(100))).status, 200);
+  }
+});
 
-  storage.failNextSql(/SELECT item_key, item_json/);
-  await assert.rejects(queue.fetch(publicationsListRequest(100)), /injected SQL failure/);
-  assert.equal((await queue.fetch(publicationsListRequest(100))).status, 200);
+test("exact-review schema barrier logs source coordinates before rejecting initialization", async (t) => {
+  const storage = new MemoryDurableStorage();
+  const failure = new Error("private schema marker");
+  failure.stack = "Error: private schema marker\n    at schema (worker.js:456:9)";
+  storage.failNextSql(/CREATE TABLE/, failure);
+  const errors: unknown[][] = [];
+  t.mock.method(console, "error", (...values: unknown[]) => errors.push(values));
+  let initialized: Promise<void> | undefined;
+  new ExactReviewQueue(
+    {
+      storage,
+      blockConcurrencyWhile: (callback: () => Promise<void>) => {
+        initialized = callback();
+        return initialized;
+      },
+    },
+    {},
+  );
+  assert.ok(initialized);
+  await assert.rejects(initialized, (error) => error === failure);
+  assert.deepEqual(errors, [
+    ["exact_review_queue_handler_failed", { phase: "initialize", location: [456, 9] }],
+  ]);
 });
 
 test("exact-review Worker retains only platform flags from rejected Durable Object calls", async () => {

--- a/test/record-export-bounds.test.ts
+++ b/test/record-export-bounds.test.ts
@@ -560,7 +560,9 @@ test("signed record export hides missing and invalid logical byte metadata", asy
     assert.equal(invalidResponse.headers.get("content-type"), "application/json; charset=utf-8");
     assert.deepEqual(await invalidResponse.json(), { error: "exact_review_queue_unavailable" });
     assert.deepEqual(errors, [
+      ["exact_review_queue_handler_failed", { phase: "fetch", location: null }],
       ["exact_review_queue_request_failed", { remote: false, retryable: false, overloaded: false }],
+      ["exact_review_queue_handler_failed", { phase: "fetch", location: null }],
       ["exact_review_queue_request_failed", { remote: false, retryable: false, overloaded: false }],
     ]);
   } finally {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where operators investigating exact-review queue failures can see that a Durable Object threw, but cannot locate the original failure. The remote call replaces the originating stack before the outer Worker receives it.

Related: https://github.com/openclaw/clawsweeper/pull/1317

## Why This Change Was Made

Record only the first numeric source coordinates inside the Durable Object, before rethrowing the original exception. Cover both initialization barriers and request handling. Keep the fixed public error response and existing retry policy. This is a diagnostic prerequisite; it does not claim to fix the underlying intermittent queue failure.

## User Impact

Operators can map a failure to the matching deployed worker bundle. Error messages, SQL, paths, raw stacks, request payloads, and credentials are excluded from these application logs. Clients retain the same response and recovery behavior.

## OpenClaw Bay Impact

Bay is unaffected: no queue, lifecycle, telemetry data contract, public response, or browser behavior changes. The new event is a server-only diagnostic log.

## Documentation Impact

Updated the active `docs/live-dashboard.md` operator runbook with the event shape and requirement to match coordinates to the exact deployment bundle. The Worker and queue implementation own this contract; changes to the log shape, module name, or bundling require the runbook to be updated. Added a changelog entry.

## Evidence

`pnpm run check` passed on Node 24.18.1: 4,152 unit tests passed, 8 skipped, plus all 13 static checks. The 11 focused tests passed. Codex precommit and committed-branch reviews found no actionable findings at their configured P0 scope.

## Real Behavior Proof

**Claim and surface:** the real Worker -> Durable Object -> SQLite failure path retains originating coordinates before remote transport replaces the stack, without changing the public failure or leaking error text.

**Revision/environment:** candidate `61e6308bac3e83dcd3808b712cace125fec7dea7`, tested tree `d5b37aee2a51c962df0b4972e0c1680ce73745b2`, compared with main `62241350beef738542b4802c172c28d7a8013db7`. Crabbox provider **aws**, lease `cbx_500a9817fb0b`, run `run_2c0cbab8167d`, image `ami-0461d919be7deb53c`; Node 24.18.1, pnpm 11.10.0, Miniflare 4.20260701.0, workerd 1.20260701.1, esbuild 0.28.1. The instance had no instance role or production credentials.

**Scenario:** bundle the actual Worker and queue into workerd with real SQLite Durable Objects. Send a signed publications-list POST, inject one native SQL failure on the next request, and retry the same request after that fault. Separately inject a native SQL failure in the constructor schema barrier. The fault contains a synthetic private marker. Only the fixture captures application log events into a response header for assertions.

**Observed before:** healthy 200 -> failure 500 -> recovery 200. Request and initialization failures expose only the outer `{remote:true,retryable:false,overloaded:false}` flags; the original SQL location is absent.

**Observed after:** the same 200 -> 500 -> 200 sequence and identical public `{error:"exact_review_queue_unavailable"}` body. Each failure additionally logs `exact_review_queue_handler_failed`, phase `fetch` or `initialize`, and `[38412,44]`, exactly matching the injected native SQL line in the generated bundle. The outer flags remain intact. Assertions reject private marker text and private paths in application logs.

**Commands/artifact:** the standalone reproducible driver and exact normalized trace are included below. Save the driver as `/tmp/clawsweeper-queue-locations-proof.mjs`. Install the pinned fixture tools outside the repository, then run it from the relevant checkout:

```sh
mkdir -p /tmp/clawsweeper-queue-stack-tools
npm install --prefix /tmp/clawsweeper-queue-stack-tools --no-audit --no-fund miniflare@4.20260701.0 esbuild@0.28.1
node /tmp/clawsweeper-queue-locations-proof.mjs before # base revision
node /tmp/clawsweeper-queue-locations-proof.mjs after  # candidate revision
```

**Limits:** controlled native-runtime fault injection, not reproduction of the unknown production cause. No live queue mutation or apply/close action was performed. A stack without a matching deployed module frame logs `null`. Production coordinates must be matched to that deployment's bundle, not the fixture's line numbers. This change does not add retries or alter alarm handling.

<details>
<summary>Normalized before/after trace</summary>

```json
{"phase":"before","faultLine":38388,"healthy":200,"failure":{"status":500,"body":{"error":"exact_review_queue_unavailable"},"logs":[["exact_review_queue_request_failed",{"remote":true,"retryable":false,"overloaded":false}]]},"recovery":200,"initialization":{"status":500,"body":{"error":"exact_review_queue_unavailable"},"logs":[["exact_review_queue_request_failed",{"remote":true,"retryable":false,"overloaded":false}]]}}
{"phase":"after","faultLine":38412,"healthy":200,"failure":{"status":500,"body":{"error":"exact_review_queue_unavailable"},"logs":[["exact_review_queue_handler_failed",{"phase":"fetch","location":[38412,44]}],["exact_review_queue_request_failed",{"remote":true,"retryable":false,"overloaded":false}]]},"recovery":200,"initialization":{"status":500,"body":{"error":"exact_review_queue_unavailable"},"logs":[["exact_review_queue_handler_failed",{"phase":"initialize","location":[38412,44]}],["exact_review_queue_request_failed",{"remote":true,"retryable":false,"overloaded":false}]]}}
```

</details>

<details>
<summary>Standalone native-runtime proof driver (includes deferred initialization)</summary>

```js
import assert from 'node:assert/strict';
import {createRequire} from 'node:module';
import {createHmac} from 'node:crypto';
import {readFileSync,mkdirSync} from 'node:fs';
import {resolve} from 'node:path';
const require=createRequire('/tmp/clawsweeper-queue-stack-tools/package.json');
const {build}=require('esbuild');
const {Miniflare,Log,LogLevel}=require('miniflare');
const phase=process.argv[2];assert.ok(['before','after','merged','deferred-probe'].includes(phase));
mkdirSync('.artifacts',{recursive:true});
const output=resolve('.artifacts/worker.js');
await build({stdin:{contents:`
import worker,{ExactReviewQueue} from './dashboard/worker.ts';
const events=[];
console.error=(...args)=>events.push(args);
function faultingState(state, shouldFail) {
 const sql=new Proxy(state.storage.sql,{get(target,name){
  if(name==='exec')return (query,...args)=>{
   if(shouldFail(query)) return target.exec('SELECT * FROM synthetic_private_sql_marker');
   return target.exec(query,...args);
  };
  const value=Reflect.get(target,name,target);
  return typeof value==='function'?value.bind(target):value;
 }});
 const storage=new Proxy(state.storage,{get(target,name){
  if(name==='sql')return sql;
  const value=Reflect.get(target,name,target);
  return typeof value==='function'?value.bind(target):value;
 }});
 return {storage,blockConcurrencyWhile:state.blockConcurrencyWhile.bind(state),waitUntil:state.waitUntil.bind(state),id:state.id};
}
export class FaultingQueue extends ExactReviewQueue {
 requests=0;arm;
 constructor(state,env){
  let armed=false;
  super(faultingState(state,query=>{if(armed&&/SELECT item_key, item_json/.test(query)){armed=false;return true}return false}),env);
  this.arm=()=>{armed=true};
 }
 async fetch(request){if(++this.requests===2)this.arm();return super.fetch(request)}
}
export class FaultingInitQueue extends ExactReviewQueue {
 constructor(state,env){super(faultingState(state,query=>/CREATE TABLE/.test(query)),env)}
}
export class FaultingDeferredQueue extends ExactReviewQueue {
 constructor(state,env){super(faultingState(state,query=>/CREATE TABLE IF NOT EXISTS exact_review_queue_meta/.test(query)),env)}
}
export default {async fetch(request,env,ctx){
 const selected=request.headers.get('x-proof-init')==='deferred'?{...env,EXACT_REVIEW_QUEUE:env.DEFERRED_QUEUE}:request.headers.get('x-proof-init')==='1'?{...env,EXACT_REVIEW_QUEUE:env.INIT_QUEUE}:env;
 const original=await worker.fetch(request,selected,ctx);
 const response=new Response(original.body,{status:original.status,headers:original.headers});
 response.headers.set('x-proof-events',JSON.stringify(events.splice(0)));
 return response;
}};`,resolveDir:process.cwd(),sourcefile:'queue-locations-proof.ts',loader:'ts'},bundle:true,format:'esm',platform:'neutral',target:'es2022',external:['cloudflare:workers'],outfile:output});
const faultLine=readFileSync(output,'utf8').split('\n').findIndex(line=>line.includes('SELECT * FROM synthetic_private_sql_marker'))+1;
assert.ok(faultLine>0);
const mf=new Miniflare({modules:true,scriptPath:output,compatibilityDate:'2026-05-11',durableObjects:{EXACT_REVIEW_QUEUE:{className:'FaultingQueue',useSQLite:true},INIT_QUEUE:{className:'FaultingInitQueue',useSQLite:true},DEFERRED_QUEUE:{className:'FaultingDeferredQueue',useSQLite:true}},bindings:{CLAWSWEEPER_WEBHOOK_SECRET:'synthetic-proof-secret'},log:new Log(LogLevel.NONE)});
async function request(init=false){
 const body=JSON.stringify({limit:1});
 const response=await mf.dispatchFetch('https://clawsweeper.openclaw.ai/internal/exact-review/publications/list',{method:'POST',headers:{'content-type':'application/json','x-proof-init':init==='deferred'?'deferred':init?'1':'0','x-clawsweeper-exact-review-signature':'sha256='+createHmac('sha256','synthetic-proof-secret').update(body).digest('hex')},body});
 const text=await response.text();
 let responseBody;try{responseBody=JSON.parse(text)}catch{throw new Error('unexpected fixture response: '+text)}
 return {status:response.status,body:responseBody,logs:JSON.parse(response.headers.get('x-proof-events'))};
}
function verifyFailure(result,expectedPhase){
 assert.equal(result.status,500);assert.deepEqual(result.body,{error:'exact_review_queue_unavailable'});
 const origin=result.logs.filter(entry=>entry[0]==='exact_review_queue_handler_failed');
 if(phase==='before')assert.deepEqual(origin,[]);
 else {
  assert.equal(origin.length,1);assert.equal(origin[0][1].phase,expectedPhase);
  assert.equal(origin[0][1].location[0],faultLine);assert.ok(origin[0][1].location[1]>0);
  assert.deepEqual(Object.keys(origin[0][1]).sort(),['location','phase']);
 }
 const transport=result.logs.filter(entry=>entry[0]==='exact_review_queue_request_failed');
 assert.equal(transport.length,1);
 assert.deepEqual(Object.keys(transport[0][1]).sort(),['overloaded','remote','retryable']);
 assert.ok(!JSON.stringify(result).includes('synthetic_private_sql_marker'));
 assert.ok(!JSON.stringify(result).includes('file:///'));
}
try{
 if(phase==='deferred-probe'){const deferred=await request('deferred');verifyFailure(deferred,'initialize');console.log(JSON.stringify({phase,faultLine,deferred}));}else{
 const first=await request();assert.equal(first.status,200);assert.deepEqual(first.logs,[]);
 const failure=await request();verifyFailure(failure,'fetch');
 const recovery=await request();assert.equal(recovery.status,200);assert.deepEqual(recovery.logs,[]);
 const initialization=await request(true);verifyFailure(initialization,'initialize');
 const deferred=await request('deferred');verifyFailure(deferred,'initialize');
 console.log(JSON.stringify({phase,faultLine,healthy:first.status,failure,recovery:recovery.status,initialization,deferred}));
}
}finally{await mf.dispose()}
```

</details>

## Review Finding Disposition

The reported P2 duplicate initialization log was investigated on the exact candidate in real workerd, rather than treating a Promise-only test double as the Durable Object runtime. **Rejected for the deployed path:** a failure inside `blockConcurrencyWhile` terminates/resets the object, so the surrounding request catch does not run. [Cloudflare documents this reset behavior](https://developers.cloudflare.com/durable-objects/api/state/#blockconcurrencywhile).

The extended driver above adds `FaultingDeferredQueue`: the constructor lifecycle schema barrier succeeds, then the first publications-list request fails native SQLite specifically at `CREATE TABLE IF NOT EXISTS exact_review_queue_meta` inside deferred full initialization. `verifyFailure` asserts exactly one origin event, phase `initialize`, coordinates matching the actual injected SQL line, the unchanged public 500, the existing transport flags, and no private marker/path. This directly covers the missing scenario and both proposed Rank-up moves' underlying concern. No production error-deduplication state is needed. The lightweight direct-call unit harness does not implement platform reset semantics, so it is not the oracle for this lifecycle claim.

The constructor, deferred initialization, request fault, and recovery cases were rerun together on unchanged head `61e6308bac3e83dcd3808b712cace125fec7dea7` in AWS lease `cbx_500a9817fb0b`, run `run_ef8740eb29bd`, with the same pinned environment. No source changed after the two Codex autoreviews or full check. Current CI passed: https://github.com/openclaw/clawsweeper/actions/runs/33370859506 ; CodeQL passed: https://github.com/openclaw/clawsweeper/actions/runs/33370859425.

Extended exact trace:

```json
{"phase":"after","faultLine":38412,"healthy":200,"failure":{"status":500,"body":{"error":"exact_review_queue_unavailable"},"logs":[["exact_review_queue_handler_failed",{"phase":"fetch","location":[38412,44]}],["exact_review_queue_request_failed",{"remote":true,"retryable":false,"overloaded":false}]]},"recovery":200,"initialization":{"status":500,"body":{"error":"exact_review_queue_unavailable"},"logs":[["exact_review_queue_handler_failed",{"phase":"initialize","location":[38412,44]}],["exact_review_queue_request_failed",{"remote":true,"retryable":false,"overloaded":false}]]},"deferred":{"status":500,"body":{"error":"exact_review_queue_unavailable"},"logs":[["exact_review_queue_handler_failed",{"phase":"initialize","location":[38412,44]}],["exact_review_queue_request_failed",{"remote":true,"retryable":false,"overloaded":false}]]}}
```
