### PR TITLE
fix(dashboard): correlate exact-review queue failures

### DIFF
--- a/dashboard/exact-review-direct-publication.ts
+++ b/dashboard/exact-review-direct-publication.ts
@@ -196,6 +196,13 @@ export class CanonicalRecordTupleConflictError extends Error {
   }
 }
 
+export class RecordExportConsistencyError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "RecordExportConsistencyError";
+  }
+}
+
 export class ExactReviewDirectPublicationStore {
   private readonly storage: DurableStorage;
 
@@ -1204,7 +1211,7 @@ export class ExactReviewDirectPublicationStore {
     )[0];
     const revision = Number(row?.current_revision);
     if (!Number.isSafeInteger(revision) || revision < 1) {
-      throw new Error("record export revision allocation failed");
+      throw new RecordExportConsistencyError("record export revision allocation failed");
     }
     return revision;
   }
@@ -1218,7 +1225,7 @@ export class ExactReviewDirectPublicationStore {
     )[0];
     const revision = Number(row?.current_revision ?? 0);
     if (!Number.isSafeInteger(revision) || revision < 0) {
-      throw new Error("invalid record export revision watermark");
+      throw new RecordExportConsistencyError("invalid record export revision watermark");
     }
     return revision;
   }
@@ -1233,11 +1240,23 @@ export class ExactReviewDirectPublicationStore {
       if (String(row.source) === "canonical" && section !== "commits") {
         const itemId = Number(id);
         if (!Number.isSafeInteger(itemId) || itemId < 1) {
-          throw new Error(`invalid canonical export identity: ${repoSlug}/${section}/${id}`);
+          throw new RecordExportConsistencyError(
+            `invalid canonical export identity: ${repoSlug}/${section}/${id}`,
+          );
         }
-        const canonical = this.readCanonical(repoSlug, section, itemId);
+        let canonical: CanonicalRecord | null;
+        try {
+          canonical = this.readCanonical(repoSlug, section, itemId);
+        } catch (error) {
+          if (error instanceof RecordExportConsistencyError) throw error;
+          throw new RecordExportConsistencyError("canonical export content is malformed", {
+            cause: error,
+          });
+        }
         if (!canonical || canonical.deleted || canonical.content === null) {
-          throw new Error(`canonical export content missing: ${repoSlug}/${section}/${id}`);
+          throw new RecordExportConsistencyError(
+            `canonical export content missing: ${repoSlug}/${section}/${id}`,
+          );
         }
         content = canonical.content;
       } else {
@@ -1302,7 +1321,11 @@ export class ExactReviewDirectPublicationStore {
         id,
       ),
     )[0];
-    if (!row) throw new Error(`backfill export content missing: ${repoSlug}/${section}/${id}`);
+    if (!row) {
+      throw new RecordExportConsistencyError(
+        `backfill export content missing: ${repoSlug}/${section}/${id}`,
+      );
+    }
     if (row.content !== null) return String(row.content);
     const chunks = Array.from(
       this.storage.sql.exec(
@@ -1316,19 +1339,30 @@ export class ExactReviewDirectPublicationStore {
       ),
     );
     if (chunks.length !== Number(row.chunk_count)) {
-      throw new Error(`backfill export chunk count mismatch: ${repoSlug}/${section}/${id}`);
+      throw new RecordExportConsistencyError(
+        `backfill export chunk count mismatch: ${repoSlug}/${section}/${id}`,
+      );
     }
-    const parts = chunks.map((chunk) => base64Bytes(String(chunk.content_base64)));
-    const bytes = new Uint8Array(parts.reduce((sum, part) => sum + part.byteLength, 0));
-    let offset = 0;
-    for (const part of parts) {
-      bytes.set(part, offset);
-      offset += part.byteLength;
+    try {
+      const parts = chunks.map((chunk) => base64Bytes(String(chunk.content_base64)));
+      const bytes = new Uint8Array(parts.reduce((sum, part) => sum + part.byteLength, 0));
+      let offset = 0;
+      for (const part of parts) {
+        bytes.set(part, offset);
+        offset += part.byteLength;
+      }
+      if (bytes.byteLength !== Number(row.byte_length)) {
+        throw new RecordExportConsistencyError(
+          `backfill export byte count mismatch: ${repoSlug}/${section}/${id}`,
+        );
+      }
+      return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    } catch (error) {
+      if (error instanceof RecordExportConsistencyError) throw error;
+      throw new RecordExportConsistencyError("backfill export content is malformed", {
+        cause: error,
+      });
     }
-    if (bytes.byteLength !== Number(row.byte_length)) {
-      throw new Error(`backfill export byte count mismatch: ${repoSlug}/${section}/${id}`);
-    }
-    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
   }
 
   private insertSync(row: DirectPublicationRow) {
@@ -1370,7 +1404,7 @@ function recordExportSourceByteLength(row: Record<string, unknown>) {
     byteLength < 0 ||
     (Number(row.deleted) === 1 && byteLength !== 0)
   ) {
-    throw new Error(
+    throw new RecordExportConsistencyError(
       `invalid record export byte metadata: ${String(row.repo_slug)}/${String(row.section)}/${String(row.record_id)}`,
     );
   }

--- a/dashboard/exact-review-queue-observability.ts
+++ b/dashboard/exact-review-queue-observability.ts
@@ -1,0 +1,104 @@
+export const EXACT_REVIEW_QUEUE_TRACE_HEADER = "x-clawsweeper-exact-review-trace";
+
+const TRACE_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+const EXACT_REVIEW_QUEUE_ENDPOINTS = new Map<string, string>([
+  ["/artifact-cache/receipt/lookup", "artifact_cache_receipt_lookup"],
+  ["/artifact-cache/receipt/store", "artifact_cache_receipt_store"],
+  ["/bay-lifecycle-metrics", "bay_lifecycle_metrics"],
+  ["/branch-authority", "branch_authority"],
+  ["/claim", "claim"],
+  ["/claimed-runs", "claimed_runs"],
+  ["/command-intake", "command_intake"],
+  ["/complete", "complete"],
+  ["/dead-letters/list", "dead_letters_list"],
+  ["/dead-letters/recover-fresh", "dead_letters_recover_fresh"],
+  ["/dead-letters/replay", "dead_letters_replay"],
+  ["/dead-letters/resolve", "dead_letters_resolve"],
+  ["/enqueue", "enqueue"],
+  ["/github-egress-observability", "github_egress_observability"],
+  ["/github-egress-telemetry", "github_egress_telemetry"],
+  ["/github-etag-cache/confirm", "github_etag_cache_confirm"],
+  ["/github-etag-cache/lookup", "github_etag_cache_lookup"],
+  ["/github-etag-cache/store", "github_etag_cache_store"],
+  ["/github-read-model/activity", "github_read_model_activity"],
+  ["/github-read-model/comments", "github_read_model_comments"],
+  ["/github-read-model/ingest", "github_read_model_ingest"],
+  ["/github-read-model/item", "github_read_model_item"],
+  ["/github-read-model/lease-item", "github_read_model_lease_item"],
+  ["/github-read-model/placeholders", "github_read_model_placeholders"],
+  ["/github-read-model/repair", "github_read_model_repair"],
+  ["/github-read-model/workflows", "github_read_model_workflows"],
+  ["/heartbeat", "heartbeat"],
+  ["/item-status", "item_status"],
+  ["/lifecycle-audit/inventory", "lifecycle_audit_inventory"],
+  ["/lifecycle-bay", "lifecycle_bay"],
+  ["/lifecycle/canonical-receipt", "lifecycle_canonical_receipt"],
+  ["/lifecycle/command-ack/attempt", "lifecycle_command_ack_attempt"],
+  ["/lifecycle/command-ack/failed", "lifecycle_command_ack_failed"],
+  ["/lifecycle/command-ack/observed", "lifecycle_command_ack_observed"],
+  ["/lifecycle/router-receipt", "lifecycle_router_receipt"],
+  ["/lifecycle/terminal-disposition", "lifecycle_terminal_disposition"],
+  ["/parked-reviews/list", "parked_reviews_list"],
+  ["/parked-reviews/recover-fresh", "parked_reviews_recover_fresh"],
+  ["/parked-reviews/resolve", "parked_reviews_resolve"],
+  ["/publication-batch-results", "publication_batch_results"],
+  ["/publication-batches/claim", "publication_batches_claim"],
+  ["/publication-batches/complete", "publication_batches_complete"],
+  ["/publication-batches/fetch", "publication_batches_fetch"],
+  ["/publication-batches/heartbeat", "publication_batches_heartbeat"],
+  ["/publication-results", "publication_results"],
+  ["/publications/list", "publications_list"],
+  ["/publications/reconcile", "publications_reconcile"],
+  ["/publications/supersede", "publications_supersede"],
+  ["/recent-durable-publication-events", "recent_durable_publication_events"],
+  ["/reconcile", "reconcile"],
+  ["/records/commits", "records_commits"],
+  ["/records/export", "records_export"],
+  ["/records/list", "records_list"],
+  ["/records/slugs", "records_slugs"],
+  ["/records/snapshots/chunk", "records_snapshots_chunk"],
+  ["/records/snapshots/latest", "records_snapshots_latest"],
+  ["/records/snapshots/trigger", "records_snapshots_trigger"],
+  ["/records/tuples", "records_tuples"],
+  ["/review-coverage", "review_coverage"],
+  ["/review-coverage/inventory", "review_coverage_inventory"],
+  ["/review-observability", "review_observability"],
+  ["/review-run-telemetry", "review_run_telemetry"],
+  ["/source-authority", "source_authority"],
+  ["/source-authority/complete", "source_authority_complete"],
+  ["/state-writer-progress", "state_writer_progress"],
+  ["/state-writer/acquire", "state_writer_acquire"],
+  ["/state-writer/heartbeat", "state_writer_heartbeat"],
+  ["/state-writer/release", "state_writer_release"],
+  ["/stats", "stats"],
+  ["/terminal-finalization/attempt", "terminal_finalization_attempt"],
+  ["/terminal-finalization/retry", "terminal_finalization_retry"],
+  ["/terminal-finalization/skip", "terminal_finalization_skip"],
+]);
+
+export function newExactReviewQueueTraceId(): string {
+  return crypto.randomUUID();
+}
+
+export function exactReviewQueueTraceId(value: unknown): string | null {
+  const candidate = typeof value === "string" ? value.toLowerCase() : "";
+  return TRACE_ID_PATTERN.test(candidate) ? candidate : null;
+}
+
+export function exactReviewQueueEndpointTemplate(path: string): string {
+  const pathname = path.split("?", 1)[0] || "";
+  const exact = EXACT_REVIEW_QUEUE_ENDPOINTS.get(pathname);
+  if (exact) return exact;
+  if (/^\/records\/[^/]+\/(?:items|closed|plans|decision-packets)\/[1-9]\d*$/.test(pathname)) {
+    return "records_item";
+  }
+  if (
+    /^\/cursors\/(?:hot-intake|normal-review|audit|review-placeholder-[a-f0-9]{16}-(?:open|closed))$/.test(
+      pathname,
+    )
+  ) {
+    return "cursor";
+  }
+  return "other";
+}

--- a/dashboard/exact-review-queue-observability.ts
+++ b/dashboard/exact-review-queue-observability.ts
@@ -72,6 +72,7 @@ const EXACT_REVIEW_QUEUE_ENDPOINTS = new Map<string, string>([
   ["/state-writer/heartbeat", "state_writer_heartbeat"],
   ["/state-writer/release", "state_writer_release"],
   ["/stats", "stats"],
+  ["/telemetry-reconciliation", "telemetry_reconciliation"],
   ["/terminal-finalization/attempt", "terminal_finalization_attempt"],
   ["/terminal-finalization/retry", "terminal_finalization_retry"],
   ["/terminal-finalization/skip", "terminal_finalization_skip"],

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -750,14 +750,16 @@ function rethrowQueueFailure(
           stack,
         )
       : null;
+  const traceId = request
+    ? exactReviewQueueTraceId(request.headers.get(EXACT_REVIEW_QUEUE_TRACE_HEADER))
+    : null;
+  const endpoint = request
+    ? exactReviewQueueEndpointTemplate(new URL(request.url).pathname)
+    : "initialization";
   console.error("exact_review_queue_handler_failed", {
     phase,
-    trace_id: request
-      ? exactReviewQueueTraceId(request.headers.get(EXACT_REVIEW_QUEUE_TRACE_HEADER))
-      : null,
-    endpoint: request
-      ? exactReviewQueueEndpointTemplate(new URL(request.url).pathname)
-      : "initialization",
+    trace_id: traceId,
+    endpoint,
     failure_category:
       error instanceof RecordExportConsistencyError
         ? "record_export_consistency"

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -28,6 +28,7 @@ import {
   EXACT_REVIEW_DIRECT_PUBLICATION_MAX_POST_BYTES,
   REVIEW_COVERAGE_INVENTORY_KEY,
   ExactReviewDirectPublicationStore,
+  RecordExportConsistencyError,
   directPublicationRejectionDetail,
   normalizeReviewCoverageInventory,
   sha256Hex,
@@ -43,6 +44,11 @@ import {
   type RecordSection,
   type ReviewCoverageSummary,
 } from "./exact-review-direct-publication.ts";
+import {
+  EXACT_REVIEW_QUEUE_TRACE_HEADER,
+  exactReviewQueueEndpointTemplate,
+  exactReviewQueueTraceId,
+} from "./exact-review-queue-observability.ts";
 import {
   REVIEW_OBSERVABILITY_RANGES,
   summarizeReviewObservability,
@@ -731,7 +737,11 @@ function exactReviewPublicBayRepositories(env): Set<string> {
   return new Set(repositories);
 }
 
-function rethrowQueueFailure(error: unknown, phase: "initialize" | "fetch"): never {
+function rethrowQueueFailure(
+  error: unknown,
+  phase: "initialize" | "fetch",
+  request?: Request,
+): never {
   const stack = objectValue(error).stack;
   // Remote error text may contain private data; retain only deployed source coordinates.
   const frame =
@@ -742,6 +752,16 @@ function rethrowQueueFailure(error: unknown, phase: "initialize" | "fetch"): nev
       : null;
   console.error("exact_review_queue_handler_failed", {
     phase,
+    trace_id: request
+      ? exactReviewQueueTraceId(request.headers.get(EXACT_REVIEW_QUEUE_TRACE_HEADER))
+      : null,
+    endpoint: request
+      ? exactReviewQueueEndpointTemplate(new URL(request.url).pathname)
+      : "initialization",
+    failure_category:
+      error instanceof RecordExportConsistencyError
+        ? "record_export_consistency"
+        : "handler_exception",
     location: frame ? [Number(frame[1]), Number(frame[2])] : null,
   });
   throw error;
@@ -828,7 +848,7 @@ export class ExactReviewQueue {
     try {
       return await this.handleFetch(request);
     } catch (error) {
-      rethrowQueueFailure(error, "fetch");
+      rethrowQueueFailure(error, "fetch", request);
     }
   }
 

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -57,6 +57,11 @@ import {
   type ExactReviewIngress,
 } from "./exact-review-queue.ts";
 import {
+  EXACT_REVIEW_QUEUE_TRACE_HEADER,
+  exactReviewQueueEndpointTemplate,
+  newExactReviewQueueTraceId,
+} from "./exact-review-queue-observability.ts";
+import {
   AUTOMERGE_METRICS_EVENT_TYPE,
   AUTOMERGE_METRICS_EVENT_KEY_PREFIX,
   AUTOMERGE_METRICS_EVENT_ID_KEY_PREFIX,
@@ -3866,7 +3871,9 @@ async function githubWebhook(request, env, ctx) {
     });
     const queue = exactReviewQueueStub(env);
     if (!queue) return json({ error: "exact_review_queue_not_configured" }, 503);
-    const intakeResponse = await queue.fetch(
+    const { response: intakeResponse } = await exactReviewQueueFetch(
+      queue,
+      "/command-intake",
       new Request("https://clawsweeper-exact-review-queue/command-intake", {
         method: "POST",
         headers: { "content-type": "application/json" },
@@ -4705,7 +4712,9 @@ async function recordLifecycleCommandAcknowledgement(env, completion) {
   const queue = exactReviewQueueStub(env);
   if (!queue) return { accepted: true, sourceDeliveryId: null, bayJourneyDeliveryId: null };
   const observedAt = Date.parse(String(completion.completed_at || ""));
-  const response = await queue.fetch(
+  const { response } = await exactReviewQueueFetch(
+    queue,
+    "/lifecycle/command-ack/observed",
     new Request("https://clawsweeper-exact-review-queue/lifecycle/command-ack/observed", {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -4743,7 +4752,9 @@ async function reserveExactReviewSourceAuthority(
 ): Promise<{ deduped: true } | { sourceAuthoritySeq: number } | null> {
   const queue = exactReviewQueueStub(env);
   if (!queue) return null;
-  const response = await queue.fetch(
+  const { response } = await exactReviewQueueFetch(
+    queue,
+    "/source-authority",
     new Request("https://clawsweeper-exact-review-queue/source-authority", {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -4775,7 +4786,9 @@ async function completeExactReviewSourceAuthority(
 ) {
   const queue = exactReviewQueueStub(env);
   if (!queue) throw new Error("exact-review queue not configured");
-  const response = await queue.fetch(
+  const { response } = await exactReviewQueueFetch(
+    queue,
+    "/source-authority/complete",
     new Request("https://clawsweeper-exact-review-queue/source-authority/complete", {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -4792,34 +4805,79 @@ async function completeExactReviewSourceAuthority(
   }
 }
 
-async function exactReviewQueueRequest(env, path, request?: Request) {
-  const queue = exactReviewQueueStub(env);
-  if (!queue) return json({ error: "exact_review_queue_not_configured" }, 503);
+async function exactReviewQueueFetch(queue: DurableObjectStub, path: string, request?: Request) {
   const body = request ? await request.text() : undefined;
+  const traceId = newExactReviewQueueTraceId();
+  const endpoint = exactReviewQueueEndpointTemplate(path);
   try {
+    const headers = new Headers(body ? { "content-type": "application/json" } : undefined);
+    headers.set(EXACT_REVIEW_QUEUE_TRACE_HEADER, traceId);
     const response = await queue.fetch(
       new Request(`https://clawsweeper-exact-review-queue${path}`, {
         method: request?.method || "GET",
-        headers: body ? { "content-type": "application/json" } : undefined,
+        headers,
         ...(body ? { body } : {}),
       }),
     );
-    if (response.status < 500) return response;
+    if (response.status < 500) return { response, malformedServerResponse: false };
     const responseBody = await response.clone().text();
     try {
       JSON.parse(responseBody);
-      return response;
+      console.error("exact_review_queue_structured_server_response", {
+        trace_id: traceId,
+        endpoint,
+        phase: "request",
+        transport: "structured_5xx",
+        upstream_status: response.status,
+        failure_category: "structured_server_response",
+      });
+      return { response, malformedServerResponse: false };
     } catch {
-      console.error("exact_review_queue_malformed_server_response");
-      return json({ error: "exact_review_queue_unavailable" }, response.status);
+      console.error("exact_review_queue_malformed_server_response", {
+        trace_id: traceId,
+        endpoint,
+        phase: "request",
+        transport: "non_json_5xx",
+        upstream_status: response.status,
+        failure_category: "malformed_server_response",
+      });
+      return { response, malformedServerResponse: true };
     }
   } catch (error) {
     const failure = objectValue(error);
+    const remote = failure.remote === true;
+    const retryable = failure.retryable === true;
+    const overloaded = failure.overloaded === true;
     console.error("exact_review_queue_request_failed", {
-      remote: failure.remote === true,
-      retryable: failure.retryable === true,
-      overloaded: failure.overloaded === true,
+      trace_id: traceId,
+      endpoint,
+      phase: "request",
+      transport: "throw",
+      upstream_status: null,
+      remote,
+      retryable,
+      overloaded,
+      failure_category: overloaded
+        ? "platform_overloaded"
+        : retryable
+          ? "platform_retryable"
+          : remote
+            ? "remote_exception"
+            : "request_exception",
     });
+    throw error;
+  }
+}
+
+async function exactReviewQueueRequest(env, path, request?: Request) {
+  const queue = exactReviewQueueStub(env);
+  if (!queue) return json({ error: "exact_review_queue_not_configured" }, 503);
+  try {
+    const { response, malformedServerResponse } = await exactReviewQueueFetch(queue, path, request);
+    return malformedServerResponse
+      ? json({ error: "exact_review_queue_unavailable" }, response.status)
+      : response;
+  } catch {
     return json({ error: "exact_review_queue_unavailable" }, 500);
   }
 }
@@ -6160,7 +6218,9 @@ async function enqueueExactReview({
 }) {
   const queue = exactReviewQueueStub(env);
   if (!queue) return null;
-  const response = await queue.fetch(
+  const { response } = await exactReviewQueueFetch(
+    queue,
+    "/enqueue",
     new Request("https://clawsweeper-exact-review-queue/enqueue", {
       method: "POST",
       headers: { "content-type": "application/json" },

--- a/scripts/check-dashboard-strict.mjs
+++ b/scripts/check-dashboard-strict.mjs
@@ -27,6 +27,7 @@ export const DASHBOARD_STRICT_BASELINE_FILES = Object.freeze([
   "dashboard/exact-review-lifecycle.ts",
   "dashboard/exact-review-publication-batches.ts",
   "dashboard/exact-review-publication-retry.ts",
+  "dashboard/exact-review-queue-observability.ts",
   "dashboard/exact-review-queue-shared.ts",
   "dashboard/exact-review-read-model.ts",
   "dashboard/github-api.ts",

--- a/test/dashboard-worker-durable-object-error.test.ts
+++ b/test/dashboard-worker-durable-object-error.test.ts
@@ -7,6 +7,9 @@ import {
   MemoryDurableNamespace,
   worker,
 } from "./dashboard-worker-harness.ts";
+import { exactReviewQueueEndpointTemplate } from "../dashboard/exact-review-queue-observability.ts";
+
+const TRACE_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 
 function publicationsListRequest(limit: number) {
   return new Request("https://clawsweeper-exact-review-queue/publications/list", {
@@ -59,7 +62,18 @@ test("exact-review Durable Object logs only source coordinates and rethrows stor
     errors.length = 0;
     storage.failNextSql(/SELECT item_key, item_json/, failure);
     await assert.rejects(queue.fetch(publicationsListRequest(100)), (error) => error === failure);
-    assert.deepEqual(errors, [["exact_review_queue_handler_failed", { phase: "fetch", location }]]);
+    assert.deepEqual(errors, [
+      [
+        "exact_review_queue_handler_failed",
+        {
+          phase: "fetch",
+          trace_id: null,
+          endpoint: "publications_list",
+          failure_category: "handler_exception",
+          location,
+        },
+      ],
+    ]);
     assert.equal((await queue.fetch(publicationsListRequest(100))).status, 200);
   }
 });
@@ -85,8 +99,40 @@ test("exact-review schema barrier logs source coordinates before rejecting initi
   assert.ok(initialized);
   await assert.rejects(initialized, (error) => error === failure);
   assert.deepEqual(errors, [
-    ["exact_review_queue_handler_failed", { phase: "initialize", location: [456, 9] }],
+    [
+      "exact_review_queue_handler_failed",
+      {
+        phase: "initialize",
+        trace_id: null,
+        endpoint: "initialization",
+        failure_category: "handler_exception",
+        location: [456, 9],
+      },
+    ],
   ]);
+});
+
+test("exact-review endpoint templates never retain dynamic record coordinates", () => {
+  assert.equal(
+    exactReviewQueueEndpointTemplate("/records/private-repository/items/12345"),
+    "records_item",
+  );
+  assert.equal(
+    exactReviewQueueEndpointTemplate("/records/private-repository/unknown/private-marker"),
+    "other",
+  );
+  assert.equal(
+    exactReviewQueueEndpointTemplate("/records/export?cursor=private-marker"),
+    "records_export",
+  );
+  assert.equal(
+    exactReviewQueueEndpointTemplate("/lifecycle/command-ack/observed"),
+    "lifecycle_command_ack_observed",
+  );
+  assert.equal(
+    exactReviewQueueEndpointTemplate("/publication-batches/heartbeat"),
+    "publication_batches_heartbeat",
+  );
 });
 
 test("exact-review Worker retains only platform flags from rejected Durable Object calls", async () => {
@@ -132,7 +178,29 @@ test("exact-review Worker retains only platform flags from rejected Durable Obje
       assert.equal(response.status, 500);
       assert.equal(response.headers.get("content-type"), "application/json; charset=utf-8");
       assert.deepEqual(await response.json(), { error: "exact_review_queue_unavailable" });
-      assert.deepEqual(errors, [["exact_review_queue_request_failed", flags]]);
+      assert.equal(errors.length, 1);
+      assert.equal(errors[0]?.[0], "exact_review_queue_request_failed");
+      const metadata = errors[0]?.[1] as Record<string, unknown>;
+      assert.match(String(metadata.trace_id), TRACE_ID_PATTERN);
+      assert.deepEqual(
+        { ...metadata, trace_id: "<trace>" },
+        {
+          trace_id: "<trace>",
+          endpoint: "publications_list",
+          phase: "request",
+          transport: "throw",
+          upstream_status: null,
+          ...flags,
+          failure_category: flags.overloaded
+            ? "platform_overloaded"
+            : flags.retryable
+              ? "platform_retryable"
+              : flags.remote
+                ? "remote_exception"
+                : "request_exception",
+        },
+      );
+      assert.equal(JSON.stringify(errors).includes(internalStack), false);
     }
   } finally {
     console.error = originalError;
@@ -162,7 +230,22 @@ test("exact-review Worker projects malformed Durable Object 5xx responses to a f
     assert.equal(response.status, 503);
     assert.equal(response.headers.get("content-type"), "application/json; charset=utf-8");
     assert.deepEqual(await response.json(), { error: "exact_review_queue_unavailable" });
-    assert.deepEqual(errors, [["exact_review_queue_malformed_server_response"]]);
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0]?.[0], "exact_review_queue_malformed_server_response");
+    const metadata = errors[0]?.[1] as Record<string, unknown>;
+    assert.match(String(metadata.trace_id), TRACE_ID_PATTERN);
+    assert.deepEqual(
+      { ...metadata, trace_id: "<trace>" },
+      {
+        trace_id: "<trace>",
+        endpoint: "publications_list",
+        phase: "request",
+        transport: "non_json_5xx",
+        upstream_status: 503,
+        failure_category: "malformed_server_response",
+      },
+    );
+    assert.equal(JSON.stringify(errors).includes(plantedMarker), false);
   } finally {
     console.error = originalError;
   }
@@ -172,21 +255,44 @@ test("exact-review Worker preserves structured Durable Object 5xx responses", as
   const secret = "test-webhook-secret";
   const body = JSON.stringify({ limit: 100 });
   const responseBody = { error: "lease_decision_unavailable", retryable: true };
-  const response = await worker.fetch(signedPublicationsListRequest(body, secret), {
-    CLAWSWEEPER_WEBHOOK_SECRET: secret,
-    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace({
-      async fetch() {
-        return new Response(JSON.stringify(responseBody), {
-          status: 503,
-          headers: { "content-type": "application/json" },
-        });
-      },
-    }),
-  });
+  const originalError = console.error;
+  const errors: unknown[][] = [];
+  console.error = (...values: unknown[]) => errors.push(values);
+  try {
+    const response = await worker.fetch(signedPublicationsListRequest(body, secret), {
+      CLAWSWEEPER_WEBHOOK_SECRET: secret,
+      EXACT_REVIEW_QUEUE: new MemoryDurableNamespace({
+        async fetch() {
+          return new Response(JSON.stringify(responseBody), {
+            status: 503,
+            headers: { "content-type": "application/json" },
+          });
+        },
+      }),
+    });
 
-  assert.equal(response.status, 503);
-  assert.equal(response.headers.get("content-type"), "application/json");
-  assert.deepEqual(await response.json(), responseBody);
+    assert.equal(response.status, 503);
+    assert.equal(response.headers.get("content-type"), "application/json");
+    assert.deepEqual(await response.json(), responseBody);
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0]?.[0], "exact_review_queue_structured_server_response");
+    const metadata = errors[0]?.[1] as Record<string, unknown>;
+    assert.match(String(metadata.trace_id), TRACE_ID_PATTERN);
+    assert.deepEqual(
+      { ...metadata, trace_id: "<trace>" },
+      {
+        trace_id: "<trace>",
+        endpoint: "publications_list",
+        phase: "request",
+        transport: "structured_5xx",
+        upstream_status: 503,
+        failure_category: "structured_server_response",
+      },
+    );
+    assert.equal(JSON.stringify(errors).includes(responseBody.error), false);
+  } finally {
+    console.error = originalError;
+  }
 });
 
 test("exact-review Worker preserves intentional non-JSON 4xx responses", async () => {

--- a/test/dashboard-worker-durable-object-error.test.ts
+++ b/test/dashboard-worker-durable-object-error.test.ts
@@ -133,6 +133,10 @@ test("exact-review endpoint templates never retain dynamic record coordinates", 
     exactReviewQueueEndpointTemplate("/publication-batches/heartbeat"),
     "publication_batches_heartbeat",
   );
+  assert.equal(
+    exactReviewQueueEndpointTemplate("/telemetry-reconciliation?public_repo=openclaw%2Fopenclaw"),
+    "telemetry_reconciliation",
+  );
 });
 
 test("exact-review Worker retains only platform flags from rejected Durable Object calls", async () => {

--- a/test/record-export-bounds.test.ts
+++ b/test/record-export-bounds.test.ts
@@ -50,6 +50,15 @@ const behaviorProof: {
     reconstructionQueries: number;
     nextCursor: number | null;
   } | null;
+  failureCorrelation: {
+    responseStatus: number;
+    responseBody: { error: string };
+    traceId: string;
+    durableObject: Record<string, unknown>;
+    worker: Record<string, unknown>;
+    pairedTraceId: boolean;
+    contentRedacted: boolean;
+  } | null;
 } = {
   claim:
     "a signed records export stays within source-byte and reconstruction-work budgets, advances its cursor, and repeated calls materialize the exact fixture",
@@ -60,6 +69,7 @@ const behaviorProof: {
   expectedManifest: [],
   materializedManifest: [],
   oversizedFirst: null,
+  failureCorrelation: null,
 };
 
 test.after(() => {
@@ -536,7 +546,8 @@ test("signed record export hides missing and invalid logical byte metadata", asy
     const missingResponse = await exportResponse(missingHarness.env, 0);
     assert.equal(missingResponse.status, 500);
     assert.equal(missingResponse.headers.get("content-type"), "application/json; charset=utf-8");
-    assert.deepEqual(await missingResponse.json(), { error: "exact_review_queue_unavailable" });
+    const missingResponseBody = (await missingResponse.json()) as { error: string };
+    assert.deepEqual(missingResponseBody, { error: "exact_review_queue_unavailable" });
 
     const invalidHarness = await exportHarness();
     const invalid = fixtureRecord({
@@ -676,6 +687,23 @@ test("signed record export hides missing and invalid logical byte metadata", asy
     assert.equal(serializedErrors.includes("malformed-chunk"), false);
     assert.equal(serializedErrors.includes("invalid-utf8"), false);
     assert.equal(serializedErrors.includes("canonical-malformed"), false);
+    const proofHandler = errors[0]?.[1] as Record<string, unknown>;
+    const proofWorker = errors[1]?.[1] as Record<string, unknown>;
+    behaviorProof.failureCorrelation = {
+      responseStatus: missingResponse.status,
+      responseBody: missingResponseBody,
+      traceId: String(proofHandler.trace_id),
+      durableObject: proofHandler,
+      worker: proofWorker,
+      pairedTraceId: proofHandler.trace_id === proofWorker.trace_id,
+      contentRedacted:
+        !serializedErrors.includes(REPO_SLUG) &&
+        !serializedErrors.includes("missing-metadata") &&
+        !serializedErrors.includes("invalid-metadata") &&
+        !serializedErrors.includes("malformed-chunk") &&
+        !serializedErrors.includes("invalid-utf8") &&
+        !serializedErrors.includes("canonical-malformed"),
+    };
   } finally {
     console.error = originalError;
   }

--- a/test/record-export-bounds.test.ts
+++ b/test/record-export-bounds.test.ts
@@ -559,12 +559,123 @@ test("signed record export hides missing and invalid logical byte metadata", asy
     assert.equal(invalidResponse.status, 500);
     assert.equal(invalidResponse.headers.get("content-type"), "application/json; charset=utf-8");
     assert.deepEqual(await invalidResponse.json(), { error: "exact_review_queue_unavailable" });
-    assert.deepEqual(errors, [
-      ["exact_review_queue_handler_failed", { phase: "fetch", location: null }],
-      ["exact_review_queue_request_failed", { remote: false, retryable: false, overloaded: false }],
-      ["exact_review_queue_handler_failed", { phase: "fetch", location: null }],
-      ["exact_review_queue_request_failed", { remote: false, retryable: false, overloaded: false }],
-    ]);
+    const malformedHarness = await exportHarness();
+    const malformed = fixtureRecord({
+      source: "backfill",
+      section: "commits",
+      id: "c".repeat(40),
+      content: "malformed-chunk",
+      storeRevision: 1,
+    });
+    seedFixtureRecord(malformedHarness.storage, malformed);
+    malformedHarness.storage.sql.exec(
+      `UPDATE ${EXACT_REVIEW_RECORD_BACKFILL_TABLE}
+          SET content = NULL, byte_length = 1, chunk_count = 1
+        WHERE repo_slug = ? AND section = ? AND record_id = ?`,
+      REPO_SLUG,
+      malformed.section,
+      malformed.id,
+    );
+    malformedHarness.storage.sql.exec(
+      `INSERT INTO ${EXACT_REVIEW_RECORD_BACKFILL_CHUNK_TABLE}
+         (repo_slug, section, record_id, chunk_index, content_base64)
+       VALUES (?, ?, ?, 0, '%%%')`,
+      REPO_SLUG,
+      malformed.section,
+      malformed.id,
+    );
+    const malformedResponse = await exportResponse(malformedHarness.env, 0);
+    assert.equal(malformedResponse.status, 500);
+    assert.deepEqual(await malformedResponse.json(), { error: "exact_review_queue_unavailable" });
+
+    const invalidUtf8Harness = await exportHarness();
+    const invalidUtf8 = fixtureRecord({
+      source: "backfill",
+      section: "commits",
+      id: "d".repeat(40),
+      content: "invalid-utf8",
+      storeRevision: 1,
+    });
+    seedFixtureRecord(invalidUtf8Harness.storage, invalidUtf8);
+    invalidUtf8Harness.storage.sql.exec(
+      `UPDATE ${EXACT_REVIEW_RECORD_BACKFILL_TABLE}
+          SET content = NULL, byte_length = 1, chunk_count = 1
+        WHERE repo_slug = ? AND section = ? AND record_id = ?`,
+      REPO_SLUG,
+      invalidUtf8.section,
+      invalidUtf8.id,
+    );
+    invalidUtf8Harness.storage.sql.exec(
+      `INSERT INTO ${EXACT_REVIEW_RECORD_BACKFILL_CHUNK_TABLE}
+         (repo_slug, section, record_id, chunk_index, content_base64)
+       VALUES (?, ?, ?, 0, '/w==')`,
+      REPO_SLUG,
+      invalidUtf8.section,
+      invalidUtf8.id,
+    );
+    const invalidUtf8Response = await exportResponse(invalidUtf8Harness.env, 0);
+    assert.equal(invalidUtf8Response.status, 500);
+    assert.deepEqual(await invalidUtf8Response.json(), { error: "exact_review_queue_unavailable" });
+
+    const malformedCanonicalHarness = await exportHarness();
+    const malformedCanonical = fixtureRecord({
+      source: "canonical",
+      section: "items",
+      id: "2",
+      content: "canonical-malformed".repeat(EXACT_REVIEW_CANONICAL_INLINE_BYTES),
+      storeRevision: 1,
+    });
+    seedFixtureRecord(malformedCanonicalHarness.storage, malformedCanonical);
+    malformedCanonicalHarness.storage.sql.exec(
+      `DELETE FROM ${EXACT_REVIEW_CANONICAL_RECORD_CHUNK_TABLE}
+        WHERE repo_slug = ? AND section = ? AND item_id = ?`,
+      REPO_SLUG,
+      malformedCanonical.section,
+      Number(malformedCanonical.id),
+    );
+    const malformedCanonicalResponse = await exportResponse(malformedCanonicalHarness.env, 0);
+    assert.equal(malformedCanonicalResponse.status, 500);
+    assert.deepEqual(await malformedCanonicalResponse.json(), {
+      error: "exact_review_queue_unavailable",
+    });
+
+    assert.equal(errors.length, 10);
+    for (let index = 0; index < errors.length; index += 2) {
+      assert.equal(errors[index]?.[0], "exact_review_queue_handler_failed");
+      assert.equal(errors[index + 1]?.[0], "exact_review_queue_request_failed");
+      const handler = errors[index]?.[1] as Record<string, unknown>;
+      const request = errors[index + 1]?.[1] as Record<string, unknown>;
+      assert.match(
+        String(handler.trace_id),
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+      );
+      assert.equal(request.trace_id, handler.trace_id);
+      assert.deepEqual(handler, {
+        phase: "fetch",
+        trace_id: handler.trace_id,
+        endpoint: "records_export",
+        failure_category: "record_export_consistency",
+        location: null,
+      });
+      assert.deepEqual(request, {
+        trace_id: handler.trace_id,
+        endpoint: "records_export",
+        phase: "request",
+        transport: "throw",
+        upstream_status: null,
+        remote: false,
+        retryable: false,
+        overloaded: false,
+        failure_category: "request_exception",
+      });
+    }
+    const serializedErrors = JSON.stringify(errors);
+    assert.equal(serializedErrors.includes(REPO_SLUG), false);
+    assert.equal(serializedErrors.includes("missing-metadata"), false);
+    assert.equal(serializedErrors.includes("invalid-metadata"), false);
+    assert.equal(serializedErrors.includes("malformed-chunk"), false);
+    assert.equal(serializedErrors.includes("invalid-utf8"), false);
+    assert.equal(serializedErrors.includes("canonical-malformed"), false);
   } finally {
     console.error = originalError;
   }

--- a/tsconfig.dashboard-strict.json
+++ b/tsconfig.dashboard-strict.json
@@ -22,6 +22,7 @@
     "dashboard/exact-review-lifecycle.ts",
     "dashboard/exact-review-publication-batches.ts",
     "dashboard/exact-review-publication-retry.ts",
+    "dashboard/exact-review-queue-observability.ts",
     "dashboard/exact-review-queue-shared.ts",
     "dashboard/exact-review-read-model.ts",
     "dashboard/github-api.ts",


### PR DESCRIPTION
## Summary

- add one opaque trace identifier across dashboard Worker-to-`ExactReviewQueue` requests and private failure logs
- classify record-export consistency failures separately from generic handler failures
- route every direct Worker `queue.fetch` call through the same privacy-bounded wrapper
- preserve all existing public response projections and fail-closed state hydration

## Problem

Scheduled state setup can fail with the public, sanitized `exact_review_queue_unavailable` response. That response is intentionally content-free, but the Worker and Durable Object logs previously had no bounded correlation key and could not distinguish an export consistency failure from a generic handler or platform failure.

The recurrence after #1299 therefore remained ambiguous between record-state inconsistency, a Worker/DO exception, and platform availability or capacity.

## Implementation

- generate a UUID v4 per Worker-to-queue request and propagate it in `x-clawsweeper-exact-review-trace`
- validate the header in the Durable Object before logging it
- reduce request paths to a fixed endpoint allow-list; dynamic record coordinates and query strings are never logged
- retain only fixed transport/category fields, upstream status, and existing platform flags
- classify invalid export watermarks, index/content joins, byte metadata, chunk reconstruction, UTF-8, and canonical record reconstruction as `record_export_consistency`
- include the observability module in dashboard strict-compilation allow-lists
- retain an opt-in local proof artifact from the existing SQLite-backed Worker/DO harness

No response body, request body, repository/item identity, exception message, filesystem path, stack text, or record content is added to logs.

## Validation

Exact base: `ce333f9cf9dfb8a29d20ca966b9db4ee78ca1676`

Exact head: `279512f1631467955258264cf28e3607845481ca`

- `pnpm run build:all`
- `pnpm run check:dashboard-strict`
- `pnpm run lint:dashboard`
- `pnpm run check:dashboard-queue-boundary`
- `node --test test/dashboard-worker-queue-runtime.test.ts` — 149/149 passed, including the static bounded-log-call guard that caught and drove the follow-up repair
- `node --test test/dashboard-worker-durable-object-error.test.ts test/record-export-bounds.test.ts` — 12/12 passed
- `node --test --test-concurrency=1 test/dashboard-worker-command-intake.test.ts test/dashboard-worker-webhook-ingress.test.ts test/dashboard-worker-publication-lifecycle.test.ts test/dashboard-worker-queue-policy.test.ts` — 112/112 passed
- `node --test test/dashboard-worker-queue-runtime.test.ts test/dashboard-worker-bay-records-routes.test.ts test/dashboard-worker-observability.test.ts test/dashboard-worker-status-privacy.test.ts test/dashboard-worker-dashboard-status.test.ts` — 367/367 passed after rebasing onto #1301
- committed Codex review also ran `pnpm run test:unit` — 314/314 passed
- `git diff --check`

Rebase integration:

- rebased onto merged #1301 at `ce333f9cf9dfb8a29d20ca966b9db4ee78ca1676`
- added the new `/telemetry-reconciliation` route to the fixed endpoint map as `telemetry_reconciliation`, including a query-string redaction assertion
- `git range-diff 206fe726bbadaae32dcb9822a2511a351a5c9317..181cd6f5c46ac1de48b9da030002e62ebe5782d2 ce333f9cf9dfb8a29d20ca966b9db4ee78ca1676..279512f1631467955258264cf28e3607845481ca` shows the three reviewed patches unchanged, plus only the bounded #1301 integration commit
- the Windows-wide `pnpm check` formatter gate reports the existing checkout-wide CRLF baseline across 776 files; the scoped formatter, strict compilation, lint, queue-boundary, build, focused tests, integrated tests, and `git diff --check` pass

Codex review loop:

- dirty production patch: clean after resolving all three accepted P2 findings
- dirty proof-artifact addition: clean
- committed range against exact rebased `origin/main` after the #1301 integration: clean; no actionable regressions

Local ClawSweeper `review --local-range` at the exact head completed with high confidence, found the patch correct, cleared security review, and returned no code comments. Its sole pre-PR gate was attaching an executed Worker-to-Durable-Object trace; that evidence is below.

## Real Behavior Proof

Claim: a controlled record-export consistency failure produces the same opaque trace ID at the Durable Object and Worker boundaries, returns only the unchanged public error, and retains no fixture content or coordinates in the logged metadata.

Exercised surface: dashboard Worker route plus SQLite-backed `ExactReviewQueue` Durable Object using the real request wrapper and record-export store.

Scenario: initialize a signed export, seed a canonical record, remove its required canonical content row, then call the signed `/internal/state/records/export` Worker route. The same suite also covers invalid byte metadata, malformed base64 chunks, invalid UTF-8, and missing canonical chunks.

Environment and command:

```text
provider=local-container
image=node:24-bookworm
lease=cbx_605b962142a8
run=run_08c6e86888eb
proof_head=181cd6f5c46ac1de48b9da030002e62ebe5782d2
node --test test/dashboard-worker-queue-runtime.test.ts test/dashboard-worker-durable-object-error.test.ts test/record-export-bounds.test.ts
```

Observed redacted artifact:

```json
{
  "responseStatus": 500,
  "responseBody": { "error": "exact_review_queue_unavailable" },
  "traceId": "<uuid-v4>",
  "durableObject": {
    "phase": "fetch",
    "trace_id": "<same-uuid-v4>",
    "endpoint": "records_export",
    "failure_category": "record_export_consistency",
    "location": null
  },
  "worker": {
    "trace_id": "<same-uuid-v4>",
    "endpoint": "records_export",
    "phase": "request",
    "transport": "throw",
    "upstream_status": null,
    "remote": false,
    "retryable": false,
    "overloaded": false,
    "failure_category": "request_exception"
  },
  "pairedTraceId": true,
  "contentRedacted": true
}
```

Result: 161/161 focused and queue-runtime tests passed in the container. `build:all`, strict dashboard compilation, dashboard lint, and the queue-boundary check also passed. The lease auto-stopped after success. Range-diff proves those three container-proven patches are unchanged after the rebase; the fourth commit only adds the #1301 endpoint to the fixed map and is covered by the post-rebase deterministic and integrated tests above.

Limits: this is controlled local-container proof with the in-repository Memory Durable Object and SQLite implementation. It proves response stability, correlation, classification, and redaction for the patch-equivalent runtime changes; a fresh post-rebase container lease was unavailable because the local Docker Desktop Linux daemon was not running. The bounded rebase-only endpoint-map addition is instead covered by deterministic and integrated tests. This proof does not claim production Cloudflare availability, CPU-limit behavior, capacity, or repair of existing production Durable Object state.

## Risks and rollout

- the wrapper is shared by Worker-to-queue calls, so the change is intentionally limited to header propagation and private allow-listed logging
- the #1301 telemetry-reconciliation route is explicitly mapped to a fixed identifier, so its query values cannot fall through into logged endpoint metadata
- OpenClaw Bay is unaffected: this changes no public Bay payload, data source, lifecycle timing or denominator semantics, dashboard rendering, or operator projection; it only adds private Worker/Durable Object failure metadata
- public payloads and status handling are unchanged; scheduled state hydration remains fail-closed
- no retry, notification, queue policy, schema, binding, Wrangler, or Cloudflare configuration changes
- no deployment is part of this PR

The new metadata should distinguish a consistency failure from a structured 5xx, malformed 5xx, remote exception, retryable platform exception, or overload without exposing request content.

## Links

- follow-up to #1299
