### PR TITLE
fix(review): reuse exact Codex source cache during remote outages

### DIFF
--- a/.github/actions/setup-openclaw-codex-source/install.sh
+++ b/.github/actions/setup-openclaw-codex-source/install.sh
@@ -54,7 +54,7 @@ pin_root="$(cd "$pin_dir_input" && pwd -P)"
 review_tree_root="$review_artifact_root/review-trees"
 if [[ "$pin_root" != "$target_root" ]] &&
   { [[ "$(dirname "$pin_root")" != "$review_tree_root" ]] ||
-    [[ "$(basename "$pin_root")" != +([0-9]) ]]; }; then
+    [[ "$(basename "$pin_root")" == *[!0-9]* ]]; }; then
   echo "Codex version pin must come from the target checkout or one of its PR review trees." >&2
   exit 1
 fi
@@ -100,28 +100,48 @@ fetch_tag() {
     "refs/tags/$tag:refs/tags/$tag"
 }
 
-cache_has_complete_tag() {
-  ! git -C "$cache_dir" rev-list --objects --missing=print "$tag^{commit}" | grep -q '^?'
+clear_partial_clone_config() {
+  for key in extensions.partialclone remote.origin.promisor remote.origin.partialclonefilter; do
+    git -C "$cache_dir" config --unset-all "$key" 2>/dev/null || true
+  done
 }
 
-if [[ -d "$cache_dir" ]] && git -C "$cache_dir" rev-parse --is-bare-repository >/dev/null 2>&1; then
-  git -C "$cache_dir" remote set-url origin "$source_url"
-  git -C "$cache_dir" config --unset-all remote.origin.promisor 2>/dev/null || true
-  git -C "$cache_dir" config --unset-all remote.origin.partialclonefilter 2>/dev/null || true
+cache_tag_head() {
+  git -C "$cache_dir" rev-parse --verify "refs/tags/$tag^{commit}" 2>/dev/null
+}
+
+cache_has_complete_tag() {
+  local head
+  head="$(cache_tag_head)" || return 1
+  git -C "$cache_dir" fsck --connectivity-only --no-dangling "$head" >/dev/null 2>&1
+}
+
+cache_ready=false
+if [[ -d "$cache_dir" ]] &&
+  [[ "$(git -C "$cache_dir" rev-parse --is-bare-repository 2>/dev/null || true)" == "true" ]] &&
+  [[ "$(git -C "$cache_dir" config --get-all remote.origin.url 2>/dev/null || true)" == "$source_url" ]]; then
+  clear_partial_clone_config
+  if cache_has_complete_tag; then
+    cache_ready=true
+  elif cache_tag_head >/dev/null; then
+    echo "Cached Codex source is incomplete; rebuilding cache." >&2
+    refresh_cache
+  fi
 else
   refresh_cache
 fi
-if ! fetch_tag; then
-  echo "Cached Codex source fetch failed; rebuilding cache." >&2
-  refresh_cache
-  fetch_tag
+if [[ "$cache_ready" != "true" ]]; then
+  if ! fetch_tag; then
+    echo "Cached Codex source fetch failed." >&2
+    exit 1
+  fi
+  clear_partial_clone_config
+  if ! cache_has_complete_tag; then
+    echo "Cached Codex source is incomplete after fetch." >&2
+    exit 1
+  fi
 fi
-if ! cache_has_complete_tag; then
-  echo "Cached Codex source is incomplete; rebuilding cache." >&2
-  refresh_cache
-  fetch_tag
-fi
-expected_head="$(git -C "$cache_dir" rev-parse "$tag^{commit}")"
+expected_head="$(cache_tag_head)"
 
 source_ready=false
 if [[ -d "$source_dir" && ! -L "$source_dir" ]] &&

--- a/test/setup-openclaw-codex-source-action.test.ts
+++ b/test/setup-openclaw-codex-source-action.test.ts
@@ -1,11 +1,13 @@
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
 import {
+  chmodSync,
   existsSync,
   lstatSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  renameSync,
   realpathSync,
   rmSync,
   symlinkSync,
@@ -15,7 +17,35 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
-test("OpenClaw Codex source setup materializes the pinned sibling for base and PR review trees", () => {
+const script = ".github/actions/setup-openclaw-codex-source/install.sh";
+const realGit = execFileSync("/usr/bin/env", ["which", "git"], { encoding: "utf8" }).trim();
+
+type Fixture = ReturnType<typeof createFixture>;
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync(realGit, args, { cwd, encoding: "utf8" }).trim();
+}
+
+function writePin(root: string, version: string): void {
+  mkdirSync(join(root, "extensions", "codex"), { recursive: true });
+  writeFileSync(
+    join(root, "extensions", "codex", "package.json"),
+    `${JSON.stringify({ dependencies: { "@openai/codex": version } })}\n`,
+  );
+}
+
+function addVersion(fixture: { remote: string }, version: string, selection: string): string {
+  writeFileSync(
+    join(fixture.remote, "contract.rs"),
+    `pub const SKILL_SELECTION: &str = "${selection}";\n`,
+  );
+  git(fixture.remote, ["add", "contract.rs"]);
+  git(fixture.remote, ["commit", "--quiet", "-m", `fixture ${version}`]);
+  git(fixture.remote, ["tag", `rust-v${version}`]);
+  return git(fixture.remote, ["rev-parse", "HEAD"]);
+}
+
+function createFixture() {
   const root = mkdtempSync(join(tmpdir(), "clawsweeper-openclaw-codex-source-"));
   const workspace = join(root, "workspace");
   const target = join(workspace, "openclaw");
@@ -23,120 +53,213 @@ test("OpenClaw Codex source setup materializes the pinned sibling for base and P
   const cache = join(workspace, "openclaw-codex-cache.git");
   const artifacts = join(workspace, "artifacts", "event");
   const githubEnv = join(workspace, "github-env");
-  const script = ".github/actions/setup-openclaw-codex-source/install.sh";
-
-  try {
-    mkdirSync(join(target, "extensions", "codex"), { recursive: true });
-    writeFileSync(
-      join(target, "extensions", "codex", "package.json"),
-      `${JSON.stringify({ dependencies: { "@openai/codex": "1.2.3" } })}\n`,
-    );
-    mkdirSync(remote, { recursive: true });
-    execFileSync("git", ["init", "--quiet"], { cwd: remote });
-    execFileSync("git", ["config", "user.name", "ClawSweeper test"], { cwd: remote });
-    execFileSync("git", ["config", "user.email", "clawsweeper@example.invalid"], {
-      cwd: remote,
-    });
-    writeFileSync(join(remote, "contract.rs"), 'pub const SKILL_SELECTION: &str = "path";\n');
-    execFileSync("git", ["add", "contract.rs"], { cwd: remote });
-    execFileSync("git", ["commit", "--quiet", "-m", "fixture"], { cwd: remote });
-    execFileSync("git", ["tag", "rust-v1.2.3"], { cwd: remote });
-    const expectedHead = execFileSync("git", ["rev-parse", "HEAD"], {
-      cwd: remote,
-      encoding: "utf8",
-    }).trim();
-
-    const result = spawnSync(
-      "bash",
-      [script, "OpenClaw/OpenClaw", target, artifacts, cache, remote],
-      {
-        cwd: process.cwd(),
-        env: { ...process.env, GITHUB_ENV: githubEnv, GITHUB_WORKSPACE: workspace },
-        encoding: "utf8",
-      },
-    );
-
-    assert.equal(result.status, 0, result.stderr);
-    assert.match(
-      readFileSync(githubEnv, "utf8"),
-      /CLAWSWEEPER_OPENCLAW_CODEX_SETUP_SCRIPT=.*\/setup-openclaw-codex-source\/install\.sh/u,
-    );
-    const source = join(workspace, "codex");
-    assert.equal(
-      execFileSync("git", ["rev-parse", "HEAD"], { cwd: source, encoding: "utf8" }).trim(),
-      expectedHead,
-    );
-    assert.equal(
-      execFileSync("git", ["remote", "get-url", "origin"], {
-        cwd: source,
-        encoding: "utf8",
-      }).trim(),
-      realpathSync(cache),
-    );
-    assert.equal(
-      readFileSync(join(source, "contract.rs"), "utf8"),
-      'pub const SKILL_SELECTION: &str = "path";\n',
-    );
-    const reviewSibling = join(artifacts, "review-trees", "codex");
-    assert.equal(existsSync(reviewSibling), true);
-    assert.equal(lstatSync(reviewSibling).isSymbolicLink(), true);
-    assert.equal(realpathSync(reviewSibling), realpathSync(source));
-    const pullRequestTree = join(artifacts, "review-trees", "131584");
-    mkdirSync(pullRequestTree);
-    assert.equal(
-      readFileSync(join(pullRequestTree, "..", "codex", "contract.rs"), "utf8"),
-      'pub const SKILL_SELECTION: &str = "path";\n',
-    );
-
-    mkdirSync(join(pullRequestTree, "extensions", "codex"), { recursive: true });
-    writeFileSync(
-      join(pullRequestTree, "extensions", "codex", "package.json"),
-      `${JSON.stringify({ dependencies: { "@openai/codex": "2.0.0" } })}\n`,
-    );
-    writeFileSync(join(remote, "contract.rs"), 'pub const SKILL_SELECTION: &str = "name";\n');
-    execFileSync("git", ["add", "contract.rs"], { cwd: remote });
-    execFileSync("git", ["commit", "--quiet", "-m", "updated fixture"], { cwd: remote });
-    execFileSync("git", ["tag", "rust-v2.0.0"], { cwd: remote });
-    const updatedHead = execFileSync("git", ["rev-parse", "HEAD"], {
-      cwd: remote,
-      encoding: "utf8",
-    }).trim();
-
-    const retargetResult = spawnSync(
-      "bash",
-      [script, "openclaw/openclaw", target, artifacts, cache, remote, pullRequestTree],
-      {
-        cwd: process.cwd(),
-        env: { ...process.env, GITHUB_ENV: githubEnv, GITHUB_WORKSPACE: workspace },
-        encoding: "utf8",
-      },
-    );
-
-    assert.equal(retargetResult.status, 0, retargetResult.stderr);
-    assert.equal(
-      execFileSync("git", ["rev-parse", "HEAD"], { cwd: source, encoding: "utf8" }).trim(),
-      updatedHead,
-    );
-    assert.equal(
-      readFileSync(join(pullRequestTree, "..", "codex", "contract.rs"), "utf8"),
-      'pub const SKILL_SELECTION: &str = "name";\n',
-    );
-
-    const pullRequestManifest = join(pullRequestTree, "extensions", "codex", "package.json");
-    rmSync(pullRequestManifest);
-    symlinkSync(join(target, "extensions", "codex", "package.json"), pullRequestManifest);
-    const escapedPinResult = spawnSync(
-      "bash",
-      [script, "openclaw/openclaw", target, artifacts, cache, remote, pullRequestTree],
-      {
-        cwd: process.cwd(),
-        env: { ...process.env, GITHUB_ENV: githubEnv, GITHUB_WORKSPACE: workspace },
-        encoding: "utf8",
-      },
-    );
-    assert.notEqual(escapedPinResult.status, 0);
-    assert.match(escapedPinResult.stderr, /regular file|stay inside/u);
-  } finally {
-    rmSync(root, { force: true, recursive: true });
+  const bin = join(root, "bin");
+  const fetchLog = join(root, "git-fetch.log");
+  mkdirSync(remote, { recursive: true });
+  git(remote, ["init", "--quiet"]);
+  for (const [key, value] of [
+    ["user.name", "ClawSweeper test"],
+    ["user.email", "clawsweeper@example.invalid"],
+    ["commit.gpgSign", "false"],
+    ["tag.gpgSign", "false"],
+  ]) {
+    git(remote, ["config", key, value]);
   }
+  mkdirSync(bin);
+  writeFileSync(
+    join(bin, "git"),
+    '#!/usr/bin/env bash\nfor arg in "$@"; do\n  if [[ "$arg" == "fetch" ]]; then\n    printf "fetch\\n" >> "$GIT_FETCH_LOG"\n    break\n  fi\ndone\nexec "$REAL_GIT" "$@"\n',
+  );
+  chmodSync(join(bin, "git"), 0o755);
+  writePin(target, "1.2.3");
+  const initialHead = addVersion({ remote }, "1.2.3", "path");
+  return {
+    artifacts,
+    bin,
+    cache,
+    fetchLog,
+    githubEnv,
+    initialHead,
+    remote,
+    root,
+    source: join(workspace, "codex"),
+    target,
+    workspace,
+  };
+}
+
+function runSetup(
+  fixture: Fixture,
+  options: { pinRoot?: string; sourceUrl?: string } = {},
+): ReturnType<typeof spawnSync> & { fetchCount: number } {
+  rmSync(fixture.fetchLog, { force: true });
+  const result = spawnSync(
+    "bash",
+    [
+      script,
+      "openclaw/openclaw",
+      fixture.target,
+      fixture.artifacts,
+      fixture.cache,
+      options.sourceUrl ?? fixture.remote,
+      options.pinRoot ?? fixture.target,
+    ],
+    {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        GITHUB_ENV: fixture.githubEnv,
+        GITHUB_WORKSPACE: fixture.workspace,
+        GIT_FETCH_LOG: fixture.fetchLog,
+        PATH: `${fixture.bin}:${process.env.PATH}`,
+        REAL_GIT: realGit,
+      },
+      encoding: "utf8",
+    },
+  );
+  const fetchCount = existsSync(fixture.fetchLog)
+    ? readFileSync(fixture.fetchLog, "utf8").trim().split("\n").filter(Boolean).length
+    : 0;
+  return Object.assign(result, { fetchCount });
+}
+
+function createReviewTree(fixture: Fixture, name: string, version: string): string {
+  const tree = join(fixture.artifacts, "review-trees", name);
+  writePin(tree, version);
+  return tree;
+}
+
+function assertPrepared(fixture: Fixture, expectedHead: string, selection: string): void {
+  assert.equal(git(fixture.source, ["rev-parse", "HEAD"]), expectedHead);
+  assert.equal(git(fixture.source, ["status", "--porcelain=v1", "--untracked-files=all"]), "");
+  assert.equal(
+    readFileSync(join(fixture.source, "contract.rs"), "utf8"),
+    `pub const SKILL_SELECTION: &str = "${selection}";\n`,
+  );
+}
+
+function useFixture(t: test.TestContext): Fixture {
+  const fixture = createFixture();
+  t.after(() => rmSync(fixture.root, { force: true, recursive: true }));
+  return fixture;
+}
+
+test("reuses a complete same-pin cache without network access", (t) => {
+  const fixture = useFixture(t);
+  const first = runSetup(fixture);
+  assert.equal(first.status, 0, first.stderr);
+  assert.equal(first.fetchCount, 1);
+
+  renameSync(fixture.remote, `${fixture.remote}.offline`);
+  const offline = runSetup(fixture);
+  assert.equal(offline.status, 0, offline.stderr);
+  assert.equal(offline.fetchCount, 0);
+  assertPrepared(fixture, fixture.initialHead, "path");
+
+  const reviewSibling = join(fixture.artifacts, "review-trees", "codex");
+  assert.equal(lstatSync(reviewSibling).isSymbolicLink(), true);
+  assert.equal(realpathSync(reviewSibling), realpathSync(fixture.source));
+  assert.equal(
+    readFileSync(fixture.githubEnv, "utf8").includes("CLAWSWEEPER_OPENCLAW_CODEX_SETUP_SCRIPT="),
+    true,
+  );
+});
+
+test("retargets to a cached pin offline and replaces a wrong dirty checkout", (t) => {
+  const fixture = useFixture(t);
+  assert.equal(runSetup(fixture).status, 0);
+  const updatedHead = addVersion(fixture, "2.0.0", "name");
+  const pullRequestTree = createReviewTree(fixture, "131584", "2.0.0");
+  assert.equal(runSetup(fixture, { pinRoot: pullRequestTree }).status, 0);
+  assertPrepared(fixture, updatedHead, "name");
+
+  writeFileSync(join(fixture.source, "dirty.txt"), "dirty\n");
+  renameSync(fixture.remote, `${fixture.remote}.offline`);
+  const retarget = runSetup(fixture);
+  assert.equal(retarget.status, 0, retarget.stderr);
+  assert.equal(retarget.fetchCount, 0);
+  assertPrepared(fixture, fixture.initialHead, "path");
+});
+
+test("fetches a missing changed pin exactly once and checks out its peeled commit", (t) => {
+  const fixture = useFixture(t);
+  assert.equal(runSetup(fixture).status, 0);
+  const updatedHead = addVersion(fixture, "2.0.0", "name");
+  const pullRequestTree = createReviewTree(fixture, "131584", "2.0.0");
+
+  const retarget = runSetup(fixture, { pinRoot: pullRequestTree });
+  assert.equal(retarget.status, 0, retarget.stderr);
+  assert.equal(retarget.fetchCount, 1);
+  assertPrepared(fixture, updatedHead, "name");
+});
+
+test("rebuilds an existing tag whose object graph is incomplete", (t) => {
+  const fixture = useFixture(t);
+  assert.equal(runSetup(fixture).status, 0);
+  const commit = git(fixture.remote, ["cat-file", "commit", fixture.initialHead]);
+  rmSync(fixture.cache, { force: true, recursive: true });
+  git(fixture.root, ["init", "--bare", "--quiet", fixture.cache]);
+  git(fixture.cache, ["remote", "add", "origin", fixture.remote]);
+  const recreatedHead = execFileSync(
+    realGit,
+    ["-C", fixture.cache, "hash-object", "-t", "commit", "-w", "--stdin"],
+    { encoding: "utf8", input: `${commit}\n` },
+  ).trim();
+  assert.equal(recreatedHead, fixture.initialHead);
+  git(fixture.cache, ["update-ref", "refs/tags/rust-v1.2.3", recreatedHead]);
+  rmSync(fixture.source, { force: true, recursive: true });
+
+  const recovered = runSetup(fixture);
+  assert.equal(recovered.status, 0, recovered.stderr);
+  assert.equal(recovered.fetchCount, 1);
+  assertPrepared(fixture, fixture.initialHead, "path");
+});
+
+test("fails closed when a missing changed pin cannot be fetched", (t) => {
+  const fixture = useFixture(t);
+  assert.equal(runSetup(fixture).status, 0);
+  const pullRequestTree = createReviewTree(fixture, "131584", "2.0.0");
+  renameSync(fixture.remote, `${fixture.remote}.offline`);
+
+  const missing = runSetup(fixture, { pinRoot: pullRequestTree });
+  assert.notEqual(missing.status, 0);
+  assert.equal(missing.fetchCount, 1);
+  assert.doesNotMatch(missing.stdout, /Prepared Codex/u);
+  assertPrepared(fixture, fixture.initialHead, "path");
+});
+
+test("fails closed when an incomplete requested pin cannot be rebuilt", (t) => {
+  const fixture = useFixture(t);
+  assert.equal(runSetup(fixture).status, 0);
+  const commit = git(fixture.remote, ["cat-file", "commit", fixture.initialHead]);
+  rmSync(fixture.cache, { force: true, recursive: true });
+  git(fixture.root, ["init", "--bare", "--quiet", fixture.cache]);
+  git(fixture.cache, ["remote", "add", "origin", fixture.remote]);
+  execFileSync(realGit, ["-C", fixture.cache, "hash-object", "-t", "commit", "-w", "--stdin"], {
+    input: `${commit}\n`,
+  });
+  git(fixture.cache, ["update-ref", "refs/tags/rust-v1.2.3", fixture.initialHead]);
+  renameSync(fixture.remote, `${fixture.remote}.offline`);
+
+  const incomplete = runSetup(fixture);
+  assert.notEqual(incomplete.status, 0);
+  assert.equal(incomplete.fetchCount, 1);
+  assert.doesNotMatch(incomplete.stdout, /Prepared Codex/u);
+  assertPrepared(fixture, fixture.initialHead, "path");
+});
+
+test("rejects nonnumeric review trees and escaped pin manifests", (t) => {
+  const fixture = useFixture(t);
+  const invalidTree = createReviewTree(fixture, "not-a-pr", "1.2.3");
+  const invalidTreeResult = runSetup(fixture, { pinRoot: invalidTree });
+  assert.notEqual(invalidTreeResult.status, 0);
+  assert.match(invalidTreeResult.stderr, /version pin must come from/u);
+
+  const pullRequestTree = createReviewTree(fixture, "131584", "1.2.3");
+  const pullRequestManifest = join(pullRequestTree, "extensions", "codex", "package.json");
+  rmSync(pullRequestManifest);
+  symlinkSync(join(fixture.target, "extensions", "codex", "package.json"), pullRequestManifest);
+  const escapedPinResult = runSetup(fixture, { pinRoot: pullRequestTree });
+  assert.notEqual(escapedPinResult.status, 0);
+  assert.match(escapedPinResult.stderr, /regular file|stay inside/u);
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where repeated OpenClaw review setup for the same exact Codex pin failed when the source remote was temporarily unavailable, even though the local bare cache already contained the complete requested commit graph.

Observed failures:

- https://github.com/openclaw/clawsweeper/actions/runs/33506178940
- https://github.com/openclaw/clawsweeper/actions/runs/33507058170

## Why This Change Was Made

The setup action is the owner of Codex source provisioning. The workflow initially prepared exact Codex 0.151.0 commit `78c290807ce710180111df227df3b7a4fe845452`, but `runCodex` synchronously invoked the installer again and the installer fetched unconditionally before checking whether the exact cached graph was complete.

The installer now:

1. Reuses a cache only when it is a valid bare repository, its configured origin exactly equals the requested source URL, the exact requested tag peels to a commit, and `git fsck --connectivity-only --no-dangling <head>` confirms the requested graph after partial-clone/promisor configuration is cleared.
2. Performs zero network access when the requested tag is complete.
3. Fetches a missing requested tag exactly once from an otherwise valid cache.
4. Rebuilds before that single fetch when the cache is invalid, its origin differs, or the requested tag exists with an incomplete graph.
5. Fails immediately when the requested tag remains absent or incomplete after the fetch. It does not retry or fall back to a previous pin.

The exact-head clean checkout replacement, PR-review sibling symlink, path validation, environment exports, and `prepareOpenClawCodexSourceForReview` behavior are unchanged. Bash 3-compatible review-tree numeric validation replaces the extglob expression.

Production delta: `+36/-16`, net `+20`.
Test delta: `+238/-115`, net `+123`.

## User Impact

OpenClaw reviews can reuse a complete exact-pin Codex source cache while the remote is unavailable. Missing or incomplete requested pins still fail closed instead of silently reviewing against a previous pin.

## OpenClaw Bay Impact

Bay is unaffected. This changes source provisioning before review execution and does not alter observer, status, queue, telemetry, or dashboard contracts.

## Documentation Impact

No documentation change is needed. The existing exact-pin source-preparation contract remains the same; this repair makes its cache behavior match that contract.

No changelog entry is included because this is an internal review-infrastructure repair with its operational behavior and proof recorded here.

Follow-up: source-preparation failures need a distinct safe diagnostic classification/detail rather than `codex_execution` with null process metadata.

Follow-up: failed exact-review setup must release or promptly expire its lease so queued retries do not wait for the full lease window.

## Evidence

### Pre-fix reproduction

AWS Crabbox run: https://crabbox.openclaw.ai/portal/runs/run_c19792b36f3a

Using the actual installer, the run created a temporary Git remote and exact tag, invoked the installer to populate a complete same-pin cache, made the origin unavailable, then invoked the installer again:

```json
{"firstStatus":0,"secondStatus":128,"failedBeforeCodex":true}
```

This reproduces the unconditional pre-validation fetch failure in the original execution order.

### Automated validation

- `bash -n .github/actions/setup-openclaw-codex-source/install.sh`
- `node --test test/setup-openclaw-codex-source-action.test.ts`: 7 passed, 0 failed
- Fresh Linux Crabbox `pnpm run build:all && pnpm run test:unit && pnpm run check`: succeeded
  - 2,967 unit tests: 2,960 passed, 7 platform skips, 0 failed
  - Full run: https://crabbox.openclaw.ai/portal/runs/run_dce37e978958
- `git diff --check`
- Local autoreview with `gpt-5.6-sol`, high reasoning: correct, no accepted findings, confidence 0.98

The focused behavior cases cover same-pin offline reuse; cached changed-pin offline retargeting with wrong/dirty checkout replacement; one-fetch missing-pin recovery at the peeled commit; incomplete object-graph rebuild; unavailable-remote fail-closed behavior without previous-pin fallback; sibling linking; and escaped-manifest rejection. Fixtures disable commit and tag signing.

Mutation proof is preserved by the pre-fix actual-installer failure and independent cases that detect unconditional fetch, missing-tag false success, omitted connectivity validation, retry/fallback behavior, and skipped checkout replacement.

### Codex hard gate

Personally inspected `openai/codex` source at `codex-rs/cli/src/main.rs:220-245` and `codex-rs/cli/src/main.rs:2840-2870`. These sections cover CLI command/completion dispatch and prompt CRLF normalization/test setup; they do not provide or perform OpenClaw's Codex source-cache fetching. The source-preparation action remains the correct owner.

## Real Behavior Proof

- **Claim:** a complete exact-pin cache permits a second same-pin installer invocation with no network access.
- **Exercised surface:** `.github/actions/setup-openclaw-codex-source/install.sh`.
- **Scenario:** create a temporary Git source and exact tag, run the actual installer once, remove the source remote, then run the actual installer again against the same cache.
- **Command and environment:** final branch bytes on a fresh AWS Linux Crabbox using `crabbox run --no-hydrate`; both invocations execute the actual installer.
- **Observed result:**

```json
{"firstStatus":0,"secondStatus":0,"secondFetches":0,"exactHead":true,"clean":true}
```

- **Artifact/trace:** https://crabbox.openclaw.ai/portal/runs/run_2789ed0dbf1f
- **Limits:** the fixture uses a temporary local Git remote rather than GitHub. It exercises the real installer, bare cache, tag peel, object connectivity, offline reuse, and final checkout state; broader repository validation is covered by the separate fresh-Linux full gate above.
