### PR TITLE
fix(repair): prefer Telegram for live behavior proof

### DIFF
--- a/src/repair/fix-prompt-builder.test.ts
+++ b/src/repair/fix-prompt-builder.test.ts
@@ -112,23 +112,24 @@ test("fix prompt makes Codex own the validation loop", () => {
   assert.match(prompt, /do not report validation as passed unless it passed after your last edit/);
 });
 
-test("fix prompt routes applicable Telegram behavior through the repository skill", () => {
+test("fix prompt uses Telegram as the primary surface for applicable core behavior", () => {
   const prompt = promptFor({
-    summary: "Repair a Telegram-visible reply regression.",
-    affected_surfaces: ["extensions/telegram"],
-    likely_files: ["extensions/telegram/src/bot-message.ts"],
+    summary: "Repair a shared reply lifecycle regression.",
+    affected_surfaces: ["src/agents"],
+    likely_files: ["src/agents/reply-lifecycle.ts"],
     changelog_required: false,
   });
 
   assert.match(
     prompt,
-    /Telegram-visible behavior: when the changed behavior is observable on Telegram's Test Server/,
+    /Live behavior: use Telegram as the primary proof surface whenever it can exercise the changed behavior/,
   );
+  assert.match(prompt, /including shared core behavior/);
   assert.match(
     prompt,
     /after base sync read and use `.agents\/skills\/telegram-e2e-userbot\/SKILL.md`/,
   );
-  assert.match(prompt, /exercise the exact changed behavior/);
+  assert.match(prompt, /exercise the exact change/);
   assert.match(prompt, /extend its harness or recipes when needed/);
 });
 

--- a/src/repair/fix-prompt-builder.ts
+++ b/src/repair/fix-prompt-builder.ts
@@ -50,7 +50,7 @@ export function buildFixPrompt({
     "- address review-bot concerns named in the artifact;",
     "- resolve actionable human review comments, bot comments, and requested changes named in the artifact;",
     "- fix relevant failing CI/check output named in the artifact; do not leave known changed-surface CI failures for a later pass;",
-    "- Telegram-visible behavior: when the changed behavior is observable on Telegram's Test Server, after base sync read and use `.agents/skills/telegram-e2e-userbot/SKILL.md` to exercise the exact changed behavior; extend its harness or recipes when needed;",
+    "- Live behavior: use Telegram as the primary proof surface whenever it can exercise the changed behavior, including shared core behavior; after base sync read and use `.agents/skills/telegram-e2e-userbot/SKILL.md` to exercise the exact change; extend its harness or recipes when needed;",
     isAutomergeRepair ? renderAutomergeRepairGuidance() : "",
     renderChangelogRule(fixArtifact),
     "- prepare the PR so it can pass the ClawSweeper Repair merge_preflight gate;",


### PR DESCRIPTION
## Summary

- Use Telegram as the primary live proof surface whenever it can exercise the changed behavior.
- Apply the rule to shared core behavior, not only Telegram-owned code.
- Keep the existing exact-behavior and extensible-harness requirements.

## Validation

- Focused repair prompt tests: 13 passed.
- Full repository validation runs in CI.
