### PR TITLE
fix(review): provision pinned Codex source

### DIFF
--- a/.github/actions/setup-openclaw-codex-source/action.yml
+++ b/.github/actions/setup-openclaw-codex-source/action.yml
@@ -1,0 +1,40 @@
+name: Setup OpenClaw Codex source
+description: Materialize the OpenClaw-pinned Codex source beside review checkouts.
+inputs:
+  target-repo:
+    description: Repository being reviewed.
+    required: true
+  target-dir:
+    description: Target repository checkout path.
+    required: true
+  review-artifact-dir:
+    description: Artifact directory where PR review trees are materialized.
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Normalize target repository
+      id: target
+      shell: bash
+      env:
+        TARGET_REPOSITORY: ${{ inputs.target-repo }}
+      run: echo "repository=$(printf '%s' "$TARGET_REPOSITORY" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+    - name: Restore Codex source object cache
+      if: ${{ steps.target.outputs.repository == 'openclaw/openclaw' && env.CLAWSWEEPER_RUNNER != 'openclaw' }}
+      uses: actions/cache@v6
+      with:
+        path: ${{ inputs.target-dir }}-codex-cache.git
+        key: ${{ runner.os }}-openclaw-codex-source-${{ github.run_id }}-${{ github.run_attempt }}
+        restore-keys: |
+          ${{ runner.os }}-openclaw-codex-source-
+
+    - name: Materialize pinned Codex source
+      if: ${{ steps.target.outputs.repository == 'openclaw/openclaw' && env.CLAWSWEEPER_RUNNER != 'openclaw' }}
+      shell: bash
+      run: |
+        "$GITHUB_ACTION_PATH/install.sh" \
+          "${{ steps.target.outputs.repository }}" \
+          "${{ inputs.target-dir }}" \
+          "${{ inputs.review-artifact-dir }}" \
+          "${{ inputs.target-dir }}-codex-cache.git"

