### PR TITLE
fix(review): show publication-pending command status

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1344,6 +1344,28 @@ jobs:
             echo "terminal_during_review=true" >> "$GITHUB_OUTPUT"
           fi
 
+      # Keep this producer-owned phase before publication can create the terminal finalizer.
+      # A later nonterminal PATCH could overwrite the finalizer's Complete status.
+      - name: Mark exact review ready for publication
+        if: ${{ always() && !cancelled() && steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.target.outputs.has_command_context == 'true' && steps.live-item.outputs.proceed == 'true' && steps.setup-pnpm.outcome == 'success' && steps.review-exact-event-item.outcome == 'success' && steps.review-exact-event-item.outputs.superseded != 'true' && steps.review-exact-event-item.outputs.retry_at == '' && steps.target-write-token.outputs.token != '' }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
+          TARGET_REPO: ${{ steps.target.outputs.target_repo }}
+          ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
+          COMMAND_STATUS_MARKER: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).commandStatusMarker || '' }}
+          STATUS_COMMENT_ID: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).statusCommentId || '' }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          pnpm run repair:update-command-status -- \
+            --repo "$TARGET_REPO" \
+            --item-number "$ITEM_NUMBER" \
+            --marker "$COMMAND_STATUS_MARKER" \
+            --status-comment-id "$STATUS_COMMENT_ID" \
+            --state "Publication pending" \
+            --detail "The exact review is complete; durable result publication is pending." \
+            --run-url "$RUN_URL"
+
       - name: Finalize exact event action ledger
         if: ${{ always() && steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.live-item.outputs.proceed == 'true' }}
         continue-on-error: true

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -5563,21 +5563,99 @@ test("event review completion removes ClawSweeper eyes reaction", () => {
   assert.doesNotMatch(block, /issues\/comments\/\$ITEM_NUMBER\/reactions/);
 });
 
