### PR TITLE
fix(state): retry canonical record reads

### DIFF
--- a/scripts/worker-records.ts
+++ b/scripts/worker-records.ts
@@ -115,6 +115,25 @@ export class WorkerRecordRequestError extends Error {
   }
 }
 
+type SignedRequestRetryDelays = readonly [number, number];
+
+const DEFAULT_SIGNED_REQUEST_RETRY_DELAYS_MS = [250, 500] as const;
+const WORKER_RECORD_READ_RETRY_DELAYS_MS = [60_000, 180_000] as const;
+
+type SignedRequestOptions = {
+  baseUrl: string;
+  path: string;
+  webhookSecret: string;
+  body: unknown;
+  method?: "GET" | "POST";
+  fetch?: typeof globalThis.fetch;
+  retryDelaysMs?: SignedRequestRetryDelays;
+};
+
+type SignedPostOptions = Omit<SignedRequestOptions, "method"> & {
+  validateResponse?: (value: unknown) => boolean;
+};
+
 // Cold hydration (no stored snapshot yet) replays the full journal from
 // revision 0, so it must stay a small-repo affordance: a slug whose record set
 // outgrows this bound has earned a real snapshot and still refuses cutover.
@@ -155,7 +174,7 @@ export async function exportWorkerRecords(options: {
   let cursor: number | null = 0;
   let revision = sinceRevision;
   do {
-    const page = await signedPost<ExportPage>({
+    const page = await signedWorkerRecordReadPost<ExportPage>({
       baseUrl: options.baseUrl,
       path: "/internal/state/records/export",
       webhookSecret: options.webhookSecret,
@@ -167,6 +186,30 @@ export async function exportWorkerRecords(options: {
         limit: options.limit ?? 100,
       },
       fetch: options.fetch,
+      validateResponse: (value) => {
+        const page = value as Partial<ExportPage> | null;
+        if (
+          typeof page === "object" &&
+          page !== null &&
+          !Array.isArray(page) &&
+          page.repoSlug === options.repoSlug &&
+          Number.isSafeInteger(page.revision) &&
+          Number(page.revision) >= 0 &&
+          Array.isArray(page.records) &&
+          (page.nextCursor === null ||
+            (Number.isSafeInteger(page.nextCursor) &&
+              Number(page.nextCursor) >= 1 &&
+              page.nextCursor !== cursor))
+        ) {
+          try {
+            for (const record of page.records) validateWorkerRecord(record);
+            return true;
+          } catch {
+            return false;
+          }
+        }
+        return false;
+      },
     });
     if (page.repoSlug !== options.repoSlug || !Number.isSafeInteger(page.revision)) {
       throw new Error("Worker returned an invalid record export envelope");
@@ -456,13 +499,30 @@ export async function fetchWorkerStoredSnapshot(options: {
 }): Promise<WorkerStoredSnapshot> {
   const endpoint = "/internal/state/records/snapshots/latest";
   try {
-    const envelope = await signedPost<{
+    const envelope = await signedWorkerRecordReadPost<{
       snapshotStoreAvailable: boolean;
       snapshot: WorkerStoredSnapshot;
     }>({
       ...options,
       path: endpoint,
       body: { repoSlug: options.repoSlug },
+      validateResponse: (value) => {
+        const candidate = value as { snapshotStoreAvailable?: unknown; snapshot?: unknown } | null;
+        if (
+          typeof candidate !== "object" ||
+          candidate === null ||
+          Array.isArray(candidate) ||
+          candidate.snapshotStoreAvailable !== true
+        ) {
+          return false;
+        }
+        try {
+          validateStoredSnapshot(candidate.snapshot, options.repoSlug);
+          return true;
+        } catch {
+          return false;
+        }
+      },
     });
     validateStoredSnapshot(envelope.snapshot, options.repoSlug);
     return envelope.snapshot;
@@ -535,12 +595,35 @@ export async function discoverWorkerRecordRepoSlugs(options: {
   const endpoint = "/internal/state/records/slugs";
   let envelope: { repositories?: unknown };
   try {
-    envelope = await signedPost<{ repositories?: unknown }>({
+    envelope = await signedWorkerRecordReadPost<{ repositories?: unknown }>({
       baseUrl: options.baseUrl,
       path: endpoint,
       webhookSecret: options.webhookSecret,
       body: {},
       fetch: options.fetch,
+      validateResponse: (value) => {
+        const candidate = value as { repositories?: unknown } | null;
+        if (
+          typeof candidate === "object" &&
+          candidate !== null &&
+          !Array.isArray(candidate) &&
+          Array.isArray(candidate.repositories)
+        ) {
+          return candidate.repositories.every((entry) => {
+            const repository = entry as { repoSlug?: unknown; revision?: unknown } | null;
+            return (
+              typeof repository === "object" &&
+              repository !== null &&
+              !Array.isArray(repository) &&
+              typeof repository.repoSlug === "string" &&
+              isRepoSlug(repository.repoSlug) &&
+              Number.isSafeInteger(repository.revision) &&
+              Number(repository.revision) >= 0
+            );
+          });
+        }
+        return false;
+      },
     });
   } catch (error) {
     // The canonical slug list is mandatory; surface request failures as a
@@ -584,7 +667,7 @@ export async function fetchWorkerCanonicalItemIds(options: {
   let nextCursor: number | null = 0;
   while (nextCursor !== null) {
     const cursor = nextCursor;
-    const page = await signedPost<{
+    const page = await signedWorkerRecordReadPost<{
       repoSlug: string;
       section: string;
       records: Array<{ id: number }>;
@@ -595,6 +678,43 @@ export async function fetchWorkerCanonicalItemIds(options: {
       webhookSecret: options.webhookSecret,
       body: { repoSlug: options.repoSlug, section: "items", cursor, limit: 500 },
       fetch: options.fetch,
+      validateResponse: (value) => {
+        const candidate = value as {
+          repoSlug?: unknown;
+          section?: unknown;
+          records?: unknown;
+          nextCursor?: unknown;
+        } | null;
+        if (
+          typeof candidate === "object" &&
+          candidate !== null &&
+          !Array.isArray(candidate) &&
+          candidate.repoSlug === options.repoSlug &&
+          candidate.section === "items" &&
+          Array.isArray(candidate.records)
+        ) {
+          const pageIds: number[] = [];
+          for (const record of candidate.records) {
+            const itemId = Number((record as { id?: unknown } | null)?.id);
+            if (
+              !Number.isSafeInteger(itemId) ||
+              itemId <= cursor ||
+              seen.has(itemId) ||
+              pageIds.includes(itemId)
+            ) {
+              return false;
+            }
+            pageIds.push(itemId);
+          }
+          return (
+            candidate.nextCursor === null ||
+            (Number.isSafeInteger(candidate.nextCursor) &&
+              Number(candidate.nextCursor) > cursor &&
+              candidate.nextCursor === pageIds.at(-1))
+          );
+        }
+        return false;
+      },
     });
     if (
       page.repoSlug !== options.repoSlug ||
@@ -747,6 +867,7 @@ async function downloadSnapshot(options: {
           length,
         },
         fetch: options.fetch,
+        retryDelaysMs: WORKER_RECORD_READ_RETRY_DELAYS_MS,
       });
       if (!response.ok) {
         throw workerRequestError(response.status, await response.text().catch(() => ""));
@@ -825,19 +946,43 @@ function applyWorkerRecords(repoRoot: string, records: readonly WorkerRecord[]) 
   }
 }
 
-export async function signedPost<T>(options: {
-  baseUrl: string;
-  path: string;
-  webhookSecret: string;
-  body: unknown;
-  fetch?: typeof globalThis.fetch;
-}): Promise<T> {
+function signedWorkerRecordReadPost<T>(options: SignedPostOptions): Promise<T> {
+  return signedPostWithRetryMode<T>(
+    { ...options, retryDelaysMs: WORKER_RECORD_READ_RETRY_DELAYS_MS },
+    true,
+  );
+}
+
+export async function signedPost<T>(options: SignedPostOptions): Promise<T> {
+  return signedPostWithRetryMode<T>(options, false);
+}
+
+async function signedPostWithRetryMode<T>(
+  options: SignedPostOptions,
+  unifiedAttemptBudget: boolean,
+): Promise<T> {
   for (let attempt = 1; ; attempt += 1) {
-    const response = await signedRequest(options);
+    let response: Response;
+    try {
+      response = unifiedAttemptBudget
+        ? await signedRequestWithMaxAttempts(options, 1)
+        : await signedRequest(options);
+    } catch (error) {
+      if (!(error instanceof RetryableSignedRequestError) || !unifiedAttemptBudget) throw error;
+      if (attempt >= SIGNED_REQUEST_MAX_ATTEMPTS) throw error.cause;
+      await signedRequestBackoff(attempt, options.retryDelaysMs);
+      continue;
+    }
     // Read the body exactly once; a Response body is a one-shot stream and a
     // later clone() of a consumed response throws, masking the real failure.
     const bodyText = await response.text().catch(() => "");
-    if (!response.ok) throw workerRequestError(response.status, bodyText);
+    if (!response.ok) {
+      if (unifiedAttemptBudget && response.status >= 500 && attempt < SIGNED_REQUEST_MAX_ATTEMPTS) {
+        await signedRequestBackoff(attempt, options.retryDelaysMs);
+        continue;
+      }
+      throw workerRequestError(response.status, bodyText);
+    }
     let value: unknown;
     try {
       value = JSON.parse(bodyText);
@@ -849,9 +994,13 @@ export async function signedPost<T>(options: {
     // object envelope. The edge occasionally serves such bodies transiently
     // (observed as blank 200s), so retry within the bounded budget before
     // failing loudly with the status and a body snippet.
-    if (typeof value !== "object" || value === null) {
+    if (
+      typeof value !== "object" ||
+      value === null ||
+      (options.validateResponse !== undefined && !options.validateResponse(value))
+    ) {
       if (attempt < SIGNED_REQUEST_MAX_ATTEMPTS) {
-        await signedRequestBackoff(attempt);
+        await signedRequestBackoff(attempt, options.retryDelaysMs);
         continue;
       }
       throw new WorkerRecordRequestError(
@@ -871,9 +1020,31 @@ async function signedGet<T>(options: {
   fetch?: typeof globalThis.fetch;
 }): Promise<T> {
   for (let attempt = 1; ; attempt += 1) {
-    const response = await signedRequest({ ...options, method: "GET", body: undefined });
+    let response: Response;
+    try {
+      response = await signedRequestWithMaxAttempts(
+        {
+          ...options,
+          method: "GET",
+          body: undefined,
+          retryDelaysMs: WORKER_RECORD_READ_RETRY_DELAYS_MS,
+        },
+        1,
+      );
+    } catch (error) {
+      if (!(error instanceof RetryableSignedRequestError)) throw error;
+      if (attempt >= SIGNED_REQUEST_MAX_ATTEMPTS) throw error.cause;
+      await signedRequestBackoff(attempt, WORKER_RECORD_READ_RETRY_DELAYS_MS);
+      continue;
+    }
     const bodyText = await response.text().catch(() => "");
-    if (!response.ok) throw workerRequestError(response.status, bodyText);
+    if (!response.ok) {
+      if (response.status >= 500 && attempt < SIGNED_REQUEST_MAX_ATTEMPTS) {
+        await signedRequestBackoff(attempt, WORKER_RECORD_READ_RETRY_DELAYS_MS);
+        continue;
+      }
+      throw workerRequestError(response.status, bodyText);
+    }
     let value: unknown;
     try {
       value = JSON.parse(bodyText);
@@ -894,7 +1065,7 @@ async function signedGet<T>(options: {
       Number(envelope.revision) < 1
     ) {
       if (attempt < SIGNED_REQUEST_MAX_ATTEMPTS) {
-        await signedRequestBackoff(attempt);
+        await signedRequestBackoff(attempt, WORKER_RECORD_READ_RETRY_DELAYS_MS);
         continue;
       }
       throw new WorkerRecordRequestError(
@@ -908,16 +1079,19 @@ async function signedGet<T>(options: {
 }
 
 const SIGNED_REQUEST_MAX_ATTEMPTS = 3;
-const SIGNED_REQUEST_RETRY_BASE_MS = 250;
 
-export async function signedRequest(options: {
-  baseUrl: string;
-  path: string;
-  webhookSecret: string;
-  body: unknown;
-  method?: "GET" | "POST";
-  fetch?: typeof globalThis.fetch;
-}) {
+class RetryableSignedRequestError extends Error {
+  constructor(cause: unknown) {
+    super("Signed request fetch failed", { cause });
+    this.name = "RetryableSignedRequestError";
+  }
+}
+
+export async function signedRequest(options: SignedRequestOptions) {
+  return signedRequestWithMaxAttempts(options, SIGNED_REQUEST_MAX_ATTEMPTS);
+}
+
+async function signedRequestWithMaxAttempts(options: SignedRequestOptions, maxAttempts: number) {
   const baseUrl = options.baseUrl.replace(/\/$/, "");
   if (!baseUrl.startsWith("https://") && !baseUrl.startsWith("http://127.0.0.1:")) {
     throw new Error("Worker record URL must use HTTPS");
@@ -942,20 +1116,27 @@ export async function signedRequest(options: {
         ...(method === "POST" ? { body } : {}),
       });
     } catch (error) {
-      if (attempt >= SIGNED_REQUEST_MAX_ATTEMPTS) throw error;
-      await signedRequestBackoff(attempt);
+      if (attempt >= maxAttempts) {
+        if (maxAttempts === 1) throw new RetryableSignedRequestError(error);
+        throw error;
+      }
+      await signedRequestBackoff(attempt, options.retryDelaysMs);
       continue;
     }
-    if (response.status < 500 || attempt >= SIGNED_REQUEST_MAX_ATTEMPTS) return response;
+    if (response.status < 500 || attempt >= maxAttempts) return response;
     await response.body?.cancel().catch(() => {});
-    await signedRequestBackoff(attempt);
+    await signedRequestBackoff(attempt, options.retryDelaysMs);
   }
 }
 
-function signedRequestBackoff(attempt: number) {
-  return new Promise((resolve) =>
-    setTimeout(resolve, SIGNED_REQUEST_RETRY_BASE_MS * 2 ** (attempt - 1)),
-  );
+function signedRequestBackoff(
+  attempt: number,
+  retryDelaysMs: SignedRequestRetryDelays = DEFAULT_SIGNED_REQUEST_RETRY_DELAYS_MS,
+) {
+  const delayMs = retryDelaysMs[attempt - 1];
+  if (delayMs === undefined)
+    throw new Error(`Missing signed request retry delay for attempt ${attempt}`);
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
 }
 
 function workerRequestError(status: number, bodyText: string) {

--- a/scripts/worker-records.ts
+++ b/scripts/worker-records.ts
@@ -788,7 +788,7 @@ async function ensureSnapshotCache(options: {
   const temporaryTree = path.join(temporaryRoot, "tree");
   mkdirSync(temporaryTree, { recursive: true });
   try {
-    await downloadSnapshot({ ...options, archivePath });
+    await downloadWorkerSnapshot({ ...options, archivePath });
     const unpacked = spawnSync("tar", ["-xzf", archivePath, "-C", temporaryTree], {
       encoding: "utf8",
     });
@@ -841,7 +841,7 @@ function validSnapshotCache(
   }
 }
 
-async function downloadSnapshot(options: {
+export async function downloadWorkerSnapshot(options: {
   archivePath: string;
   baseUrl: string;
   webhookSecret: string;
@@ -856,40 +856,86 @@ async function downloadSnapshot(options: {
         options.snapshot.access.maxChunkBytes,
         options.snapshot.bytes - offset,
       );
-      const response = await signedRequest({
-        baseUrl: options.baseUrl,
-        path: "/internal/state/records/snapshots/chunk",
-        webhookSecret: options.webhookSecret,
-        body: {
-          repoSlug: options.snapshot.repoSlug,
-          revisionWatermark: options.snapshot.revisionWatermark,
-          offset,
-          length,
-        },
-        fetch: options.fetch,
-        retryDelaysMs: WORKER_RECORD_READ_RETRY_DELAYS_MS,
+      const bytes = await fetchWorkerSnapshotChunk({
+        ...options,
+        offset,
+        length,
       });
-      if (!response.ok) {
-        throw workerRequestError(response.status, await response.text().catch(() => ""));
-      }
-      if (response.status !== 206) {
-        throw new Error(`Worker snapshot chunk returned status ${response.status}`);
-      }
-      const expectedRange = `bytes ${offset}-${offset + length - 1}/${options.snapshot.bytes}`;
-      if (response.headers.get("content-range") !== expectedRange) {
-        throw new Error("Worker snapshot chunk returned an invalid content range");
-      }
-      const bytes = new Uint8Array(await response.arrayBuffer());
-      if (bytes.byteLength !== length) {
-        throw new Error(
-          `Worker snapshot chunk length mismatch: expected ${length}, received ${bytes.byteLength}`,
-        );
-      }
       writeSync(descriptor, bytes);
       offset += bytes.byteLength;
     }
   } finally {
     closeSync(descriptor);
+  }
+}
+
+async function fetchWorkerSnapshotChunk(options: {
+  baseUrl: string;
+  webhookSecret: string;
+  snapshot: WorkerStoredSnapshot;
+  offset: number;
+  length: number;
+  fetch?: typeof globalThis.fetch;
+}) {
+  const expectedRange = `bytes ${options.offset}-${options.offset + options.length - 1}/${options.snapshot.bytes}`;
+  for (let attempt = 1; ; attempt += 1) {
+    let response: Response;
+    try {
+      response = await signedRequestWithMaxAttempts(
+        {
+          baseUrl: options.baseUrl,
+          path: "/internal/state/records/snapshots/chunk",
+          webhookSecret: options.webhookSecret,
+          body: {
+            repoSlug: options.snapshot.repoSlug,
+            revisionWatermark: options.snapshot.revisionWatermark,
+            offset: options.offset,
+            length: options.length,
+          },
+          fetch: options.fetch,
+          retryDelaysMs: WORKER_RECORD_READ_RETRY_DELAYS_MS,
+        },
+        1,
+      );
+    } catch (error) {
+      if (!(error instanceof RetryableSignedRequestError)) throw error;
+      if (attempt >= SIGNED_REQUEST_MAX_ATTEMPTS) throw error.cause;
+      await signedRequestBackoff(attempt, WORKER_RECORD_READ_RETRY_DELAYS_MS);
+      continue;
+    }
+
+    if (!response.ok) {
+      const bodyText = await response.text().catch(() => "");
+      if (response.status >= 500 && attempt < SIGNED_REQUEST_MAX_ATTEMPTS) {
+        await signedRequestBackoff(attempt, WORKER_RECORD_READ_RETRY_DELAYS_MS);
+        continue;
+      }
+      throw workerRequestError(response.status, bodyText);
+    }
+
+    let bytes: Uint8Array | undefined;
+    let protocolError: Error | undefined;
+    if (response.status !== 206) {
+      protocolError = new Error(`Worker snapshot chunk returned status ${response.status}`);
+    } else if (response.headers.get("content-range") !== expectedRange) {
+      protocolError = new Error("Worker snapshot chunk returned an invalid content range");
+    } else {
+      try {
+        bytes = new Uint8Array(await response.arrayBuffer());
+      } catch (error) {
+        protocolError = error instanceof Error ? error : new Error(String(error));
+      }
+      if (bytes !== undefined && bytes.byteLength !== options.length) {
+        protocolError = new Error(
+          `Worker snapshot chunk length mismatch: expected ${options.length}, received ${bytes.byteLength}`,
+        );
+      }
+    }
+
+    if (protocolError === undefined && bytes !== undefined) return bytes;
+    await response.body?.cancel().catch(() => {});
+    if (attempt >= SIGNED_REQUEST_MAX_ATTEMPTS) throw protocolError;
+    await signedRequestBackoff(attempt, WORKER_RECORD_READ_RETRY_DELAYS_MS);
   }
 }
 

--- a/scripts/worker-records.ts
+++ b/scripts/worker-records.ts
@@ -118,7 +118,7 @@ export class WorkerRecordRequestError extends Error {
 type SignedRequestRetryDelays = readonly [number, number];
 
 const DEFAULT_SIGNED_REQUEST_RETRY_DELAYS_MS = [250, 500] as const;
-const WORKER_RECORD_READ_RETRY_DELAYS_MS = [60_000, 180_000] as const;
+const WORKER_RECORD_READ_RETRY_DELAYS_MS = [30_000, 60_000] as const;
 
 type SignedRequestOptions = {
   baseUrl: string;

--- a/test/repair/focused-state-hydration.test.ts
+++ b/test/repair/focused-state-hydration.test.ts
@@ -4,7 +4,7 @@ import fs, { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs
 import { syncBuiltinESMExports } from "node:module";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import test from "node:test";
+import test, { type TestContext } from "node:test";
 
 import { hydrateState } from "../../scripts/hydrate-state.ts";
 import { materializeWorkerItems } from "../../scripts/worker-records.ts";
@@ -12,6 +12,21 @@ import { materializeWorkerItems } from "../../scripts/worker-records.ts";
 const repoSlug = "openclaw-openclaw";
 const itemNumber = 111745;
 const webhookSecret = "single-record-test-secret";
+
+function captureRetryDelays(t: TestContext) {
+  const delays: number[] = [];
+  const immediateSetTimeout = (
+    callback: (...args: unknown[]) => void,
+    delay?: number,
+    ...args: unknown[]
+  ) => {
+    delays.push(Number(delay));
+    queueMicrotask(() => callback(...args));
+    return 0 as unknown as ReturnType<typeof setTimeout>;
+  };
+  t.mock.method(globalThis, "setTimeout", immediateSetTimeout as typeof setTimeout);
+  return delays;
+}
 
 test("focused batch hydration ignores unavailable snapshots and preserves complete item tuples", async (t) => {
   const root = mkdtempSync(join(tmpdir(), "clawsweeper-focused-batch-"));
@@ -265,7 +280,8 @@ test("single-issue hydration refuses corrupt Worker content without replacing lo
   assert.equal(readFileSync(preservedPath, "utf8"), "keep\n");
 });
 
-test("single-issue hydration retries malformed successful edge responses", async () => {
+test("single-issue hydration retries malformed successful edge responses", async (t) => {
+  const delays = captureRetryDelays(t);
   const root = mkdtempSync(join(tmpdir(), "clawsweeper-focused-edge-"));
   const content = "current canonical report\n";
   let reads = 0;
@@ -291,13 +307,15 @@ test("single-issue hydration retries malformed successful edge responses", async
     fetch: fetchImpl as typeof fetch,
   });
   assert.equal(reads, 2);
+  assert.deepEqual(delays, [60_000]);
   assert.equal(
     readFileSync(join(root, "records", repoSlug, "items", `${itemNumber}.md`), "utf8"),
     content,
   );
 });
 
-test("single-issue hydration retries malformed Worker record envelopes", async () => {
+test("single-issue hydration retries malformed Worker record envelopes", async (t) => {
+  const delays = captureRetryDelays(t);
   const content = "current canonical report\n";
   const digest = createHash("sha256").update(content).digest("hex");
   for (const malformed of [
@@ -328,9 +346,11 @@ test("single-issue hydration retries malformed Worker record envelopes", async (
       content,
     );
   }
+  assert.deepEqual(delays, [60_000, 60_000, 60_000, 60_000, 60_000]);
 });
 
-test("single-issue hydration bounds repeated malformed Worker record envelopes", async () => {
+test("single-issue hydration bounds repeated malformed Worker record envelopes", async (t) => {
+  const delays = captureRetryDelays(t);
   const root = mkdtempSync(join(tmpdir(), "clawsweeper-focused-envelope-failure-"));
   let reads = 0;
   await assert.rejects(
@@ -348,6 +368,7 @@ test("single-issue hydration bounds repeated malformed Worker record envelopes",
     /invalid_json_body/,
   );
   assert.equal(reads, 3);
+  assert.deepEqual(delays, [60_000, 180_000]);
 });
 
 test("failed staged record installation restores the existing canonical record tree", async () => {

--- a/test/repair/focused-state-hydration.test.ts
+++ b/test/repair/focused-state-hydration.test.ts
@@ -307,7 +307,7 @@ test("single-issue hydration retries malformed successful edge responses", async
     fetch: fetchImpl as typeof fetch,
   });
   assert.equal(reads, 2);
-  assert.deepEqual(delays, [60_000]);
+  assert.deepEqual(delays, [30_000]);
   assert.equal(
     readFileSync(join(root, "records", repoSlug, "items", `${itemNumber}.md`), "utf8"),
     content,
@@ -346,7 +346,7 @@ test("single-issue hydration retries malformed Worker record envelopes", async (
       content,
     );
   }
-  assert.deepEqual(delays, [60_000, 60_000, 60_000, 60_000, 60_000]);
+  assert.deepEqual(delays, [30_000, 30_000, 30_000, 30_000, 30_000]);
 });
 
 test("single-issue hydration bounds repeated malformed Worker record envelopes", async (t) => {
@@ -368,7 +368,7 @@ test("single-issue hydration bounds repeated malformed Worker record envelopes",
     /invalid_json_body/,
   );
   assert.equal(reads, 3);
-  assert.deepEqual(delays, [60_000, 180_000]);
+  assert.deepEqual(delays, [30_000, 60_000]);
 });
 
 test("failed staged record installation restores the existing canonical record tree", async () => {

--- a/test/worker-records-request.test.ts
+++ b/test/worker-records-request.test.ts
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import test, { type TestContext } from "node:test";
 
 import {
+  discoverWorkerRecordRepoSlugs,
   exportWorkerRecords,
   fetchWorkerCanonicalItemIds,
+  fetchWorkerStoredSnapshot,
   signedPost,
 } from "../scripts/worker-records.ts";
 
@@ -27,6 +29,21 @@ function fetchStub(responses: Array<Response | Error>) {
     return next;
   };
   return { calls, fetchImpl };
+}
+
+function captureRetryDelays(t: TestContext) {
+  const delays: number[] = [];
+  const immediateSetTimeout = (
+    callback: (...args: unknown[]) => void,
+    delay?: number,
+    ...args: unknown[]
+  ) => {
+    delays.push(Number(delay));
+    queueMicrotask(() => callback(...args));
+    return 0 as unknown as ReturnType<typeof setTimeout>;
+  };
+  t.mock.method(globalThis, "setTimeout", immediateSetTimeout as typeof setTimeout);
+  return delays;
 }
 
 test("signedPost surfaces status and error code from a non-OK response without cloning", async () => {
@@ -157,7 +174,8 @@ test("signedPost resends the full JSON request body on a retry after a 502", asy
   assert.equal(bodies[1], bodies[0], "retry must resend an identical body payload");
 });
 
-test("signedPost retries 5xx responses and succeeds within the attempt budget", async () => {
+test("signedPost keeps the short retry schedule for callers outside record reads", async (t) => {
+  const delays = captureRetryDelays(t);
   const { calls, fetchImpl } = fetchStub([
     jsonResponse(502, "<html>bad gateway</html>", "text/html"),
     jsonResponse(502, { error: "upstream_unavailable" }),
@@ -172,6 +190,7 @@ test("signedPost retries 5xx responses and succeeds within the attempt budget", 
   });
   assert.deepEqual(value, { ok: true });
   assert.equal(calls.length, 3);
+  assert.deepEqual(delays, [250, 500]);
 });
 
 test("signedPost surfaces the final 5xx after exhausting retries", async () => {
@@ -208,7 +227,8 @@ test("signedPost retries network errors and succeeds", async () => {
   assert.equal(calls.length, 2);
 });
 
-test("exportWorkerRecords surfaces the worker error code for a consumed-body failure", async () => {
+test("exportWorkerRecords does not retry a deterministic 4xx", async (t) => {
+  const delays = captureRetryDelays(t);
   const { calls, fetchImpl } = fetchStub([jsonResponse(409, { error: "revision_conflict" })]);
   await assert.rejects(
     exportWorkerRecords({
@@ -225,11 +245,14 @@ test("exportWorkerRecords surfaces the worker error code for a consumed-body fai
     },
   );
   assert.equal(calls.length, 1);
+  assert.deepEqual(delays, []);
 });
 
-test("exportWorkerRecords rides out a transient 502 during export", async () => {
+test("exportWorkerRecords waits one minute then three minutes across eligible retries", async (t) => {
+  const delays = captureRetryDelays(t);
   const { calls, fetchImpl } = fetchStub([
     jsonResponse(502, "<html>cloudflare 502</html>", "text/html"),
+    jsonResponse(500, { error: "exact_review_queue_unavailable" }),
     jsonResponse(200, {
       repoSlug: "openclaw-openclaw",
       revision: 7,
@@ -245,7 +268,156 @@ test("exportWorkerRecords rides out a transient 502 during export", async () => 
   });
   assert.equal(snapshot.revision, 7);
   assert.deepEqual(snapshot.records, []);
+  assert.equal(calls.length, 3);
+  assert.deepEqual(delays, [60_000, 180_000]);
+});
+
+test("record reads share one three-attempt budget across 5xx and invalid 2xx failures", async (t) => {
+  const delays = captureRetryDelays(t);
+  const { calls, fetchImpl } = fetchStub([
+    jsonResponse(502, { error: "exact_review_queue_unavailable" }),
+    jsonResponse(200, "null"),
+    jsonResponse(200, {
+      repoSlug: "openclaw-openclaw",
+      revision: 7,
+      records: [],
+      nextCursor: null,
+    }),
+  ]);
+  const snapshot = await exportWorkerRecords({
+    baseUrl,
+    webhookSecret,
+    repoSlug: "openclaw-openclaw",
+    fetch: fetchImpl,
+  });
+  assert.equal(snapshot.revision, 7);
+  assert.equal(calls.length, 3);
+  assert.deepEqual(delays, [60_000, 180_000]);
+});
+
+test("record reads retry malformed endpoint envelopes, rows, and cursors", async (t) => {
+  const delays = captureRetryDelays(t);
+  const { calls, fetchImpl } = fetchStub([
+    jsonResponse(200, {
+      repoSlug: "openclaw-openclaw",
+      revision: 7,
+      records: [{}],
+      nextCursor: null,
+    }),
+    jsonResponse(200, {
+      repoSlug: "openclaw-openclaw",
+      revision: 7,
+      records: [],
+      nextCursor: 0,
+    }),
+    jsonResponse(200, {
+      repoSlug: "openclaw-openclaw",
+      revision: 7,
+      records: [],
+      nextCursor: null,
+    }),
+  ]);
+  const snapshot = await exportWorkerRecords({
+    baseUrl,
+    webhookSecret,
+    repoSlug: "openclaw-openclaw",
+    fetch: fetchImpl,
+  });
+  assert.equal(snapshot.revision, 7);
+  assert.equal(calls.length, 3);
+  assert.deepEqual(delays, [60_000, 180_000]);
+});
+
+test("record reads surface pre-fetch configuration errors without long retries", async (t) => {
+  const delays = captureRetryDelays(t);
+  const { calls, fetchImpl } = fetchStub([]);
+  await assert.rejects(
+    exportWorkerRecords({
+      baseUrl: "http://worker.example.test",
+      webhookSecret,
+      repoSlug: "openclaw-openclaw",
+      fetch: fetchImpl,
+    }),
+    /Worker record URL must use HTTPS/,
+  );
+  assert.equal(calls.length, 0);
+  assert.deepEqual(delays, []);
+});
+
+test("stored-snapshot reads remain fail-closed after the long retry budget", async (t) => {
+  const delays = captureRetryDelays(t);
+  const { calls, fetchImpl } = fetchStub([
+    jsonResponse(500, { error: "exact_review_queue_unavailable" }),
+    jsonResponse(500, { error: "exact_review_queue_unavailable" }),
+    jsonResponse(500, { error: "exact_review_queue_unavailable" }),
+  ]);
+  await assert.rejects(
+    fetchWorkerStoredSnapshot({
+      baseUrl,
+      webhookSecret,
+      repoSlug: "openclaw-openclaw",
+      fetch: fetchImpl,
+    }),
+    (error: Error & { status?: number; code?: string }) => {
+      assert.equal(error.name, "WorkerRecordRequestError");
+      assert.equal(error.status, 500);
+      assert.equal(error.code, "exact_review_queue_unavailable");
+      return true;
+    },
+  );
+  assert.equal(calls.length, 3);
+  assert.deepEqual(delays, [60_000, 180_000]);
+});
+
+test("slug discovery retries malformed repository entries", async (t) => {
+  const delays = captureRetryDelays(t);
+  const { calls, fetchImpl } = fetchStub([
+    jsonResponse(200, { repositories: [{}] }),
+    jsonResponse(200, {
+      repositories: [{ repoSlug: "openclaw-openclaw", revision: 12 }],
+    }),
+  ]);
+  assert.deepEqual(
+    await discoverWorkerRecordRepoSlugs({ baseUrl, webhookSecret, fetch: fetchImpl }),
+    [{ repoSlug: "openclaw-openclaw", revision: 12 }],
+  );
   assert.equal(calls.length, 2);
+  assert.deepEqual(delays, [60_000]);
+});
+
+test("canonical item listing retries malformed rows and inconsistent cursors", async (t) => {
+  const delays = captureRetryDelays(t);
+  const { calls, fetchImpl } = fetchStub([
+    jsonResponse(200, {
+      repoSlug: "openclaw-openclaw",
+      section: "items",
+      records: [{}],
+      nextCursor: null,
+    }),
+    jsonResponse(200, {
+      repoSlug: "openclaw-openclaw",
+      section: "items",
+      records: [{ id: 1 }],
+      nextCursor: 2,
+    }),
+    jsonResponse(200, {
+      repoSlug: "openclaw-openclaw",
+      section: "items",
+      records: [{ id: 1 }],
+      nextCursor: null,
+    }),
+  ]);
+  assert.deepEqual(
+    await fetchWorkerCanonicalItemIds({
+      baseUrl,
+      webhookSecret,
+      repoSlug: "openclaw-openclaw",
+      fetch: fetchImpl,
+    }),
+    [1],
+  );
+  assert.equal(calls.length, 3);
+  assert.deepEqual(delays, [60_000, 180_000]);
 });
 
 test("fetchWorkerCanonicalItemIds pages the exact coverage identity set", async () => {

--- a/test/worker-records-request.test.ts
+++ b/test/worker-records-request.test.ts
@@ -45,7 +45,7 @@ function captureRetryDelays(t: TestContext) {
     delay?: number,
     ...args: unknown[]
   ) => {
-    if (![250, 500, 60_000, 180_000].includes(Number(delay))) {
+    if (![250, 500, 30_000, 60_000].includes(Number(delay))) {
       return originalSetTimeout(callback, delay, ...args);
     }
     delays.push(Number(delay));
@@ -108,7 +108,7 @@ test("canonical record export recovers through a signed loopback HTTP transport"
 
   assert.equal(snapshot.revision, 7);
   assert.equal(requests.length, 2);
-  assert.deepEqual(delays, [60_000]);
+  assert.deepEqual(delays, [30_000]);
   for (const request of requests) {
     assert.equal(request.method, "POST");
     assert.equal(request.path, "/internal/state/records/export");
@@ -321,7 +321,7 @@ test("exportWorkerRecords does not retry a deterministic 4xx", async (t) => {
   assert.deepEqual(delays, []);
 });
 
-test("exportWorkerRecords waits one minute then three minutes across eligible retries", async (t) => {
+test("exportWorkerRecords waits thirty seconds then one minute across eligible retries", async (t) => {
   const delays = captureRetryDelays(t);
   const { calls, fetchImpl } = fetchStub([
     jsonResponse(502, "<html>cloudflare 502</html>", "text/html"),
@@ -342,7 +342,7 @@ test("exportWorkerRecords waits one minute then three minutes across eligible re
   assert.equal(snapshot.revision, 7);
   assert.deepEqual(snapshot.records, []);
   assert.equal(calls.length, 3);
-  assert.deepEqual(delays, [60_000, 180_000]);
+  assert.deepEqual(delays, [30_000, 60_000]);
 });
 
 test("record reads share one three-attempt budget across 5xx and invalid 2xx failures", async (t) => {
@@ -365,7 +365,7 @@ test("record reads share one three-attempt budget across 5xx and invalid 2xx fai
   });
   assert.equal(snapshot.revision, 7);
   assert.equal(calls.length, 3);
-  assert.deepEqual(delays, [60_000, 180_000]);
+  assert.deepEqual(delays, [30_000, 60_000]);
 });
 
 test("record reads retry malformed endpoint envelopes, rows, and cursors", async (t) => {
@@ -398,7 +398,7 @@ test("record reads retry malformed endpoint envelopes, rows, and cursors", async
   });
   assert.equal(snapshot.revision, 7);
   assert.equal(calls.length, 3);
-  assert.deepEqual(delays, [60_000, 180_000]);
+  assert.deepEqual(delays, [30_000, 60_000]);
 });
 
 test("record reads surface pre-fetch configuration errors without long retries", async (t) => {
@@ -439,7 +439,7 @@ test("stored-snapshot reads remain fail-closed after the long retry budget", asy
     },
   );
   assert.equal(calls.length, 3);
-  assert.deepEqual(delays, [60_000, 180_000]);
+  assert.deepEqual(delays, [30_000, 60_000]);
 });
 
 test("snapshot chunks retry malformed successful responses within the shared budget", async (t) => {
@@ -478,7 +478,7 @@ test("snapshot chunks retry malformed successful responses within the shared bud
   });
 
   assert.equal(calls.length, 3);
-  assert.deepEqual(delays, [60_000, 180_000]);
+  assert.deepEqual(delays, [30_000, 60_000]);
   assert.deepEqual(readFileSync(archivePath), bytes);
 });
 
@@ -495,7 +495,7 @@ test("slug discovery retries malformed repository entries", async (t) => {
     [{ repoSlug: "openclaw-openclaw", revision: 12 }],
   );
   assert.equal(calls.length, 2);
-  assert.deepEqual(delays, [60_000]);
+  assert.deepEqual(delays, [30_000]);
 });
 
 test("canonical item listing retries malformed rows and inconsistent cursors", async (t) => {
@@ -530,7 +530,7 @@ test("canonical item listing retries malformed rows and inconsistent cursors", a
     [1],
   );
   assert.equal(calls.length, 3);
-  assert.deepEqual(delays, [60_000, 180_000]);
+  assert.deepEqual(delays, [30_000, 60_000]);
 });
 
 test("fetchWorkerCanonicalItemIds pages the exact coverage identity set", async () => {

--- a/test/worker-records-request.test.ts
+++ b/test/worker-records-request.test.ts
@@ -1,8 +1,14 @@
 import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test, { type TestContext } from "node:test";
 
 import {
   discoverWorkerRecordRepoSlugs,
+  downloadWorkerSnapshot,
   exportWorkerRecords,
   fetchWorkerCanonicalItemIds,
   fetchWorkerStoredSnapshot,
@@ -33,11 +39,15 @@ function fetchStub(responses: Array<Response | Error>) {
 
 function captureRetryDelays(t: TestContext) {
   const delays: number[] = [];
+  const originalSetTimeout = globalThis.setTimeout;
   const immediateSetTimeout = (
     callback: (...args: unknown[]) => void,
     delay?: number,
     ...args: unknown[]
   ) => {
+    if (![250, 500, 60_000, 180_000].includes(Number(delay))) {
+      return originalSetTimeout(callback, delay, ...args);
+    }
     delays.push(Number(delay));
     queueMicrotask(() => callback(...args));
     return 0 as unknown as ReturnType<typeof setTimeout>;
@@ -45,6 +55,69 @@ function captureRetryDelays(t: TestContext) {
   t.mock.method(globalThis, "setTimeout", immediateSetTimeout as typeof setTimeout);
   return delays;
 }
+
+test("canonical record export recovers through a signed loopback HTTP transport", async (t) => {
+  const requests: Array<{
+    body: string;
+    method: string | undefined;
+    path: string;
+    signature: string;
+  }> = [];
+  const server = createServer(async (request, response) => {
+    const chunks: Buffer[] = [];
+    for await (const chunk of request) chunks.push(Buffer.from(chunk));
+    requests.push({
+      body: Buffer.concat(chunks).toString("utf8"),
+      method: request.method,
+      path: request.url ?? "",
+      signature: String(request.headers["x-clawsweeper-exact-review-signature"] ?? ""),
+    });
+    response.setHeader("content-type", "application/json");
+    if (requests.length === 1) {
+      response.statusCode = 500;
+      response.end(JSON.stringify({ error: "exact_review_queue_unavailable" }));
+      return;
+    }
+    response.statusCode = 200;
+    response.end(
+      JSON.stringify({
+        repoSlug: "openclaw-openclaw",
+        revision: 7,
+        records: [],
+        nextCursor: null,
+      }),
+    );
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  t.after(() => new Promise<void>((resolve) => server.close(() => resolve())));
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  const delays = captureRetryDelays(t);
+
+  const snapshot = await exportWorkerRecords({
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    webhookSecret,
+    repoSlug: "openclaw-openclaw",
+  });
+
+  assert.equal(snapshot.revision, 7);
+  assert.equal(requests.length, 2);
+  assert.deepEqual(delays, [60_000]);
+  for (const request of requests) {
+    assert.equal(request.method, "POST");
+    assert.equal(request.path, "/internal/state/records/export");
+    assert.equal(
+      request.signature,
+      `sha256=${createHmac("sha256", webhookSecret).update(request.body).digest("hex")}`,
+    );
+  }
+});
 
 test("signedPost surfaces status and error code from a non-OK response without cloning", async () => {
   const { calls, fetchImpl } = fetchStub([jsonResponse(422, { error: "invalid_repo" })]);
@@ -367,6 +440,46 @@ test("stored-snapshot reads remain fail-closed after the long retry budget", asy
   );
   assert.equal(calls.length, 3);
   assert.deepEqual(delays, [60_000, 180_000]);
+});
+
+test("snapshot chunks retry malformed successful responses within the shared budget", async (t) => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-snapshot-chunk-retry-"));
+  t.after(() => rmSync(root, { force: true, recursive: true }));
+  const archivePath = join(root, "snapshot.tar.gz");
+  const bytes = Buffer.from("snapshot-bytes");
+  const expectedRange = `bytes 0-${bytes.byteLength - 1}/${bytes.byteLength}`;
+  const malformedStatus = new Response(bytes, { status: 200 });
+  const malformedRange = new Response(bytes, {
+    status: 206,
+    headers: { "content-range": `bytes 1-${bytes.byteLength}/${bytes.byteLength}` },
+  });
+  const valid = new Response(bytes, {
+    status: 206,
+    headers: { "content-range": expectedRange },
+  });
+  const { calls, fetchImpl } = fetchStub([malformedStatus, malformedRange, valid]);
+  const delays = captureRetryDelays(t);
+
+  await downloadWorkerSnapshot({
+    archivePath,
+    baseUrl,
+    webhookSecret,
+    snapshot: {
+      repoSlug: "openclaw-openclaw",
+      revisionWatermark: 7,
+      objectKey: "records/openclaw-openclaw/7.tar.gz",
+      bytes: bytes.byteLength,
+      uncompressedBytes: bytes.byteLength,
+      fileCount: 0,
+      createdAt: "2026-09-01T00:00:00.000Z",
+      access: { mode: "worker_range_proxy", maxChunkBytes: bytes.byteLength },
+    },
+    fetch: fetchImpl,
+  });
+
+  assert.equal(calls.length, 3);
+  assert.deepEqual(delays, [60_000, 180_000]);
+  assert.deepEqual(readFileSync(archivePath), bytes);
 });
 
 test("slug discovery retries malformed repository entries", async (t) => {


### PR DESCRIPTION
## Summary

- give canonical Worker record reads a three-attempt retry budget
- wait 30 seconds after the first eligible failure and 60 seconds after the second
- keep unrelated signed requests on their existing short retry schedule
- validate successful endpoint envelopes inside the same bounded retry budget
- retry malformed successful snapshot chunks inside that same budget

## Problem

Scheduled state hydration can fail closed during setup when the authenticated canonical-record boundary returns the sanitized `exact_review_queue_unavailable` 500. The failure recurred after the bounded record-export repair in #1299. Public evidence still does not expose the lower-level Worker/Durable Object exception, so this change does not claim to repair that unobserved root cause; it adds bounded client resilience for the read-only, idempotent side of the boundary.

## Implementation

Canonical record reads now make at most three attempts, with delays of 30 seconds and 60 seconds between eligible failures. The extended schedule is limited to:

- record export journal pages
- stored snapshot metadata and chunks
- repository slug discovery
- canonical item listing
- direct canonical record reads

Eligible failures are transport errors, 5xx responses, malformed/invalid successful response envelopes, and invalid successful snapshot chunk status/range/length. The attempts share one budget per request or chunk. Deterministic 4xx responses and pre-fetch configuration errors still fail immediately. After the third eligible failure, hydration still fails closed with the original sanitized Worker error status/code where available.

The exported generic `signedPost` path retains its existing 250 ms / 500 ms schedule, so write-capable or unrelated callers do not inherit the long waits.

## Validation

Base: `48bd2b42f1dd0504c9afc8643c9781290604b3b2`

Head: `e5b25f3f7980af50c68782095604df8ea9155fa0`

- `node --test test/worker-records-request.test.ts` — 21/21 passed
- focused malformed-response hydration tests — 3/3 passed on Windows
- `pnpm run build:all` — passed
- `pnpm exec oxlint scripts/worker-records.ts test/worker-records-request.test.ts test/repair/focused-state-hydration.test.ts` — zero warnings/errors
- `pnpm exec oxfmt --check` on the three changed files — passed
- `git diff --check` — passed on the host checkout

One existing test in `focused-state-hydration.test.ts` checks for a literal `/records` suffix and therefore misses the simulated rename failure on Windows. The same failure reproduces at the exact base commit and the unchanged test passes in the Linux proof below; it is unrelated baseline platform-fixture noise.

## Real Behavior Proof

**Claim:** the production canonical-record client retries read-only transient failures on the requested 30-second / 60-second schedule, accepts a later valid response, rejects deterministic failures immediately, and remains fail closed after exhaustion.

**Exercised surface:** the real `scripts/worker-records.ts` request, validation, pagination, snapshot, and focused-hydration paths. Timers and fetch responses were controlled; the production client implementation itself was not replaced.

**Scenario / fixture:** focused tests inject mixed 502/500 `exact_review_queue_unavailable` responses, transport failures, malformed 2xx bodies/envelopes/rows/cursors, malformed successful snapshot chunk status/range/length, eventual valid responses, persistent 500s, deterministic 4xx responses, and pre-fetch configuration errors. Timer capture verifies the exact `[30000, 60000]` delay sequence without making the proof wait 90 wall-clock seconds. A separate loopback scenario uses the production client's global `fetch` over a real HTTP socket, validates the actual HMAC signature and request body at the server, returns the sanitized 500 once, and then returns a valid canonical export page.

**Command / environment:** Docker-backed Crabbox `local-container`, image `node:24-bookworm`, Node `v24.20.0`:

```text
C:\Users\marti\.local\bin\crabbox.exe run --provider local-container --local-container-image node:24-bookworm --no-hydrate --timing-json --script C:\clawsweeper-work\notes\csw-147-crabbox-proof.sh
```

The clean host checkout was at head `e5b25f3f7980af50c68782095604df8ea9155fa0` when Crabbox synchronized it.

**Observed result:** lease `cbx_70e698f9996b`, run `run_2d0d1bcc1043`, provider `local-container`, type `node_24-bookworm`, exit `0`. All 32 affected Linux tests passed, including the staged-install restoration fixture, the signed real-transport recovery case, and malformed successful snapshot-chunk recovery; all three TypeScript builds passed; focused oxlint completed with zero warnings/errors.

**Trace:** the passing test output explicitly records the signed loopback HTTP recovery, the three-attempt 30s/60s case, the shared mixed-failure budget, malformed envelope/row/cursor and snapshot-chunk retries, immediate configuration failure, persistent fail-closed snapshot reads, canonical item pagination, and 32 tests / 32 passed / 0 failed.

**Limits:** the loopback case proves recovery through the production client's real HTTP/HMAC transport, but it is not a live Cloudflare Worker/Durable Object trace. This proof does not contact Cloudflare, rerun a scheduled workflow, mutate a queue or Durable Object, or demonstrate recovery from a live production incident. The public error remains redacted, so the lower-level cause of the recurrent 500 is still unknown. Production workflow-timeout impact is not empirically measured; a persistent eligible failure can add 90 seconds per failed canonical read before the existing fail-closed result.

## Review Closeout

- dirty-patch Codex review: no actionable defects after accepted fixes for endpoint-envelope validation and pre-fetch error classification
- committed branch Codex review against `origin/main`: no actionable correctness issues
- first hosted ClawSweeper review: accepted P2 finding that malformed successful snapshot chunks bypassed the shared retry budget; fixed in `974ec0fb0b` with focused coverage
- user-requested timeout revision: reduced the delays from 60s/180s to 30s/60s in `e5b25f3f79`, reducing per-read wait from four minutes to 90 seconds
- final dirty-patch and committed-range Codex reviews: no actionable findings; the committed review preserved immediate 4xx handling, fail-closed exhaustion, and short retries for generic callers
- final local committed-range ClawSweeper review: `keep_open`, high confidence, overall correctness `patch is correct`, no review comments, security cleared; its current-head proof gap is satisfied by the exact-head Crabbox evidence above

## Risks / Rollout

- persistent availability failures take up to 90 additional seconds per affected canonical read before failing closed
- multi-read hydration can still accumulate waits; affected job timeouts range from 10 to 360 minutes, including 30 minutes for scheduled target fanout
- the repair does not diagnose or mask the underlying Worker/Durable Object failure
- no Worker, Durable Object, workflow, queue, configuration, deployment, notification, or public error-redaction behavior changes

Related: CSW-147; follow-up to #1299.
