### PR TITLE
fix(review): hydrate the complete pinned source

### DIFF
--- a/docs/review-cache.md
+++ b/docs/review-cache.md
@@ -71,6 +71,24 @@ Git history and blob hydration still make both sides of the PR available in
 the restricted review checkout. There is no compiler-backed cache, separate
 cache-only patch payload, or source-equivalence revalidation path.
 
+When full context collection requests a review checkout, source preparation runs
+independently of cache-digest eligibility and the API's 80-file context window.
+It reads the exact raw Git delta for the pinned merge-base/head (and pinned
+base/head endpoint evidence), including deleted and historical blobs. Current
+main never replaces the pinned REST base. Blob-size metadata uses batches of at
+most 160 objects; one explicit fetch per delta retrieves missing blobs only after
+the complete set fits the scanner's shared 256 MiB upper bound. Local metadata
+reads remain bounded to 4 MiB and source hydration has a 30-second Git-work
+deadline; metadata requests retain the existing GitHub transport timeout policy.
+The scanner separately enforces its aggregate budget, including prompts and the
+binary patch, and still refuses incomplete or unsupported source without fetching.
+
+Preparation remains in full-context collection, before restricted checkout
+inspection. Structural reuse keeps its existing pinned-source scan and refusal
+behavior; it does not gain a separate hydrator. Context-only callers that do not
+request a Git checkout do no source preparation. OpenClaw Bay is unaffected:
+no observer fields, routes, or controls change.
+
 The deployed review artifact contains compiled JavaScript, runtime libraries,
 and matching configuration, prompts, and schemas. TypeScript is a build
 dependency; review shards neither load nor install a compiler. Historical

--- a/src/agent-input-scan.ts
+++ b/src/agent-input-scan.ts
@@ -67,7 +67,7 @@ export function agentInputScanFailureExitCode(error: unknown): number | null {
     : null;
 }
 
