### PR TITLE
fix(review): retain safe diagnostics for Codex failures

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1307,6 +1307,9 @@ jobs:
           fi
           set -e
           echo "exit_code=$review_exit_code" >> "$GITHUB_OUTPUT"
+          if [ "$review_exit_code" -ne 0 ] && [ -f artifacts/event/failure-diagnostics/manifest.json ]; then
+            echo "failure_diagnostics=true" >> "$GITHUB_OUTPUT"
+          fi
           # Keep 78 aligned with INCOMPLETE_AGENT_INPUT_SOURCE_EXIT_CODE. This
           # unchanged source tuple is terminal, while the workflow stays red.
           if [ "$review_exit_code" -eq 78 ]; then
@@ -1943,6 +1946,18 @@ jobs:
           EXACT_REVIEW_QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
         run: pnpm run --silent repair:github-egress-telemetry submit
+
+      - name: Upload exact review failure diagnostics
+        id: upload-exact-review-failure-diagnostics
+        if: ${{ always() && !cancelled() && steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.review-exact-event-item.outputs.failure_diagnostics == 'true' }}
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: exact-review-failure-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/event/failure-diagnostics/
+          include-hidden-files: false
+          if-no-files-found: error
+          retention-days: 14
 
       - name: Fail unsuccessful exact review generation
         # A held review lease is a successful deferral only after the durable queue

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -88,6 +88,13 @@ current decision and revision through the ordinary finishing path.
 Queue-completion failures remain visible separately from Codex or content
 failures, using the logical generation result and typed deferral rather than
 the review process exit alone. The workflow failure gate is unchanged.
+Caught Codex failures in an exact-review job also upload a separate 14-day
+diagnostic artifact while the runner remains alive. Its `error.txt`,
+`stdout.error.txt`, and `stderr.tail.txt` files are sanitized for repository
+readers and total at most 24 KiB with the readiness `manifest.json`. Raw
+reports, unstructured stdout, and non-error prompt events are omitted. It is
+never a publication input; cancellation, runner loss, or job termination can
+still prevent upload. OpenClaw Bay and queue schemas are unchanged.
 
 Recoverable parked reviews use the nominal 5/10/20-minute retry ladder, but
 each item persists a schedule-time uniform jitter of 0.75-1.5x for every rung.

--- a/src/clawsweeper-review-command-workflow.ts
+++ b/src/clawsweeper-review-command-workflow.ts
@@ -23,6 +23,7 @@ import { UserFacingCommandError } from "./command.js";
 import { LOCAL_REVIEW_WEB_SEARCH_CONFIG } from "./commit-sweeper.js";
 import { isReviewedPrActivityCursor } from "./review-activity-cursor.js";
 import { previousClawSweeperReviewDigest } from "./clawsweeper-review-comments.js";
+import { writeExactReviewFailureDiagnostics } from "./clawsweeper-review-failure-diagnostics.js";
 import {
   reviewStructuralCacheDecision,
   reviewStructuralCacheProbeDecision,
@@ -1243,6 +1244,7 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
         let decision: Decision;
         let codexElapsedMs = 0;
         let codexFailed = false;
+        let codexFailureError: unknown = null;
         let codexFailureRetryable = false;
         let codexFailureDisposition: ReturnType<typeof actionLedgerFailureDisposition> | null =
           null;
@@ -1283,6 +1285,7 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
           if (error instanceof AgentInputScanError) throw error;
           codexFailures += 1;
           codexFailed = true;
+          codexFailureError = error;
           codexFailureRetryable = codexReviewFailureRetryable(error);
           codexFailureDisposition = actionLedgerFailureDisposition(error);
           if (error instanceof CodexReviewError) {
@@ -1345,6 +1348,24 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
               : {}),
         });
         writeFileSync(reportPath, reportMarkdown, "utf8");
