### PR TITLE
fix(review): recover exact review for merged base history

### DIFF
--- a/src/clawsweeper-review-blobs.ts
+++ b/src/clawsweeper-review-blobs.ts
@@ -28,19 +28,31 @@ function gitCommitExists(targetDir: string, sha: string): boolean {
   );
 }
 
+function gitRepositoryIsShallow(targetDir: string): boolean {
+  const result = spawnSync("git", ["rev-parse", "--is-shallow-repository"], {
+    cwd: targetDir,
+    encoding: "utf8",
+    env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" },
+  });
+  return !result.error && result.status === 0 && result.stdout.trim() === "true";
+}
+
 export function ensureReviewTreeCommit({
   targetDir,
   sha,
   sourceRef,
   destinationRef,
+  completeHistory = false,
 }: {
   targetDir: string;
   sha: string;
   sourceRef: string;
   destinationRef: string;
+  completeHistory?: boolean;
 }): boolean {
   if (!GIT_OBJECT_ID.test(sha)) return false;
-  if (gitCommitExists(targetDir, sha)) return true;
+  const shallow = completeHistory && gitRepositoryIsShallow(targetDir);
+  if (gitCommitExists(targetDir, sha) && !shallow) return true;
   const fetched = spawnSync(
     "git",
     [
@@ -50,9 +62,9 @@ export function ensureReviewTreeCommit({
       "--no-tags",
       "--no-write-fetch-head",
       "--recurse-submodules=no",
+      ...(completeHistory ? (shallow ? ["--unshallow"] : []) : ["--depth=1"]),
       "origin",
       `${sourceRef}:${destinationRef}`,
-      "--depth=1",
     ],
     {
       cwd: targetDir,
@@ -81,6 +93,7 @@ export function ensurePullRequestReviewHead({
       sha: headSha,
       sourceRef: `refs/pull/${itemNumber}/head`,
       destinationRef,
+      completeHistory: true,
     }) ||
     // The PR ref and REST head can briefly disagree after a force-push. Fetching the
     // exact validated object keeps the model bound to the revision under review.
@@ -89,6 +102,7 @@ export function ensurePullRequestReviewHead({
       sha: headSha,
       sourceRef: headSha,
       destinationRef,
+      completeHistory: true,
     })
   );
 }

--- a/src/clawsweeper-review-runtime.ts
+++ b/src/clawsweeper-review-runtime.ts
@@ -347,9 +347,23 @@ export function createReviewRuntime({
         `[review] ${new Date().toISOString()} local-checkout=managed target=${targetDir} pr=#${itemNumber} base=${baseBranch}`,
       );
     }
-    run("git", ["fetch", "--force", "origin", `refs/pull/${itemNumber}/head`, "--depth=50"], {
+    // The managed checkout already has complete base history. A depth-limited PR fetch
+    // writes repository-wide shallow boundaries and can truncate that ancestry when the
+    // PR has merged the base branch. Keep the blobless fetch time-bounded instead.
+    const unshallow = run("git", ["rev-parse", "--is-shallow-repository"], {
       cwd: targetDir,
     });
+    run(
+      "git",
+      [
+        "fetch",
+        "--force",
+        "origin",
+        `refs/pull/${itemNumber}/head`,
+        ...(unshallow === "true" ? ["--unshallow"] : []),
+      ],
+      { cwd: targetDir, timeoutMs: 30_000 },
+    );
     run("git", ["checkout", "-f", "-B", branch, "FETCH_HEAD"], { cwd: targetDir });
   }
 

--- a/test/command.test.ts
+++ b/test/command.test.ts
@@ -25,6 +25,7 @@ import {
   reviewLeaseStillMatchesContextForTest,
 } from "../dist/clawsweeper.js";
 import { runText, UserFacingCommandError } from "../dist/command.js";
+import { reviewMergeBase } from "../dist/pr-review-evidence.js";
 import { reviewStructuralPullStateDigest } from "../dist/review-structural-cache.js";
 import { mockGhBinEnv, workPlanCandidateReport } from "./helpers.ts";
 import { writeFakeScanner } from "./agent-input-scan-helpers.ts";
@@ -884,7 +885,7 @@ process.stdout.write("200");
   }
 });
 
-test("managed local review checkout fetches the pull request ref", () => {
+test("managed local review checkout preserves base ancestry for a merged pull request", () => {
   const root = mkdtempSync(join(tmpdir(), "cmd-"));
   const origin = join(root, "origin.git");
   const source = join(root, "source");
@@ -900,10 +901,37 @@ test("managed local review checkout fetches the pull request ref", () => {
     execFileSync("git", ["branch", "-M", "main"], { cwd: source });
     execFileSync("git", ["remote", "add", "origin", origin], { cwd: source });
     execFileSync("git", ["push", "origin", "main"], { cwd: source, stdio: "ignore" });
+    execFileSync("git", ["symbolic-ref", "HEAD", "refs/heads/main"], { cwd: origin });
 
+    execFileSync("git", ["checkout", "-b", "feature"], { cwd: source, stdio: "ignore" });
     writeFileSync(join(source, "feature.txt"), "from pr\n");
     execFileSync("git", ["add", "feature.txt"], { cwd: source });
     execFileSync("git", ["commit", "-m", "feature"], { cwd: source, stdio: "ignore" });
+    for (let index = 0; index < 60; index += 1) {
+      writeFileSync(join(source, "feature.txt"), `feature ${index}\n`);
+      execFileSync("git", ["commit", "-am", `feature ${index}`], {
+        cwd: source,
+        stdio: "ignore",
+      });
+    }
+
+    execFileSync("git", ["checkout", "main"], { cwd: source, stdio: "ignore" });
+    for (let index = 0; index < 60; index += 1) {
+      writeFileSync(join(source, "history.txt"), `base ${index}\n`);
+      execFileSync("git", ["add", "history.txt"], { cwd: source });
+      execFileSync("git", ["commit", "-m", `base ${index}`], { cwd: source, stdio: "ignore" });
+    }
+    const baseSha = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: source,
+      encoding: "utf8",
+    }).trim();
+    execFileSync("git", ["push", "origin", "main"], { cwd: source, stdio: "ignore" });
+
+    execFileSync("git", ["checkout", "feature"], { cwd: source, stdio: "ignore" });
+    execFileSync("git", ["merge", "--no-ff", "main", "-m", "merge main"], {
+      cwd: source,
+      stdio: "ignore",
+    });
     const pullSha = execFileSync("git", ["rev-parse", "HEAD"], {
       cwd: source,
       encoding: "utf8",
@@ -912,6 +940,23 @@ test("managed local review checkout fetches the pull request ref", () => {
       cwd: source,
       stdio: "ignore",
     });
+
+    mkdirSync(join(root, "artifacts", "local-review-357"), { recursive: true });
+    execFileSync("git", ["clone", "--filter=blob:none", "--no-checkout", origin, targetDir], {
+      stdio: "ignore",
+    });
+    execFileSync("git", ["fetch", "origin", "refs/pull/357/head", "--depth=50"], {
+      cwd: targetDir,
+      stdio: "ignore",
+    });
+    assert.equal(
+      execFileSync("git", ["rev-parse", "--is-shallow-repository"], {
+        cwd: targetDir,
+        encoding: "utf8",
+      }).trim(),
+      "true",
+    );
+    assert.equal(reviewMergeBase(targetDir, baseSha, pullSha).status, "unavailable");
 
     prepareManagedLocalReviewCheckoutForTest({
       baseBranch: "main",
@@ -932,8 +977,25 @@ test("managed local review checkout fetches the pull request ref", () => {
       execFileSync("git", ["rev-parse", "HEAD"], { cwd: targetDir, encoding: "utf8" }).trim(),
       pullSha,
     );
+    assert.equal(
+      Number(
+        execFileSync("git", ["rev-list", "--count", baseSha], {
+          cwd: targetDir,
+          encoding: "utf8",
+        }).trim(),
+      ),
+      61,
+    );
+    assert.equal(reviewMergeBase(targetDir, baseSha, pullSha).status, "verified");
+    assert.equal(
+      execFileSync("git", ["rev-parse", "--is-shallow-repository"], {
+        cwd: targetDir,
+        encoding: "utf8",
+      }).trim(),
+      "false",
+    );
     assert.ok(existsSync(join(targetDir, "feature.txt")));
-    assert.equal(normalizeLf(readFileSync(join(targetDir, "feature.txt"), "utf8")), "from pr\n");
+    assert.equal(normalizeLf(readFileSync(join(targetDir, "feature.txt"), "utf8")), "feature 59\n");
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/review-blob-hydration.test.ts
+++ b/test/review-blob-hydration.test.ts
@@ -7,6 +7,7 @@ import test from "node:test";
 
 import {
   ensurePullRequestReviewHead,
+  ensureReviewTreeCommit,
   githubReviewBlobSizes,
   hydratePullRequestReviewBlobs,
   hydratePullRequestReviewHistory,
@@ -17,6 +18,15 @@ import { reviewMergeBase } from "../dist/pr-review-evidence.js";
 
 function git(cwd: string, ...args: string[]): string {
   return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+function ensureShallowPullRequestReviewHead(targetDir: string, headSha: string): boolean {
+  return ensureReviewTreeCommit({
+    targetDir,
+    sha: headSha,
+    sourceRef: "refs/pull/982/head",
+    destinationRef: "refs/clawsweeper/review-cache/head-982",
+  });
 }
 
 function partialCloneFixture({
@@ -114,17 +124,21 @@ function reviewHistoryFixture({
   commitsBeforeBranch,
   commitsAfterBranch,
   commitsOnBranch = 0,
+  commitsAfterMerge = 0,
   commitsPastBase = 0,
   cloneDepth,
   baseRefreshDepth = 50,
+  mergeBaseIntoFeature = false,
   publishPullRef = true,
 }: {
   commitsBeforeBranch: number;
   commitsAfterBranch: number;
   commitsOnBranch?: number;
+  commitsAfterMerge?: number;
   commitsPastBase?: number;
   cloneDepth?: number;
   baseRefreshDepth?: number;
+  mergeBaseIntoFeature?: boolean;
   publishPullRef?: boolean;
 }) {
   const root = mkdtempSync(join(tmpdir(), "clawsweeper-review-history-"));
@@ -155,7 +169,7 @@ function reviewHistoryFixture({
     writeFileSync(join(source, "feature.txt"), `feature ${index}\n`);
     git(source, "commit", "-qam", `feature ${index}`);
   }
-  const headSha = git(source, "rev-parse", "HEAD");
+  let headSha = git(source, "rev-parse", "HEAD");
   git(source, "checkout", "-q", "main");
   for (let index = 0; index < commitsAfterBranch; index += 1) commit(`base ${index}`);
   // A pull request pins the base branch where it stood when the request was opened, so the
@@ -165,6 +179,15 @@ function reviewHistoryFixture({
   for (let index = 0; index < commitsPastBase; index += 1) commit(`past base ${index}`);
   git(source, "remote", "add", "origin", origin);
   git(source, "push", "-q", "origin", "main");
+  if (mergeBaseIntoFeature) {
+    git(source, "checkout", "-q", "feature");
+    git(source, "merge", "-q", "--no-ff", baseSha, "-m", "merge main");
+    for (let index = 0; index < commitsAfterMerge; index += 1) {
+      writeFileSync(join(source, "feature.txt"), `after merge ${index}\n`);
+      git(source, "commit", "-qam", `after merge ${index}`);
+    }
+    headSha = git(source, "rev-parse", "HEAD");
+  }
   if (publishPullRef) git(source, "push", "-q", "origin", "feature:refs/pull/982/head");
 
   git(
@@ -200,6 +223,42 @@ function reachable(target: string, sha: string): number {
   return count.status === 0 ? Number(count.stdout.trim()) : -1;
 }
 
+test("supplied checkout exact-review sequence recovers merged base history", () => {
+  // The hosted workflow supplies a complete base checkout, then review acquisition fetches
+  // the PR head. Keep the merge-from-base commit beyond bounded fallback hydration so this
+  // fixture proves acquisition itself preserved the history instead of relying on the retry.
+  const fixture = reviewHistoryFixture({
+    commitsBeforeBranch: 10,
+    commitsAfterBranch: 10,
+    commitsAfterMerge: 300,
+    mergeBaseIntoFeature: true,
+  });
+  try {
+    assert.ok(
+      ensurePullRequestReviewHead({
+        targetDir: fixture.target,
+        itemNumber: 982,
+        headSha: fixture.headSha,
+      }),
+    );
+    assert.equal(
+      hydratePullRequestReviewHistory({
+        targetDir: fixture.target,
+        baseSha: fixture.baseSha,
+        headSha: fixture.headSha,
+        itemNumber: 982,
+      }),
+      fixture.baseSha,
+    );
+    assert.equal(
+      reviewMergeBase(fixture.target, fixture.baseSha, fixture.headSha).status,
+      "verified",
+    );
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
 test("review history hydration keeps base ancestry the checkout already had", () => {
   // The base branch's history is present and deeper than the bounded deepening, and the
   // merge base is two commits behind the reviewed head but further behind the pinned base
@@ -211,13 +270,7 @@ test("review history hydration keeps base ancestry the checkout already had", ()
     commitsPastBase: 100,
   });
   try {
-    assert.ok(
-      ensurePullRequestReviewHead({
-        targetDir: fixture.target,
-        itemNumber: 982,
-        headSha: fixture.headSha,
-      }),
-    );
+    assert.ok(ensureShallowPullRequestReviewHead(fixture.target, fixture.headSha));
     const before = reachable(fixture.target, fixture.baseSha);
     assert.ok(before > 256, `expected deep base ancestry, saw ${before}`);
     assert.equal(
@@ -258,13 +311,7 @@ test("review history hydration still deepens a base branch that is itself shallo
     baseRefreshDepth: 1,
   });
   try {
-    assert.ok(
-      ensurePullRequestReviewHead({
-        targetDir: fixture.target,
-        itemNumber: 982,
-        headSha: fixture.headSha,
-      }),
-    );
+    assert.ok(ensureShallowPullRequestReviewHead(fixture.target, fixture.headSha));
     assert.equal(reachable(fixture.target, fixture.baseSha), 1);
 
     assert.equal(
@@ -296,13 +343,7 @@ test("review history hydration stays fail-closed when the bounded deepening cann
     baseRefreshDepth: 1,
   });
   try {
-    assert.ok(
-      ensurePullRequestReviewHead({
-        targetDir: fixture.target,
-        itemNumber: 982,
-        headSha: fixture.headSha,
-      }),
-    );
+    assert.ok(ensureShallowPullRequestReviewHead(fixture.target, fixture.headSha));
     assert.equal(
       hydratePullRequestReviewHistory({
         targetDir: fixture.target,


### PR DESCRIPTION
Closes #1325

## What Problem This Solves

Fixes an issue where exact reviews of pull requests that merged the base branch could become permanently stuck with `incomplete_source` after the managed checkout shallow-fetches the pull request head.

## Why This Change Was Made

The managed checkout now fetches the pull request head without introducing repository-wide depth boundaries. Existing managed checkouts left shallow by the previous fetch are explicitly unshallowed, while the blobless fetch remains bounded by a 30-second timeout.

The admission policy is unchanged: genuinely incomplete review ancestry still fails closed.

## User Impact

Pull requests that use GitHub's Update branch flow or otherwise merge the base branch can receive exact review without rebasing solely to clear a false incomplete-source result. Previously stuck managed checkouts recover on their next preparation.

## OpenClaw Bay Impact

OpenClaw Bay is unaffected. This changes only local managed-checkout ancestry acquisition and does not alter lifecycle publication, queue state, telemetry, or dashboard contracts.

## Documentation Impact

No documentation update is required. The managed exact-review contract is unchanged; this repairs how the runtime obtains the complete Git ancestry required to enforce it.

## Evidence

### Real Behavior Proof

- **Claim:** managed exact review preserves complete base ancestry for merge-from-base pull requests and repairs checkouts made shallow by the previous fetch.
- **Exercised surface:** the production `prepareManagedLocalReviewCheckout` path through its test export, using real Git repositories and fetches.
- **Scenario:** a local bare origin with 61 base commits and a pull request with 61 feature commits plus a real two-parent merge from `main`. The target checkout is first seeded with the previous `--depth=50` pull-ref fetch.
- **Command and environment:** Node.js 24.16.0, pnpm 11.19.0, macOS; `pnpm run build && node --test --test-name-pattern "managed local review checkout preserves base ancestry|review history hydration" test/command.test.ts test/review-blob-hydration.test.ts`.
- **Observed result:** before preparation, Git reports a shallow repository and `reviewMergeBase` reports `unavailable`; after preparation, Git reports a non-shallow repository, all 61 pinned-base commits remain reachable, and `reviewMergeBase` reports `verified`. All five focused cases pass, including the existing fail-closed case where bounded hydration genuinely cannot reach a merge base.
- **Artifact or trace:** focused test output reports 5 tests passed, 0 failed.
- **Limits:** the proof uses a local bare Git remote rather than a hosted GitHub pull ref. It exercises the same Git clone, fetch, checkout, shallow-state, and merge-base behavior without external provider credentials.

### Validation

- `pnpm run build`
- `node --test --test-name-pattern "managed local review checkout preserves base ancestry|review history hydration" test/command.test.ts test/review-blob-hydration.test.ts`
- `pnpm run check:static`
- `pnpm run build:all`
- `pnpm run lint`
- `git diff --check`

`pnpm run check` was also attempted. Its broad suite hit the pre-existing macOS-only `managed scanner cache symlinks refuse before bootstrap writes` failure in untouched scanner code; the isolated failure reproduces independently of this Git-fetch change. Static checks, all builds, lint, and the changed-path regression are clean.

### Review Findings

- Replaced the initially considered `--shallow-exclude` approach after review showed it still leaves review-relevant shallow boundaries.
- Added explicit `--unshallow` recovery after review showed a normal fetch alone does not repair previously managed shallow checkouts.
- Final committed-branch review found no P0, P1, or P2 blockers.

Disclosure: AI was used to understand the codebase and review the fix.