--- a/.github/actions/setup-openclaw-codex-source/install.sh
+++ b/.github/actions/setup-openclaw-codex-source/install.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+target_repo="${1:-}"
+target_dir_input="${2:-}"
+review_artifact_dir_input="${3:-}"
+cache_dir_input="${4:-}"
+source_url="${5:-https://github.com/openai/codex.git}"
+pin_dir_input="${6:-$target_dir_input}"
+setup_script="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)/$(basename "${BASH_SOURCE[0]}")"
+
+target_repo="$(printf '%s' "$target_repo" | tr '[:upper:]' '[:lower:]')"
+if [[ "$target_repo" != "openclaw/openclaw" ]]; then
+  echo "Codex source checkout is not required for $target_repo."
+  exit 0
+fi
+
+workspace_root="$(cd "${GITHUB_WORKSPACE:?}" && pwd -P)"
+target_root="$(cd "$target_dir_input" && pwd -P)"
+if [[ "$(dirname "$target_root")" != "$workspace_root" ]]; then
+  echo "OpenClaw target checkout must be a direct child of GITHUB_WORKSPACE." >&2
+  exit 1
+fi
+
+resolve_from_workspace() {
+  node -e '
+    const fs = require("node:fs");
+    const path = require("node:path");
+    const tail = [];
+    let current = path.resolve(process.argv[1], process.argv[2]);
+    while (!fs.existsSync(current)) {
+      const parent = path.dirname(current);
+      if (parent === current) process.exit(1);
+      tail.unshift(path.basename(current));
+      current = parent;
+    }
+    process.stdout.write(path.resolve(fs.realpathSync(current), ...tail));
+  ' "$workspace_root" "$1"
+}
+
+review_artifact_root="$(resolve_from_workspace "$review_artifact_dir_input")"
+cache_dir="$(resolve_from_workspace "$cache_dir_input")"
+for candidate in "$review_artifact_root" "$cache_dir"; do
+  case "$candidate/" in
+    "$workspace_root/"*) ;;
+    *)
+      echo "Codex source setup paths must stay inside GITHUB_WORKSPACE." >&2
+      exit 1
+      ;;
+  esac
+done
+
+pin_root="$(cd "$pin_dir_input" && pwd -P)"
+review_tree_root="$review_artifact_root/review-trees"
+if [[ "$pin_root" != "$target_root" ]] &&
+  { [[ "$(dirname "$pin_root")" != "$review_tree_root" ]] ||
+    [[ "$(basename "$pin_root")" != +([0-9]) ]]; }; then
+  echo "Codex version pin must come from the target checkout or one of its PR review trees." >&2
+  exit 1
+fi
+
+package_json_input="$pin_root/extensions/codex/package.json"
+if [[ ! -f "$package_json_input" || -L "$package_json_input" ]]; then
+  echo "OpenClaw Codex version pin must be a regular file." >&2
+  exit 1
+fi
+package_json="$(node -e 'process.stdout.write(require("node:fs").realpathSync(process.argv[1]))' "$package_json_input")"
+case "$package_json/" in
+  "$pin_root/"*) ;;
+  *)
+    echo "OpenClaw Codex version pin must stay inside its review checkout." >&2
+    exit 1
+    ;;
+esac
+version="$(node - "$package_json" <<'NODE'
+const fs = require("node:fs");
+const file = process.argv[2];
+const manifest = JSON.parse(fs.readFileSync(file, "utf8"));
+const version = manifest.dependencies?.["@openai/codex"];
+if (typeof version !== "string" || !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
+  console.error("OpenClaw must pin @openai/codex to one exact version.");
+  process.exit(1);
+}
+process.stdout.write(version);
+NODE
+)"
+tag="rust-v$version"
+source_dir="$workspace_root/codex"
+
+refresh_cache() {
+  if [[ -e "$cache_dir" ]]; then
+    rm -rf -- "$cache_dir"
+  fi
+  git init --bare --quiet "$cache_dir"
+  git -C "$cache_dir" remote add origin "$source_url"
+}
+
+fetch_tag() {
+  git -C "$cache_dir" fetch --force --depth=1 origin \
+    "refs/tags/$tag:refs/tags/$tag"
+}
+
+cache_has_complete_tag() {
+  ! git -C "$cache_dir" rev-list --objects --missing=print "$tag^{commit}" | grep -q '^?'
+}
+
+if [[ -d "$cache_dir" ]] && git -C "$cache_dir" rev-parse --is-bare-repository >/dev/null 2>&1; then
+  git -C "$cache_dir" remote set-url origin "$source_url"
+  git -C "$cache_dir" config --unset-all remote.origin.promisor 2>/dev/null || true
+  git -C "$cache_dir" config --unset-all remote.origin.partialclonefilter 2>/dev/null || true
+else
+  refresh_cache
+fi
+if ! fetch_tag; then
+  echo "Cached Codex source fetch failed; rebuilding cache." >&2
+  refresh_cache
+  fetch_tag
+fi
+if ! cache_has_complete_tag; then
+  echo "Cached Codex source is incomplete; rebuilding cache." >&2
+  refresh_cache
+  fetch_tag
+fi
+expected_head="$(git -C "$cache_dir" rev-parse "$tag^{commit}")"
+
+source_ready=false
+if [[ -d "$source_dir" && ! -L "$source_dir" ]] &&
+  [[ "$(git -C "$source_dir" rev-parse HEAD 2>/dev/null || true)" == "$expected_head" ]] &&
+  [[ -z "$(git -C "$source_dir" status --porcelain=v1 --untracked-files=all 2>/dev/null || true)" ]]; then
+  source_ready=true
+fi
+if [[ "$source_ready" != "true" ]]; then
+  if [[ -e "$source_dir" || -L "$source_dir" ]]; then
+    rm -rf -- "$source_dir"
+  fi
+  git clone --single-branch --branch "$tag" --no-local "$cache_dir" "$source_dir"
+fi
+actual_head="$(git -C "$source_dir" rev-parse HEAD)"
+if [[ "$actual_head" != "$expected_head" ]]; then
+  echo "Codex source checkout does not match $tag." >&2
+  exit 1
+fi
+if [[ -n "$(git -C "$source_dir" status --porcelain=v1 --untracked-files=all)" ]]; then
+  echo "Codex source checkout is not clean." >&2
+  exit 1
+fi
+
+review_sibling="$review_tree_root/codex"
+mkdir -p "$review_tree_root"
+if [[ -L "$review_sibling" ]]; then
+  rm -- "$review_sibling"
+elif [[ -e "$review_sibling" ]]; then
+  echo "PR review-tree Codex sibling already exists and is not a symbolic link." >&2
+  exit 1
+fi
+ln -s "$source_dir" "$review_sibling"
+
+if [[ -n "${GITHUB_ENV:-}" ]]; then
+  {
+    echo "CLAWSWEEPER_OPENCLAW_CODEX_SETUP_SCRIPT=$setup_script"
+    echo "CLAWSWEEPER_OPENCLAW_CODEX_TARGET_DIR=$target_root"
+    echo "CLAWSWEEPER_OPENCLAW_CODEX_ARTIFACT_DIR=$review_artifact_root"
+    echo "CLAWSWEEPER_OPENCLAW_CODEX_CACHE_DIR=$cache_dir"
+    echo "CLAWSWEEPER_OPENCLAW_CODEX_SOURCE_URL=$source_url"
+  } >> "$GITHUB_ENV"
+fi
+
+echo "Prepared Codex $version source for OpenClaw review at $source_dir."

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -978,6 +978,13 @@ jobs:
           fi
           git -C "$checkout_dir" rev-parse --short HEAD
 
