### PR TITLE
fix: preserve live macOS ledger lock owners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 - Stopped retrying unchanged PR revisions after an incomplete-source scan refusal while preserving newer queued revisions. Thanks @sallyom. (#1311)
 - Stopped stored-data and SQLite warnings for colocated test-support files while preserving production persistence, rename, and incomplete-evidence warnings.
+- macOS action-ledger locks use stable process identity, treat unavailable observations as unknown, and fail closed for live legacy owners during the version 2 lock transition.
 - Aligned PR proof comments and status labels with the existing host requirement when a reviewer records proof as not applicable, while preserving recorded assessments and merge gates.
 - Preserved authoritative whole-range Git line counts in local reviews and report rendering, allowing review to complete with unavailable best-effort statistics while requiring complete file enumeration under its prior capture and timeout contract and never showing unknown counts as verified zero totals.
 - Classified the explicitly approved autoreview fixture only by its exact full-URI digest and canonical or vendored source path, enforcing the same digest/path/mode policy at every scanned endpoint for all reviewed fixtures while preserving scanner gates and value-free audits.

--- a/docs/action-ledger.md
+++ b/docs/action-ledger.md
@@ -199,7 +199,19 @@ confidential-identifier checks as every other durable machine-text field.
   disappearing during cleanup is benign. Contenders reclaim a lock as soon as
   its recorded process is dead or a Linux zombie, bypass PID-only identity
   caches before stale decisions, and use sub-second macOS process start identity.
-  A live holder is never evicted solely because of lock age.
+  macOS identity binds the numeric boot seconds/microseconds, PID, and microsecond
+  start time, excluding mutable process status and the timezone-dependent human
+  boot date. Invalid or unavailable identity data remains unknown instead of
+  falling back to a different identity, and is retried on the next query. A live
+  holder is never evicted solely because of lock age.
+- macOS producer and import locks use schema version 2 for the stable identity
+  scheme; other platforms continue writing version 1. Readers accept versions
+  1 and 2 and reject unknown versions. On macOS, a live version 1 owner remains
+  unverified and cannot be reclaimed by comparing its legacy hash to the new
+  scheme; contention retains the existing 10-second timeout. Dead version 1
+  owners remain reclaimable, and version 2 owners retain fresh PID-reuse checks.
+  Older readers reject version 2, so the serialized-lock transition fails closed
+  in both directions. Non-macOS version 1 identity checks are unchanged.
 - Partition-marker reads are capped at 64 bytes. Existing and raced shard reads
   are capped at the same 2 MiB limit as new shard writes. Direct shard readers
   also require a non-empty collection of at most 1024 unique, acyclic events in

--- a/src/action-ledger-files.ts
+++ b/src/action-ledger-files.ts
@@ -8,7 +8,7 @@ const NO_FOLLOW = fs.constants.O_NOFOLLOW ?? 0;
 const DIRECTORY = fs.constants.O_DIRECTORY ?? 0;
 const NON_BLOCKING = fs.constants.O_NONBLOCK ?? 0;
 const PROCESS_IDENTITY_CACHE_MS = 100;
-const processIdentityCache = new Map<number, { expiresAt: number; identity: string | null }>();
+const processIdentityCache = new Map<number, { expiresAt: number; identity: string }>();
 const DARWIN_PROCESS_INFO_SCRIPT = String.raw`
 import ctypes
 import struct
@@ -20,10 +20,9 @@ libc = ctypes.CDLL("/usr/lib/libSystem.B.dylib")
 written = libc.proc_pidinfo(int(sys.argv[1]), 3, 0, buffer, size)
 if written != size:
     raise SystemExit(1)
-status = struct.unpack_from("=I", buffer, 4)[0]
 reported_pid = struct.unpack_from("=I", buffer, 12)[0]
 started_sec, started_usec = struct.unpack_from("=QQ", buffer, 120)
-print(f"{status}:{reported_pid}:{started_sec}:{started_usec}")
+print(f"{reported_pid}:{started_sec}:{started_usec}")
 `;
 
 export type SafeWriteTarget = {
@@ -384,10 +383,11 @@ export function processIncarnationIdentitySha256(
   const cached = processIdentityCache.get(pid);
   if (!options.fresh && cached && cached.expiresAt > now) return cached.identity;
   const rawIdentity = processIncarnationIdentity(pid);
-  const identity =
-    rawIdentity === null
-      ? null
-      : createHash("sha256").update(`${process.platform}\0${rawIdentity}`).digest("hex");
+  if (rawIdentity === null) {
+    processIdentityCache.delete(pid);
+    return null;
+  }
+  const identity = createHash("sha256").update(`${process.platform}\0${rawIdentity}`).digest("hex");
   processIdentityCache.set(pid, {
     expiresAt: pid === process.pid ? Number.POSITIVE_INFINITY : now + PROCESS_IDENTITY_CACHE_MS,
     identity,
@@ -740,18 +740,30 @@ function processIncarnationIdentity(pid: number): string | null {
       DARWIN_PROCESS_INFO_SCRIPT,
       String(pid),
     ]);
-    if (processInfo && /^\d+:\d+:\d+:\d+$/.test(processInfo)) {
-      const bootTime = commandOutput("/usr/sbin/sysctl", ["-n", "kern.boottime"]);
-      return `${bootTime ?? "unknown-boot"}\0${processInfo}`;
+    if (!processInfo || !/^\d+:\d+:\d+$/.test(processInfo)) return null;
+    const [reportedPid, startedSec, startedUsec] = processInfo.split(":");
+    if (
+      Number(reportedPid) !== pid ||
+      !Number.isSafeInteger(Number(startedSec)) ||
+      Number(startedSec) < 1 ||
+      Number(startedUsec) >= 1_000_000
+    ) {
+      return null;
     }
+    // Process status is mutable, and a lower-resolution fallback is a different identity.
+    const bootTime = commandOutput("/usr/sbin/sysctl", ["-n", "kern.boottime"]);
+    const bootFields = bootTime?.match(/^\{\s*sec\s*=\s*(\d+),\s*usec\s*=\s*(\d+)\s*\}(?:\s|$)/);
+    if (!bootFields) return null;
+    const bootSeconds = Number(bootFields[1]);
+    const bootMicroseconds = Number(bootFields[2]);
+    if (!Number.isSafeInteger(bootSeconds) || bootSeconds < 1 || bootMicroseconds >= 1_000_000) {
+      return null;
+    }
+    // The trailing human-readable date depends on the observer's timezone.
+    return `${bootSeconds}:${bootMicroseconds}\0${processInfo}`;
   }
   const startTime = commandOutput("/bin/ps", ["-p", String(pid), "-o", "lstart="]);
-  if (!startTime) return null;
-  const bootTime =
-    process.platform === "darwin"
-      ? commandOutput("/usr/sbin/sysctl", ["-n", "kern.boottime"])
-      : null;
-  return `${bootTime ?? "unknown-boot"}\0${startTime}`;
+  return startTime ? `unknown-boot\0${startTime}` : null;
 }
 
 function linuxProcessStat(pid: number): { state: string; startTime: string } | null {

--- a/src/action-ledger-runtime.ts
+++ b/src/action-ledger-runtime.ts
@@ -225,7 +225,7 @@ type WorkflowProducerFinalization = {
 
 type ActionEventLock = {
   schema: "clawsweeper.action-ledger-producer-lock" | "clawsweeper.action-ledger-import-lock";
-  schema_version: 1;
+  schema_version: 1 | 2;
   pid: number;
   process_incarnation_sha256: string;
   acquired_at_ms: number;
@@ -2115,7 +2115,7 @@ function withActionEventLock<T>(
   }
   const lock: ActionEventLock = {
     schema,
-    schema_version: 1,
+    schema_version: process.platform === "darwin" ? 2 : 1,
     pid: process.pid,
     process_incarnation_sha256: processIncarnation,
     acquired_at_ms: Date.now(),
@@ -2163,7 +2163,7 @@ function parseActionEventLock(
     typeof value !== "object" ||
     Array.isArray(value) ||
     lock.schema !== schema ||
-    lock.schema_version !== 1 ||
+    (lock.schema_version !== 1 && lock.schema_version !== 2) ||
     !Number.isSafeInteger(lock.pid) ||
     Number(lock.pid) < 1 ||
     typeof lock.process_incarnation_sha256 !== "string" ||
@@ -2181,6 +2181,8 @@ function parseActionEventLock(
 
 function actionEventLockOwnerIsStale(owner: ActionEventLock): boolean {
   if (!processIsAlive(owner.pid)) return true;
+  // Legacy macOS hashes use a different identity scheme; a live owner is unverified.
+  if (process.platform === "darwin" && owner.schema_version === 1) return false;
   const currentIncarnation = processIncarnationIdentitySha256(owner.pid, { fresh: true });
   return currentIncarnation !== null && currentIncarnation !== owner.process_incarnation_sha256;
 }

--- a/test/action-ledger-runtime.test.ts
+++ b/test/action-ledger-runtime.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
-import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import childProcess, { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { createHash } from "node:crypto";
 import fs from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import test, { after } from "node:test";
@@ -2332,7 +2333,7 @@ test("producer locks reclaim fresh dead owners and never evict a live holder by 
   );
   const deadContent = `${actionLedgerJson({
     schema: "clawsweeper.action-ledger-producer-lock",
-    schema_version: 1,
+    schema_version: process.platform === "darwin" ? 2 : 1,
     pid: 2_147_483_647,
     process_incarnation_sha256: "0".repeat(64),
     acquired_at_ms: Date.now(),
@@ -2357,7 +2358,7 @@ test("producer locks reclaim fresh dead owners and never evict a live holder by 
   assert.ok(currentIncarnation);
   const reusedContent = `${actionLedgerJson({
     schema: "clawsweeper.action-ledger-producer-lock",
-    schema_version: 1,
+    schema_version: process.platform === "darwin" ? 2 : 1,
     pid: process.pid,
     process_incarnation_sha256:
       currentIncarnation === "0".repeat(64) ? "1".repeat(64) : "0".repeat(64),
@@ -2393,7 +2394,7 @@ const processIncarnation = processIncarnationIdentitySha256();
 if (!processIncarnation) process.exit(2);
 const content = actionLedgerJson({
   schema: "clawsweeper.action-ledger-producer-lock",
-  schema_version: 1,
+  schema_version: process.platform === "darwin" ? 2 : 1,
   pid: process.pid,
   process_incarnation_sha256: processIncarnation,
   acquired_at_ms: Date.now() - 5 * 60_000 + 75,
@@ -2436,6 +2437,128 @@ release();
   assert.equal(readOutputEvents(outputRoot, paths).length, 2);
 });
 
+for (const kind of ["producer", "import"] as const) {
+  test(
+    `macOS ${kind} locks retain live V1 owners and recover dead V1 owners`,
+    { skip: process.platform === "darwin" ? false : "requires macOS lock identity transition" },
+    () => {
+      const root = tempRoot();
+      const source = tempRoot();
+      const first = recordReviewNumber(root, 61);
+      assert.ok(first);
+      writeActionEventShard(source, shardIdentity(first), [first]);
+      const target = prepareSafeWriteTarget(
+        root,
+        kind === "producer" ? producerLockRelativePath(first) : ".action-ledger-import.lock",
+        `legacy ${kind} lock`,
+      );
+      const currentIncarnation = processIncarnationIdentitySha256();
+      assert.ok(currentIncarnation);
+      const owner = {
+        schema: `clawsweeper.action-ledger-${kind}-lock`,
+        schema_version: 1,
+        pid: process.pid,
+        process_incarnation_sha256:
+          currentIncarnation === "0".repeat(64) ? "1".repeat(64) : "0".repeat(64),
+        acquired_at_ms: Date.now(),
+        nonce: "00000000-0000-4000-8000-000000000006",
+      };
+      const invoke = () =>
+        kind === "producer" ? recordReviewNumber(root, 62) : importActionEventShards(source, root);
+      const liveContent = `${actionLedgerJson(owner)}\n`;
+      const releaseLive = tryAcquireUtf8FileLockNoFollow(target, liveContent);
+      assert.ok(releaseLive);
+      try {
+        const startedAt = Date.now();
+        assert.throws(invoke, /lock timed out after 10000ms/);
+        assert.ok(Date.now() - startedAt >= 10_000);
+        assert.equal(fs.readFileSync(target.path, "utf8"), liveContent);
+      } finally {
+        releaseLive();
+      }
+
+      const deadContent = `${actionLedgerJson({ ...owner, pid: 2_147_483_647 })}\n`;
+      const releaseDead = tryAcquireUtf8FileLockNoFollow(target, deadContent);
+      assert.ok(releaseDead);
+      const deadStartedAt = Date.now();
+      assert.ok(invoke());
+      assert.ok(Date.now() - deadStartedAt < 5_000);
+      assert.doesNotThrow(releaseDead);
+    },
+  );
+
+  test(`${kind} locks reclaim current-version PID reuse and reject unknown versions`, () => {
+    const root = tempRoot();
+    const source = tempRoot();
+    const first = recordReviewNumber(root, 71);
+    assert.ok(first);
+    writeActionEventShard(source, shardIdentity(first), [first]);
+    const target = prepareSafeWriteTarget(
+      root,
+      kind === "producer" ? producerLockRelativePath(first) : ".action-ledger-import.lock",
+      `versioned ${kind} lock`,
+    );
+    const currentIncarnation = processIncarnationIdentitySha256();
+    assert.ok(currentIncarnation);
+    const invoke = () =>
+      kind === "producer" ? recordReviewNumber(root, 72) : importActionEventShards(source, root);
+    for (const version of [0, 3, process.platform === "darwin" ? 2 : 1]) {
+      const content = `${actionLedgerJson({
+        schema: `clawsweeper.action-ledger-${kind}-lock`,
+        schema_version: version,
+        pid: process.pid,
+        process_incarnation_sha256:
+          currentIncarnation === "0".repeat(64) ? "1".repeat(64) : "0".repeat(64),
+        acquired_at_ms: Date.now(),
+        nonce: "00000000-0000-4000-8000-000000000007",
+      })}\n`;
+      const release = tryAcquireUtf8FileLockNoFollow(target, content);
+      assert.ok(release);
+      try {
+        if (version === 0 || version === 3) {
+          assert.throws(invoke, /invalid action event .*lock/);
+          assert.equal(fs.readFileSync(target.path, "utf8"), content);
+        } else {
+          const startedAt = Date.now();
+          assert.ok(invoke());
+          assert.ok(Date.now() - startedAt < 5_000);
+        }
+      } finally {
+        release();
+      }
+    }
+  });
+}
+
+test("producer and import writers serialize the platform's lock identity version", () => {
+  const root = tempRoot();
+  const source = tempRoot();
+  const captured: Array<{ schema: string; schema_version: number }> = [];
+  const originalLinkSync = fs.linkSync;
+  fs.linkSync = ((existing, destination) => {
+    const result = originalLinkSync(existing, destination);
+    if (String(destination).endsWith(".lock")) {
+      captured.push(JSON.parse(fs.readFileSync(destination, "utf8")));
+    }
+    return result;
+  }) as typeof fs.linkSync;
+  try {
+    const first = recordReviewNumber(root, 73);
+    assert.ok(first);
+    writeActionEventShard(source, shardIdentity(first), [first]);
+    assert.equal(importActionEventShards(source, root).created, 1);
+  } finally {
+    fs.linkSync = originalLinkSync;
+  }
+  assert.deepEqual(
+    captured.map(({ schema, schema_version }) => ({ schema, schema_version })),
+    ["producer", "import"].map((kind) => ({
+      schema: `clawsweeper.action-ledger-${kind}-lock`,
+      schema_version: process.platform === "darwin" ? 2 : 1,
+    })),
+  );
+});
+
 test(
   "macOS process identities distinguish processes started within the same second",
   { skip: process.platform === "darwin" ? false : "requires macOS proc_pidinfo" },
@@ -2469,6 +2592,145 @@ process.stdout.write(JSON.stringify({
     const sameSecond = [...bySecond.values()].sort((left, right) => right.length - left.length)[0]!;
     assert.ok(sameSecond.length >= 2);
     assert.equal(new Set(sameSecond.map((sample) => sample.identity)).size, sameSecond.length);
+  },
+);
+
+test(
+  "macOS process identities remain stable when a live holder is stopped",
+  { skip: process.platform === "darwin" ? false : "requires macOS proc_pidinfo" },
+  async () => {
+    const root = tempRoot();
+    const readyPath = path.join(root, "holder-identity");
+    const filesModuleUrl = pathToFileURL(
+      path.join(process.cwd(), "dist", "action-ledger-files.js"),
+    ).href;
+    await withImportRaceChildren(async (own) => {
+      const holder = spawn(
+        process.execPath,
+        [
+          "--input-type=module",
+          "-e",
+          `import fs from "node:fs";
+const { processIncarnationIdentitySha256 } = await import(${JSON.stringify(filesModuleUrl)});
+fs.writeFileSync(process.argv[1] + ".tmp", JSON.stringify(processIncarnationIdentitySha256()));
+fs.renameSync(process.argv[1] + ".tmp", process.argv[1]);
+Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);`,
+          readyPath,
+        ],
+        { stdio: ["ignore", "pipe", "pipe"] },
+      );
+      own(holder);
+      await waitForPath(readyPath);
+      const identity = JSON.parse(fs.readFileSync(readyPath, "utf8"));
+      assert.ok(identity);
+      assert.equal(holder.kill("SIGSTOP"), true);
+      const deadline = Date.now() + 2_000;
+      for (;;) {
+        const result = spawnSync("/bin/ps", ["-p", String(holder.pid), "-o", "state="], {
+          encoding: "utf8",
+          timeout: 2_000,
+        });
+        assert.equal(result.status, 0, result.stderr);
+        if (result.stdout.trim().startsWith("T")) break;
+        assert.ok(Date.now() < deadline, "holder did not stop");
+      }
+      assert.equal(processIncarnationIdentitySha256(holder.pid, { fresh: true }), identity);
+      assert.doesNotThrow(() => process.kill(holder.pid!, 0));
+    });
+  },
+);
+
+test(
+  "macOS process identity query failures remain unknown and recover on the next query",
+  { skip: process.platform === "darwin" ? false : "requires macOS proc_pidinfo" },
+  () => {
+    const identity = processIncarnationIdentitySha256(process.pid, { fresh: true });
+    assert.ok(identity);
+    const originalSpawnSync = childProcess.spawnSync;
+    for (const failedCommand of ["/usr/bin/python3", "/usr/sbin/sysctl"]) {
+      let injected = false;
+      childProcess.spawnSync = ((command, ...args) => {
+        if (command === failedCommand) {
+          injected = true;
+          return { status: 1, stdout: "", stderr: "" };
+        }
+        return originalSpawnSync(command, ...args);
+      }) as typeof spawnSync;
+      syncBuiltinESMExports();
+      try {
+        assert.equal(processIncarnationIdentitySha256(process.pid, { fresh: true }), null);
+        assert.equal(injected, true);
+      } finally {
+        childProcess.spawnSync = originalSpawnSync;
+        syncBuiltinESMExports();
+      }
+      assert.equal(processIncarnationIdentitySha256(), identity);
+    }
+  },
+);
+
+test(
+  "macOS process identities ignore the observer timezone",
+  { skip: process.platform === "darwin" ? false : "requires macOS proc_pidinfo" },
+  () => {
+    const priorTimezone = process.env.TZ;
+    try {
+      process.env.TZ = "UTC";
+      const utcIdentity = processIncarnationIdentitySha256(process.pid, { fresh: true });
+      assert.ok(utcIdentity);
+      process.env.TZ = "America/Los_Angeles";
+      assert.equal(
+        processIncarnationIdentitySha256(process.pid, { fresh: true }),
+        utcIdentity,
+        "observer timezone must not change the same live process incarnation",
+      );
+    } finally {
+      if (priorTimezone === undefined) delete process.env.TZ;
+      else process.env.TZ = priorTimezone;
+      processIncarnationIdentitySha256(process.pid, { fresh: true });
+    }
+  },
+);
+
+test(
+  "macOS process identities reject malformed boot timestamps and recover",
+  { skip: process.platform === "darwin" ? false : "requires macOS proc_pidinfo" },
+  () => {
+    const identity = processIncarnationIdentitySha256(process.pid, { fresh: true });
+    assert.ok(identity);
+    const originalSpawnSync = childProcess.spawnSync;
+    for (const bootTime of [
+      "not a boot timestamp",
+      "{ sec = 123 }",
+      "{ sec = 0, usec = 0 }",
+      "{ sec = 9007199254740992, usec = 0 }",
+      "{ sec = 123, usec = -1 }",
+      "{ sec = 123, usec = 1000000 }",
+      "{ sec = 123.5, usec = 0 }",
+    ]) {
+      let injected = false;
+      childProcess.spawnSync = ((command, ...args) => {
+        if (command === "/usr/sbin/sysctl") {
+          injected = true;
+          return { status: 0, stdout: bootTime, stderr: "" };
+        }
+        return originalSpawnSync(command, ...args);
+      }) as typeof spawnSync;
+      syncBuiltinESMExports();
+      try {
+        assert.equal(
+          processIncarnationIdentitySha256(process.pid, { fresh: true }),
+          null,
+          bootTime,
+        );
+        assert.equal(injected, true);
+      } finally {
+        childProcess.spawnSync = originalSpawnSync;
+        syncBuiltinESMExports();
+        processIncarnationIdentitySha256(process.pid, { fresh: true });
+      }
+      assert.equal(processIncarnationIdentitySha256(), identity);
+    }
   },
 );
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where macOS action-ledger producers or shard importers could mistake a live lock holder for a different process when its execution state or the observer's timezone changed. An unavailable process observation could also become a cached or lower-resolution identity instead of remaining unknown.

## Why This Change Was Made

Bind macOS ownership to numeric boot seconds/microseconds, PID, and microsecond process start time. Exclude mutable process state and the human boot-date suffix; invalid or unavailable observations remain unknown and are retried.

Changing the hash scheme also requires a serialized-lock boundary: macOS writers emit V2, readers accept V1/V2 and reject unknown versions, and live macOS V1 owners remain unverified until they die. Dead V1 locks remain reclaimable; V2 keeps fresh PID-reuse checks. Older readers reject V2, so mixed-version access fails closed. Other platforms retain V1. Existing waits, assertions, child cleanup, and the 4097-event workload are unchanged.

## User Impact

Local macOS ledger operations retain live owners through process-state and timezone changes. During mixed-version contention, callers keep the existing 10-second timeout; recovery after a dead owner remains available. No workflow, deployment, or production operation is part of this change.

## OpenClaw Bay Impact

Unaffected. This changes local filesystem ownership only; observer data, lifecycle publication, status contracts, and Bay navigation do not change.

## Documentation Impact

`docs/action-ledger.md` is the active canonical contract and now documents numeric identity, unknown observations, and the V1/V2 transition. ClawSweeper's ledger maintainers own this contract; `src/action-ledger-files.ts` and `src/action-ledger-runtime.ts` are its implementation sources. The changed ownership scope was verified at `6999bcc7a15a4449903873792424a7f58e1a31b4`; changes to identity inputs, lock versions, reclamation, or timeout policy require this documentation and its proof to be refreshed. `CHANGELOG.md` records the behavior change.

## Evidence

Head: `6999bcc7a15a4449903873792424a7f58e1a31b4`; base: `220ad5673ace96b2fab6473203796639c17ac710`.

The head-bound macOS build passed, and all 11 focused runtime tests passed (39.22 seconds): live/dead ownership, both V1 transitions, V2 PID mismatch, unknown versions, actual platform writer versions, same-second starts, stopped holders, unavailable/invalid observations, and timezone stability. The focused command is included below. Both the precommit and committed structured Codex reviews found no P0 issues within their configured P0-only scope; this is not a broader clean-review claim. Merge remains gated by the exact-head GitHub Checks, including the complete Linux `pnpm run check`, and a current ClawSweeper head/body review; hosted CI success is not asserted here.

Preparation also passed build-all, static/docs/format checks, and focused source/test lint. Retained earlier attempts include pnpm aborting at its no-TTY automatic-install safeguard and an initial proof-harness ready-file partial-write race. Warning-only dependency checks preserved the read-only dependency link; atomic ready-file publication fixed the harness race before successful proof. The first public-script publication gate requested stronger interruption cleanup and waiting for complete child output. The first corrected interruption check then exposed macOS `EPERM` for an unreaped zombie-only process group; the final supervisor conservatively keeps that group present until reaped. That failed attempt and its raw stack are retained locally. The final successful probe and both controlled interruption checks passed on the unchanged head.

The initial unversioned identity candidate incorrectly reclaimed live genuine V1 owners in 593 ms (producer) and 1242 ms (import). That was an upgrade hazard introduced by changing the hash scheme, **not an upstream regression**. V2 plus the live-V1 guard prevents it. The historical 12.4-second producer failure and any hosted CI failure remain unattributed; this PR does not claim to fix them. Earlier stopped-holder evidence from public baseline `99fa19072766106fdf1586196d450b613bf2b09e` is investigation context, not current-head proof.

## Real Behavior Proof

**Claim and surface:** the real `recordWorkflowActionEvent` and `importActionEventShards` filesystem-lock paths preserve a live legacy V1 owner and a stopped current V2 owner, then reclaim only after the task-owned holder dies. This is direct two-process runtime execution, separate from the unit tests.

**Synthetic scenario:** independent Node holder and contender processes use canonical OS temporary directories. For V1, the holder uses the actual legacy hash and no-follow lock writer extracted from public baseline `99fa19072766106fdf1586196d450b613bf2b09e:src/action-ledger-files.ts`, loaded with Node 24+ built-in TypeScript stripping. For V2, the holder uses this head and is stopped with SIGSTOP. Each producer/import contender runs through the unchanged 10-second wait. The harness polls lock bytes, performs a final exact byte comparison, confirms holder liveness, kills only its own holder, verifies ESRCH, and retries successfully.

**Command/environment:** native macOS 26.6.2 arm64, Node 26.8.1, pnpm 11.10.0; no VM image or lease. Earlier preparation used Node 24.20.0; the receipt below describes the refreshed committed-head runs. The original harness used a canonical external OS TMPDIR and a five-minute process-group bound per invocation; the complete reproduction below independently passed with 90-second bounds per behavior mode. It requires a built checkout of the exact head, the public baseline Git object, Node 24+, `/usr/bin/python3`, and macOS process APIs.

**Observed result:** all four first-run contenders timed out after at least 10 seconds with byte-identical live locks; recovery took under one second. The independently executed self-contained probe repeated all four cases, with successful dead-owner recovery in about 1.1 seconds or less. An expected contender exit of 1 means the asserted lock timeout, not a failed proof run.

**Artifact/trace:** the public-safe structured receipt below embeds the executed results. Raw inputs, holder bytes, stdout/stderr stacks, liveness assertions, source manifests, and recovery outputs are retained locally; those untracked local paths are not public artifacts. The complete runnable probe below generates equivalent raw traces and `receipt.json` under its fresh `$SCRATCH`. Its SHA-256 is `ee21dd6dfa89107fcae8c2e26b26daeb62e4f76680ed2d285cff84b7eb6a4ec8`.

**Limits:** synthetic local fixtures; no production data or mutations, no full macOS suite, no forced OS PID recycling (mismatching serialized V2 identities are covered by focused tests), no bulk-I/O optimization, and no attribution of the historical timeout or unrelated CI failures. Exact-head hosted Checks are a separate merge gate.

**Interruption cleanup:** the script execs its final Python supervisor. Each behavior mode owns a separate session/process group. SIGTERM unwinds through `finally`; normal completion, nonzero exits, timeout, and KeyboardInterrupt use the same bounded group termination/reaping. Node observes child errors immediately, awaits `close` before reading complete output, and cleans up owned children on every path. Controlled SIGINT and SIGTERM sent to the supervisor after holder readiness both left no owned holder or mode group, with supervisor and mode child reaped. These are separate intentional interruption runs, not successful behavior-run exits.

<details>
<summary>Public-safe committed-head proof receipt</summary>

```json
{
  "head": "6999bcc7a15a4449903873792424a7f58e1a31b4",
  "provider": "native-macos",
  "platform": "darwin/arm64",
  "macos": "26.6.2",
  "node": "v26.8.1",
  "pnpm": "11.10.0",
  "image": null,
  "lease": null,
  "focused": {
    "tests": 11,
    "pass": 11,
    "fail": 0,
    "elapsed_seconds": 39.22
  },
  "cases": [
    {
      "case": "live-v1-producer",
      "contender_exit": 1,
      "contender_elapsed_ms": 10128,
      "lock_bytes_unchanged": true,
      "recovery_outcome": "success",
      "recovery_elapsed_ms": 566
    },
    {
      "case": "live-v1-import",
      "contender_exit": 1,
      "contender_elapsed_ms": 10106,
      "lock_bytes_unchanged": true,
      "recovery_outcome": "success",
      "recovery_elapsed_ms": 907
    },
    {
      "case": "stopped-v2-producer",
      "contender_exit": 1,
      "contender_elapsed_ms": 10195,
      "lock_bytes_unchanged": true,
      "recovery_outcome": "success",
      "recovery_elapsed_ms": 608
    },
    {
      "case": "stopped-v2-import",
      "contender_exit": 1,
      "contender_elapsed_ms": 10144,
      "lock_bytes_unchanged": true,
      "recovery_outcome": "success",
      "recovery_elapsed_ms": 873
    }
  ],
  "self_contained_probe": {
    "exit_code": 0,
    "elapsed_seconds": 47.76,
    "script_sha256": "ee21dd6dfa89107fcae8c2e26b26daeb62e4f76680ed2d285cff84b7eb6a4ec8",
    "cases": [
      {
        "case": "live-v1-producer",
        "contender_exit": 1,
        "contender_elapsed_ms": 10089,
        "contender_message": "action event producer lock timed out after 10000ms",
        "lock_bytes_unchanged": true,
        "recovery_outcome": "success",
        "recovery_elapsed_ms": 298
      },
      {
        "case": "live-v1-import",
        "contender_exit": 1,
        "contender_elapsed_ms": 10089,
        "contender_message": "action event shard import lock timed out after 10000ms",
        "lock_bytes_unchanged": true,
        "recovery_outcome": "success",
        "recovery_elapsed_ms": 645
      },
      {
        "case": "stopped-v2-producer",
        "contender_exit": 1,
        "contender_elapsed_ms": 10062,
        "contender_message": "action event producer lock timed out after 10000ms",
        "lock_bytes_unchanged": true,
        "recovery_outcome": "success",
        "recovery_elapsed_ms": 385
      },
      {
        "case": "stopped-v2-import",
        "contender_exit": 1,
        "contender_elapsed_ms": 10331,
        "contender_message": "action event shard import lock timed out after 10000ms",
        "lock_bytes_unchanged": true,
        "recovery_outcome": "success",
        "recovery_elapsed_ms": 1043
      }
    ],
    "cleanup": [
      {
        "mode": "green",
        "group_remaining": false,
        "child_reaped": true
      },
      {
        "mode": "stopped",
        "group_remaining": false,
        "child_reaped": true
      }
    ]
  },
  "controlled_interruption": {
    "script_sha256": "ee21dd6dfa89107fcae8c2e26b26daeb62e4f76680ed2d285cff84b7eb6a4ec8",
    "cases": [
      {
        "signal": "SIGINT",
        "after_holder_readiness": true,
        "probe_exit": -2,
        "elapsed_ms": 384,
        "holder_remaining": false,
        "mode_group_remaining": false,
        "supervisor_reaped": true,
        "mode_child_reaped": true
      },
      {
        "signal": "SIGTERM",
        "after_holder_readiness": true,
        "probe_exit": 143,
        "elapsed_ms": 70,
        "holder_remaining": false,
        "mode_group_remaining": false,
        "supervisor_reaped": true,
        "mode_child_reaped": true
      }
    ]
  }
}
```

</details>

<details>
<summary>Complete runnable macOS reproduction</summary>

Set `REPO` to a clean checkout at `6999bcc7a15a4449903873792424a7f58e1a31b4`. Make public baseline `99fa19072766106fdf1586196d450b613bf2b09e` available with normal Git fetch if needed. Node 24+ and `/usr/bin/python3` are prerequisites; this committed-head proof used Node 26.8.1.

```bash
cd "$REPO"
```

For a fresh checkout, enable Corepack and install the pinned dependencies once. Skip installation when intentionally using an existing read-only shared dependency link.

```bash
corepack enable
```

```bash
pnpm install --frozen-lockfile
```

The warning-only dependency option prevents automatic replacement of a shared dependency link during the build.

```bash
pnpm_config_verify_deps_before_run=warn pnpm run build
```

The supporting focused suite was already executed successfully on this head; the harness-only correction did not change or rerun it.

```bash
node --test --test-reporter=tap --test-name-pattern 'producer locks reclaim fresh dead owners|macOS process|V1 owners|current-version PID reuse|serialize the platform' test/action-ledger-runtime.test.ts
```

Create an external directory and save the complete script below there as `probe.sh`.

```bash
SCRATCH=$(mktemp -d)
```

```bash
REPO="$REPO" bash "$SCRATCH/probe.sh"
```

The script creates a separate canonical scratch directory for generated modules, synthetic fixtures, and raw traces. It prints a sanitized receipt, asserts every result, and exits nonzero on failure. Fresh directories make repeated runs independent. No unpublished local harness files are required.

```bash
#!/usr/bin/env bash
set -euo pipefail
: "${REPO:?Set REPO to a built checkout of the PR head}"
export REPO
test "$(git -C "$REPO" rev-parse HEAD)" = 6999bcc7a15a4449903873792424a7f58e1a31b4
test "$(uname -s)" = Darwin
node -e 'if (Number(process.versions.node.split(".")[0]) < 24) process.exit(1)'
/usr/bin/python3 --version >/dev/null
SCRATCH=$(mktemp -d "${TMPDIR:-/tmp}/ledger-public-proof.XXXXXX")
export SCRATCH
SCRATCH=$(/usr/bin/python3 -c 'import os; print(os.path.realpath(os.environ["SCRATCH"]))')
export SCRATCH TMPDIR="$SCRATCH"
git -C "$REPO" show 99fa19072766106fdf1586196d450b613bf2b09e:src/action-ledger-files.ts > "$SCRATCH/legacy-action-ledger-files.ts"
cat > "$SCRATCH/fixture.mjs" <<'LEDGER_PROBE_EOF'
import assert from 'node:assert/strict';
import { createHash } from 'node:crypto';
import fs from 'node:fs';
import path from 'node:path';
import { pathToFileURL } from 'node:url';
const { recordWorkflowActionEvent, flushWorkflowActionEvents, importActionEventShards } = await import(pathToFileURL(path.join(process.env.REPO,'dist/action-ledger-runtime.js')));
const { actionLedgerJson } = await import(pathToFileURL(path.join(process.env.REPO,'dist/action-ledger.js')));
export const env = {
 CLAWSWEEPER_ACTION_LEDGER_FORCE:'1', CLAWSWEEPER_ACTION_LEDGER_INVOCATION:'ledger-proof',
 CLAWSWEEPER_ACTION_LEDGER_PARTITION_DATE:'2026-07-12',GITHUB_ACTION:'proof',GITHUB_JOB:'review',
 GITHUB_REPOSITORY:'openclaw/clawsweeper',GITHUB_RUN_ATTEMPT:'1',GITHUB_RUN_ID:'100',
 GITHUB_SHA:'abc123',GITHUB_WORKFLOW:'Ledger proof',GITHUB_WORKFLOW_REF:'openclaw/clawsweeper/.github/workflows/sweep.yml@refs/heads/main'
};
export function record(root,number) {
 return recordWorkflowActionEvent(root,{
 scope:'review.completed',identity:{repository:'openclaw/openclaw',number,sourceRevision:`abc${number}`},
 type:'review.completed',component:'review',subject:{repository:'openclaw/openclaw',kind:'pull_request',number,sourceRevision:`abc${number}`},
 action:{name:'review',status:'completed',retryable:false,mutation:false},occurredAt:'2026-07-12T10:00:00.000Z'
 },{env});
}
export async function setup(root,kind) {
 const target=path.join(root,'target'); const source=path.join(root,'source');
 fs.mkdirSync(target);fs.mkdirSync(source);
 const first=record(target,41); assert.ok(first);
 if(kind==='import') await flushWorkflowActionEvents(target,{env,outputRoot:source});
 const relative=kind==='producer'?path.join('.clawsweeper-repair','action-events','_locks',createHash('sha256').update(actionLedgerJson(first.producer)).digest('hex')+'.lock'):'.action-ledger-import.lock';
 return {root:target,source,relative,kind};
}
export function contend(input) { return input.kind==='producer'?record(input.root,42):importActionEventShards(input.source,input.root); }
LEDGER_PROBE_EOF
cat > "$SCRATCH/holder.mjs" <<'LEDGER_PROBE_EOF'
import assert from 'node:assert/strict';
import fs from 'node:fs';
import path from 'node:path';
import { pathToFileURL } from 'node:url';
const { actionLedgerJson } = await import(pathToFileURL(path.join(process.env.REPO,'dist/action-ledger.js')));
const input=JSON.parse(fs.readFileSync(process.argv[2],'utf8'));
const files=await import(input.files);
const identity=files.processIncarnationIdentitySha256();assert.ok(identity);
const target=files.prepareSafeWriteTarget(input.root,input.relative,'proof holder');
const content=actionLedgerJson({schema:`clawsweeper.action-ledger-${input.kind}-lock`,schema_version:input.version,pid:process.pid,process_incarnation_sha256:identity,acquired_at_ms:Date.now(),nonce:'00000000-0000-4000-8000-000000000005'})+'\n';
assert.ok(files.tryAcquireUtf8FileLockNoFollow(target,content));
fs.writeFileSync(input.ready+".tmp",content);
fs.renameSync(input.ready+".tmp",input.ready);
Atomics.wait(new Int32Array(new SharedArrayBuffer(4)),0,0);
LEDGER_PROBE_EOF
cat > "$SCRATCH/contender.mjs" <<'LEDGER_PROBE_EOF'
import fs from 'node:fs';
import { contend } from './fixture.mjs';
const input=JSON.parse(fs.readFileSync(process.argv[2],'utf8'));
const started=performance.now();
try { const result=contend(input); console.log(JSON.stringify({outcome:'success',elapsed_ms:performance.now()-started,result})); }
catch(error) { console.error(error.stack);console.log(JSON.stringify({outcome:'error',elapsed_ms:performance.now()-started,message:error.message}));process.exitCode=1; }
LEDGER_PROBE_EOF
cat > "$SCRATCH/behavior.mjs" <<'LEDGER_PROBE_EOF'
import assert from 'node:assert/strict';
import { spawn, spawnSync } from 'node:child_process';
import fs from 'node:fs';
import os from 'node:os';
import path from 'node:path';
import { setTimeout } from 'node:timers/promises';
import { pathToFileURL, fileURLToPath } from 'node:url';
const { processIncarnationIdentitySha256 } = await import(pathToFileURL(path.join(process.env.REPO, 'dist/action-ledger-files.js')));
import { setup } from './fixture.mjs';
const mode = process.argv[2];
assert.ok(['green', 'stopped'].includes(mode));
assert.equal(process.platform, 'darwin');
const proof = path.dirname(fileURLToPath(import.meta.url));
const owned = new Set();
let interrupted;
function checkInterrupted() { if (interrupted) throw new Error(`probe interrupted by ${interrupted}`); }
function start(args) {
  checkInterrupted();
  const child = spawn(process.execPath, args, { stdio: ['ignore', 'pipe', 'pipe'] });
  const task = { child, out: '', err: '', error: null, closed: false };
  // Observe errors immediately; close also guarantees the output streams are drained.
  task.done = new Promise(resolve => {
    child.once('error', error => { task.error = error; });
    child.once('close', (code, signal) => { task.closed = true; resolve({ code, signal }); });
  });
  child.stdout.on('data', data => { task.out += data; });
  child.stderr.on('data', data => { task.err += data; });
  owned.add(task);
  return task;
}
async function stop(task) {
  if (!task.closed) task.child.kill('SIGKILL');
  let timer;
  try {
    await Promise.race([task.done, new Promise((_, reject) => {
      timer = globalThis.setTimeout(() => reject(new Error('owned child cleanup timed out')), 5000);
    })]);
  } finally { globalThis.clearTimeout(timer); }
}
function interrupt(signal) {
  interrupted = signal;
  for (const task of owned) if (!task.closed) task.child.kill('SIGKILL');
}
const onInt = () => interrupt('SIGINT');
const onTerm = () => interrupt('SIGTERM');
process.on('SIGINT', onInt);
process.on('SIGTERM', onTerm);
const results = [];
try {
  for (const kind of ['producer', 'import']) {
    checkInterrupted();
    const root = fs.realpathSync.native(fs.mkdtempSync(path.join(os.tmpdir(), 'ledger-holder-')));
    const input = await setup(root, kind);
    const dir = path.join(proof, `${process.argv[3]}-${kind}`);
    fs.mkdirSync(dir);
    Object.assign(input, {
      version: mode === 'stopped' ? 2 : 1,
      files: pathToFileURL(mode === 'stopped' ? path.join(process.env.REPO, 'dist/action-ledger-files.js') : path.join(proof, 'legacy-action-ledger-files.ts')).href,
      ready: path.join(root, 'ready')
    });
    const inputPath = path.join(dir, 'input.json');
    fs.writeFileSync(inputPath, JSON.stringify(input, null, 2) + '\n');
    const holder = start([path.join(proof, 'holder.mjs'), inputPath]);
    let contender, watch, killTimer;
    try {
      const deadline = Date.now() + 5000;
      while (!fs.existsSync(input.ready)) {
        checkInterrupted();
        assert.equal(holder.error, null);
        assert.equal(holder.closed, false, holder.err);
        assert.ok(Date.now() < deadline, 'holder readiness timeout');
        await setTimeout(10);
      }
      checkInterrupted();
      const before = fs.readFileSync(input.ready, 'utf8');
      const lock = JSON.parse(before);
      assert.equal(lock.pid, holder.child.pid);
      assert.equal(lock.schema_version, input.version);
      fs.writeFileSync(path.join(dir, 'holder-lock.json'), before);
      const currentIdentity = processIncarnationIdentitySha256(holder.child.pid, { fresh: true });
      assert.ok(currentIdentity);
      if (mode === 'stopped') {
        assert.equal(currentIdentity, lock.process_incarnation_sha256);
        holder.child.kill('SIGSTOP');
        const stopDeadline = Date.now() + 2000;
        for (;;) {
          const ps = spawnSync('/bin/ps', ['-p', String(holder.child.pid), '-o', 'state='], { encoding: 'utf8', timeout: 2000 });
          if (ps.stdout.trim().startsWith('T')) break;
          assert.ok(Date.now() < stopDeadline);
        }
        assert.equal(processIncarnationIdentitySha256(holder.child.pid, { fresh: true }), lock.process_incarnation_sha256);
      } else assert.notEqual(currentIdentity, lock.process_incarnation_sha256, 'old hash must differ to exercise transition');
      const args = [path.join(proof, 'contender.mjs'), inputPath];
      contender = start(args);
      let changed = false, polls = 0;
      watch = setInterval(() => {
        polls++;
        try { if (fs.readFileSync(path.join(input.root, input.relative), 'utf8') !== before) changed = true; }
        catch { changed = true; }
      }, 10);
      killTimer = globalThis.setTimeout(() => { if (!contender.closed) contender.child.kill('SIGKILL'); }, 20000);
      const { code, signal } = await contender.done;
      clearInterval(watch);
      globalThis.clearTimeout(killTimer);
      fs.writeFileSync(path.join(dir, 'contender.stdout.log'), contender.out);
      fs.writeFileSync(path.join(dir, 'contender.stderr.log'), contender.err);
      checkInterrupted();
      assert.equal(contender.error, null);
      const result = JSON.parse(contender.out.trim());
      assert.doesNotThrow(() => process.kill(holder.child.pid, 0));
      assert.equal(code, 1, contender.err);
      assert.match(result.message, /timed out after 10000ms/);
      assert.ok(result.elapsed_ms >= 10000);
      assert.equal(changed, false);
      assert.equal(fs.readFileSync(path.join(input.root, input.relative), 'utf8'), before);
      await stop(holder);
      assert.throws(() => process.kill(holder.child.pid, 0), { code: 'ESRCH' });
      checkInterrupted();
      const recovered = spawnSync(process.execPath, args, { encoding: 'utf8', timeout: 20000 });
      fs.writeFileSync(path.join(dir, 'recovery.stdout.log'), recovered.stdout);
      fs.writeFileSync(path.join(dir, 'recovery.stderr.log'), recovered.stderr);
      assert.equal(recovered.status, 0, recovered.stderr);
      const recovery = JSON.parse(recovered.stdout.trim());
      assert.equal(recovery.outcome, 'success');
      assert.ok(recovery.elapsed_ms < 5000);
      const record = { mode, kind, pid: holder.child.pid, version: input.version, legacyIdentity: lock.process_incarnation_sha256, currentIdentity, contender: { code, signal, ...result }, lockChangedWhileLive: changed, polls, recovery, node: process.version, platform: process.platform };
      fs.writeFileSync(path.join(dir, 'result.json'), JSON.stringify(record, null, 2) + '\n');
      results.push(record);
    } finally {
      clearInterval(watch);
      globalThis.clearTimeout(killTimer);
      const cleanup = await Promise.allSettled([stop(holder), ...(contender ? [stop(contender)] : [])]);
      fs.writeFileSync(path.join(dir, 'holder.log'), holder.out + holder.err);
      const failed = cleanup.find(result => result.status === 'rejected');
      if (failed) throw failed.reason;
    }
  }
  checkInterrupted();
  console.log(JSON.stringify(results, null, 2));
} finally {
  const cleanup = await Promise.allSettled([...owned].map(stop));
  process.removeListener('SIGINT', onInt);
  process.removeListener('SIGTERM', onTerm);
  const failed = cleanup.find(result => result.status === 'rejected');
  if (failed) throw failed.reason;
}
LEDGER_PROBE_EOF
exec /usr/bin/python3 - <<'PYTHON_PROBE_EOF'
import os, pathlib, subprocess, signal, json, hashlib, time
scratch = pathlib.Path(os.environ['SCRATCH'])
repo = pathlib.Path(os.environ['REPO'])
owned_signals = {signal.SIGINT, signal.SIGTERM}
def terminate_requested(signum, frame):
    raise SystemExit(128 + signum)
signal.signal(signal.SIGTERM, terminate_requested)

def group_exists(pgid):
    try:
        os.killpg(pgid, 0)
        return True
    except ProcessLookupError:
        return False
    except PermissionError:
        # macOS reports EPERM for a zombie-only group; keep it present until reaped.
        return True

def cleanup(child, mode):
    # Each child owns a new session. Never target the supervisor/caller group.
    pgid = child.pid
    assert pgid != os.getpgrp()
    previous_mask = signal.pthread_sigmask(signal.SIG_BLOCK, owned_signals)
    try:
        for sig, budget in [(signal.SIGTERM, 2), (signal.SIGKILL, 3)]:
            try: os.killpg(pgid, sig)
            except (ProcessLookupError, PermissionError): pass
            deadline = time.monotonic() + budget
            while time.monotonic() < deadline:
                child.poll()
                if not group_exists(pgid): break
                time.sleep(0.05)
            if not group_exists(pgid): break
        child.wait(timeout=5)
        remaining = group_exists(pgid)
        (scratch/(mode+'.cleanup.json')).write_text(json.dumps({
            'mode': mode, 'pgid': pgid, 'child_returncode': child.returncode,
            'group_remaining': remaining, 'child_reaped': True
        }, indent=2) + '\n')
        if remaining: raise RuntimeError('owned process group remains after bounded cleanup')
    finally:
        signal.pthread_sigmask(signal.SIG_SETMASK, previous_mask)

for mode in ['green', 'stopped']:
    with (scratch/(mode+'.stdout.log')).open('w') as out, (scratch/(mode+'.stderr.log')).open('w') as err:
        child = None
        try:
            # Defer signals until the spawned group is assigned to its cleanup owner.
            previous_mask = signal.pthread_sigmask(signal.SIG_BLOCK, owned_signals)
            try:
                child = subprocess.Popen(
                    ['node', str(scratch/'behavior.mjs'), mode, 'public-'+mode],
                    cwd=repo, stdout=out, stderr=err, start_new_session=True,
                    preexec_fn=lambda: signal.pthread_sigmask(signal.SIG_SETMASK, previous_mask))
            finally:
                signal.pthread_sigmask(signal.SIG_SETMASK, previous_mask)
            code = child.wait(timeout=90)
            if code: raise SystemExit('probe failed; inspect SCRATCH logs')
        finally:
            if child is not None: cleanup(child, mode)
rows = []
for mode in ['green', 'stopped']:
    for kind in ['producer', 'import']:
        result = json.loads((scratch/('public-'+mode+'-'+kind)/'result.json').read_text())
        rows.append({'case': ('live-v1' if mode=='green' else 'stopped-v2')+'-'+kind,
          'contender_exit': result['contender']['code'],
          'contender_elapsed_ms': round(result['contender']['elapsed_ms']),
          'contender_message': result['contender']['message'],
          'lock_bytes_unchanged': not result['lockChangedWhileLive'],
          'recovery_outcome': result['recovery']['outcome'],
          'recovery_elapsed_ms': round(result['recovery']['elapsed_ms'])})
receipt = {'head': subprocess.check_output(['git','rev-parse','HEAD'],cwd=repo,text=True).strip(),
 'provider':'native-macos', 'image':None, 'lease':None,
 'node':subprocess.check_output(['node','--version'],text=True).strip(),
 'source_sha256':{f:hashlib.sha256((repo/f).read_bytes()).hexdigest() for f in ['src/action-ledger-files.ts','src/action-ledger-runtime.ts','test/action-ledger-runtime.test.ts']},
 'cases':rows,
 'cleanup':[{'mode':mode, **{key:json.loads((scratch/(mode+'.cleanup.json')).read_text())[key] for key in ['group_remaining','child_reaped']}} for mode in ['green','stopped']]}
(scratch/'receipt.json').write_text(json.dumps(receipt,indent=2)+'\n')
print(json.dumps(receipt,indent=2))
PYTHON_PROBE_EOF
```

</details>