-test("event re-review status distinguishes lease deferral from interruptions", () => {
-  const workflow = readText(".github/workflows/sweep.yml");
-  const block = workflow.slice(
-    workflow.indexOf("- name: Mark unsuccessful re-review"),
-    workflow.indexOf("- name: Export exact review generation result"),
-  );
+test("exact event re-review reports review completion before durable publication", () => {
+  type Step = {
+    name?: string;
+    if?: string;
+    run?: string;
+    env?: Record<string, string>;
+    "continue-on-error"?: boolean;
+  };
+  const workflow = YAML.parse(readText(".github/workflows/sweep.yml")) as {
+    jobs: Record<string, { steps: Step[] }>;
+  };
+  const steps = workflow.jobs["event-review-apply"]!.steps;
+  const index = (name: string) => steps.findIndex((candidate) => candidate.name === name);
+  const pendingIndex = index("Mark exact review ready for publication");
+  assert.notEqual(pendingIndex, -1, "missing post-review publication status");
+  const pending = steps[pendingIndex]!;
 
-  assert.match(block, /\[ "\$REVIEW_OUTCOME" = "cancelled" \]/);
-  assert.match(block, /\[ "\$RESERVATION_STATUS" = "held" \]/);
-  assert.match(block, /state="Waiting"/);
-  assert.match(block, /Another exact-head review is already active/);
-  assert.match(block, /state="Interrupted"/);
-  assert.match(block, /The durable queue will retry it/);
-  assert.doesNotMatch(block, /CAPACITY_OUTCOME/);
-  assert.doesNotMatch(block, /state="Superseded"/);
+  assert.equal(pending["continue-on-error"], true);
+  assert.equal(pending.env?.CLAWSWEEPER_ACTION_LEDGER_DISABLED, undefined);
+  assert.equal(
+    pending.env?.STATUS_COMMENT_ID,
+    "${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).statusCommentId || '' }}",
+  );
+  assert.match(pending.run ?? "", /--state "Publication pending"/);
+  assert.match(
+    pending.run ?? "",
+    /The exact review is complete; durable result publication is pending\./,
+  );
+  assert.ok(index("Review exact event item") < pendingIndex);
+  assert.ok(pendingIndex < index("Finalize exact event action ledger"));
+  assert.ok(
+    index("Finalize exact event action ledger") < index("Create exact review artifact bundle"),
+  );
+  assert.ok(pendingIndex < index("Queue durable exact review publication"));
+  assert.ok(pendingIndex < index("Deliver GitHub effects and prepare direct state mutation"));
+  assert.ok(pendingIndex < index("Finalize direct exact review lifecycle"));
+  assert.ok(pendingIndex < index("Complete exact-review queue lease"));
+  assert.ok(pendingIndex < index("Mark unsuccessful re-review"));
+
+  const evaluate = (template: string, values: Record<string, string>) => {
+    const expression = template
+      .replace(/^\s*\$\{\{\s*|\s*\}\}\s*$/g, "")
+      .replace(/\balways\(\)/g, "true")
+      .replace(/!cancelled\(\)/g, JSON.stringify(values.cancelled !== "true"))
+      .replace(
+        /steps\.([a-z0-9-]+)\.(outputs\.([a-z0-9_]+)|outcome)/g,
+        (_match, stepId: string, access: string, output?: string) =>
+          JSON.stringify(values[`${stepId}.${output ?? access}`] ?? ""),
+      );
+    return Boolean(Function(`"use strict"; return (${expression});`)());
+  };
+  const successful = {
+    "claim-exact-review-queue.claimed": "true",
+    "target.has_command_context": "true",
+    "live-item.proceed": "true",
+    "setup-pnpm.outcome": "success",
+    "review-exact-event-item.outcome": "success",
+    "review-exact-event-item.superseded": "false",
+    "review-exact-event-item.retry_at": "",
+    "target-write-token.token": "token",
+  };
+  assert.equal(evaluate(pending.if ?? "", successful), true);
+  for (const [key, value] of [
+    ["cancelled", "true"],
+    ["target.has_command_context", "false"],
+    ["review-exact-event-item.outcome", "failure"],
+    ["review-exact-event-item.superseded", "true"],
+    ["review-exact-event-item.retry_at", "2026-09-01T12:00:00.000Z"],
+    ["target-write-token.token", ""],
+  ]) {
+    assert.equal(evaluate(pending.if ?? "", { ...successful, [key]: value }), false, key);
+  }
+
+  const markUnsuccessful = steps[index("Mark unsuccessful re-review")]!;
+  assert.match(markUnsuccessful.run ?? "", /\[ "\$REVIEW_OUTCOME" = "cancelled" \]/);
+  assert.match(markUnsuccessful.run ?? "", /\[ "\$RESERVATION_STATUS" = "held" \]/);
+  assert.match(markUnsuccessful.run ?? "", /state="Waiting"/);
+  assert.match(markUnsuccessful.run ?? "", /state="Interrupted"/);
+  assert.doesNotMatch(markUnsuccessful.run ?? "", /state="Superseded"/);
+  const fallbackPublication = {
+    ...successful,
+    "prepare-direct-exact-review-publication.failure_kind": "",
+    "direct-exact-review-publication.accepted": "false",
+    "queue-exact-review-publication.outcome": "success",
+  };
+  assert.equal(evaluate(markUnsuccessful.if ?? "", fallbackPublication), false);
+  assert.equal(
+    evaluate(markUnsuccessful.if ?? "", {
+      ...fallbackPublication,
+      "queue-exact-review-publication.outcome": "failure",
+    }),
+    true,
+  );
 });
 
 test("trusted comment router owns command ledger capacity retries", () => {


### PR DESCRIPTION
## Summary

- update command progress to `Publication pending` as soon as exact-review generation succeeds
- keep that nonterminal write before direct/fallback publication can create the terminal finalizer
- preserve the dedicated finalizer as the only owner of final `Complete`/`Failed` acknowledgement

## Root cause

The command acknowledgement is marked `Review in progress` before Codex starts. When exact-review publication was split from generation and final acknowledgement moved to the durable terminal finalizer, the producer lost its post-generation phase update. If publication queued or retried for a long time, the command comment therefore kept claiming that Codex was still reviewing even though the review artifact already existed.

Writing this phase after durable handoff is unsafe: publication completion may immediately dispatch the terminal finalizer, while the ordinary command-status updater has no monotonic phase guard. A later nonterminal PATCH could overwrite an already-published `Complete` state. The producer now records its known fact immediately after successful, non-superseded generation and before action-ledger finalization/publication begins.

## Behavior

- successful command-triggered generation: `Review in progress` -> `Publication pending`
- direct and fallback publication share the same producer transition
- failed, deferred, cancelled, or superseded generation skips the transition
- a later no-handoff failure still overwrites the phase with `Failed`, `Waiting`, or `Interrupted`
- durable terminal acknowledgement remains unchanged

## Verification

- regression test failed before the workflow change with `missing post-review publication status`
- `node --test test/sweep-workflow.test.ts` (132/132 passed before the final test consolidation; the final focused workflow set passed 3/3)
- focused terminal lifecycle tests: 2/2 passed
- focused command-status updater tests: 2/2 passed
- `pnpm check`: build, format, lint, coverage thresholds, and 4,274 tests passed; four unrelated local-environment tests failed in untouched surfaces (two require newer Bash than macOS 3.2, two loopback fixtures returned an empty local response)
- isolated autoreview: patch correct (0.98), no accepted P0 findings

Live GitHub workflow proof is not feasible before this workflow revision is deployed with repository secrets; the regression test protects the exact producer/direct/fallback ordering and state conditions.

## Scope

- production: +22 workflow lines, required for the missing owner-phase transition and its ordering invariant
- tests: +93/-15 lines
- no TypeScript production, config, schema, or protocol changes
- base locked at `04ab85792ab56e8ae51459f3d959bd085f26bdf3`

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted Codex session transcript</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, run identifiers, secrets, browser/session/auth details
omitted: raw tool outputs, system/developer prompts, and unrelated earlier browser/PR work
selection: exact-review progress defect and its standalone repair

[user]
Re-review progress:

State: Review in progress
Detail: The exact-review queue leased this run; Codex is reviewing the item.
Updated: 2026-09-01T10:52:17.890Z

卡了一个小时了哦，真的没问题吗

[assistant]
你这个判断是对的：超过一小时仍显示 “Codex is reviewing” 已经不是正常等待。我会按 ClawSweeper 运维流程检查 lease 是否过期、artifact 是否仍在发布队列、是否进入重试耗尽或死信，以及为什么命令状态没有被终态化。

有问题。你判断得对，我之前说“等自动发布即可”过于乐观。

Codex 审查本身已成功完成，并生成 artifact `[REDACTED]`。

“Review in progress” 的 lease 已过期，但评论仍停在旧状态，属于陈旧状态。

因此结论是：终态等待 durable publication 属于设计；但 run 已结束、lease 已过期，界面仍声称“Codex 正在审查”，是明确的状态生命周期/UX bug，并被当前 publisher 故障放大。

现在不应该再发一次 re-review——那只会重复生成审查。正确动作是恢复现有 artifact 的 publication，并单独修复 ClawSweeper，使状态在 generation 完成后至少切换为“等待发布/发布重试中”，不能无限保留“正在审查”。

[user]
那就单独修复

[assistant]
基线已经锁定为 ClawSweeper `04ab85792ab56e8ae51459f3d959bd085f26bdf3`，隔离分支为 `fix/exact-review-progress-status`。从现在起不再追 main。

现有代码确认了竞态风险：终态更新没有“不可降级”保护，所以不能在发布动作之后再写一个中间态，否则可能把已经写成 Complete 的评论覆盖回等待态。修复点应放在评审生成成功、开始发布之前，这样状态顺序天然单调。

回归测试已经完成红→绿：旧工作流明确失败于缺少中间状态；加入修复后通过。实现只在 Codex 成功结束且未被 supersede/延期时写入 `Publication pending`，并且放在 action ledger 关闭前，避免终态被倒写。

历史也对上了：旧架构曾由 producer 直接写 Complete；后来终态被正确迁到独立 finalizer，但迁移时漏掉了“review generation 已完成”的非终态。没有找到重复 PR/issue。

相关 owner/sibling 测试已全部通过：workflow 3/3、terminal lifecycle 2/2、status updater 2/2。全量 gate 的 4 个失败均在未改动文件，且可独立复现为本机 Bash 3.2/loopback 环境问题；我不会把这些无关问题塞进本 PR。

修复已提交并推送：

- 分支：`fix/exact-review-progress-status`
- Commit：`620310258f`
- 聚焦测试全部通过，autoreview 评分 0.98、无 P0 问题

[user]
可以给

[assistant]
好，我会按 agent-transcript skill 生成脱敏版本，只保留这次 ClawSweeper 状态修复的目标、设计判断、测试和结果；之前浏览器 PR 等无关内容会删掉。检查安全后附到 PR 正文并创建 PR。
````

</details>
<!-- agent-transcript:end -->