+      - uses: ./.github/actions/setup-openclaw-codex-source
+        if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.live-item.outputs.proceed == 'true' }}
+        with:
+          target-repo: ${{ steps.target.outputs.target_repo }}
+          target-dir: ${{ steps.target.outputs.target_checkout_dir }}
+          review-artifact-dir: ${{ github.workspace }}/artifacts/event
+
       - name: Mark re-review command in progress
         if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.live-item.outputs.proceed == 'true' }}
         continue-on-error: true
@@ -4335,6 +4342,12 @@ jobs:
             git clone --filter=blob:none --branch "$target_branch" --single-branch "$url" "$checkout_dir"
           fi
           git -C "$checkout_dir" rev-parse --short HEAD
+
+      - uses: ./clawsweeper/.github/actions/setup-openclaw-codex-source
+        with:
+          target-repo: ${{ needs.plan.outputs.target_repo }}
+          target-dir: ${{ needs.plan.outputs.target_checkout_dir }}
+          review-artifact-dir: ${{ github.workspace }}/review-artifacts/shard-${{ matrix.shard }}
 
       - name: Mark shard start
         id: shard-start

--- a/src/clawsweeper-review-command-workflow.ts
+++ b/src/clawsweeper-review-command-workflow.ts
@@ -391,8 +391,9 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
           ) {
             return false;
           }
-          pullRequestReviewTreeSha = headSha;
           reviewOpenclawDir = pullRequestReviewTreeDir;
+          pullRequestReviewTreeFailure = null;
+          pullRequestReviewTreeSha = headSha;
           if (readonlyOpenclaw) {
             makeTreeReadOnly(reviewOpenclawDir, itemReadonlyModeSnapshots);
           }