-const MAX_SCAN_BYTES = 256 * 1024 * 1024;
+export const MAX_SCAN_BYTES = 256 * 1024 * 1024;
 const OBJECT_ID = /^[0-9a-f]{40}(?:[0-9a-f]{24})?$/;
 const hostRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const REVIEW_TOOL_BOOTSTRAP_ENV = [

--- a/src/clawsweeper-context-hydration.ts
+++ b/src/clawsweeper-context-hydration.ts
@@ -896,7 +896,6 @@ export function createContextHydration(dependencies: CreateContextHydrationDepen
   }
 
   function hydratePullRequestReviewSource(options: {
-    files: readonly unknown[];
     itemNumber: number;
     pullRequest: unknown;
     targetDir: string;
@@ -938,7 +937,6 @@ export function createContextHydration(dependencies: CreateContextHydrationDepen
           targetDir: options.targetDir,
           baseSha: revision,
           headSha,
-          files: options.files,
           resolveBlobSizes: (objectIds) =>
             githubReviewBlobSizes({
               repository: targetRepo(),

--- a/src/clawsweeper-item-context.ts
+++ b/src/clawsweeper-item-context.ts
@@ -90,7 +90,6 @@ interface CreateItemContextDependencies {
   reviewCommentContentRevision: (entries: readonly unknown[]) => string;
   reviewTimelineDigestParts: (entries: unknown) => unknown;
   hydratePullRequestReviewSource: (options: {
-    files: readonly unknown[];
     itemNumber: number;
     pullRequest: unknown;
     targetDir: string;
@@ -378,14 +377,8 @@ export function createItemContext(dependencies: CreateItemContextDependencies) {
         80,
         compactPullFile,
       );
-      if (
-        options.reviewCacheDigest &&
-        options.reviewCacheGitDir &&
-        !pullFilesWindow.truncated &&
-        pullFilesWindow.total === pullFiles.length
-      ) {
+      if (options.reviewCacheGitDir) {
         hydratePullRequestReviewSource({
-          files: pullFiles,
           itemNumber: item.number,
           pullRequest,
           targetDir: options.reviewCacheGitDir,

--- a/src/clawsweeper-review-blobs.ts
+++ b/src/clawsweeper-review-blobs.ts
@@ -1,17 +1,11 @@
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { reviewMergeBase } from "./pr-review-evidence.js";
+import { readReviewGit, reviewMergeBase } from "./pr-review-evidence.js";
+import { MAX_SCAN_BYTES } from "./agent-input-scan.js";
 
-const MAX_REVIEW_FILES = 80;
+const MAX_BLOB_SIZE_OBJECTS = 160;
 const MAX_GIT_OUTPUT_BYTES = 4 * 1024 * 1024;
-const MAX_REVIEW_BLOB_BYTES = 4 * 1024 * 1024;
 const GIT_OBJECT_ID = /^[0-9a-f]{40,64}$/i;
-
-type ReviewBlobFile = {
-  filename?: unknown;
-  previous_filename?: unknown;
-  status?: unknown;
-};
 
 export type ReviewBlobHydration = {
   hydrated: boolean;
@@ -239,58 +233,60 @@ export function hydratePullRequestReviewBlobs({
   targetDir,
   baseSha,
   headSha,
-  files,
   resolveBlobSizes,
 }: {
   targetDir: string;
   baseSha: string;
   headSha: string;
-  files: readonly unknown[];
   resolveBlobSizes?: (objectIds: readonly string[]) => ReadonlyMap<string, number>;
 }): ReviewBlobHydration {
-  if (
-    !GIT_OBJECT_ID.test(baseSha) ||
-    !GIT_OBJECT_ID.test(headSha) ||
-    files.length > MAX_REVIEW_FILES
-  ) {
+  if (!GIT_OBJECT_ID.test(baseSha) || !GIT_OBJECT_ID.test(headSha)) {
     return { hydrated: false, blobs: 0 };
   }
-
-  const basePaths = new Set<string>();
-  const headPaths = new Set<string>();
-  for (const value of files) {
-    if (!value || typeof value !== "object") return { hydrated: false, blobs: 0 };
-    const file = value as ReviewBlobFile;
-    const filename = safeReviewPath(file.filename);
-    if (!filename) return { hydrated: false, blobs: 0 };
-    const previous =
-      file.previous_filename == null ? filename : safeReviewPath(file.previous_filename);
-    if (!previous) return { hydrated: false, blobs: 0 };
-    const status = typeof file.status === "string" ? file.status.toLowerCase() : "";
-    if (status !== "added" && status !== "a") basePaths.add(previous);
-    if (status !== "removed" && status !== "deleted" && status !== "d") {
-      headPaths.add(filename);
-    }
+  const deadlineAt = Date.now() + 30_000;
+  const readOptions = { deadlineAt, maxBytes: MAX_GIT_OUTPUT_BYTES };
+  const raw = readReviewGit(
+    targetDir,
+    [
+      "diff",
+      "--raw",
+      "--no-abbrev",
+      "-z",
+      "--no-renames",
+      "--no-ext-diff",
+      "--no-textconv",
+      "--ignore-submodules=none",
+      baseSha,
+      headSha,
+      "--",
+    ],
+    readOptions,
+  );
+  if (!raw) return { hydrated: false, blobs: 0 };
+  let fields: string[];
+  try {
+    fields = new TextDecoder("utf-8", { fatal: true }).decode(raw).split("\0");
+  } catch {
+    return { hydrated: false, blobs: 0 };
   }
-
+  if (fields.pop() !== "" || fields.length % 2 !== 0) return { hydrated: false, blobs: 0 };
+  const paths = new Set<string>();
   const objectIds = new Set<string>();
-  for (const [sha, paths] of [
-    [baseSha, basePaths],
-    [headSha, headPaths],
-  ] as const) {
-    if (paths.size === 0) continue;
-    const tree = spawnSync("git", ["--literal-pathspecs", "ls-tree", "-z", sha, "--", ...paths], {
-      cwd: targetDir,
-      encoding: "utf8",
-      env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" },
-      maxBuffer: MAX_GIT_OUTPUT_BYTES,
-    });
-    if (tree.error || tree.status !== 0) return { hydrated: false, blobs: 0 };
-    for (const entry of tree.stdout.split("\0")) {
-      if (!entry) continue;
-      const match = entry.match(/^\d{6} (blob|commit) ([0-9a-f]{40,64})\t(.*)$/s);
-      if (!match || !paths.has(match[3]!)) return { hydrated: false, blobs: 0 };
-      if (match[1] === "blob") objectIds.add(match[2]!);
+  for (let index = 0; index < fields.length; index += 2) {
+    const match = /^:(\d{6}) (\d{6}) ([0-9a-f]{40,64}) ([0-9a-f]{40,64}) [AMDT]$/.exec(
+      fields[index]!,
+    );
+    const path = safeReviewPath(fields[index + 1]);
+    if (!match || !path) return { hydrated: false, blobs: 0 };
+    paths.add(path);
+    for (const [mode, oid] of [
+      [match[1]!, match[3]!],
+      [match[2]!, match[4]!],
+    ]) {
+      // Gitlinks are not blobs; the scanner still refuses changed gitlinks.
+      if (mode === "000000" || mode === "160000") continue;
+      if (!["100644", "100755", "120000"].includes(mode!)) return { hydrated: false, blobs: 0 };
+      objectIds.add(oid!);
     }
   }
 
@@ -308,13 +304,19 @@ export function hydratePullRequestReviewBlobs({
       `${baseSha}^{tree}`,
       `${headSha}^{tree}`,
       "--",
-      ...new Set([...basePaths, ...headPaths]),
+      ...paths,
     ],
     {
       cwd: targetDir,
       encoding: "utf8",
-      env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" },
+      env: {
+        ...process.env,
+        GIT_OPTIONAL_LOCKS: "0",
+        GIT_NO_LAZY_FETCH: "1",
+        GIT_NO_REPLACE_OBJECTS: "1",
+      },
       maxBuffer: MAX_GIT_OUTPUT_BYTES,
+      timeout: Math.max(1, deadlineAt - Date.now()),
     },
   );
   if (objectAvailability.error || objectAvailability.status !== 0) {
@@ -333,19 +335,13 @@ export function hydratePullRequestReviewBlobs({
   const sizes = new Map<string, number>();
   const localObjectIds = [...objectIds].filter((objectId) => !missing.has(objectId));
   if (localObjectIds.length > 0) {
-    const localObjects = spawnSync(
-      "git",
+    const localObjects = readReviewGit(
+      targetDir,
       ["cat-file", "--batch-check=%(objectname) %(objecttype) %(objectsize)"],
-      {
-        cwd: targetDir,
-        encoding: "utf8",
-        env: { ...process.env, GIT_OPTIONAL_LOCKS: "0", GIT_NO_LAZY_FETCH: "1" },
-        input: `${localObjectIds.join("\n")}\n`,
-        maxBuffer: MAX_GIT_OUTPUT_BYTES,
-      },
+      { ...readOptions, input: Buffer.from(`${localObjectIds.join("\n")}\n`) },
     );
-    if (localObjects.error || localObjects.status !== 0) return { hydrated: false, blobs: 0 };
-    const found = localObjects.stdout.trim().split("\n");
+    if (!localObjects) return { hydrated: false, blobs: 0 };
+    const found = localObjects.toString().trim().split("\n");
     if (found.length !== localObjectIds.length) return { hydrated: false, blobs: 0 };
     for (const entry of found) {
       const [objectId, type, size] = entry.split(" ");
@@ -371,25 +367,21 @@ export function hydratePullRequestReviewBlobs({
   }
 
   let objectBytes = 0;
-  let skippedOversizedBlob = false;
-  const bounded = new Set<string>();
   for (const objectId of objectIds) {
     const bytes = sizes.get(objectId);
     if (
       bytes === undefined ||
       !Number.isSafeInteger(bytes) ||
       bytes < 0 ||
-      bytes > MAX_REVIEW_BLOB_BYTES - objectBytes
+      bytes > MAX_SCAN_BYTES - objectBytes
     ) {
-      skippedOversizedBlob = true;
-      continue;
+      return { hydrated: false, blobs: 0 };
     }
-    bounded.add(objectId);
     objectBytes += bytes;
   }
 
-  const boundedMissing = [...missing].filter((objectId) => bounded.has(objectId));
-  if (boundedMissing.length > 0) {
+  if (Date.now() >= deadlineAt) return { hydrated: false, blobs: 0 };
+  if (missing.size > 0) {
     const fetched = spawnSync(
       "git",
       [
@@ -407,13 +399,14 @@ export function hydratePullRequestReviewBlobs({
         cwd: targetDir,
         encoding: "utf8",
         env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" },
-        input: `${boundedMissing.join("\n")}\n`,
+        input: `${[...missing].join("\n")}\n`,
+        timeout: Math.max(1, deadlineAt - Date.now()),
         maxBuffer: MAX_GIT_OUTPUT_BYTES,
       },
     );
     if (fetched.error || fetched.status !== 0) return { hydrated: false, blobs: 0 };
   }
-  return { hydrated: !skippedOversizedBlob, blobs: bounded.size };
+  return { hydrated: true, blobs: objectIds.size };
 }
 
 export function githubReviewBlobSizes({
@@ -426,43 +419,43 @@ export function githubReviewBlobSizes({
   request: (query: string) => unknown;
 }): ReadonlyMap<string, number> {
   const match = repository.match(/^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/);
-  if (
-    !match ||
-    match[1] === "." ||
-    match[1] === ".." ||
-    match[2] === "." ||
-    match[2] === ".." ||
-    objectIds.length > MAX_REVIEW_FILES * 2
-  ) {
+  if (!match || match[1] === "." || match[1] === ".." || match[2] === "." || match[2] === "..") {
     throw new Error("invalid bounded review blob metadata request");
   }
-  const objects = objectIds.map((objectId, index) => {
-    if (!GIT_OBJECT_ID.test(objectId)) throw new Error("invalid review blob object ID");
-    return `b${index}: object(oid: "${objectId}") { ... on Blob { byteSize } }`;
-  });
-  const query = `query { repository(owner: "${match[1]}", name: "${match[2]}") { ${objects.join(" ")} } }`;
-  const response = request(query);
-  if (!response || typeof response !== "object") throw new Error("invalid review blob response");
-  const data = (response as { data?: unknown }).data;
-  if (!data || typeof data !== "object") throw new Error("missing review blob response data");
-  const values = (data as { repository?: unknown }).repository;
-  if (!values || typeof values !== "object") throw new Error("missing review blob repository");
+  if (objectIds.some((objectId) => !GIT_OBJECT_ID.test(objectId))) {
+    throw new Error("invalid review blob object ID");
+  }
   const result = new Map<string, number>();
-  for (const [index, objectId] of objectIds.entries()) {
-    const object = (values as Record<string, unknown>)[`b${index}`];
-    const bytes =
-      object && typeof object === "object" ? (object as { byteSize?: unknown }).byteSize : null;
-    if (typeof bytes !== "number" || !Number.isSafeInteger(bytes) || bytes < 0) {
-      throw new Error("invalid review blob size");
+  const deadlineAt = Date.now() + 30_000;
+  for (let offset = 0; offset < objectIds.length; offset += MAX_BLOB_SIZE_OBJECTS) {
+    if (Date.now() >= deadlineAt) throw new Error("review blob metadata deadline exceeded");
+    const batch = objectIds.slice(offset, offset + MAX_BLOB_SIZE_OBJECTS);
+    const objects = batch.map(
+      (objectId, index) => `b${index}: object(oid: "${objectId}") { ... on Blob { byteSize } }`,
+    );
+    const query = `query { repository(owner: "${match[1]}", name: "${match[2]}") { ${objects.join(" ")} } }`;
+    const response = request(query);
+    if (!response || typeof response !== "object") throw new Error("invalid review blob response");
+    const data = (response as { data?: unknown }).data;
+    if (!data || typeof data !== "object") throw new Error("missing review blob response data");
+    const values = (data as { repository?: unknown }).repository;
+    if (!values || typeof values !== "object") throw new Error("missing review blob repository");
+    for (const [index, objectId] of batch.entries()) {
+      const object = (values as Record<string, unknown>)[`b${index}`];
+      const bytes =
+        object && typeof object === "object" ? (object as { byteSize?: unknown }).byteSize : null;
+      if (typeof bytes !== "number" || !Number.isSafeInteger(bytes) || bytes < 0) {
+        throw new Error("invalid review blob size");
+      }
+      result.set(objectId, bytes);
     }
-    result.set(objectId, bytes);
   }
   return result;
 }
 
 function safeReviewPath(value: unknown): string | null {
   if (typeof value !== "string" || !value || value.length > 4096) return null;
-  if (value.startsWith("/") || value.includes("\\")) {
+  if (value.startsWith("/") || /^[A-Za-z]:/.test(value) || value.includes("\\")) {
     return null;
   }
   for (let index = 0; index < value.length; index += 1) {
@@ -470,7 +463,9 @@ function safeReviewPath(value: unknown): string | null {
     if (code < 32 || code === 127) return null;
   }
   const parts = value.split("/");
-  if (parts.some((part) => !part || part === "." || part === ".." || part === ".git")) {
+  if (
+    parts.some((part) => !part || part === "." || part === ".." || part.toLowerCase() === ".git")
+  ) {
     return null;
   }
   return value;

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -642,3 +642,67 @@ test("ghPagedLinkHeaderContextWindow falls back when link headers are unavailabl
     truncated: false,
   });
 });
+
+test("bounded PR context prepares source independently of cache digest and API file completeness", async () => {
+  const { createItemContext } = await import("../dist/clawsweeper-item-context.js");
+  const { hydration, sourceTools, sha256 } = await import("./primary-body-fixture.ts");
+  const { asRecord } = await import("../dist/clawsweeper-item-policy.js");
+  const { item } = await import("./helpers.ts");
+  const target = item({ kind: "pull_request" });
+  const pullRequest = {
+    head: { sha: "b".repeat(40) },
+    base: { sha: "a".repeat(40), ref: "main" },
+    changed_files: 341,
+    commits: 113,
+    review_comments: 0,
+  };
+  const empty = { items: [], total: 0, hydrated: 0, truncated: false };
+  const prepared: unknown[] = [];
+  const { collectItemContext } = createItemContext({
+    ...hydration,
+    ...sourceTools,
+    asRecord,
+    sha256,
+    stringOrUndefined: (value) => (typeof value === "string" ? value : undefined),
+    targetRepo: () => target.repo,
+    ghJson: <T>(args: string[]) =>
+      (args[1]!.includes("/pulls/") ? pullRequest : { comments: 0 }) as T,
+    ghPaged: () => [],
+    ghPagedContextWindow: <T>(path: string) =>
+      path.endsWith("/files")
+        ? {
+            items: Array.from({ length: 80 }, (_, index) => ({
+              filename: `file-${index}.txt`,
+            })) as T[],
+            total: 341,
+            hydrated: 80,
+            truncated: true,
+          }
+        : empty,
+    ghPagedLinkHeaderContextWindow: () => empty,
+    closingPullRequestsForIssue: () => [],
+    referencingMergedPullRequestsForIssue: () => [],
+    relatedItemsContext: () => [],
+    fetchReviewedPrActivityCursor: () => null,
+    pullChecksContext: () => ({ complete: true, checkRuns: [], statuses: [] }),
+    hydratePullRequestReviewSource: (options) => prepared.push(options),
+  });
+  for (const reviewCacheDigest of [false, true]) {
+    const context = collectItemContext(target, {
+      reviewCacheDigest,
+      reviewCacheGitDir: "/synthetic/source",
+    });
+    assert.equal(context.counts?.pullFiles, 341);
+    assert.equal(context.counts?.pullFilesHydrated, 80);
+    assert.equal(context.counts?.pullFilesTruncated, true);
+    assert.equal(context.pullFiles?.length, 81, "80 files plus the explicit omission marker");
+    assert.deepEqual(prepared.at(-1), {
+      itemNumber: target.number,
+      pullRequest,
+      targetDir: "/synthetic/source",
+    });
+  }
+  assert.equal(prepared.length, 2);
+  collectItemContext(target);
+  assert.equal(prepared.length, 2, "context-only callers do not request a Git checkout");
+});

--- a/test/review-blob-hydration.test.ts
+++ b/test/review-blob-hydration.test.ts
@@ -1,6 +1,15 @@
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -14,7 +23,8 @@ import {
   materializePullRequestReviewTree,
   removePullRequestReviewTree,
 } from "../dist/clawsweeper-review-blobs.js";
-import { reviewMergeBase } from "../dist/pr-review-evidence.js";
+import { MAX_SCAN_BYTES } from "../dist/agent-input-scan.js";
+import { readReviewGit, reviewMergeBase } from "../dist/pr-review-evidence.js";
 
 function git(cwd: string, ...args: string[]): string {
   return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
@@ -33,7 +43,13 @@ function partialCloneFixture({
   extraFiles = 0,
   largeFiles = [],
   prefetchHead = true,
-}: { extraFiles?: number; largeFiles?: number[]; prefetchHead?: boolean } = {}) {
+  historicalBase = false,
+}: {
+  extraFiles?: number;
+  largeFiles?: number[];
+  prefetchHead?: boolean;
+  historicalBase?: boolean;
+} = {}) {
   const root = mkdtempSync(join(tmpdir(), "clawsweeper-review-promisor-"));
   const origin = join(root, "origin.git");
   const source = join(root, "source");
@@ -47,6 +63,17 @@ function partialCloneFixture({
   git(source, "config", "commit.gpgsign", "false");
   writeFileSync(join(source, "changed.txt"), "before\n");
   writeFileSync(join(source, "removed.txt"), "remove me\n");
+  if (historicalBase) {
+    writeFileSync(join(source, "mode.txt"), "mode only\n");
+    for (let index = 0; index < extraFiles; index++) {
+      writeFileSync(join(source, `additional-${index}.txt`), `before ${index}\n`);
+    }
+    for (const [index, bytes] of largeFiles.entries()) {
+      const data = Buffer.alloc(bytes, index + 10);
+      data[0] = 0;
+      writeFileSync(join(source, `large-${index}.bin`), data);
+    }
+  }
   git(source, "add", ".");
   git(source, "update-index", "--add", "--cacheinfo", `160000,${"1".repeat(40)},vendor/library`);
   git(source, "commit", "-qm", "base");
@@ -64,16 +91,36 @@ function partialCloneFixture({
     writeFileSync(join(source, `additional-${index}.txt`), `additional ${index}\n`);
   }
   for (const [index, bytes] of largeFiles.entries()) {
-    writeFileSync(join(source, `large-${index}.bin`), Buffer.alloc(bytes, index + 1));
+    const data = Buffer.alloc(bytes, index + 1);
+    data[0] = 0;
+    writeFileSync(join(source, `large-${index}.bin`), data);
   }
   git(source, "rm", "-q", "removed.txt");
   git(source, "add", ".");
   git(source, "update-index", "--add", "--cacheinfo", `160000,${"2".repeat(40)},vendor/library`);
+  if (historicalBase) {
+    chmodSync(join(source, "mode.txt"), 0o755);
+    git(source, "update-index", "--chmod=+x", "mode.txt");
+  }
   git(source, "commit", "-qm", "feature");
   const headSha = git(source, "rev-parse", "HEAD");
   const addedBlobSha = git(source, "rev-parse", "HEAD:added.txt");
   const changedBlobSha = git(source, "rev-parse", "HEAD:changed.txt");
   git(source, "push", "-q", "origin", "HEAD:refs/pull/982/head");
+  if (historicalBase) {
+    git(source, "checkout", "-q", "main");
+    writeFileSync(join(source, "changed.txt"), "current main\n");
+    git(source, "rm", "-q", "removed.txt");
+    for (let index = 0; index < extraFiles; index++) {
+      writeFileSync(join(source, `additional-${index}.txt`), `main ${index}\n`);
+    }
+    for (const [index] of largeFiles.entries()) {
+      writeFileSync(join(source, `large-${index}.bin`), "main binary replacement\n");
+    }
+    git(source, "add", ".");
+    git(source, "commit", "-qm", "advance main past pinned base");
+    git(source, "push", "-q", "origin", "main");
+  }
   git(
     root,
     "clone",
@@ -100,10 +147,22 @@ function partialCloneFixture({
 }
 
 function resolveFixtureBlobSizes(source: string) {
-  return (objectIds: readonly string[]) =>
-    new Map(
-      objectIds.map((objectId) => [objectId, Number(git(source, "cat-file", "-s", objectId))]),
+  return (objectIds: readonly string[]) => {
+    const output = execFileSync("git", ["cat-file", "--batch-check=%(objectname) %(objectsize)"], {
+      cwd: source,
+      encoding: "utf8",
+      input: `${objectIds.join("\n")}\n`,
+    });
+    return new Map(
+      output
+        .trim()
+        .split("\n")
+        .map((line) => {
+          const [oid, bytes] = line.split(" ");
+          return [oid!, Number(bytes)];
+        }),
     );
+  };
 }
 
 function objectExistsOffline(cwd: string, sha: string): boolean {
@@ -399,14 +458,6 @@ test("restricted PR review can inspect changed blobs from a genuine blobless clo
       baseSha: fixture.baseSha,
       headSha: fixture.headSha,
       resolveBlobSizes: resolveFixtureBlobSizes(fixture.source),
-      files: [
-        { filename: "added.txt", status: "added" },
-        { filename: "nested/feature[1].txt", status: "added" },
-        { filename: ":(glob)literal.txt", status: "added" },
-        { filename: "changed.txt", status: "modified" },
-        { filename: "vendor/library", status: "modified" },
-        { filename: "removed.txt", status: "removed" },
-      ],
     });
 
     assert.equal(result.hydrated, true);
@@ -429,30 +480,6 @@ test("restricted PR review can inspect changed blobs from a genuine blobless clo
       /\+after/,
     );
     assert.equal(git(fixture.target, "status", "--porcelain"), "");
-  } finally {
-    rmSync(fixture.root, { recursive: true, force: true });
-  }
-});
-
-test("persisted snapshot null previous filenames still hydrate missing blobs", () => {
-  const fixture = partialCloneFixture();
-  try {
-    assert.equal(objectExistsOffline(fixture.target, fixture.addedBlobSha), false);
-    assert.equal(objectExistsOffline(fixture.target, fixture.changedBlobSha), false);
-    const result = hydratePullRequestReviewBlobs({
-      targetDir: fixture.target,
-      baseSha: fixture.baseSha,
-      headSha: fixture.headSha,
-      resolveBlobSizes: resolveFixtureBlobSizes(fixture.source),
-      files: [
-        { filename: "added.txt", previous_filename: null, status: "added" },
-        { filename: "changed.txt", previous_filename: null, status: "modified" },
-        { filename: "removed.txt", previous_filename: null, status: "removed" },
-      ],
-    });
-    assert.deepEqual(result, { hydrated: true, blobs: 4 });
-    assert.equal(objectExistsOffline(fixture.target, fixture.addedBlobSha), true);
-    assert.equal(objectExistsOffline(fixture.target, fixture.changedBlobSha), true);
   } finally {
     rmSync(fixture.root, { recursive: true, force: true });
   }
@@ -520,30 +547,39 @@ test("restricted review binds a force-pushed pull request to the exact REST head
   }
 });
 
-test("review blob hydration rejects unsafe paths and oversized changes without fetching", () => {
+test("review hydration refuses unsafe Git paths and missing source without fetching", () => {
   const fixture = partialCloneFixture();
   try {
-    for (const filename of ["../secret", "/absolute", ".git/config", "nested/../secret", "a\\b"]) {
+    for (const filename of ["a\\b", "C:drive", "control\npath"]) {
+      writeFileSync(join(fixture.source, filename), "unsafe path\n");
+      git(fixture.source, "add", ".");
+      git(fixture.source, "commit", "-qm", "unsafe source");
+      const headSha = git(fixture.source, "rev-parse", "HEAD");
+      git(fixture.source, "push", "-q", "origin", "HEAD:refs/heads/unsafe");
+      git(fixture.target, "fetch", "-q", "--filter=blob:none", "origin", "refs/heads/unsafe");
       assert.deepEqual(
         hydratePullRequestReviewBlobs({
           targetDir: fixture.target,
           baseSha: fixture.baseSha,
-          headSha: fixture.headSha,
-          files: [{ filename, status: "added" }],
+          headSha,
+          resolveBlobSizes: () => {
+            throw new Error("unsafe paths must refuse before metadata");
+          },
         }),
         { hydrated: false, blobs: 0 },
-        filename,
+      );
+      git(fixture.source, "rm", "-q", "--", filename);
+    }
+    for (const baseSha of ["--unsafe", "f".repeat(40), fixture.baseSha]) {
+      assert.deepEqual(
+        hydratePullRequestReviewBlobs({
+          targetDir: fixture.target,
+          baseSha,
+          headSha: fixture.headSha,
+        }),
+        { hydrated: false, blobs: 0 },
       );
     }
-    assert.deepEqual(
-      hydratePullRequestReviewBlobs({
-        targetDir: fixture.target,
-        baseSha: fixture.baseSha,
-        headSha: fixture.headSha,
-        files: Array.from({ length: 81 }, () => ({ filename: "added.txt", status: "added" })),
-      }),
-      { hydrated: false, blobs: 0 },
-    );
     assert.equal(objectExistsOffline(fixture.target, fixture.addedBlobSha), false);
   } finally {
     rmSync(fixture.root, { recursive: true, force: true });
@@ -583,7 +619,6 @@ test("missing partial-clone objects are fetched in one bounded network request",
       baseSha: fixture.baseSha,
       headSha: fixture.headSha,
       resolveBlobSizes: resolveFixtureBlobSizes(fixture.source),
-      files: paths.map((filename) => ({ filename, status: "added" })),
     });
     if (previousTrace === undefined) delete process.env.GIT_TRACE2_EVENT;
     else process.env.GIT_TRACE2_EVENT = previousTrace;
@@ -601,7 +636,7 @@ test("missing partial-clone objects are fetched in one bounded network request",
     const explicitFetches = traceEvents.filter(
       (event) => event.event === "start" && event.argv?.includes("fetch"),
     );
-    assert.deepEqual(result, { hydrated: true, blobs: 12 });
+    assert.deepEqual(result, { hydrated: true, blobs: 18 });
     assert.equal(revLists.length, 1);
     assert.ok(revLists[0]!.argv?.includes(`${fixture.baseSha}^{tree}`));
     assert.ok(revLists[0]!.argv?.includes(`${fixture.headSha}^{tree}`));
@@ -619,32 +654,34 @@ test("missing partial-clone objects are fetched in one bounded network request",
   }
 });
 
-test("review hydration enforces per-review byte limits without fetching oversized blobs", () => {
-  for (const largeFiles of [[5 * 1024 * 1024], [3 * 1024 * 1024, 2 * 1024 * 1024]]) {
-    const fixture = partialCloneFixture({ largeFiles });
-    try {
-      const oversizedBlob = git(
-        fixture.target,
-        "rev-parse",
-        `${fixture.headSha}:large-${largeFiles.length - 1}.bin`,
+test("review hydration rejects aggregate scan budget overflow and incomplete size metadata before fetching", () => {
+  const fixture = partialCloneFixture();
+  try {
+    for (const size of [MAX_SCAN_BYTES + 1, Math.ceil(MAX_SCAN_BYTES / 2), NaN, -1, undefined]) {
+      assert.deepEqual(
+        hydratePullRequestReviewBlobs({
+          targetDir: fixture.target,
+          baseSha: fixture.baseSha,
+          headSha: fixture.headSha,
+          resolveBlobSizes: (ids) => new Map(ids.map((id) => [id, size as number])),
+        }),
+        { hydrated: false, blobs: 0 },
       );
-      const result = hydratePullRequestReviewBlobs({
+      assert.equal(objectExistsOffline(fixture.target, fixture.addedBlobSha), false);
+    }
+    git(fixture.target, "remote", "set-url", "origin", join(fixture.root, "unavailable.git"));
+    assert.deepEqual(
+      hydratePullRequestReviewBlobs({
         targetDir: fixture.target,
         baseSha: fixture.baseSha,
         headSha: fixture.headSha,
         resolveBlobSizes: resolveFixtureBlobSizes(fixture.source),
-        files: [
-          { filename: "added.txt", status: "added" },
-          ...largeFiles.map((_, index) => ({ filename: `large-${index}.bin`, status: "added" })),
-        ],
-      });
-
-      assert.equal(result.hydrated, false);
-      assert.equal(objectExistsOffline(fixture.target, fixture.addedBlobSha), true);
-      assert.equal(objectExistsOffline(fixture.target, oversizedBlob), false);
-    } finally {
-      rmSync(fixture.root, { recursive: true, force: true });
-    }
+      }),
+      { hydrated: false, blobs: 0 },
+    );
+    assert.equal(objectExistsOffline(fixture.target, fixture.addedBlobSha), false);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
   }
 });
 
@@ -675,4 +712,96 @@ test("review blob sizes use one bounded GraphQL metadata request", () => {
     () => githubReviewBlobSizes({ repository: "../unsafe", objectIds, request: () => ({}) }),
     /invalid bounded review blob metadata request/,
   );
+});
+
+test("large pinned deltas hydrate historical blobs after head checkout and produce the full offline binary patch", (t) => {
+  const fixture = partialCloneFixture({
+    extraFiles: 170,
+    largeFiles: [3 * 1024 * 1024],
+    historicalBase: true,
+  });
+  const reviewTree = join(fixture.root, "review-tree");
+  try {
+    assert.notEqual(git(fixture.target, "rev-parse", "HEAD"), fixture.baseSha);
+    assert.equal(
+      materializePullRequestReviewTree({
+        targetDir: fixture.target,
+        worktreeDir: reviewTree,
+        itemNumber: 982,
+        headSha: fixture.headSha,
+      }),
+      true,
+    );
+    const mergeBase = reviewMergeBase(reviewTree, fixture.baseSha, fixture.headSha);
+    assert.equal(mergeBase.sha, fixture.baseSha, "the REST base must not become current main");
+    const args = [
+      "diff",
+      "--no-ext-diff",
+      "--no-textconv",
+      "--no-renames",
+      "--ignore-submodules=none",
+      fixture.baseSha,
+      fixture.headSha,
+    ];
+    const raw = readReviewGit(reviewTree, [...args, "--raw", "--no-abbrev", "-z", "--"]);
+    assert.ok(raw);
+    assert.equal(raw.toString().split("\0").length, 2 * 178 + 1);
+    const patchArgs = [...args, "--patch", "--binary", "--full-index", "--"];
+    assert.equal(
+      readReviewGit(reviewTree, patchArgs),
+      null,
+      "head checkout leaves historical blobs missing",
+    );
+    const removedOid = git(fixture.source, "rev-parse", `${fixture.baseSha}:removed.txt`);
+    assert.equal(objectExistsOffline(reviewTree, removedOid), false);
+    const batches: number[] = [];
+    const result = hydratePullRequestReviewBlobs({
+      targetDir: reviewTree,
+      baseSha: mergeBase.sha!,
+      headSha: fixture.headSha,
+      resolveBlobSizes: (objectIds) =>
+        githubReviewBlobSizes({
+          repository: "openclaw/clawsweeper",
+          objectIds,
+          request: (query) => {
+            const ids = [...query.matchAll(/b(\d+): object\(oid: "([0-9a-f]+)"\)/g)];
+            batches.push(ids.length);
+            const sizes = resolveFixtureBlobSizes(fixture.source)(ids.map((match) => match[2]!));
+            return {
+              data: {
+                repository: Object.fromEntries(
+                  ids.map((match) => [`b${match[1]}`, { byteSize: sizes.get(match[2]!) }]),
+                ),
+              },
+            };
+          },
+        }),
+    });
+    assert.deepEqual(result, { hydrated: true, blobs: 349 });
+    assert.deepEqual(batches, [160, 13]);
+    assert.equal(objectExistsOffline(reviewTree, removedOid), true);
+    git(fixture.target, "remote", "set-url", "origin", join(fixture.root, "offline.git"));
+    const patch = readReviewGit(reviewTree, patchArgs);
+    assert.ok(patch);
+    assert.deepEqual(patch, readReviewGit(fixture.source, patchArgs));
+    assert.match(patch.toString(), /GIT binary patch/);
+    assert.match(patch.toString(), /old mode 100644\nnew mode 100755/);
+    assert.match(patch.toString(), /deleted file mode 100644/);
+    assert.match(patch.toString(), /:\(glob\)literal.txt/);
+    assert.match(patch.toString(), /feature\[1\].txt/);
+    assert.equal(git(reviewTree, "status", "--porcelain"), "");
+    t.diagnostic(
+      JSON.stringify({
+        changedFiles: 178,
+        blobs: result.blobs,
+        metadataBatches: batches,
+        patchBytes: patch.length,
+        patchSha256: createHash("sha256").update(patch).digest("hex"),
+        patchUnreadableBefore: true,
+        offlinePatchMatchesSource: true,
+      }),
+    );
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
Full reviews could refuse valid pull requests with `incomplete_source` when GitHub's bounded file context omitted part of the pinned diff. Source hydration depended on the cache digest and the 80-file API window. A partial clone's head checkout populated current files but left historical and deleted baseline blobs missing, so the raw delta was readable while the scanner's complete binary patch was not.

Prepare source from the exact Git delta, independently of API context and cache eligibility. This removes the duplicate API file/status mapping and keeps the pinned REST base/head identities. Missing-object metadata stays in batches of at most 160 objects; fetching uses the scanner's existing 256 MiB upper bound. The scanner still owns aggregate input accounting and refuses incomplete, unsupported, or changed source.

This follows https://github.com/openclaw/clawsweeper/pull/1308 and fixes a different source-completeness failure exposed while reviewing https://github.com/openclaw/clawsweeper/pull/1070 and https://github.com/openclaw/clawsweeper/pull/1073. Their terminal failures correctly stopped retrying the unchanged revisions.

## Live proof

Replayed the actual public PR1070 in a fresh blobless clone, using the production hydration helpers, real GitHub blob-size metadata, and the unchanged production scanner on Node24.20.0.

- Pinned base: `02c930c53d1c7e22ce89d23ba76e6b547a4e2a7f`; head: `8d583a05915f737926cd54e8943aee471e2d35ac`.
- Exact delta: 341 files, 588 unique blobs totaling 21,579,924 bytes. The verified merge base remained the pinned base.
- Before: raw delta readable; binary patch unreadable; production scanner refused `incomplete_source`.
- After: 248 missing historical blobs fetched in two batches (160 + 88); the complete 3,473,391-byte binary patch is readable with lazy fetching disabled; the production scanner passed in 93.423 seconds. Its existing reviewed-synthetic-fixture classification handled the known test URI normally.

Regression coverage extends the existing partial-clone fixture to a historical base, more than 80 files, more than 160 missing objects, binary content, deletion, mode changes, and literal pathspec names. It compares the complete offline patch with the source repository. Negative coverage retains invalid-source/path and over-budget refusal before fetching; bounded API context remains bounded.

## Validation

Build and all 24 focused context tests pass. Managed Codex reviews before and after commit are scoped-clean at P0. The committed AWS full check passed 4,252 tests, 14 skipped, zero failures, plus 13/13 focused coverage tests on Node24.18.1 and pnpm11.10.0: https://crabbox.openclaw.ai/portal/runs/run_dc9562e86e1f. Current-head CI, CodeQL, sparse repair build, and Windows launcher checks passed: https://github.com/openclaw/clawsweeper/actions/runs/33489263316.

Maintainer review accepts the bounded preparation cost. The existing two-endpoint preparation can perform two hydration passes; this change removes incomplete API-derived inputs without adding another hydrator. Exact-head functional proof and full validation are complete. Large or incomplete inputs still refuse safely; this is not a maximum-size throughput benchmark.

Preparation remains in full-context collection before restricted checkout inspection. Structural reuse retains its existing pinned-source scan and refusal behavior. The change adds no dependencies or new source-preparation mechanism.