+        if (codexFailureError && process.env.EXACT_REVIEW_ITEM_KEY) {
+          try {
+            writeExactReviewFailureDiagnostics({
+              artifactDir,
+              error: codexFailureError,
+              prompt: prompt.text,
+              model,
+              classification: codexFailureLogKind(reportMarkdown),
+              repo: item.repo,
+              itemKind: item.kind,
+              itemNumber: item.number,
+              sourceSha: context.sourceRevision ?? process.env.EXACT_REVIEW_SOURCE_HEAD_SHA,
+              workflowExit: 1,
+            });
+          } catch {
+            console.error("[review] exact-review failure diagnostics could not be written.");
+          }
+        }
         if (itemLocalReviewHistoryPath) {
           const nextLocalReviewCommentBody =
             frontMatterValue(reportMarkdown, "review_status") === "complete"
@@ -1505,7 +1526,7 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
         }
         const message = `Codex failed for ${codexFailures} item${
           codexFailures === 1 ? "" : "s"
-        }; review artifacts were written and the workflow recovery lane can requeue the planned set.${
+        }; local failure reports were written and the workflow recovery lane can requeue the planned set.${
           codexFailureReports.length > 0
             ? ` Report${codexFailureReports.length === 1 ? "" : "s"}: ${codexFailureReports
                 .map(displayPath)

--- a/src/clawsweeper-review-failure-diagnostics.ts
+++ b/src/clawsweeper-review-failure-diagnostics.ts
@@ -1,0 +1,190 @@
+import { existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { codexJsonlFailureDetail } from "./codex-transient.js";
+
+const FILE_LIMITS = { "error.txt": 4096, "stdout.error.txt": 4096, "stderr.tail.txt": 12_288 };
+const TOTAL_LIMIT = 24 * 1024;
+const OMITTED = "[omitted: unsafe diagnostic content]\n";
+const SENSITIVE_NAME = String.raw`(?:ACCOUNT|ACTOR|AUTH|CODEX_HOME|COOKIE|CREDENTIAL|HOST|KEY|MODEL|PASSWORD|PRIVATE|PROVIDER|PROXY|RUNNER|SECRET|SESSION|TOKEN|USER|WEBHOOK)`;
+const ASSIGNMENT = new RegExp(
+  String.raw`\b[A-Z0-9_-]*${SENSITIVE_NAME}[A-Z0-9_-]*[ \t]*[:=][ \t]*(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s,;]+)`,
+  "gi",
+);
+const TOKEN =
+  /\b(?:bearer|basic)\s+\S+|\b(?:sk-(?:proj-)?|github_pat_|gh[pousr]_)[A-Za-z0-9_-]{12,}|\bxox[baprs]-[A-Za-z0-9-]{12,}|\bAKIA[A-Z0-9]{16}\b|\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/gi;
+const OPAQUE =
+  /(?<![A-Za-z0-9_+/=-])(?=[A-Za-z0-9_+/=-]{32,}(?![A-Za-z0-9_+/=-]))(?=[A-Za-z0-9_+/=-]*[A-Za-z])(?=[A-Za-z0-9_+/=-]*\d)[A-Za-z0-9_+/=-]+/g;
+const URL = /\b[a-z][a-z0-9+.-]*:\/\/[^\s"'<>]+/gi;
+const PRIVATE_PATH =
+  /(?:~\/|(?<![A-Za-z0-9_+=-])\/(?!\/)[^\s"'<>]+|[A-Za-z]:\\[^\s"'<>]+|\\\\[^\\\s"'<>]+\\[^\s"'<>]+)/gi;
+const INTERNAL_HOST =
+  /\b(?:localhost|(?:[a-z0-9-]+\.)*(?:corp|internal|local)(?:\.[a-z0-9-]+)*)(?::\d+)?\b/gi;
+const PRIVATE_IP =
+  /(?<![A-Za-z0-9])(?:10(?:\.\d{1,3}){3}|127(?:\.\d{1,3}){3}|169\.254(?:\.\d{1,3}){2}|192\.168(?:\.\d{1,3}){2}|172\.(?:1[6-9]|2\d|3[01])(?:\.\d{1,3}){2})(?::\d+)?(?![A-Za-z0-9])|\[(?:::1|f[cd][0-9a-f:]*|fe[89ab][0-9a-f:]*)\](?::\d+)?|(?<![A-Za-z0-9])(?:::1|f[cd][0-9a-f:]*|fe[89ab][0-9a-f:]*)(?![A-Za-z0-9])/gi;
+const AMBIGUOUS = new RegExp(
+  String.raw`(?:^|\n)\s*[A-Z0-9_-]*${SENSITIVE_NAME}[A-Z0-9_-]*\s*[:=]\s*(?:[>|][+-]?\d*|["'][^"'\r\n]*$|[^\r\n]*\\\s*$)`,
+  "im",
+);
+
+export function writeExactReviewFailureDiagnostics(options: {
+  artifactDir: string;
+  error: unknown;
+  prompt: string;
+  model: string;
+  classification: string;
+  repo: string;
+  itemKind: "issue" | "pull_request";
+  itemNumber: number;
+  sourceSha?: string | null | undefined;
+  workflowExit: number;
+  env?: NodeJS.ProcessEnv;
+}): string {
+  const error = record(options.error);
+  const values = exactValues(options.prompt, options.model, options.env ?? process.env);
+  const inputs = {
+    "error.txt": options.error instanceof Error ? options.error.message : String(options.error),
+    "stdout.error.txt": codexJsonlFailureDetail(stringValue(error.stdout)),
+    "stderr.tail.txt": stringValue(error.stderr),
+  };
+  const files = Object.entries(inputs).map(([name, value]) => {
+    const result = sanitize(value, values, FILE_LIMITS[name as keyof typeof FILE_LIMITS]);
+    return { name, ...result };
+  });
+  const manifest = `${JSON.stringify(
+    {
+      version: 1,
+      classification:
+        /^(?:provider_throttle|transport_network|content_or_output|model_access|timeout|codex_execution)$/.test(
+          options.classification,
+        )
+          ? options.classification
+          : "codex_execution",
+      retryable: error.retryable === true,
+      process: {
+        status: Number.isInteger(error.status) && Number(error.status) >= 0 ? error.status : null,
+        signal: safeCode(error.signal, /^SIG[A-Z0-9]+$/),
+        error_code: safeCode(error.errorCode, /^[A-Z][A-Z0-9_]{1,63}$/),
+        workflow_exit: options.workflowExit,
+      },
+      source: {
+        repository: /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(options.repo)
+          ? options.repo
+          : "unknown/unknown",
+        item_kind: options.itemKind,
+        item_number: options.itemNumber,
+        sha: /^[0-9a-f]{40,64}$/i.test(options.sourceSha ?? "")
+          ? options.sourceSha!.toLowerCase()
+          : null,
+      },
+      omitted_files: files.filter((file) => file.omitted).map((file) => file.name),
+    },
+    null,
+    2,
+  )}\n`;
+  const total =
+    Buffer.byteLength(manifest) +
+    files.reduce((bytes, file) => bytes + Buffer.byteLength(file.content), 0);
+  if (total > TOTAL_LIMIT) throw new Error(`Exact-review diagnostics exceed ${TOTAL_LIMIT} bytes.`);
+
+  const outputDir = join(options.artifactDir, "failure-diagnostics");
+  const stagingDir = `${outputDir}.tmp-${process.pid}`;
+  mkdirSync(options.artifactDir, { recursive: true, mode: 0o700 });
+  if (existsSync(outputDir)) throw new Error("Exact-review failure diagnostics already exist.");
+  rmSync(stagingDir, { recursive: true, force: true });
+  try {
+    mkdirSync(stagingDir, { mode: 0o700 });
+    for (const file of files) {
+      writeFileSync(join(stagingDir, file.name), file.content, { mode: 0o600 });
+    }
+    writeFileSync(join(stagingDir, "manifest.json"), manifest, { mode: 0o600 });
+    renameSync(stagingDir, outputDir);
+  } catch (writeError) {
+    rmSync(stagingDir, { recursive: true, force: true });
+    throw writeError;
+  }
+  return outputDir;
+}
+
+function sanitize(value: string, exact: readonly string[], limit: number) {
+  if (!value) return { content: "[no diagnostic detail]\n", omitted: false };
+  if (unsafeControl(value) || ambiguous(value, exact)) return { content: OMITTED, omitted: true };
+  let redacted = value;
+  for (const secret of exact) redacted = redacted.replaceAll(secret, "[REDACTED]");
+  redacted = redacted
+    .replace(ASSIGNMENT, (entry) => `${entry.slice(0, entry.search(/[:=]/) + 1)}[REDACTED]`)
+    .replace(TOKEN, "[REDACTED]")
+    .replace(URL, "[REDACTED_URL]")
+    .replace(PRIVATE_PATH, "[REDACTED_PATH]")
+    .replace(INTERNAL_HOST, "[REDACTED_HOST]")
+    .replace(PRIVATE_IP, "[REDACTED_HOST]");
+  const content = utf8Tail(redacted.endsWith("\n") ? redacted : `${redacted}\n`, limit);
+  return residual(content, exact)
+    ? { content: OMITTED, omitted: true }
+    : { content, omitted: false };
+}
+
+function exactValues(prompt: string, model: string, env: NodeJS.ProcessEnv): string[] {
+  const promptLines = prompt
+    .split(/\r?\n/)
+    .flatMap((line) => (line.trim().length >= 2 ? [line, line.trim()] : []));
+  const values = [
+    prompt,
+    ...promptLines,
+    model,
+    ...Object.entries(env)
+      .filter(([name, value]) => value && new RegExp(SENSITIVE_NAME, "i").test(name))
+      .map(([, value]) => value!),
+  ].filter(Boolean);
+  return [...new Set(values.flatMap((value) => [value, JSON.stringify(value).slice(1, -1)]))]
+    .filter(Boolean)
+    .sort((left, right) => right.length - left.length);
+}
+
+function ambiguous(value: string, exact: readonly string[]): boolean {
+  return (
+    /-----BEGIN [A-Z0-9 -]*PRIVATE KEY(?: BLOCK)?-----/i.test(value) ||
+    AMBIGUOUS.test(value) ||
+    exact.some((secret) => /[\r\n]/.test(secret) && value.includes(secret))
+  );
+}
+
+function residual(value: string, exact: readonly string[]): boolean {
+  const clean = value.replace(/\[REDACTED(?:_[A-Z]+)?\]/g, "");
+  return (
+    unsafeControl(value) ||
+    exact.some((secret) => clean.includes(secret)) ||
+    [ASSIGNMENT, TOKEN, OPAQUE, URL, PRIVATE_PATH, INTERNAL_HOST, PRIVATE_IP].some((pattern) =>
+      new RegExp(pattern.source, pattern.flags.replace("g", "")).test(clean),
+    )
+  );
+}
+
+function utf8Tail(value: string, limit: number): string {
+  if (Buffer.byteLength(value) <= limit) return value;
+  const marker = "...[truncated]...\n";
+  let tail = "";
+  for (const character of Array.from(value).reverse()) {
+    if (Buffer.byteLength(marker + character + tail) > limit) break;
+    tail = character + tail;
+  }
+  return marker + tail;
+}
+
+function unsafeControl(value: string): boolean {
+  return Array.from(value).some((character) => {
+    const code = character.charCodeAt(0);
+    return code < 9 || code === 11 || code === 12 || (code > 13 && code < 32) || code === 127;
+  });
+}
+
+function safeCode(value: unknown, pattern: RegExp): string | null {
+  return typeof value === "string" && pattern.test(value) ? value : null;
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+}

--- a/test/exact-review-failure-diagnostics.test.ts
+++ b/test/exact-review-failure-diagnostics.test.ts
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, readdirSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { writeExactReviewFailureDiagnostics } from "../dist/clawsweeper-review-failure-diagnostics.js";
+
+const expectedFiles = ["error.txt", "manifest.json", "stderr.tail.txt", "stdout.error.txt"];
+
+function failure(message: string, stderr: string, stdout = ""): Error {
+  return Object.assign(new Error(message), {
+    status: 1,
+    signal: "SIGTERM",
+    errorCode: "ECONNRESET",
+    retryable: true,
+    stderr,
+    stdout,
+  });
+}
+
+function write(root: string, error: Error, env: NodeJS.ProcessEnv = {}) {
+  return writeExactReviewFailureDiagnostics({
+    artifactDir: root,
+    error,
+    prompt: "private prompt text\n  qz  \nmultiline prompt-only directive",
+    model: "private-model",
+    classification: "codex_execution",
+    repo: "openclaw/openclaw",
+    itemKind: "pull_request",
+    itemNumber: 1318,
+    sourceSha: "a".repeat(40),
+    workflowExit: 1,
+    env,
+  });
+}
+
+test("exact-review diagnostics retain distinct safe causes within the aggregate bound", () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-diagnostics-"));
+  const secret = "fixture-secret-value";
+  try {
+    const stdout = [
+      JSON.stringify({
+        type: "item.completed",
+        item: { type: "agent_message", text: "private prompt text" },
+      }),
+      "private prompt text",
+      JSON.stringify({
+        type: "turn.failed",
+        error: { message: `proxy negotiation failed after CONNECT; token=${secret}` },
+      }),
+    ].join("\n");
+    const first = write(
+      join(root, "first"),
+      failure(
+        `Codex exited for private-model at /Users/example/work`,
+        [
+          "x".repeat(20_000),
+          "TLS certificate negotiation failed before transport startup",
+          `AUTH_TOKEN=${secret}`,
+          "AWS_ACCOUNT_ID=123456789012",
+          "endpoint=https://proxy.internal.example/v1",
+          "fallback [::1]:8080",
+          "multiline prompt-only directive",
+          "prompt raw:   qz  ",
+          "prompt trimmed: qz",
+        ].join("\n"),
+        stdout,
+      ),
+      { CODEX_TOKEN: secret },
+    );
+    const second = write(
+      join(root, "second"),
+      failure("Codex process failed", "child process could not load its dynamic library"),
+    );
+
+    const firstText = expectedFiles
+      .map((name) => readFileSync(join(first, name), "utf8"))
+      .join("\n");
+    const secondText = expectedFiles
+      .map((name) => readFileSync(join(second, name), "utf8"))
+      .join("\n");
+    const manifest = JSON.parse(readFileSync(join(first, "manifest.json"), "utf8"));
+    assert.deepEqual(readdirSync(first).sort(), expectedFiles);
+    assert.equal(manifest.classification, "codex_execution");
+    assert.deepEqual(manifest.process, {
+      status: 1,
+      signal: "SIGTERM",
+      error_code: "ECONNRESET",
+      workflow_exit: 1,
+    });
+    assert.deepEqual(manifest.source, {
+      repository: "openclaw/openclaw",
+      item_kind: "pull_request",
+      item_number: 1318,
+      sha: "a".repeat(40),
+    });
+    assert.match(firstText, /TLS certificate negotiation failed/);
+    assert.match(secondText, /could not load its dynamic library/);
+    assert.notEqual(firstText, secondText);
+    for (const forbidden of [
+      secret,
+      "private prompt text",
+      "multiline prompt-only directive",
+      "qz",
+      "123456789012",
+      "private-model",
+      "/Users/example",
+      "proxy.internal.example",
+      "::1",
+      "agent_message",
+    ]) {
+      assert.doesNotMatch(firstText, new RegExp(forbidden.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    }
+    assert.match(readFileSync(join(first, "stdout.error.txt"), "utf8"), /proxy negotiation failed/);
+    for (const [name, limit] of [
+      ["error.txt", 4096],
+      ["stdout.error.txt", 4096],
+      ["stderr.tail.txt", 12288],
+    ] as const) {
+      assert.ok(statSync(join(first, name)).size <= limit, name);
+    }
+    assert.ok(
+      expectedFiles.reduce((size, name) => size + statSync(join(first, name)).size, 0) <= 24 * 1024,
+    );
+    assert.throws(() => write(join(root, "first"), failure("later", "later")), /already exist/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("unsafe files are omitted whole and recorded in the readiness manifest", () => {
+  const cases = [
+    ["control byte", "startup failed\u0000after fork"],
+    ["yaml secret", "TOKEN: |\n  first\n  second"],
+    ["private key", "-----BEGIN PRIVATE KEY-----\nmaterial\n-----END PRIVATE KEY-----"],
+    ["opaque residual", "startup failed Abcd1234Efgh5678Ijkl9012Mnop+/=="],
+  ] as const;
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-diagnostics-"));
+  try {
+    for (const [name, stderr] of cases) {
+      const output = write(join(root, name.replace(" ", "-")), failure("Codex failed", stderr));
+      assert.equal(
+        readFileSync(join(output, "stderr.tail.txt"), "utf8"),
+        "[omitted: unsafe diagnostic content]\n",
+      );
+      assert.deepEqual(
+        JSON.parse(readFileSync(join(output, "manifest.json"), "utf8")).omitted_files,
+        ["stderr.tail.txt"],
+      );
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/review-command-workflow.test.ts
+++ b/test/review-command-workflow.test.ts
@@ -154,12 +154,16 @@ for (const scenario of [
   "structural-refusal",
   "content-refusal",
   "changed-pr-refusal",
+  "changed-pr-codex-failure",
+  "changed-pr-exact-codex-failure",
   "changed-pr-clean",
   "content-clean",
   "fresh-refusal",
 ]) {
   test(`scheduled ${scenario} preserves admission and terminal ledger classification`, (t) => {
     const refuseScan = scenario.endsWith("refusal");
+    const codexFailure = scenario.endsWith("codex-failure");
+    const exactFailure = scenario.includes("exact");
     const changedPr = scenario.startsWith("changed-pr-");
     const fresh = scenario === "fresh-refusal" || changedPr;
     const hydrated = fresh || scenario.startsWith("content-");
@@ -306,6 +310,7 @@ for (const scenario of [
       GITHUB_RUN_ATTEMPT: "1",
       GITHUB_JOB: "review",
       GITHUB_SHA: headSha,
+      EXACT_REVIEW_ITEM_KEY: exactFailure ? `${REPO}#${ITEM_NUMBER}` : "",
     };
     t.after(() => {
       process.env = oldEnv;
@@ -359,6 +364,7 @@ for (const scenario of [
         throw new Error("the workflow-supplied lease is externally owned");
       },
       detectBulkFiler: () => ({ context: null, labelPending: false, labelApplied: false }),
+      displayPath: (value: string) => value,
       ensureDir: (path: string) => mkdirSync(path, { recursive: true }),
       existingReview: () => ({
         path: join(itemsDir, `${ITEM_NUMBER}.md`),
@@ -461,12 +467,15 @@ for (const scenario of [
       prepareMediaProofArtifacts: () => ({ manifestPath: null, summaryPath: null, artifacts: [] }),
       buildReviewPrompt: () => ({ text: "Review the current item." }),
       itemSnapshotHash: () => digest("snapshot"),
+      codexFailureLogKind: () => "codex_execution",
       codexReviewFailureRetryable: () => false,
       codexFailureDecision: () => {
+        if (codexFailure) return closeDecision({ decision: "keep_open", closeReason: null });
         throw new Error("scan refusal must not become a decision");
       },
       runCodex: () => {
         generationCalls += 1;
+        if (codexFailure) throw new Error("Codex process startup failed");
         if (fresh && refuseScan)
           return runAgentProcess({
             label: "fresh-review",
@@ -529,6 +538,11 @@ for (const scenario of [
         assert.equal(cachedCompletions, 0);
         assert.equal(generationCalls, fresh ? 1 : 0);
         assert.equal(existsSync(join(artifactDir, `${ITEM_NUMBER}.md`)), false);
+        return;
+      }
+      if (codexFailure) {
+        assert.throws(execute, /Codex failed/);
+        assert.equal(existsSync(join(artifactDir, "failure-diagnostics")), exactFailure);
         return;
       }
       execute();

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1078,6 +1078,7 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
     "Dispatch exact high-confidence bug implementation",
   );
   const upload = step(reviewer, "Upload exact review artifact bundle");
+  const failureDiagnostics = step(reviewer, "Upload exact review failure diagnostics");
   const queuePublication = step(reviewer, "Queue durable exact review publication");
   const complete = step(reviewer, "Complete exact-review queue lease");
   const generationResult = step(reviewer, "Export exact review generation result");
@@ -1099,6 +1100,26 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
       (create.run ?? "").indexOf("exact-review-bundle create"),
   );
   assert.equal(upload.uses, "actions/upload-artifact@v7");
+  assert.equal(failureDiagnostics.uses, "actions/upload-artifact@v7");
+  assert.equal(failureDiagnostics["continue-on-error"], true);
+  assert.match(
+    failureDiagnostics.if ?? "",
+    /review-exact-event-item\.outputs\.failure_diagnostics == 'true'/,
+  );
+  assert.match(failureDiagnostics.if ?? "", /always\(\) && !cancelled\(\)/);
+  assert.equal(
+    failureDiagnostics.with?.name,
+    "exact-review-failure-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}",
+  );
+  assert.equal(failureDiagnostics.with?.path, "artifacts/event/failure-diagnostics/");
+  assert.equal(failureDiagnostics.with?.["retention-days"], 14);
+  assert.equal(failureDiagnostics.with?.["include-hidden-files"], false);
+  assert.equal(failureDiagnostics.with?.["if-no-files-found"], "error");
+  assert.ok(reviewer.steps.indexOf(failureDiagnostics) > reviewer.steps.indexOf(queuePublication));
+  assert.ok(reviewer.steps.indexOf(failureDiagnostics) > reviewer.steps.indexOf(complete));
+  assert.ok(reviewer.steps.indexOf(failureDiagnostics) < reviewer.steps.indexOf(failGeneration));
+  assert.doesNotMatch(queuePublication.if ?? "", /failure-diagnostics/);
+  assert.doesNotMatch(JSON.stringify(queuePublication), /failure-diagnostics/);
   assert.match(prepareDirect.run ?? "", /repair:publish-event-result/);
   assert.equal(prepareDirect.env?.GH_TOKEN, "${{ steps.target-write-token.outputs.token }}");
   assert.equal(prepareDirect.env?.REPO_TOKEN, "${{ github.token }}");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an exact review could catch a Codex process failure, keep the runner alive long enough to write a local failure report, and then finish without durable diagnostic evidence for the underlying startup or execution cause.

## Why This Change Was Made

Caught exact-review failures now produce a publication-isolated `failure-diagnostics/` bundle containing a typed manifest plus bounded, sanitized error, structured stdout error, and stderr-tail files. The writer stores `manifest.json` last as the readiness marker, caps the complete bundle at 24 KiB, and fails closed per file when content remains unsafe.

The security boundary is deliberately narrow:

- exact environment, prompt-line, and model values are redacted before generic high-confidence token, assignment, private-path, and internal-host rules
- unstructured stdout and prompt events are omitted; only existing Codex `error` / `turn.failed` JSONL detail is retained from stdout
- ambiguous multiline secrets, private keys, control bytes, or residual opaque credentials replace the whole file with an omission sentinel
- no raw report, prompt, stdout, session log, action ledger, provider metadata, or publication input is uploaded
- diagnostic write and upload failures remain secondary; the original review failure remains primary

The workflow uploads this bundle only for a non-cancelled failed exact-review job, with a unique run/attempt name and 14-day retention. It does not feed queue publication or exact-review bundle construction.

## User Impact

Maintainers can inspect useful, bounded evidence for caught Codex execution failures after the runner has exited. Cancellation and runner loss remain outside this guarantee.

## OpenClaw Bay Impact

Bay, queue, dashboard, publication, ledger, and persistent schemas are unchanged. The new artifact is failure-only and has no dependency edge into durable exact-review publication.

## Documentation Impact

Updated the active scheduler runbook to describe the failure-only artifact, its retained file set, sanitization boundary, and 14-day retention. The workflow is the source of truth; this documentation should be updated when the diagnostic file set, upload condition, or retention policy changes. No changelog entry is included because this is an internal operational diagnostic repair within the independently reviewed seven-file scope.

## Evidence

- Signed head: `fa9b1e2e938bcdc77e79ae115e5b0b76d8fe1022`
- Focused owner tests: 13/13 passed
- Workflow structural test: 1/1 passed
- Diagnostics coverage: 97.99% lines, 84.85% branches, 100% functions
- All three TypeScript builds, full lint, static checks, formatting, and `git diff --check`: passed
- Codex local preflight with `gpt-5.6-sol`: passed
- Exact branch autoreview with Sol/high: clean, correctness 0.96, no accepted P0 finding

`pnpm run check` itself was not used in the linked worktree because pnpm attempted to reconcile the required shared `node_modules` symlink. Its static, build, lint, format, and changed-owner coverage surfaces were run directly. A prior repo-wide coverage attempt reached 4,252 tests and passed coverage thresholds, with unrelated host-specific failures and one unrelated live-proof timeout.

### Real Behavior Proof

- **Claim:** the compiled review CLI retains distinguishable, repository-reader-safe diagnostics for caught generic Codex failures only in exact mode.
- **Surface:** `node dist/clawsweeper.js review --local-range`.
- **Scenario:** a synthetic committed range, trusted fake scanner, and fake Codex process produced two different status-17 `codex_execution` failures containing adversarial prompt, model, prefixed assignment, credential, private-path, internal-host, and unstructured stdout values. A third run omitted exact mode.
- **Environment:** direct AWS Crabbox, Linux, Node 24, compiled from the signed head.
- **Command:** Crabbox script invoking the compiled CLI three times with `--local-range`.
- **Observed result:** two exact bundles remained distinguishable through structured stdout and sanitized stderr; the non-exact run wrote no bundle; typed status/classification/source facts matched; known leak count was zero; each aggregate stayed within 24 KiB.
- **Trace:** run `run_c4ff948163e5`, lease `cbx_48bbe54562d8`, result `succeeded`, `leaseStopped=true`.
- **Limits:** fake scanner and Codex were used to avoid manufacturing a production outage. Cancellation and runner loss are not covered; the first production canary is the next natural caught failure.

Codex contract inspection covered `codex-rs/cli/src/main.rs:220-245,2840-2870`, `codex-rs/exec/src/event_processor_with_jsonl_output.rs:103-115,531-550`, and `codex-rs/exec/src/exec_events.rs:1-65`.

### Scope And LOC

Changed paths are limited to the approved workflow, scheduler docs, command wiring, private diagnostics writer, and three focused tests.

- production TypeScript: +211 net
- workflow: +15 net
- docs: +7 net
- production/workflow/docs total: +233 net, within the reviewed +240 hard ceiling
- tests: +189 net, within the reviewed +190 hard ceiling

The +190-line private writer owns the new bounded sanitization and atomic readiness capability. The remaining production growth is +21 lines of failure-only command wiring; workflow and docs add the upload contract and operator description.

### Overlap

- https://github.com/openclaw/clawsweeper/pull/1318 remains open; its overlapping files contain distant dependency-version updates only.
- https://github.com/openclaw/clawsweeper/pull/1292 remains open; it owns hosted-target admission and does not change this diagnostics writer or upload dependency.
- https://github.com/openclaw/clawsweeper/pull/1073 and https://github.com/openclaw/clawsweeper/pull/1070 are merged and were already present in the starting main revision.
- Current `origin/main` advanced through `b445c64591bcf9bf6d68122f28f6c95c4fa1dbf4`; those intervening commits do not touch the seven retained paths.
