### PR TITLE
fix(review): recognize approved Browser redaction fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Classify the exact reviewed OpenClaw Browser CDP credential-redaction fixtures without treating their shared test path as a wildcard, allowing multiple independently approved digests per source while preserving all scanner gates.
 - Bound standalone webhook bodies to 2 MiB before signature verification, preserving chunked deliveries and flushing rejection responses before closing oversized requests. Thanks @SebTardif.
 - Preserve committed lifecycle outcomes when later queue completions disagree, preventing terminal-state conflicts from failing completion callbacks and acknowledgement drivers.
 - Retain numeric queue failure source locations inside the Durable Object before remote transport discards the original stack, without logging private error text.

--- a/README.md
+++ b/README.md
@@ -570,9 +570,17 @@ The host classifies the reviewed synthetic malformed-configuration URI in
 `test/action-ledger-runtime.test.ts` and the explicitly approved autoreview
 negative-test URI in the [canonical autoreview test](https://github.com/openclaw/agent-skills/blob/a8466c1d860588a083610fe41fd277c1d88b14e0/skills/autoreview/tests/test_autoreview_hardening.py)
 or its [vendored OpenClaw copy](https://github.com/openclaw/openclaw/blob/136eab023035dd5943818f791d3c3db7d92e4491/.agents/skills/autoreview/tests/test_autoreview_hardening.py)
-as non-sensitive after a complete scan. Static host policy associates each
+as non-sensitive after a complete scan. The same exact-fixture policy covers
+the reviewed OpenClaw Browser CDP credential-redaction fixtures in
+[`chrome.test.ts`](https://github.com/openclaw/openclaw/blob/8e03b0c62e76dc25c77045a84ab3098a111a7be3/extensions/browser/src/browser/chrome.test.ts),
+its later [remote-CDP coverage](https://github.com/openclaw/openclaw/blob/58da2f5897feb6840937d8e50cf7ee6f26aa57d7/extensions/browser/src/browser/chrome.test.ts),
+and the [server-context redaction test](https://github.com/openclaw/openclaw/blob/4b5987829d0f82ea44ae50f2f418ffe5ea445e7f/extensions/browser/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts)
+after a complete scan. Static host policy associates each
 exact full-URI SHA-256 with only its approved source paths, requiring a literal
 at the reported line of a host-staged Git blob from mode `100644`.
+One source path may contain multiple independently reviewed fixtures; each
+digest/path/mode tuple must match exactly, so source membership alone never
+qualifies a finding.
 Deduplicated blobs retain every scanned logical endpoint's path and Git mode,
 including mode-only transitions and shared-path aliases. Every captured reference
 must qualify under the same digest's exact path and mode `100644` policy before

--- a/docs/pr-review-comments.md
+++ b/docs/pr-review-comments.md
@@ -31,6 +31,10 @@ Each synced comment includes the durable identity marker:
 ClawSweeper edits that comment in place instead of posting repeated comments.
 Report front matter stores the synced comment id, URL, hash, and sync time.
 
+Trailing marker recovery stops at visible prose, including prose ending in
+`-->`. An already-closed HTML comment cannot extend across that prose into the
+final marker block; valid contiguous trailing markers remain recoverable.
+
 When review starts and no ClawSweeper-owned comment exists yet, the review
 shard posts a short status placeholder with the same durable identity marker.
 The placeholder is intentionally light and crustacean-friendly, then the final

--- a/docs/repair/auto-update-prs.md
+++ b/docs/repair/auto-update-prs.md
@@ -71,6 +71,11 @@ The trusted automation lane exists only for review bots we control. It does
 not treat random `@clawsweeper`, `@openclaw-clawsweeper`, or contributor prose as
 permission to spend workers or push commits.
 
+Status comment adoption and recovery require a readable trusted author login.
+Missing, empty, and unknown authors are rejected. Logins match case-insensitively
+without trimming: the router accepts `clawsweeper` and its configured trusted
+bots; the repair executor accepts `clawsweeper` and the two default bots above.
+
 ## Review Comment Shape
 
 ClawSweeper comments are meant to be readable by maintainers and parseable by

--- a/docs/review-cache.md
+++ b/docs/review-cache.md
@@ -71,6 +71,24 @@ Git history and blob hydration still make both sides of the PR available in
 the restricted review checkout. There is no compiler-backed cache, separate
 cache-only patch payload, or source-equivalence revalidation path.
 
+When full context collection requests a review checkout, source preparation runs
+independently of cache-digest eligibility and the API's 80-file context window.
+It reads the exact raw Git delta for the pinned merge-base/head (and pinned
+base/head endpoint evidence), including deleted and historical blobs. Current
+main never replaces the pinned REST base. Blob-size metadata uses batches of at
+most 160 objects; one explicit fetch per delta retrieves missing blobs only after
+the complete set fits the scanner's shared 256 MiB upper bound. Local metadata
+reads remain bounded to 4 MiB and source hydration has a 30-second Git-work
+deadline; metadata requests retain the existing GitHub transport timeout policy.
+The scanner separately enforces its aggregate budget, including prompts and the
+binary patch, and still refuses incomplete or unsupported source without fetching.
+
+Preparation remains in full-context collection, before restricted checkout
+inspection. Structural reuse keeps its existing pinned-source scan and refusal
+behavior; it does not gain a separate hydrator. Context-only callers that do not
+request a Git checkout do no source preparation. OpenClaw Bay is unaffected:
+no observer fields, routes, or controls change.
+
 The deployed review artifact contains compiled JavaScript, runtime libraries,
 and matching configuration, prompts, and schemas. TypeScript is a build
 dependency; review shards neither load nor install a compiler. Historical

--- a/src/agent-input-scan-fixtures.ts
+++ b/src/agent-input-scan-fixtures.ts
@@ -16,12 +16,28 @@ const REVIEWED_FIXTURES = [
       ".agents/skills/autoreview/tests/test_autoreview_hardening.py",
     ],
   },
+  {
+    // OpenClaw Browser local-CDP credential-redaction fixture introduced by 8e03b0c62e76.
+    fixtureSha256: "d69d650dc6c312f3e1071f8613df780323fadd01b8c40e6edd02715cd731ae60",
+    sources: ["extensions/browser/src/browser/chrome.test.ts"],
+  },
+  {
+    // OpenClaw Browser remote-CDP redaction fixtures introduced by 58da2f5897 and 4b5987829.
+    fixtureSha256: "60267342b1ab046bd8c42e2226fdfce2aa081e7f18e17c35c9c013d7b1de5720",
+    sources: [
+      "extensions/browser/src/browser/chrome.test.ts",
+      "extensions/browser/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts",
+    ],
+  },
 ] as const;
 
-export function reviewedFixtureForSource(source: string, mode: string) {
+export function reviewedFixtureForSource(source: string, mode: string, fixtureSha256: string) {
   const fixture =
     mode === "100644"
-      ? REVIEWED_FIXTURES.find((entry) => entry.sources.some((path) => path === source))
+      ? REVIEWED_FIXTURES.find(
+          (entry) =>
+            entry.fixtureSha256 === fixtureSha256 && entry.sources.some((path) => path === source),
+        )
       : undefined;
   return fixture ? { fixtureSha256: fixture.fixtureSha256, source } : undefined;
 }
@@ -125,7 +141,7 @@ export function classifyReviewedFixtureScan(
         !staged.references.length ||
         staged.references.some(
           ({ source, mode }) =>
-            reviewedFixtureForSource(source, mode)?.fixtureSha256 !== fixture.fixtureSha256,
+            reviewedFixtureForSource(source, mode, digest)?.fixtureSha256 !== fixture.fixtureSha256,
         ) ||
         typeof source.line !== "number" ||
         !Number.isSafeInteger(source.line) ||

--- a/src/agent-input-scan.ts
+++ b/src/agent-input-scan.ts
@@ -67,7 +67,7 @@ export function agentInputScanFailureExitCode(error: unknown): number | null {
     : null;
 }
 
-const MAX_SCAN_BYTES = 256 * 1024 * 1024;
+export const MAX_SCAN_BYTES = 256 * 1024 * 1024;
 const OBJECT_ID = /^[0-9a-f]{40}(?:[0-9a-f]{24})?$/;
 const hostRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const REVIEW_TOOL_BOOTSTRAP_ENV = [

--- a/src/clawsweeper-context-hydration.ts
+++ b/src/clawsweeper-context-hydration.ts
@@ -896,7 +896,6 @@ export function createContextHydration(dependencies: CreateContextHydrationDepen
   }
 
   function hydratePullRequestReviewSource(options: {
-    files: readonly unknown[];
     itemNumber: number;
     pullRequest: unknown;
     targetDir: string;
@@ -938,7 +937,6 @@ export function createContextHydration(dependencies: CreateContextHydrationDepen
           targetDir: options.targetDir,
           baseSha: revision,
           headSha,
-          files: options.files,
           resolveBlobSizes: (objectIds) =>
             githubReviewBlobSizes({
               repository: targetRepo(),

--- a/src/clawsweeper-item-context.ts
+++ b/src/clawsweeper-item-context.ts
@@ -90,7 +90,6 @@ interface CreateItemContextDependencies {
   reviewCommentContentRevision: (entries: readonly unknown[]) => string;
   reviewTimelineDigestParts: (entries: unknown) => unknown;
   hydratePullRequestReviewSource: (options: {
-    files: readonly unknown[];
     itemNumber: number;
     pullRequest: unknown;
     targetDir: string;
@@ -378,14 +377,8 @@ export function createItemContext(dependencies: CreateItemContextDependencies) {
         80,
         compactPullFile,
       );
-      if (
-        options.reviewCacheDigest &&
-        options.reviewCacheGitDir &&
-        !pullFilesWindow.truncated &&
-        pullFilesWindow.total === pullFiles.length
-      ) {
+      if (options.reviewCacheGitDir) {
         hydratePullRequestReviewSource({
-          files: pullFiles,
           itemNumber: item.number,
           pullRequest,
           targetDir: options.reviewCacheGitDir,

--- a/src/clawsweeper-review-blobs.ts
+++ b/src/clawsweeper-review-blobs.ts
@@ -1,17 +1,11 @@
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { reviewMergeBase } from "./pr-review-evidence.js";
+import { readReviewGit, reviewMergeBase } from "./pr-review-evidence.js";
+import { MAX_SCAN_BYTES } from "./agent-input-scan.js";
 
-const MAX_REVIEW_FILES = 80;
+const MAX_BLOB_SIZE_OBJECTS = 160;
 const MAX_GIT_OUTPUT_BYTES = 4 * 1024 * 1024;
-const MAX_REVIEW_BLOB_BYTES = 4 * 1024 * 1024;
 const GIT_OBJECT_ID = /^[0-9a-f]{40,64}$/i;
-
-type ReviewBlobFile = {
-  filename?: unknown;
-  previous_filename?: unknown;
-  status?: unknown;
-};
 
 export type ReviewBlobHydration = {
   hydrated: boolean;
@@ -239,58 +233,60 @@ export function hydratePullRequestReviewBlobs({
   targetDir,
   baseSha,
   headSha,
-  files,
   resolveBlobSizes,
 }: {
   targetDir: string;
   baseSha: string;
   headSha: string;
-  files: readonly unknown[];
   resolveBlobSizes?: (objectIds: readonly string[]) => ReadonlyMap<string, number>;
 }): ReviewBlobHydration {
-  if (
-    !GIT_OBJECT_ID.test(baseSha) ||
-    !GIT_OBJECT_ID.test(headSha) ||
-    files.length > MAX_REVIEW_FILES
-  ) {
+  if (!GIT_OBJECT_ID.test(baseSha) || !GIT_OBJECT_ID.test(headSha)) {
     return { hydrated: false, blobs: 0 };
   }
-
-  const basePaths = new Set<string>();
-  const headPaths = new Set<string>();
-  for (const value of files) {
-    if (!value || typeof value !== "object") return { hydrated: false, blobs: 0 };
-    const file = value as ReviewBlobFile;
-    const filename = safeReviewPath(file.filename);
-    if (!filename) return { hydrated: false, blobs: 0 };
-    const previous =
-      file.previous_filename == null ? filename : safeReviewPath(file.previous_filename);
-    if (!previous) return { hydrated: false, blobs: 0 };
-    const status = typeof file.status === "string" ? file.status.toLowerCase() : "";
-    if (status !== "added" && status !== "a") basePaths.add(previous);
-    if (status !== "removed" && status !== "deleted" && status !== "d") {
-      headPaths.add(filename);
-    }
+  const deadlineAt = Date.now() + 30_000;
+  const readOptions = { deadlineAt, maxBytes: MAX_GIT_OUTPUT_BYTES };
+  const raw = readReviewGit(
+    targetDir,
+    [
+      "diff",
+      "--raw",
+      "--no-abbrev",
+      "-z",
+      "--no-renames",
+      "--no-ext-diff",
+      "--no-textconv",
+      "--ignore-submodules=none",
+      baseSha,
+      headSha,
+      "--",
+    ],
+    readOptions,
+  );
+  if (!raw) return { hydrated: false, blobs: 0 };
+  let fields: string[];
+  try {
+    fields = new TextDecoder("utf-8", { fatal: true }).decode(raw).split("\0");
+  } catch {
+    return { hydrated: false, blobs: 0 };
   }
-
+  if (fields.pop() !== "" || fields.length % 2 !== 0) return { hydrated: false, blobs: 0 };
+  const paths = new Set<string>();
   const objectIds = new Set<string>();
-  for (const [sha, paths] of [
-    [baseSha, basePaths],
-    [headSha, headPaths],
-  ] as const) {
-    if (paths.size === 0) continue;
-    const tree = spawnSync("git", ["--literal-pathspecs", "ls-tree", "-z", sha, "--", ...paths], {
-      cwd: targetDir,
-      encoding: "utf8",
-      env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" },
-      maxBuffer: MAX_GIT_OUTPUT_BYTES,
-    });
-    if (tree.error || tree.status !== 0) return { hydrated: false, blobs: 0 };
-    for (const entry of tree.stdout.split("\0")) {
-      if (!entry) continue;
-      const match = entry.match(/^\d{6} (blob|commit) ([0-9a-f]{40,64})\t(.*)$/s);
-      if (!match || !paths.has(match[3]!)) return { hydrated: false, blobs: 0 };
-      if (match[1] === "blob") objectIds.add(match[2]!);
+  for (let index = 0; index < fields.length; index += 2) {
+    const match = /^:(\d{6}) (\d{6}) ([0-9a-f]{40,64}) ([0-9a-f]{40,64}) [AMDT]$/.exec(
+      fields[index]!,
+    );
+    const path = safeReviewPath(fields[index + 1]);
+    if (!match || !path) return { hydrated: false, blobs: 0 };
+    paths.add(path);
+    for (const [mode, oid] of [
+      [match[1]!, match[3]!],
+      [match[2]!, match[4]!],
+    ]) {
+      // Gitlinks are not blobs; the scanner still refuses changed gitlinks.
+      if (mode === "000000" || mode === "160000") continue;
+      if (!["100644", "100755", "120000"].includes(mode!)) return { hydrated: false, blobs: 0 };
+      objectIds.add(oid!);
     }
   }
 
@@ -308,13 +304,19 @@ export function hydratePullRequestReviewBlobs({
       `${baseSha}^{tree}`,
       `${headSha}^{tree}`,
       "--",
-      ...new Set([...basePaths, ...headPaths]),
+      ...paths,
     ],
     {
       cwd: targetDir,
       encoding: "utf8",
-      env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" },
+      env: {
+        ...process.env,
+        GIT_OPTIONAL_LOCKS: "0",
+        GIT_NO_LAZY_FETCH: "1",
+        GIT_NO_REPLACE_OBJECTS: "1",
+      },
       maxBuffer: MAX_GIT_OUTPUT_BYTES,
+      timeout: Math.max(1, deadlineAt - Date.now()),
     },
   );
   if (objectAvailability.error || objectAvailability.status !== 0) {
@@ -333,19 +335,13 @@ export function hydratePullRequestReviewBlobs({
   const sizes = new Map<string, number>();
   const localObjectIds = [...objectIds].filter((objectId) => !missing.has(objectId));
   if (localObjectIds.length > 0) {
-    const localObjects = spawnSync(
-      "git",
+    const localObjects = readReviewGit(
+      targetDir,
       ["cat-file", "--batch-check=%(objectname) %(objecttype) %(objectsize)"],
-      {
-        cwd: targetDir,
-        encoding: "utf8",
-        env: { ...process.env, GIT_OPTIONAL_LOCKS: "0", GIT_NO_LAZY_FETCH: "1" },
-        input: `${localObjectIds.join("\n")}\n`,
-        maxBuffer: MAX_GIT_OUTPUT_BYTES,
-      },
+      { ...readOptions, input: Buffer.from(`${localObjectIds.join("\n")}\n`) },
     );
-    if (localObjects.error || localObjects.status !== 0) return { hydrated: false, blobs: 0 };
-    const found = localObjects.stdout.trim().split("\n");
+    if (!localObjects) return { hydrated: false, blobs: 0 };
+    const found = localObjects.toString().trim().split("\n");
     if (found.length !== localObjectIds.length) return { hydrated: false, blobs: 0 };
     for (const entry of found) {
       const [objectId, type, size] = entry.split(" ");
@@ -371,25 +367,21 @@ export function hydratePullRequestReviewBlobs({
   }
 
   let objectBytes = 0;
-  let skippedOversizedBlob = false;
-  const bounded = new Set<string>();
   for (const objectId of objectIds) {
     const bytes = sizes.get(objectId);
     if (
       bytes === undefined ||
       !Number.isSafeInteger(bytes) ||
       bytes < 0 ||
-      bytes > MAX_REVIEW_BLOB_BYTES - objectBytes
+      bytes > MAX_SCAN_BYTES - objectBytes
     ) {
-      skippedOversizedBlob = true;
-      continue;
+      return { hydrated: false, blobs: 0 };
     }
-    bounded.add(objectId);
     objectBytes += bytes;
   }
 
-  const boundedMissing = [...missing].filter((objectId) => bounded.has(objectId));
-  if (boundedMissing.length > 0) {
+  if (Date.now() >= deadlineAt) return { hydrated: false, blobs: 0 };
+  if (missing.size > 0) {
     const fetched = spawnSync(
       "git",
       [
@@ -407,13 +399,14 @@ export function hydratePullRequestReviewBlobs({
         cwd: targetDir,
         encoding: "utf8",
         env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" },
-        input: `${boundedMissing.join("\n")}\n`,
+        input: `${[...missing].join("\n")}\n`,
+        timeout: Math.max(1, deadlineAt - Date.now()),
         maxBuffer: MAX_GIT_OUTPUT_BYTES,
       },
     );
     if (fetched.error || fetched.status !== 0) return { hydrated: false, blobs: 0 };
   }
-  return { hydrated: !skippedOversizedBlob, blobs: bounded.size };
+  return { hydrated: true, blobs: objectIds.size };
 }
 
 export function githubReviewBlobSizes({
@@ -426,43 +419,43 @@ export function githubReviewBlobSizes({
   request: (query: string) => unknown;
 }): ReadonlyMap<string, number> {
   const match = repository.match(/^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/);
-  if (
-    !match ||
-    match[1] === "." ||
-    match[1] === ".." ||
-    match[2] === "." ||
-    match[2] === ".." ||
-    objectIds.length > MAX_REVIEW_FILES * 2
-  ) {
+  if (!match || match[1] === "." || match[1] === ".." || match[2] === "." || match[2] === "..") {
     throw new Error("invalid bounded review blob metadata request");
   }
-  const objects = objectIds.map((objectId, index) => {
-    if (!GIT_OBJECT_ID.test(objectId)) throw new Error("invalid review blob object ID");
-    return `b${index}: object(oid: "${objectId}") { ... on Blob { byteSize } }`;
-  });
-  const query = `query { repository(owner: "${match[1]}", name: "${match[2]}") { ${objects.join(" ")} } }`;
-  const response = request(query);
-  if (!response || typeof response !== "object") throw new Error("invalid review blob response");
-  const data = (response as { data?: unknown }).data;
-  if (!data || typeof data !== "object") throw new Error("missing review blob response data");
-  const values = (data as { repository?: unknown }).repository;
-  if (!values || typeof values !== "object") throw new Error("missing review blob repository");
+  if (objectIds.some((objectId) => !GIT_OBJECT_ID.test(objectId))) {
+    throw new Error("invalid review blob object ID");
+  }
   const result = new Map<string, number>();
-  for (const [index, objectId] of objectIds.entries()) {
-    const object = (values as Record<string, unknown>)[`b${index}`];
-    const bytes =
-      object && typeof object === "object" ? (object as { byteSize?: unknown }).byteSize : null;
-    if (typeof bytes !== "number" || !Number.isSafeInteger(bytes) || bytes < 0) {
-      throw new Error("invalid review blob size");
+  const deadlineAt = Date.now() + 30_000;
+  for (let offset = 0; offset < objectIds.length; offset += MAX_BLOB_SIZE_OBJECTS) {
+    if (Date.now() >= deadlineAt) throw new Error("review blob metadata deadline exceeded");
+    const batch = objectIds.slice(offset, offset + MAX_BLOB_SIZE_OBJECTS);
+    const objects = batch.map(
+      (objectId, index) => `b${index}: object(oid: "${objectId}") { ... on Blob { byteSize } }`,
+    );
+    const query = `query { repository(owner: "${match[1]}", name: "${match[2]}") { ${objects.join(" ")} } }`;
+    const response = request(query);
+    if (!response || typeof response !== "object") throw new Error("invalid review blob response");
+    const data = (response as { data?: unknown }).data;
+    if (!data || typeof data !== "object") throw new Error("missing review blob response data");
+    const values = (data as { repository?: unknown }).repository;
+    if (!values || typeof values !== "object") throw new Error("missing review blob repository");
+    for (const [index, objectId] of batch.entries()) {
+      const object = (values as Record<string, unknown>)[`b${index}`];
+      const bytes =
+        object && typeof object === "object" ? (object as { byteSize?: unknown }).byteSize : null;
+      if (typeof bytes !== "number" || !Number.isSafeInteger(bytes) || bytes < 0) {
+        throw new Error("invalid review blob size");
+      }
+      result.set(objectId, bytes);
     }
-    result.set(objectId, bytes);
   }
   return result;
 }
 
 function safeReviewPath(value: unknown): string | null {
   if (typeof value !== "string" || !value || value.length > 4096) return null;
-  if (value.startsWith("/") || value.includes("\\")) {
+  if (value.startsWith("/") || /^[A-Za-z]:/.test(value) || value.includes("\\")) {
     return null;
   }
   for (let index = 0; index < value.length; index += 1) {
@@ -470,7 +463,9 @@ function safeReviewPath(value: unknown): string | null {
     if (code < 32 || code === 127) return null;
   }
   const parts = value.split("/");
-  if (parts.some((part) => !part || part === "." || part === ".." || part === ".git")) {
+  if (
+    parts.some((part) => !part || part === "." || part === ".." || part.toLowerCase() === ".git")
+  ) {
     return null;
   }
   return value;

--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -822,6 +822,15 @@ export function existingRepairLoopModeOutcome({ intent, trustedBot }: LooseRecor
   };
 }
 
+export function isTrustedStatusCommentAuthor(
+  comment: LooseRecord | null | undefined,
+  trustedAuthors: ReadonlySet<string>,
+): boolean {
+  // Missing authors fail closed; do not normalize padded logins into trusted identities.
+  const author = String(comment?.user?.login ?? "").toLowerCase();
+  return !!author && (author === "clawsweeper" || trustedAuthors.has(author));
+}
+
 export function isCanonicalLandingNeedsHumanText(value: JsonValue) {
   const text = String(value ?? "");
   if (!text) return false;

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -61,6 +61,7 @@ import {
   issueImplementationClusterId,
   issueImplementationJobPath,
   isReadyHumanReviewPause,
+  isTrustedStatusCommentAuthor,
   latestTrustedExactHeadReview,
   maintainerModeCommandCanResumePausedMode,
   maintainerApprovalAppliesToExactHeadReview,
@@ -5449,8 +5450,7 @@ function findExistingCommandStatusComment(command: LooseRecord) {
 }
 
 function isTrustedStatusComment(comment: LooseRecord) {
-  const author = String(comment.user?.login ?? "").toLowerCase();
-  return !author || author === "clawsweeper" || trustedBots.has(author);
+  return isTrustedStatusCommentAuthor(comment, trustedBots);
 }
 
 function reactToComment(command: LooseRecord, content: string) {

--- a/src/repair/execute-fix-artifact.ts
+++ b/src/repair/execute-fix-artifact.ts
@@ -55,7 +55,10 @@ import {
   automergeOutcomeReviewedShaFromResult,
   automergePlanningHeadBlock,
 } from "./automerge-outcome.js";
-import { isCanonicalLandingNeedsHumanText } from "./comment-router-core.js";
+import {
+  isCanonicalLandingNeedsHumanText,
+  isTrustedStatusCommentAuthor,
+} from "./comment-router-core.js";
 import { parsePullRequestUrl, pullRequestNumberFromUrl, sameRepoSlug } from "./github-ref.js";
 import {
   clawsweeperGitUserEmail,
@@ -80,6 +83,7 @@ import {
 } from "./constants.js";
 
 const AUTOMERGE_LABEL = "clawsweeper:automerge";
+const REPAIR_TRUSTED_STATUS_AUTHORS = new Set(["clawsweeper[bot]", "openclaw-clawsweeper[bot]"]);
 const AUTOFIX_LABEL = "clawsweeper:autofix";
 const AUTOFIX_LABEL_COLOR = "0A3069";
 const AUTOFIX_LABEL_DESCRIPTION =
@@ -4584,13 +4588,7 @@ function fetchPullRequestViewForRepo({ repo, number }: LooseRecord) {
 }
 
 function isTrustedStatusComment(comment: LooseRecord) {
-  const author = String(comment.user?.login ?? "").toLowerCase();
-  return (
-    !author ||
-    author === "clawsweeper" ||
-    author === "clawsweeper[bot]" ||
-    author === "openclaw-clawsweeper[bot]"
-  );
+  return isTrustedStatusCommentAuthor(comment, REPAIR_TRUSTED_STATUS_AUTHORS);
 }
 
 function hasAutomergeStatusMarker(body: JsonValue, number: JsonValue) {

--- a/src/review-comment-markers.ts
+++ b/src/review-comment-markers.ts
@@ -9,6 +9,8 @@ export function trailingHtmlComments(value: string): string[] {
 
     const commentStart = value.lastIndexOf("<!--", end - 3);
     if (commentStart < 0) break;
+    // An earlier terminator means this candidate spans visible prose.
+    if (value.indexOf("-->", commentStart + 4) !== end - 3) break;
     trailing.push(value.slice(commentStart, end));
     end = commentStart;
   }

--- a/test/agent-input-scan.test.ts
+++ b/test/agent-input-scan.test.ts
@@ -532,23 +532,34 @@ const autoreviewSources = [
   "skills/autoreview/tests/test_autoreview_hardening.py",
   ".agents/skills/autoreview/tests/test_autoreview_hardening.py",
 ];
+const browserChromeSource = "extensions/browser/src/browser/chrome.test.ts";
+const browserServerContextSource =
+  "extensions/browser/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts";
+const ledgerFixtureSha256 = "a728de5dbbef23b8aa5ef2d99060835f4f2fb5a0fa2abb9fe249d08aa09bd09e";
 
 test("reviewed fixture registry binds exact digests to exact regular-file source paths", () => {
   for (const [source, digest] of [
-    [ledgerSource, "a728de5dbbef23b8aa5ef2d99060835f4f2fb5a0fa2abb9fe249d08aa09bd09e"],
+    [ledgerSource, ledgerFixtureSha256],
     ...autoreviewSources.map((source) => [
       source,
       "662a886a0fd7447dad0acda3aeccc9eb539fc90438b453de7e2f523ca7ee6c83",
     ]),
+    [browserChromeSource, "d69d650dc6c312f3e1071f8613df780323fadd01b8c40e6edd02715cd731ae60"],
+    [browserChromeSource, "60267342b1ab046bd8c42e2226fdfce2aa081e7f18e17c35c9c013d7b1de5720"],
+    [
+      browserServerContextSource,
+      "60267342b1ab046bd8c42e2226fdfce2aa081e7f18e17c35c9c013d7b1de5720",
+    ],
   ]) {
-    assert.deepEqual(reviewedFixtureForSource(source!, "100644"), {
+    assert.deepEqual(reviewedFixtureForSource(source!, "100644", digest!), {
       fixtureSha256: digest,
       source,
     });
     for (const mode of ["100755", "120000", "160000", "000000", "644"])
-      assert.equal(reviewedFixtureForSource(source!, mode), undefined);
+      assert.equal(reviewedFixtureForSource(source!, mode, digest!), undefined);
     for (const alias of [`./${source}`, `other/${source}`, `${source}.bak`, source!.toUpperCase()])
-      assert.equal(reviewedFixtureForSource(alias, "100644"), undefined);
+      assert.equal(reviewedFixtureForSource(alias, "100644", digest!), undefined);
+    assert.equal(reviewedFixtureForSource(source!, "100644", "0".repeat(64)), undefined);
   }
 });
 
@@ -782,7 +793,7 @@ process.exit(scenario === 'unexpected successful output' ? 0 : 183);
       assert.equal(notice.source, ledgerSource);
       assert.equal(
         notice.fixtureSha256,
-        reviewedFixtureForSource(ledgerSource, "100644")!.fixtureSha256,
+        reviewedFixtureForSource(ledgerSource, "100644", ledgerFixtureSha256)!.fixtureSha256,
       );
       assert.equal(notice.detector, "URI");
       assert.match(notice.notice, /classified as non-sensitive/);

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -642,3 +642,67 @@ test("ghPagedLinkHeaderContextWindow falls back when link headers are unavailabl
     truncated: false,
   });
 });
+
+test("bounded PR context prepares source independently of cache digest and API file completeness", async () => {
+  const { createItemContext } = await import("../dist/clawsweeper-item-context.js");
+  const { hydration, sourceTools, sha256 } = await import("./primary-body-fixture.ts");
+  const { asRecord } = await import("../dist/clawsweeper-item-policy.js");
+  const { item } = await import("./helpers.ts");
+  const target = item({ kind: "pull_request" });
+  const pullRequest = {
+    head: { sha: "b".repeat(40) },
+    base: { sha: "a".repeat(40), ref: "main" },
+    changed_files: 341,
+    commits: 113,
+    review_comments: 0,
+  };
+  const empty = { items: [], total: 0, hydrated: 0, truncated: false };
+  const prepared: unknown[] = [];
+  const { collectItemContext } = createItemContext({
+    ...hydration,
+    ...sourceTools,
+    asRecord,
+    sha256,
+    stringOrUndefined: (value) => (typeof value === "string" ? value : undefined),
+    targetRepo: () => target.repo,
+    ghJson: <T>(args: string[]) =>
+      (args[1]!.includes("/pulls/") ? pullRequest : { comments: 0 }) as T,
+    ghPaged: () => [],
+    ghPagedContextWindow: <T>(path: string) =>
+      path.endsWith("/files")
+        ? {
+            items: Array.from({ length: 80 }, (_, index) => ({
+              filename: `file-${index}.txt`,
+            })) as T[],
+            total: 341,
+            hydrated: 80,
+            truncated: true,
+          }
+        : empty,
+    ghPagedLinkHeaderContextWindow: () => empty,
+    closingPullRequestsForIssue: () => [],
+    referencingMergedPullRequestsForIssue: () => [],
+    relatedItemsContext: () => [],
+    fetchReviewedPrActivityCursor: () => null,
+    pullChecksContext: () => ({ complete: true, checkRuns: [], statuses: [] }),
+    hydratePullRequestReviewSource: (options) => prepared.push(options),
+  });
+  for (const reviewCacheDigest of [false, true]) {
+    const context = collectItemContext(target, {
+      reviewCacheDigest,
+      reviewCacheGitDir: "/synthetic/source",
+    });
+    assert.equal(context.counts?.pullFiles, 341);
+    assert.equal(context.counts?.pullFilesHydrated, 80);
+    assert.equal(context.counts?.pullFilesTruncated, true);
+    assert.equal(context.pullFiles?.length, 81, "80 files plus the explicit omission marker");
+    assert.deepEqual(prepared.at(-1), {
+      itemNumber: target.number,
+      pullRequest,
+      targetDir: "/synthetic/source",
+    });
+  }
+  assert.equal(prepared.length, 2);
+  collectItemContext(target);
+  assert.equal(prepared.length, 2, "context-only callers do not request a Git checkout");
+});

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -44,6 +44,7 @@ import {
   latestTrustedExactHeadReview,
   isCanonicalLandingNeedsHumanText,
   isReadyHumanReviewPause,
+  isTrustedStatusCommentAuthor,
   latestRepairLoopResumeTime,
   isAuthorReadOnlyCommandAllowed,
   isMaintainerCommandAllowed,
@@ -84,6 +85,44 @@ import {
 import { CLAWSWEEPER_CO_AUTHOR_TRAILER } from "../../dist/repair/co-author-credit.js";
 import { issueSourceRevisionSha256 } from "../../dist/repair/issue-source-guard.js";
 import { parseSimpleYaml, validateJob } from "../../dist/repair/lib.js";
+
+test("status comment authors fail closed even when the allowlist contains an empty login", () => {
+  const trusted = new Set(["", "clawsweeper[bot]", "openclaw-clawsweeper[bot]"]);
+  for (const comment of [
+    null,
+    undefined,
+    {},
+    { user: null },
+    { user: {} },
+    { user: { login: null } },
+    ...["", " ", "ghost", "contributor", " clawsweeper[bot] "].map((login) => ({
+      user: { login },
+    })),
+  ]) {
+    assert.equal(isTrustedStatusCommentAuthor(comment, trusted), false, JSON.stringify(comment));
+  }
+});
+
+test("status comment authors preserve consumer allowlists and untrimmed case-insensitive matching", () => {
+  const fixed = new Set(["clawsweeper[bot]", "openclaw-clawsweeper[bot]"]);
+  const configured = new Set(["custom[bot]"]);
+  for (const login of [
+    "clawsweeper",
+    "CLAWSWEEPER",
+    "ClawSweeper[bot]",
+    "OpenClaw-ClawSweeper[bot]",
+  ]) {
+    assert.equal(isTrustedStatusCommentAuthor({ user: { login } }, fixed), true, login);
+  }
+  assert.equal(isTrustedStatusCommentAuthor({ user: { login: "CUSTOM[bot]" } }, configured), true);
+  assert.equal(isTrustedStatusCommentAuthor({ user: { login: "CUSTOM[bot]" } }, fixed), false);
+  assert.equal(
+    isTrustedStatusCommentAuthor({ user: { login: "clawsweeper[bot]" } }, configured),
+    false,
+  );
+  assert.equal(isTrustedStatusCommentAuthor({ user: { login: "clawsweeper" } }, new Set()), true);
+  assert.equal(isTrustedStatusCommentAuthor({ user: { login: " clawsweeper " } }, fixed), false);
+});
 
 test("review comment section extraction supports headings and stops at metadata", () => {
   const body = [

--- a/test/review-blob-hydration.test.ts
+++ b/test/review-blob-hydration.test.ts
@@ -1,6 +1,15 @@
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -14,7 +23,8 @@ import {
   materializePullRequestReviewTree,
   removePullRequestReviewTree,
 } from "../dist/clawsweeper-review-blobs.js";
-import { reviewMergeBase } from "../dist/pr-review-evidence.js";
+import { MAX_SCAN_BYTES } from "../dist/agent-input-scan.js";
+import { readReviewGit, reviewMergeBase } from "../dist/pr-review-evidence.js";
 
 function git(cwd: string, ...args: string[]): string {
   return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
@@ -33,7 +43,13 @@ function partialCloneFixture({
   extraFiles = 0,
   largeFiles = [],
   prefetchHead = true,
-}: { extraFiles?: number; largeFiles?: number[]; prefetchHead?: boolean } = {}) {
+  historicalBase = false,
+}: {
+  extraFiles?: number;
+  largeFiles?: number[];
+  prefetchHead?: boolean;
+  historicalBase?: boolean;
+} = {}) {
   const root = mkdtempSync(join(tmpdir(), "clawsweeper-review-promisor-"));
   const origin = join(root, "origin.git");
   const source = join(root, "source");
@@ -47,6 +63,17 @@ function partialCloneFixture({
   git(source, "config", "commit.gpgsign", "false");
   writeFileSync(join(source, "changed.txt"), "before\n");
   writeFileSync(join(source, "removed.txt"), "remove me\n");
+  if (historicalBase) {
+    writeFileSync(join(source, "mode.txt"), "mode only\n");
+    for (let index = 0; index < extraFiles; index++) {
+      writeFileSync(join(source, `additional-${index}.txt`), `before ${index}\n`);
+    }
+    for (const [index, bytes] of largeFiles.entries()) {
+      const data = Buffer.alloc(bytes, index + 10);
+      data[0] = 0;
+      writeFileSync(join(source, `large-${index}.bin`), data);
+    }
+  }
   git(source, "add", ".");
   git(source, "update-index", "--add", "--cacheinfo", `160000,${"1".repeat(40)},vendor/library`);
   git(source, "commit", "-qm", "base");
@@ -64,16 +91,36 @@ function partialCloneFixture({
     writeFileSync(join(source, `additional-${index}.txt`), `additional ${index}\n`);
   }
   for (const [index, bytes] of largeFiles.entries()) {
-    writeFileSync(join(source, `large-${index}.bin`), Buffer.alloc(bytes, index + 1));
+    const data = Buffer.alloc(bytes, index + 1);
+    data[0] = 0;
+    writeFileSync(join(source, `large-${index}.bin`), data);
   }
   git(source, "rm", "-q", "removed.txt");
   git(source, "add", ".");
   git(source, "update-index", "--add", "--cacheinfo", `160000,${"2".repeat(40)},vendor/library`);
+  if (historicalBase) {
+    chmodSync(join(source, "mode.txt"), 0o755);
+    git(source, "update-index", "--chmod=+x", "mode.txt");
+  }
   git(source, "commit", "-qm", "feature");
   const headSha = git(source, "rev-parse", "HEAD");
   const addedBlobSha = git(source, "rev-parse", "HEAD:added.txt");
   const changedBlobSha = git(source, "rev-parse", "HEAD:changed.txt");
   git(source, "push", "-q", "origin", "HEAD:refs/pull/982/head");
+  if (historicalBase) {
+    git(source, "checkout", "-q", "main");
+    writeFileSync(join(source, "changed.txt"), "current main\n");
+    git(source, "rm", "-q", "removed.txt");
+    for (let index = 0; index < extraFiles; index++) {
+      writeFileSync(join(source, `additional-${index}.txt`), `main ${index}\n`);
+    }
+    for (const [index] of largeFiles.entries()) {
+      writeFileSync(join(source, `large-${index}.bin`), "main binary replacement\n");
+    }
+    git(source, "add", ".");
+    git(source, "commit", "-qm", "advance main past pinned base");
+    git(source, "push", "-q", "origin", "main");
+  }
   git(
     root,
     "clone",
@@ -100,10 +147,22 @@ function partialCloneFixture({
 }
 
 function resolveFixtureBlobSizes(source: string) {
-  return (objectIds: readonly string[]) =>
-    new Map(
-      objectIds.map((objectId) => [objectId, Number(git(source, "cat-file", "-s", objectId))]),
+  return (objectIds: readonly string[]) => {
+    const output = execFileSync("git", ["cat-file", "--batch-check=%(objectname) %(objectsize)"], {
+      cwd: source,
+      encoding: "utf8",
+      input: `${objectIds.join("\n")}\n`,
+    });
+    return new Map(
+      output
+        .trim()
+        .split("\n")
+        .map((line) => {
+          const [oid, bytes] = line.split(" ");
+          return [oid!, Number(bytes)];
+        }),
     );
+  };
 }
 
 function objectExistsOffline(cwd: string, sha: string): boolean {
@@ -399,14 +458,6 @@ test("restricted PR review can inspect changed blobs from a genuine blobless clo
       baseSha: fixture.baseSha,
       headSha: fixture.headSha,
       resolveBlobSizes: resolveFixtureBlobSizes(fixture.source),
-      files: [
-        { filename: "added.txt", status: "added" },
-        { filename: "nested/feature[1].txt", status: "added" },
-        { filename: ":(glob)literal.txt", status: "added" },
-        { filename: "changed.txt", status: "modified" },
-        { filename: "vendor/library", status: "modified" },
-        { filename: "removed.txt", status: "removed" },
-      ],
     });
 
     assert.equal(result.hydrated, true);
@@ -429,30 +480,6 @@ test("restricted PR review can inspect changed blobs from a genuine blobless clo
       /\+after/,
     );
     assert.equal(git(fixture.target, "status", "--porcelain"), "");
-  } finally {
-    rmSync(fixture.root, { recursive: true, force: true });
-  }
-});
-
-test("persisted snapshot null previous filenames still hydrate missing blobs", () => {
-  const fixture = partialCloneFixture();
-  try {
-    assert.equal(objectExistsOffline(fixture.target, fixture.addedBlobSha), false);
-    assert.equal(objectExistsOffline(fixture.target, fixture.changedBlobSha), false);
-    const result = hydratePullRequestReviewBlobs({
-      targetDir: fixture.target,
-      baseSha: fixture.baseSha,
-      headSha: fixture.headSha,
-      resolveBlobSizes: resolveFixtureBlobSizes(fixture.source),
-      files: [
-        { filename: "added.txt", previous_filename: null, status: "added" },
-        { filename: "changed.txt", previous_filename: null, status: "modified" },
-        { filename: "removed.txt", previous_filename: null, status: "removed" },
-      ],
-    });
-    assert.deepEqual(result, { hydrated: true, blobs: 4 });
-    assert.equal(objectExistsOffline(fixture.target, fixture.addedBlobSha), true);
-    assert.equal(objectExistsOffline(fixture.target, fixture.changedBlobSha), true);
   } finally {
     rmSync(fixture.root, { recursive: true, force: true });
   }
@@ -520,30 +547,39 @@ test("restricted review binds a force-pushed pull request to the exact REST head
   }
 });
 
-test("review blob hydration rejects unsafe paths and oversized changes without fetching", () => {
+test("review hydration refuses unsafe Git paths and missing source without fetching", () => {
   const fixture = partialCloneFixture();
   try {
-    for (const filename of ["../secret", "/absolute", ".git/config", "nested/../secret", "a\\b"]) {
+    for (const filename of ["a\\b", "C:drive", "control\npath"]) {
+      writeFileSync(join(fixture.source, filename), "unsafe path\n");
+      git(fixture.source, "add", ".");
+      git(fixture.source, "commit", "-qm", "unsafe source");
+      const headSha = git(fixture.source, "rev-parse", "HEAD");
+      git(fixture.source, "push", "-q", "origin", "HEAD:refs/heads/unsafe");
+      git(fixture.target, "fetch", "-q", "--filter=blob:none", "origin", "refs/heads/unsafe");
       assert.deepEqual(
         hydratePullRequestReviewBlobs({
           targetDir: fixture.target,
           baseSha: fixture.baseSha,
-          headSha: fixture.headSha,
-          files: [{ filename, status: "added" }],
+          headSha,
+          resolveBlobSizes: () => {
+            throw new Error("unsafe paths must refuse before metadata");
+          },
         }),
         { hydrated: false, blobs: 0 },
-        filename,
+      );
+      git(fixture.source, "rm", "-q", "--", filename);
+    }
+    for (const baseSha of ["--unsafe", "f".repeat(40), fixture.baseSha]) {
+      assert.deepEqual(
+        hydratePullRequestReviewBlobs({
+          targetDir: fixture.target,
+          baseSha,
+          headSha: fixture.headSha,
+        }),
+        { hydrated: false, blobs: 0 },
       );
     }
-    assert.deepEqual(
-      hydratePullRequestReviewBlobs({
-        targetDir: fixture.target,
-        baseSha: fixture.baseSha,
-        headSha: fixture.headSha,
-        files: Array.from({ length: 81 }, () => ({ filename: "added.txt", status: "added" })),
-      }),
-      { hydrated: false, blobs: 0 },
-    );
     assert.equal(objectExistsOffline(fixture.target, fixture.addedBlobSha), false);
   } finally {
     rmSync(fixture.root, { recursive: true, force: true });
@@ -583,7 +619,6 @@ test("missing partial-clone objects are fetched in one bounded network request",
       baseSha: fixture.baseSha,
       headSha: fixture.headSha,
       resolveBlobSizes: resolveFixtureBlobSizes(fixture.source),
-      files: paths.map((filename) => ({ filename, status: "added" })),
     });
     if (previousTrace === undefined) delete process.env.GIT_TRACE2_EVENT;
     else process.env.GIT_TRACE2_EVENT = previousTrace;
@@ -601,7 +636,7 @@ test("missing partial-clone objects are fetched in one bounded network request",
     const explicitFetches = traceEvents.filter(
       (event) => event.event === "start" && event.argv?.includes("fetch"),
     );
-    assert.deepEqual(result, { hydrated: true, blobs: 12 });
+    assert.deepEqual(result, { hydrated: true, blobs: 18 });
     assert.equal(revLists.length, 1);
     assert.ok(revLists[0]!.argv?.includes(`${fixture.baseSha}^{tree}`));
     assert.ok(revLists[0]!.argv?.includes(`${fixture.headSha}^{tree}`));
@@ -619,32 +654,34 @@ test("missing partial-clone objects are fetched in one bounded network request",
   }
 });
 
-test("review hydration enforces per-review byte limits without fetching oversized blobs", () => {
-  for (const largeFiles of [[5 * 1024 * 1024], [3 * 1024 * 1024, 2 * 1024 * 1024]]) {
-    const fixture = partialCloneFixture({ largeFiles });
-    try {
-      const oversizedBlob = git(
-        fixture.target,
-        "rev-parse",
-        `${fixture.headSha}:large-${largeFiles.length - 1}.bin`,
+test("review hydration rejects aggregate scan budget overflow and incomplete size metadata before fetching", () => {
+  const fixture = partialCloneFixture();
+  try {
+    for (const size of [MAX_SCAN_BYTES + 1, Math.ceil(MAX_SCAN_BYTES / 2), NaN, -1, undefined]) {
+      assert.deepEqual(
+        hydratePullRequestReviewBlobs({
+          targetDir: fixture.target,
+          baseSha: fixture.baseSha,
+          headSha: fixture.headSha,
+          resolveBlobSizes: (ids) => new Map(ids.map((id) => [id, size as number])),
+        }),
+        { hydrated: false, blobs: 0 },
       );
-      const result = hydratePullRequestReviewBlobs({
+      assert.equal(objectExistsOffline(fixture.target, fixture.addedBlobSha), false);
+    }
+    git(fixture.target, "remote", "set-url", "origin", join(fixture.root, "unavailable.git"));
+    assert.deepEqual(
+      hydratePullRequestReviewBlobs({
         targetDir: fixture.target,
         baseSha: fixture.baseSha,
         headSha: fixture.headSha,
         resolveBlobSizes: resolveFixtureBlobSizes(fixture.source),
-        files: [
-          { filename: "added.txt", status: "added" },
-          ...largeFiles.map((_, index) => ({ filename: `large-${index}.bin`, status: "added" })),
-        ],
-      });
-
-      assert.equal(result.hydrated, false);
-      assert.equal(objectExistsOffline(fixture.target, fixture.addedBlobSha), true);
-      assert.equal(objectExistsOffline(fixture.target, oversizedBlob), false);
-    } finally {
-      rmSync(fixture.root, { recursive: true, force: true });
-    }
+      }),
+      { hydrated: false, blobs: 0 },
+    );
+    assert.equal(objectExistsOffline(fixture.target, fixture.addedBlobSha), false);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
   }
 });
 
@@ -675,4 +712,96 @@ test("review blob sizes use one bounded GraphQL metadata request", () => {
     () => githubReviewBlobSizes({ repository: "../unsafe", objectIds, request: () => ({}) }),
     /invalid bounded review blob metadata request/,
   );
+});
+
+test("large pinned deltas hydrate historical blobs after head checkout and produce the full offline binary patch", (t) => {
+  const fixture = partialCloneFixture({
+    extraFiles: 170,
+    largeFiles: [3 * 1024 * 1024],
+    historicalBase: true,
+  });
+  const reviewTree = join(fixture.root, "review-tree");
+  try {
+    assert.notEqual(git(fixture.target, "rev-parse", "HEAD"), fixture.baseSha);
+    assert.equal(
+      materializePullRequestReviewTree({
+        targetDir: fixture.target,
+        worktreeDir: reviewTree,
+        itemNumber: 982,
+        headSha: fixture.headSha,
+      }),
+      true,
+    );
+    const mergeBase = reviewMergeBase(reviewTree, fixture.baseSha, fixture.headSha);
+    assert.equal(mergeBase.sha, fixture.baseSha, "the REST base must not become current main");
+    const args = [
+      "diff",
+      "--no-ext-diff",
+      "--no-textconv",
+      "--no-renames",
+      "--ignore-submodules=none",
+      fixture.baseSha,
+      fixture.headSha,
+    ];
+    const raw = readReviewGit(reviewTree, [...args, "--raw", "--no-abbrev", "-z", "--"]);
+    assert.ok(raw);
+    assert.equal(raw.toString().split("\0").length, 2 * 178 + 1);
+    const patchArgs = [...args, "--patch", "--binary", "--full-index", "--"];
+    assert.equal(
+      readReviewGit(reviewTree, patchArgs),
+      null,
+      "head checkout leaves historical blobs missing",
+    );
+    const removedOid = git(fixture.source, "rev-parse", `${fixture.baseSha}:removed.txt`);
+    assert.equal(objectExistsOffline(reviewTree, removedOid), false);
+    const batches: number[] = [];
+    const result = hydratePullRequestReviewBlobs({
+      targetDir: reviewTree,
+      baseSha: mergeBase.sha!,
+      headSha: fixture.headSha,
+      resolveBlobSizes: (objectIds) =>
+        githubReviewBlobSizes({
+          repository: "openclaw/clawsweeper",
+          objectIds,
+          request: (query) => {
+            const ids = [...query.matchAll(/b(\d+): object\(oid: "([0-9a-f]+)"\)/g)];
+            batches.push(ids.length);
+            const sizes = resolveFixtureBlobSizes(fixture.source)(ids.map((match) => match[2]!));
+            return {
+              data: {
+                repository: Object.fromEntries(
+                  ids.map((match) => [`b${match[1]}`, { byteSize: sizes.get(match[2]!) }]),
+                ),
+              },
+            };
+          },
+        }),
+    });
+    assert.deepEqual(result, { hydrated: true, blobs: 349 });
+    assert.deepEqual(batches, [160, 13]);
+    assert.equal(objectExistsOffline(reviewTree, removedOid), true);
+    git(fixture.target, "remote", "set-url", "origin", join(fixture.root, "offline.git"));
+    const patch = readReviewGit(reviewTree, patchArgs);
+    assert.ok(patch);
+    assert.deepEqual(patch, readReviewGit(fixture.source, patchArgs));
+    assert.match(patch.toString(), /GIT binary patch/);
+    assert.match(patch.toString(), /old mode 100644\nnew mode 100755/);
+    assert.match(patch.toString(), /deleted file mode 100644/);
+    assert.match(patch.toString(), /:\(glob\)literal.txt/);
+    assert.match(patch.toString(), /feature\[1\].txt/);
+    assert.equal(git(reviewTree, "status", "--porcelain"), "");
+    t.diagnostic(
+      JSON.stringify({
+        changedFiles: 178,
+        blobs: result.blobs,
+        metadataBatches: batches,
+        patchBytes: patch.length,
+        patchSha256: createHash("sha256").update(patch).digest("hex"),
+        patchUnreadableBefore: true,
+        offlinePatchMatchesSource: true,
+      }),
+    );
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
 });

--- a/test/review-comment-markers.test.ts
+++ b/test/review-comment-markers.test.ts
@@ -27,6 +27,23 @@ test("trailingHtmlComments rejects an unterminated adversarial suffix", () => {
   assert.deepEqual(trailingHtmlComments(value), []);
 });
 
+test("trailingHtmlComments stops at visible prose ending in a closing delimiter", () => {
+  assert.deepEqual(
+    trailingHtmlComments(
+      [
+        "<!-- earlier -->",
+        "Visible review details plan --> review -->",
+        "<!-- clawsweeper-verdict:needs-human item=321 sha=head -->",
+        "<!-- clawsweeper-review item=321 -->",
+      ].join("\n"),
+    ),
+    [
+      "<!-- clawsweeper-verdict:needs-human item=321 sha=head -->",
+      "<!-- clawsweeper-review item=321 -->",
+    ],
+  );
+});
+
 test("trailingHtmlComments recovers when prose contains an unmatched opener", () => {
   assert.deepEqual(
     trailingHtmlComments(


### PR DESCRIPTION
## What Problem This Solves

Exact reviews of Browser changes can stop with `AgentInputScanError: findings` before Codex starts because complete changed files include existing synthetic authentication and credential-redaction fixtures. This affects the source reported in [OpenClaw PR 134400](https://github.com/openclaw/openclaw/pull/134400). Source hydration was fixed separately in [PR 1333](https://github.com/openclaw/clawsweeper/pull/1333); the Browser literals still need classification.

## Why This Change Was Made

Approve two exact synthetic URI digests at three existing Browser test paths. The classifier now checks every blob reference against the fixture it already selected by digest. Removing `reviewedFixtureForSource` eliminates the second lookup and its one-fixture-per-source assumption, so both approved literals in `chrome.test.ts` work without adding another policy mechanism.

The fixtures were independently read from their immutable public source blobs, their Git hashes recomputed, and their introduction checked against raw commit parents and patches. The local value is dummy authentication for a loopback test server; the remote value is dummy credential-redaction input under `browserless.example.com`:

- [Local Chrome authentication fixture](https://github.com/openclaw/openclaw/blob/8e03b0c62e76dc25c77045a84ab3098a111a7be3/extensions/browser/src/browser/chrome.test.ts#L591).
- [Remote Chrome redaction fixture](https://github.com/openclaw/openclaw/blob/58da2f5897feb6840937d8e50cf7ee6f26aa57d7/extensions/browser/src/browser/chrome.test.ts#L457).
- [Remote server-context redaction fixture](https://github.com/openclaw/openclaw/blob/4b5987829d0f82ea44ae50f2f418ffe5ea445e7f/extensions/browser/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts#L187).

Every reference must still match the same digest, exact path, and Git mode `100644`. Complete-scan, detector, literal-line, source-drift, staging, and cleanup checks remain active. These hashes identify the scanner's URI literals, not whole files or arbitrary surrounding URL content. The existing policy is not repository/commit scoped; the links above document provenance.

## User Impact

Reviews can inspect the approved Browser fixture changes. Unclassified findings continue to stop admission. OpenClaw Bay, publication, queueing, and mutation authority are unchanged.

## Documentation Impact

The README documents the approved sources and exact digest/path/mode membership. Release-note context is in this PR; the changelog is unchanged. The original contributor commit and credit for @scotthuang are preserved.

## Evidence

Candidate: `52d62998d9a4a67e7b3c28b35635b1dfebd63435`. Production classifier source SHA-256: `b7bb49034223716b67bd229fa0d9596a00813ad18ac00eb4a0c11366ffd8d30f`; compiled module SHA-256: `9ada61cd1421f8f37a566f07c48960e6de887462966d0187b568408b6b2d9563`. The committed source is checked against the bytes exercised below. Against main `abfcb0dc084c962d123d49e560a82446bb0988c0`, the integration delta is three files, +55/-44; production code is +14/-9.

Build and repair build, targeted source/test lint, formatting, documentation checks, and the 55-case fixture admission matrix passed. The new cases exercise all three approved pairs and reject the local fixture on the remote server-context path. Managed Codex reviews of both the final uncommitted change and committed branch completed scoped-clean at P0 with no findings.

Full current-head CI passed 4,263 tests with 14 skips and zero failures, plus 13 changed-file coverage tests: https://github.com/openclaw/clawsweeper/actions/runs/33494736334. CI checked out `52368029af08f4bf14bf45182ca4739f18f23fc6`, merging this candidate with then-main `b056c0ab1510b23330f15bd44af7087129f9f270`, using Node 24.19.0 and pnpm 11.10.0. CodeQL passed in https://github.com/openclaw/clawsweeper/actions/runs/33494736366. The fresh hosted review accepted the native owner proof and found no correctness or security defects.

The first local scanner-file run passed 88/89 tests. Its existing cache-symlink test supplied the macOS `/var` alias as the canonical checkout argument, unlike both production callers. A same-function baseline/candidate probe reproduced that mismatch and confirmed both production-shaped calls reject with `unsafe_path`. The test now supplies `realpathSync(f.cwd)` while retaining the lexical argument and rejection assertion; its exact case was rerun after correction. No cache runtime code changed.

## Real Behavior Proof

The built production `scanAgentInput` owner used native TruffleHog 3.97.1 on Node 24.20.0/macOS arm64, with a 60-second scan budget. A task-owned two-file Git repository contains the exact public Chrome and server-context test bytes from upstream `72dab3e751988337961c3d80fb41164fded7128a` and `fafc74649c9afc279e581883805d9b4d5fccc761`. All four Git blob IDs were verified; its complete 4,362-byte binary diff contains neither approved URI literal. Commands were `node owner-proof.mjs before` and `node owner-proof.mjs after`; the script invokes the real compiled owner on committed source and consumes its normal sanitized notices.

| Production path | Observed result | Notices | Elapsed |
| --- | --- | --- | ---: |
| Current-main-equivalent scanner | Refused `findings` | None | 1,910 ms |
| Simplified candidate | Admitted | 3 fixture/path groups, 6 findings across old/new blobs | 3,660 ms |
| Candidate with tracked Chrome mode `100755` | Refused `findings` | None | 7,623 ms |

Sanitized result:

```text
before: refused=findings, staging_removed=true, checkout_clean=true
after: admitted=true, fixture_groups=3, findings=6, staging_removed=true, checkout_clean=true
executable-mode: refused=findings, staging_removed=true, checkout_clean=true
```

The three admitted groups were `d69d650dc6c3…` at the Chrome path and `60267342b1ab…` at the Chrome and server-context paths. Production notices identify only digest, source, detector, blob, line, decoder, and occurrence count. No raw fixture values or verification diagnostics were published.

This proves real native admission over a synthetic two-file range containing exact public source bytes. It is not the complete 13-file upstream PR, a hosted deployment, or a model review. Browser code was never executed or imported. No real credentials, GitHub mutations, or remote lease were needed. The individual durations are observations, not a performance benchmark.