@@ -895,7 +896,7 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
         if (!localRangeData && item.kind === "pull_request") {
           const headSha = pullHeadShaFromContext(context);
           if (!headSha || !preparePullRequestReviewTree(headSha)) {
-            pullRequestReviewTreeFailure = new Error(
+            pullRequestReviewTreeFailure ??= new Error(
               `Read-only checkout inspection failed: pull request #${item.number} head ${headSha ?? "unknown"} was unavailable in the restricted review checkout`,
             );
             cachePreflightState = "failed";

--- a/src/clawsweeper-review-runtime.ts
+++ b/src/clawsweeper-review-runtime.ts
@@ -49,6 +49,7 @@ import {
 } from "./codex-transient.js";
 import { UserFacingCommandError } from "./command.js";
 import { emptyMaintainerDecision } from "./decision-packets.js";
+import { prepareOpenClawCodexSourceForReview } from "./openclaw-codex-source.js";
 import { repositoryProfileFor, type RepositoryProfile } from "./repository-profiles.js";
 
 interface ReviewRuntimeDependencies {
@@ -959,6 +960,10 @@ ${extra}
     extraCodexConfig?: string[];
   }): Decision {
     const startedAt = Date.now();
+    prepareOpenClawCodexSourceForReview({
+      targetRepo: options.item.repo,
+      reviewDir: options.openclawDir,
+    });
     ensureDir(options.workDir);
     const promptPath = join(options.workDir, `${options.item.number}.prompt.md`);
     rmSync(promptPath, { force: true });

--- a/src/clawsweeper-runtime.ts
+++ b/src/clawsweeper-runtime.ts
@@ -405,6 +405,7 @@ function reviewPolicyHash(options: {
   sandboxMode?: string;
   serviceTier?: string;
 }): string {
+  const policyTargetRepo = targetRepo();
   return sha256(
     stableJson({
       version: REVIEW_POLICY_VERSION,
@@ -423,7 +424,10 @@ function reviewPolicyHash(options: {
       // hash value so tier changes cannot mark every stored review policy-stale
       // and trigger a fleet-wide re-review wave.
       serviceTier: "",
-      targetRepo: targetRepo(),
+      targetRepo: policyTargetRepo,
+      ...(policyTargetRepo.toLowerCase() === "openclaw/openclaw"
+        ? { openclawCodexSourceProvisioning: "v1" }
+        : {}),
       repositoryProfile: targetProfile(),
       prompt: reviewPromptTemplate(),
       schema: reviewDecisionSchemaText(),

--- a/src/openclaw-codex-source.ts
+++ b/src/openclaw-codex-source.ts
@@ -1,0 +1,46 @@
+import { spawnSync } from "node:child_process";
+
+const OPENCLAW_REPOSITORY = "openclaw/openclaw";
+const DEFAULT_CODEX_SOURCE_URL = "https://github.com/openai/codex.git";
+
+type Spawn = (
+  command: string,
+  args: string[],
+) => { error?: Error; status: number | null; stderr: string };
+
+export function prepareOpenClawCodexSourceForReview(options: {
+  targetRepo: string;
+  reviewDir: string;
+  env?: NodeJS.ProcessEnv;
+  spawn?: Spawn;
+}): void {
+  if (options.targetRepo.toLowerCase() !== OPENCLAW_REPOSITORY) return;
+  const env = options.env ?? process.env;
+  const script = env.CLAWSWEEPER_OPENCLAW_CODEX_SETUP_SCRIPT;
+  if (!script) return;
+
+  const targetDir = requiredEnvironmentPath(env, "CLAWSWEEPER_OPENCLAW_CODEX_TARGET_DIR");
+  const artifactDir = requiredEnvironmentPath(env, "CLAWSWEEPER_OPENCLAW_CODEX_ARTIFACT_DIR");
+  const cacheDir = requiredEnvironmentPath(env, "CLAWSWEEPER_OPENCLAW_CODEX_CACHE_DIR");
+  const sourceUrl = env.CLAWSWEEPER_OPENCLAW_CODEX_SOURCE_URL?.trim() || DEFAULT_CODEX_SOURCE_URL;
+  const run = options.spawn ?? ((command, args) => spawnSync(command, args, { encoding: "utf8" }));
+  const result = run("bash", [
+    script,
+    OPENCLAW_REPOSITORY,
+    targetDir,
+    artifactDir,
+    cacheDir,
+    sourceUrl,
+    options.reviewDir,
+  ]);
+  if (result.error || result.status !== 0) {
+    const detail = result.stderr.trim() || result.error?.message || `exit ${result.status}`;
+    throw new Error(`Could not prepare the PR-pinned Codex source: ${detail}`);
+  }
+}
+
+function requiredEnvironmentPath(env: NodeJS.ProcessEnv, name: string): string {
+  const value = env[name]?.trim();
+  if (!value) throw new Error(`Missing ${name} for OpenClaw Codex source setup.`);
+  return value;
+}

--- a/test/openclaw-codex-source.test.ts
+++ b/test/openclaw-codex-source.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import type { SpawnSyncReturns } from "node:child_process";
+import test from "node:test";
+import { prepareOpenClawCodexSourceForReview } from "../dist/openclaw-codex-source.js";
+
+test("PR review source preparation invokes the workflow-provisioned setup for the current tree", () => {
+  const calls: Array<{ command: string; args: readonly string[] }> = [];
+  prepareOpenClawCodexSourceForReview({
+    targetRepo: "openclaw/openclaw",
+    reviewDir: "/workspace/artifacts/review-trees/131584",
+    env: {
+      CLAWSWEEPER_OPENCLAW_CODEX_SETUP_SCRIPT: "/action/install.sh",
+      CLAWSWEEPER_OPENCLAW_CODEX_TARGET_DIR: "/workspace/openclaw",
+      CLAWSWEEPER_OPENCLAW_CODEX_ARTIFACT_DIR: "/workspace/artifacts",
+      CLAWSWEEPER_OPENCLAW_CODEX_CACHE_DIR: "/workspace/openclaw-codex-cache.git",
+      CLAWSWEEPER_OPENCLAW_CODEX_SOURCE_URL: "https://github.com/openai/codex.git",
+    },
+    spawn: (command, args) => {
+      calls.push({ command, args: args ?? [] });
+      return { status: 0, stderr: "" } as SpawnSyncReturns<string>;
+    },
+  });
+  prepareOpenClawCodexSourceForReview({
+    targetRepo: "openclaw/openclaw",
+    reviewDir: "/workspace/openclaw",
+    env: {
+      CLAWSWEEPER_OPENCLAW_CODEX_SETUP_SCRIPT: "/action/install.sh",
+      CLAWSWEEPER_OPENCLAW_CODEX_TARGET_DIR: "/workspace/openclaw",
+      CLAWSWEEPER_OPENCLAW_CODEX_ARTIFACT_DIR: "/workspace/artifacts",
+      CLAWSWEEPER_OPENCLAW_CODEX_CACHE_DIR: "/workspace/openclaw-codex-cache.git",
+      CLAWSWEEPER_OPENCLAW_CODEX_SOURCE_URL: "https://github.com/openai/codex.git",
+    },
+    spawn: (command, args) => {
+      calls.push({ command, args: args ?? [] });
+      return { status: 0, stderr: "" } as SpawnSyncReturns<string>;
+    },
+  });
+
+  assert.deepEqual(calls, [
+    {
+      command: "bash",
+      args: [
+        "/action/install.sh",
+        "openclaw/openclaw",
+        "/workspace/openclaw",
+        "/workspace/artifacts",
+        "/workspace/openclaw-codex-cache.git",
+        "https://github.com/openai/codex.git",
+        "/workspace/artifacts/review-trees/131584",
+      ],
+    },
+    {
+      command: "bash",
+      args: [
+        "/action/install.sh",
+        "openclaw/openclaw",
+        "/workspace/openclaw",
+        "/workspace/artifacts",
+        "/workspace/openclaw-codex-cache.git",
+        "https://github.com/openai/codex.git",
+        "/workspace/openclaw",
+      ],
+    },
+  ]);
+});
+
+test("PR review source preparation is inactive outside provisioned OpenClaw workflows", () => {
+  let invoked = false;
+  for (const options of [
+    { targetRepo: "openclaw/clawhub", env: {} },
+    { targetRepo: "openclaw/openclaw", env: {} },
+  ]) {
+    prepareOpenClawCodexSourceForReview({
+      ...options,
+      reviewDir: "/workspace/review-tree",
+      spawn: () => {
+        invoked = true;
+        return { status: 0, stderr: "" } as SpawnSyncReturns<string>;
+      },
+    });
+  }
+  assert.equal(invoked, false);
+});

--- a/test/setup-openclaw-codex-source-action.test.ts
+++ b/test/setup-openclaw-codex-source-action.test.ts
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+test("OpenClaw Codex source setup materializes the pinned sibling for base and PR review trees", () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-openclaw-codex-source-"));
+  const workspace = join(root, "workspace");
+  const target = join(workspace, "openclaw");
+  const remote = join(root, "codex-remote");
+  const cache = join(workspace, "openclaw-codex-cache.git");
+  const artifacts = join(workspace, "artifacts", "event");
+  const githubEnv = join(workspace, "github-env");
+  const script = ".github/actions/setup-openclaw-codex-source/install.sh";
+
+  try {
+    mkdirSync(join(target, "extensions", "codex"), { recursive: true });
+    writeFileSync(
+      join(target, "extensions", "codex", "package.json"),
+      `${JSON.stringify({ dependencies: { "@openai/codex": "1.2.3" } })}\n`,
+    );
+    mkdirSync(remote, { recursive: true });
+    execFileSync("git", ["init", "--quiet"], { cwd: remote });
+    execFileSync("git", ["config", "user.name", "ClawSweeper test"], { cwd: remote });
+    execFileSync("git", ["config", "user.email", "clawsweeper@example.invalid"], {
+      cwd: remote,
+    });
+    writeFileSync(join(remote, "contract.rs"), 'pub const SKILL_SELECTION: &str = "path";\n');
+    execFileSync("git", ["add", "contract.rs"], { cwd: remote });
+    execFileSync("git", ["commit", "--quiet", "-m", "fixture"], { cwd: remote });
+    execFileSync("git", ["tag", "rust-v1.2.3"], { cwd: remote });
+    const expectedHead = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: remote,
+      encoding: "utf8",
+    }).trim();
+
+    const result = spawnSync(
+      "bash",
+      [script, "OpenClaw/OpenClaw", target, artifacts, cache, remote],
+      {
+        cwd: process.cwd(),
+        env: { ...process.env, GITHUB_ENV: githubEnv, GITHUB_WORKSPACE: workspace },
+        encoding: "utf8",
+      },
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(
+      readFileSync(githubEnv, "utf8"),
+      /CLAWSWEEPER_OPENCLAW_CODEX_SETUP_SCRIPT=.*\/setup-openclaw-codex-source\/install\.sh/u,
+    );
+    const source = join(workspace, "codex");
+    assert.equal(
+      execFileSync("git", ["rev-parse", "HEAD"], { cwd: source, encoding: "utf8" }).trim(),
+      expectedHead,
+    );
+    assert.equal(
+      execFileSync("git", ["remote", "get-url", "origin"], {
+        cwd: source,
+        encoding: "utf8",
+      }).trim(),
+      realpathSync(cache),
+    );
+    assert.equal(
+      readFileSync(join(source, "contract.rs"), "utf8"),
+      'pub const SKILL_SELECTION: &str = "path";\n',
+    );
+    const reviewSibling = join(artifacts, "review-trees", "codex");
+    assert.equal(existsSync(reviewSibling), true);
+    assert.equal(lstatSync(reviewSibling).isSymbolicLink(), true);
+    assert.equal(realpathSync(reviewSibling), realpathSync(source));
+    const pullRequestTree = join(artifacts, "review-trees", "131584");
+    mkdirSync(pullRequestTree);
+    assert.equal(
+      readFileSync(join(pullRequestTree, "..", "codex", "contract.rs"), "utf8"),
+      'pub const SKILL_SELECTION: &str = "path";\n',
+    );
+
+    mkdirSync(join(pullRequestTree, "extensions", "codex"), { recursive: true });
+    writeFileSync(
+      join(pullRequestTree, "extensions", "codex", "package.json"),
+      `${JSON.stringify({ dependencies: { "@openai/codex": "2.0.0" } })}\n`,
+    );
+    writeFileSync(join(remote, "contract.rs"), 'pub const SKILL_SELECTION: &str = "name";\n');
+    execFileSync("git", ["add", "contract.rs"], { cwd: remote });
+    execFileSync("git", ["commit", "--quiet", "-m", "updated fixture"], { cwd: remote });
+    execFileSync("git", ["tag", "rust-v2.0.0"], { cwd: remote });
+    const updatedHead = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: remote,
+      encoding: "utf8",
+    }).trim();
+
+    const retargetResult = spawnSync(
+      "bash",
+      [script, "openclaw/openclaw", target, artifacts, cache, remote, pullRequestTree],
+      {
+        cwd: process.cwd(),
+        env: { ...process.env, GITHUB_ENV: githubEnv, GITHUB_WORKSPACE: workspace },
+        encoding: "utf8",
+      },
+    );
+
+    assert.equal(retargetResult.status, 0, retargetResult.stderr);
+    assert.equal(
+      execFileSync("git", ["rev-parse", "HEAD"], { cwd: source, encoding: "utf8" }).trim(),
+      updatedHead,
+    );
+    assert.equal(
+      readFileSync(join(pullRequestTree, "..", "codex", "contract.rs"), "utf8"),
+      'pub const SKILL_SELECTION: &str = "name";\n',
+    );
+
+    const pullRequestManifest = join(pullRequestTree, "extensions", "codex", "package.json");
+    rmSync(pullRequestManifest);
+    symlinkSync(join(target, "extensions", "codex", "package.json"), pullRequestManifest);
+    const escapedPinResult = spawnSync(
+      "bash",
+      [script, "openclaw/openclaw", target, artifacts, cache, remote, pullRequestTree],
+      {
+        cwd: process.cwd(),
+        env: { ...process.env, GITHUB_ENV: githubEnv, GITHUB_WORKSPACE: workspace },
+        encoding: "utf8",
+      },
+    );
+    assert.notEqual(escapedPinResult.status, 0);
+    assert.match(escapedPinResult.stderr, /regular file|stay inside/u);
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
+});

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -201,6 +201,64 @@ test("exact event review exposes the token-only signal before runtime setup", ()
   assert.equal(steps[ordered[7][1]]!.id, "reserve-exact-review-lease");
 });
 
+test("OpenClaw review jobs provision the pinned sibling Codex source before review", () => {
+  type Step = {
+    name?: string;
+    uses?: string;
+    with?: Record<string, string>;
+  };
+  const workflow = YAML.parse(readText(".github/workflows/sweep.yml")) as {
+    jobs: Record<string, { steps: Step[] }>;
+  };
+  for (const scenario of [
+    {
+      job: "event-review-apply",
+      action: "./.github/actions/setup-openclaw-codex-source",
+      targetRepo: "${{ steps.target.outputs.target_repo }}",
+      targetDir: "${{ steps.target.outputs.target_checkout_dir }}",
+      artifactDir: "${{ github.workspace }}/artifacts/event",
+      reviewStep: "Review exact event item",
+    },
+    {
+      job: "review",
+      action: "./clawsweeper/.github/actions/setup-openclaw-codex-source",
+      targetRepo: "${{ needs.plan.outputs.target_repo }}",
+      targetDir: "${{ needs.plan.outputs.target_checkout_dir }}",
+      artifactDir: "${{ github.workspace }}/review-artifacts/shard-${{ matrix.shard }}",
+      reviewStep: "Review shard",
+    },
+  ] as const) {
+    const steps = workflow.jobs[scenario.job]!.steps;
+    const targetCheckout = steps.findIndex((step) => step.name === "Check out target repository");
+    const sourceCheckout = steps.findIndex((step) => step.uses === scenario.action);
+    const review = steps.findIndex((step) => step.name === scenario.reviewStep);
+
+    assert.notEqual(targetCheckout, -1, `${scenario.job}: target checkout`);
+    assert.notEqual(sourceCheckout, -1, `${scenario.job}: Codex source checkout`);
+    assert.notEqual(review, -1, `${scenario.job}: review`);
+    assert.ok(targetCheckout < sourceCheckout, `${scenario.job}: source follows target checkout`);
+    assert.ok(sourceCheckout < review, `${scenario.job}: source precedes review`);
+    assert.deepEqual(steps[sourceCheckout]!.with, {
+      "target-repo": scenario.targetRepo,
+      "target-dir": scenario.targetDir,
+      "review-artifact-dir": scenario.artifactDir,
+    });
+  }
+});
+
+test("Codex source setup normalizes OpenClaw casing and stays out of the OpenClaw runner", () => {
+  const action = YAML.parse(readText(".github/actions/setup-openclaw-codex-source/action.yml")) as {
+    runs: { steps: Array<{ id?: string; if?: string; uses?: string }> };
+  };
+  const normalize = action.runs.steps.find((step) => step.id === "target");
+  const cache = action.runs.steps.find((step) => step.uses === "actions/cache@v6");
+  assert.ok(normalize);
+  assert.match(cache?.if ?? "", /steps\.target\.outputs\.repository == 'openclaw\/openclaw'/u);
+  assert.match(cache?.if ?? "", /env\.CLAWSWEEPER_RUNNER != 'openclaw'/u);
+  const setup = action.runs.steps.at(-1);
+  assert.match(setup?.if ?? "", /env\.CLAWSWEEPER_RUNNER != 'openclaw'/u);
+});
+
 test("automatic OpenClaw bug dispatch uses one gate across direct and deferred publication", () => {
   const workflow = YAML.parse(readText(".github/workflows/sweep.yml")) as {
     jobs: Record<


### PR DESCRIPTION
## Summary

- provision the exact OpenClaw-pinned Codex source as a sibling checkout for Codex-backed exact and scheduled reviews
- retarget that source at each actual model invocation so PRs changing the pin and later items in the same shard inspect the correct revision
- reject escaped manifests and paths, normalize repository casing, reuse a complete Git object cache, and invalidate pre-provisioning OpenClaw review caches

This addresses the reviewer-infrastructure gap exposed by https://github.com/openclaw/openclaw/pull/131584. It does not change that OpenClaw PR directly.

## Behavior proof

Claim: when an OpenClaw review has an affirmative dependency signal requiring `../codex`, the Codex-backed reviewer can inspect the exact source version pinned by the reviewed base or PR tree.

- Surfaces: the exact-event job, scheduled review shards, and the per-item `runCodex` boundary
- Fixture: temporary OpenClaw and Codex Git repositories with distinct tagged pins for the base and PR trees
- Assertion: each review tree resolves `../codex` to the expected tagged commit; a manifest symlink escaping the reviewed tree is rejected
- Sandbox proof: a read-only Codex sandbox launched from the reviewed tree successfully read a tracked file through `../codex`
- Limit: hosted GitHub Actions execution remains for PR CI; local proof covered the composite action script, workflow structure, runtime retargeting, and containment checks

## Validation

- `pnpm run build:all`
- 177 focused tests passed across Codex runner, source setup, command, and sweep workflow coverage
- `git diff --check`
- two fresh Codex reviews against `origin/main`; the first found the cache-rollout gap, which the second commit fixes, and the repeated review found no actionable issues
- `pnpm run check` was attempted: 4,248 tests passed, 9 skipped, and the existing `test/agent-input-scan.test.ts` managed scanner cache-symlink assertion failed independently on current `main`

## OpenClaw Bay impact

No Bay impact. This changes internal review-worker setup and cache identity only; it does not alter public status, observer, or data contracts.
