### PR TITLE
fix(review): preserve complete source ancestry

### DIFF
--- a/docs/pr-review-comments.md
+++ b/docs/pr-review-comments.md
@@ -171,8 +171,10 @@ automatically a PR edit. Findings in untouched files remain valid when an
 introduced hunk elsewhere causes the failure; risks, labels, scores, and fixups
 must use that same ownership boundary.
 
-The existing PR hydration path may fetch up to 256 commits of ancestry per tip
-and the pinned open-PR test merge before restricted review. The evidence reader
+PR source acquisition fetches complete blobless ancestry and the pinned open-PR
+test merge before restricted review, with a 30-second deadline per fetch. Branch
+and release refreshes preserve that ancestry; existing shallow checkouts are
+unshallowed rather than deepened to a fixed commit count. The evidence reader
 itself cannot fetch objects or run external diff drivers. It bounds each Git read
 to 1 MiB and five seconds, lists to 80 paths, and the introduced patch to 24,000
 characters. Missing blobs, incomplete shallow ancestry, multiple merge bases,

--- a/docs/review-cache.md
+++ b/docs/review-cache.md
@@ -75,8 +75,12 @@ When full context collection requests a review checkout, source preparation runs
 independently of cache-digest eligibility and the API's 80-file context window.
 It reads the exact raw Git delta for the pinned merge-base/head (and pinned
 base/head endpoint evidence), including deleted and historical blobs. Current
-main never replaces the pinned REST base. Blob-size metadata uses batches of at
-most 160 objects; one explicit fetch per delta retrieves missing blobs only after
+main never replaces the pinned REST base. Commit acquisition fetches complete
+blobless ancestry, including when the branch has advanced past that base, and
+unshallows existing shallow checkouts. Branch, release-tag, and test-merge
+fetches never introduce new depth boundaries. A missing pinned commit still
+blocks preparation; no newer revision substitutes for it. Blob-size metadata uses
+batches of at most 160 objects; one explicit fetch per delta retrieves missing blobs only after
 the complete set fits the scanner's shared 256 MiB upper bound. Local metadata
 reads remain bounded to 4 MiB and source hydration has a 30-second Git-work
 deadline; metadata requests retain the existing GitHub transport timeout policy.

--- a/src/clawsweeper-review-blobs.ts
+++ b/src/clawsweeper-review-blobs.ts
@@ -36,16 +36,14 @@ export function ensureReviewTreeCommit({
   sha,
   sourceRef,
   destinationRef,
-  completeHistory = false,
 }: {
   targetDir: string;
   sha: string;
   sourceRef: string;
   destinationRef: string;
-  completeHistory?: boolean;
 }): boolean {
   if (!GIT_OBJECT_ID.test(sha)) return false;
-  const shallow = completeHistory && gitRepositoryIsShallow(targetDir);
+  const shallow = gitRepositoryIsShallow(targetDir);
   if (gitCommitExists(targetDir, sha) && !shallow) return true;
   const fetched = spawnSync(
     "git",
@@ -56,7 +54,7 @@ export function ensureReviewTreeCommit({
       "--no-tags",
       "--no-write-fetch-head",
       "--recurse-submodules=no",
-      ...(completeHistory ? (shallow ? ["--unshallow"] : []) : ["--depth=1"]),
+      ...(shallow ? ["--unshallow"] : []),
       "origin",
       `${sourceRef}:${destinationRef}`,
     ],
@@ -67,7 +65,12 @@ export function ensureReviewTreeCommit({
       timeout: 30_000,
     },
   );
-  return !fetched.error && fetched.status === 0 && gitCommitExists(targetDir, sha);
+  return (
+    !fetched.error &&
+    fetched.status === 0 &&
+    gitCommitExists(targetDir, sha) &&
+    !gitRepositoryIsShallow(targetDir)
+  );
 }
 
 export function ensurePullRequestReviewHead({
@@ -87,7 +90,6 @@ export function ensurePullRequestReviewHead({
       sha: headSha,
       sourceRef: `refs/pull/${itemNumber}/head`,
       destinationRef,
-      completeHistory: true,
     }) ||
     // The PR ref and REST head can briefly disagree after a force-push. Fetching the
     // exact validated object keeps the model bound to the revision under review.
@@ -96,32 +98,7 @@ export function ensurePullRequestReviewHead({
       sha: headSha,
       sourceRef: headSha,
       destinationRef,
-      completeHistory: true,
     })
-  );
-}
-
-const REVIEW_HISTORY_DEPTH = 256;
-
-function deepenReviewHistory(targetDir: string, revisions: readonly string[]): void {
-  spawnSync(
-    "git",
-    [
-      "fetch",
-      "--filter=blob:none",
-      "--no-tags",
-      "--no-write-fetch-head",
-      "--recurse-submodules=no",
-      `--depth=${REVIEW_HISTORY_DEPTH}`,
-      "origin",
-      ...revisions,
-    ],
-    {
-      cwd: targetDir,
-      env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" },
-      stdio: "ignore",
-      timeout: 30_000,
-    },
   );
 }
 
@@ -140,22 +117,6 @@ export function hydratePullRequestReviewHistory(options: {
     itemNumber <= 0
   )
     return null;
-  if (reviewMergeBase(targetDir, baseSha, headSha).status === "unavailable") {
-    // Existing tree hydration may have fetched only the PR tip. Bound history, not
-    // the reviewed identity; failure remains explicit in the local evidence reader.
-    //
-    // Deepen the reviewed head on its own first. A depth-limited fetch re-bounds the
-    // ancestry of every revision it names, so naming the pinned base here as well
-    // truncates a base branch whose history the checkout already had -- the very
-    // ancestry a merge base is found in. Only deepen the base when the head alone did
-    // not establish one, which is the case where the base is itself shallow.
-    deepenReviewHistory(targetDir, [headSha]);
-    if (reviewMergeBase(targetDir, baseSha, headSha).status === "unavailable") {
-      // Unchanged fallback: the same fetch this function has always issued, for the case
-      // where the base is itself shallow and has to be deepened to reach an ancestor.
-      deepenReviewHistory(targetDir, [baseSha, headSha]);
-    }
-  }
   if (testMergeSha && GIT_OBJECT_ID.test(testMergeSha)) {
     ensureReviewTreeCommit({
       targetDir,

--- a/src/clawsweeper-review-runtime.ts
+++ b/src/clawsweeper-review-runtime.ts
@@ -95,16 +95,21 @@ export function createReviewRuntime({
   function gitInfo(openclawDir: string, options: ReviewGitInfoOptions = {}): GitInfo {
     const targetBranch = options.targetBranch ?? reviewTargetBranch(openclawDir);
     requireSafeGitBranchName(targetBranch, "target branch");
+    const shallow = run("git", ["rev-parse", "--is-shallow-repository"], { cwd: openclawDir });
     run(
       "git",
       [
         "fetch",
+        "--filter=blob:none",
+        "--no-tags",
+        "--recurse-submodules=no",
+        ...(shallow === "true" ? ["--unshallow"] : []),
         "origin",
         `refs/heads/${targetBranch}:refs/remotes/origin/${targetBranch}`,
-        "--depth=50",
       ],
       {
         cwd: openclawDir,
+        timeoutMs: 30_000,
       },
     );
     const mainSha = run("git", ["rev-parse", `refs/remotes/origin/${targetBranch}`], {
@@ -134,9 +139,22 @@ export function createReviewRuntime({
     }
     if (latestRelease?.tagName) {
       try {
-        run("git", ["fetch", "--force", "origin", "tag", latestRelease.tagName, "--depth=1"], {
-          cwd: openclawDir,
-        });
+        run(
+          "git",
+          [
+            "fetch",
+            "--force",
+            "--filter=blob:none",
+            "--recurse-submodules=no",
+            "origin",
+            "tag",
+            latestRelease.tagName,
+          ],
+          {
+            cwd: openclawDir,
+            timeoutMs: 30_000,
+          },
+        );
         latestRelease.sha = run("git", ["rev-list", "-n", "1", latestRelease.tagName], {
           cwd: openclawDir,
         });

--- a/test/review-blob-hydration.test.ts
+++ b/test/review-blob-hydration.test.ts
@@ -23,6 +23,7 @@ import {
   materializePullRequestReviewTree,
   removePullRequestReviewTree,
 } from "../dist/clawsweeper-review-blobs.js";
+import { createReviewRuntime } from "../dist/clawsweeper-review-runtime.js";
 import { MAX_SCAN_BYTES } from "../dist/agent-input-scan.js";
 import { readReviewGit, reviewMergeBase } from "../dist/pr-review-evidence.js";
 
@@ -30,7 +31,7 @@ function git(cwd: string, ...args: string[]): string {
   return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
 }
 
-function ensureShallowPullRequestReviewHead(targetDir: string, headSha: string): boolean {
+function acquirePullRequestReviewHead(targetDir: string, headSha: string): boolean {
   return ensureReviewTreeCommit({
     targetDir,
     sha: headSha,
@@ -175,10 +176,7 @@ function objectExistsOffline(cwd: string, sha: string): boolean {
   );
 }
 
-// A review target is a single-branch, blobless clone of the base branch, so the reviewed
-// head arrives shallow and history hydration has to reach a merge base. A depth-limited
-// fetch re-bounds every revision it names, so hydration must not name a base branch whose
-// ancestry the checkout already holds.
+// Include legacy depth-limited checkouts to prove acquisition recovers their ancestry.
 function reviewHistoryFixture({
   commitsBeforeBranch,
   commitsAfterBranch,
@@ -231,9 +229,7 @@ function reviewHistoryFixture({
   let headSha = git(source, "rev-parse", "HEAD");
   git(source, "checkout", "-q", "main");
   for (let index = 0; index < commitsAfterBranch; index += 1) commit(`base ${index}`);
-  // A pull request pins the base branch where it stood when the request was opened, so the
-  // branch usually moves on past it. Commits past that point put the pinned base behind the
-  // depth-limited refresh boundary, exactly as it sits in a hosted review.
+  // Model branch movement after REST captures the pinned base.
   const baseSha = git(source, "rev-parse", "HEAD");
   for (let index = 0; index < commitsPastBase; index += 1) commit(`past base ${index}`);
   git(source, "remote", "add", "origin", origin);
@@ -261,7 +257,7 @@ function reviewHistoryFixture({
     `file://${origin}`,
     target,
   );
-  // The review runtime refreshes the base branch with a depth-limited fetch before reviewing.
+  // Model the previous runtime's depth-limited refresh.
   git(
     target,
     "fetch",
@@ -282,10 +278,81 @@ function reachable(target: string, sha: string): number {
   return count.status === 0 ? Number(count.stdout.trim()) : -1;
 }
 
+test("review acquisition preserves a pinned base after main advances", () => {
+  const fixture = partialCloneFixture({ prefetchHead: false });
+  try {
+    git(fixture.source, "checkout", "-q", "main");
+    writeFileSync(join(fixture.source, "main.txt"), "pinned base\n");
+    git(fixture.source, "add", "main.txt");
+    git(fixture.source, "commit", "-qm", "pinned REST base");
+    const pinnedBase = git(fixture.source, "rev-parse", "HEAD");
+    writeFileSync(join(fixture.source, "main.txt"), "new main\n");
+    git(fixture.source, "commit", "-qam", "advance main");
+    git(fixture.source, "push", "-q", "origin", "main");
+    assert.equal(objectExistsOffline(fixture.target, pinnedBase), false);
+    assert.equal(git(fixture.target, "rev-parse", "--is-shallow-repository"), "false");
+    assert.equal(
+      ensureReviewTreeCommit({
+        targetDir: fixture.target,
+        sha: pinnedBase,
+        sourceRef: "refs/heads/main",
+        destinationRef: "refs/clawsweeper/review-cache/base-982",
+      }),
+      true,
+    );
+    assert.equal(objectExistsOffline(fixture.target, pinnedBase), true);
+    assert.equal(git(fixture.target, "rev-parse", "--is-shallow-repository"), "false");
+    assert.equal(git(fixture.target, "rev-parse", "HEAD"), fixture.baseSha);
+    assert.equal(git(fixture.target, "status", "--porcelain"), "");
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("review runtime refreshes and test merges preserve acquired ancestry", () => {
+  const fixture = partialCloneFixture({ prefetchHead: false });
+  try {
+    git(fixture.source, "-c", "tag.gpgsign=false", "tag", "proof-v1", fixture.baseSha);
+    git(fixture.source, "push", "-q", "origin", "refs/tags/proof-v1");
+    git(fixture.source, "checkout", "-q", "main");
+    git(fixture.source, "merge", "-q", "--no-ff", "feature", "-m", "test merge");
+    const testMergeSha = git(fixture.source, "rev-parse", "HEAD");
+    git(fixture.source, "push", "-q", "origin", "HEAD:refs/pull/982/merge");
+    assert.ok(acquirePullRequestReviewHead(fixture.target, fixture.headSha));
+    const runtime = createReviewRuntime({
+      run: (command, args, options) =>
+        execFileSync(command, args, {
+          cwd: options?.cwd,
+          encoding: "utf8",
+          timeout: options?.timeoutMs,
+          stdio: "pipe",
+        }).trim(),
+      ghJson: () => [{ tagName: "proof-v1", isLatest: true }],
+    } as Parameters<typeof createReviewRuntime>[0]);
+    const info = runtime.gitInfo(fixture.target, { targetBranch: "main" });
+    assert.equal(info.latestRelease?.sha, fixture.baseSha);
+    assert.equal(info.releaseStateComplete, true);
+    assert.equal(git(fixture.target, "rev-parse", "--is-shallow-repository"), "false");
+    assert.equal(
+      hydratePullRequestReviewHistory({
+        targetDir: fixture.target,
+        baseSha: fixture.baseSha,
+        headSha: fixture.headSha,
+        itemNumber: 982,
+        testMergeSha,
+      }),
+      fixture.baseSha,
+    );
+    assert.equal(git(fixture.target, "rev-parse", "--is-shallow-repository"), "false");
+    assert.equal(git(fixture.target, "rev-parse", "HEAD"), fixture.baseSha);
+    assert.equal(git(fixture.target, "status", "--porcelain"), "");
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
 test("supplied checkout exact-review sequence recovers merged base history", () => {
-  // The hosted workflow supplies a complete base checkout, then review acquisition fetches
-  // the PR head. Keep the merge-from-base commit beyond bounded fallback hydration so this
-  // fixture proves acquisition itself preserved the history instead of relying on the retry.
+  // Keep the merge-from-base commit beyond the former fixed-depth fallback.
   const fixture = reviewHistoryFixture({
     commitsBeforeBranch: 10,
     commitsAfterBranch: 10,
@@ -319,22 +386,18 @@ test("supplied checkout exact-review sequence recovers merged base history", () 
 });
 
 test("review history hydration keeps base ancestry the checkout already had", () => {
-  // The base branch's history is present and deeper than the bounded deepening, and the
-  // merge base is two commits behind the reviewed head but further behind the pinned base
-  // than the bound reaches. Naming the base in that fetch re-bounds ancestry the checkout
-  // already had and loses the merge base with it; deepening the head alone finds it.
   const fixture = reviewHistoryFixture({
     commitsBeforeBranch: 300,
     commitsAfterBranch: 300,
     commitsPastBase: 100,
   });
   try {
-    assert.ok(ensureShallowPullRequestReviewHead(fixture.target, fixture.headSha));
     const before = reachable(fixture.target, fixture.baseSha);
     assert.ok(before > 256, `expected deep base ancestry, saw ${before}`);
+    assert.ok(acquirePullRequestReviewHead(fixture.target, fixture.headSha));
     assert.equal(
       reviewMergeBase(fixture.target, fixture.baseSha, fixture.headSha).status,
-      "unavailable",
+      "verified",
     );
 
     assert.equal(
@@ -360,9 +423,7 @@ test("review history hydration keeps base ancestry the checkout already had", ()
   }
 });
 
-test("review history hydration still deepens a base branch that is itself shallow", () => {
-  // Shallow clone: the pinned base arrives with no ancestry, so reaching a merge base needs
-  // the base deepened too. Deepening only the head must not be the whole story.
+test("review acquisition recovers a base branch that is itself shallow", () => {
   const fixture = reviewHistoryFixture({
     commitsBeforeBranch: 10,
     commitsAfterBranch: 20,
@@ -370,8 +431,9 @@ test("review history hydration still deepens a base branch that is itself shallo
     baseRefreshDepth: 1,
   });
   try {
-    assert.ok(ensureShallowPullRequestReviewHead(fixture.target, fixture.headSha));
     assert.equal(reachable(fixture.target, fixture.baseSha), 1);
+    assert.ok(acquirePullRequestReviewHead(fixture.target, fixture.headSha));
+    assert.equal(git(fixture.target, "rev-parse", "--is-shallow-repository"), "false");
 
     assert.equal(
       hydratePullRequestReviewHistory({
@@ -391,10 +453,7 @@ test("review history hydration still deepens a base branch that is itself shallo
   }
 });
 
-test("review history hydration stays fail-closed when the bounded deepening cannot reach", () => {
-  // The merge base is further from the reviewed head than the bounded deepening reaches.
-  // That is the documented bound doing its job, not the defect above: no merge base is
-  // reported and the caller keeps refusing.
+test("review acquisition reaches ancestors beyond the former fixed depth", () => {
   const fixture = reviewHistoryFixture({
     commitsBeforeBranch: 5,
     commitsAfterBranch: 400,
@@ -402,7 +461,7 @@ test("review history hydration stays fail-closed when the bounded deepening cann
     baseRefreshDepth: 1,
   });
   try {
-    assert.ok(ensureShallowPullRequestReviewHead(fixture.target, fixture.headSha));
+    assert.ok(acquirePullRequestReviewHead(fixture.target, fixture.headSha));
     assert.equal(
       hydratePullRequestReviewHistory({
         targetDir: fixture.target,
@@ -410,11 +469,11 @@ test("review history hydration stays fail-closed when the bounded deepening cann
         headSha: fixture.headSha,
         itemNumber: 982,
       }),
-      null,
+      fixture.branchPoint,
     );
     assert.equal(
       reviewMergeBase(fixture.target, fixture.baseSha, fixture.headSha).status,
-      "unavailable",
+      "verified",
     );
   } finally {
     rmSync(fixture.root, { recursive: true, force: true });


### PR DESCRIPTION
## What Problem This Solves

Fixes https://github.com/openclaw/clawsweeper/issues/1342. When main advances after REST captures a PR base, a depth-one fetch can miss that pinned commit and turn a complete review checkout shallow. Branch refresh, release-tag fetches, and the bounded history retry can introduce similar ancestry boundaries later in the same review.

## Why This Change Was Made

Every review commit acquisition now uses complete blobless ancestry and unshallows existing shallow checkouts. The optional shallow mode and separate 256-commit retry path are removed. Branch/release refreshes preserve that ancestry, with a 30-second deadline per fetch.

The pinned base/head, exact-head force-push fallback, test-merge parent validation, restricted evidence reader and scanner admission remain authoritative. A newer branch tip never substitutes for a missing pinned commit. Full history can still exceed the fetch deadline; that remains an explicit source-preparation failure.

## User Impact

Reviews can inspect their original source revisions after main advances, without a later metadata refresh destroying usable history. The production change removes 21 net lines; regression coverage and documentation grow separately.

## OpenClaw Bay Impact

None. This changes Git source preparation before restricted review, with no observer API, lifecycle field, status contract, or mutation control change.

## Evidence

- The baseline fails the moving-main and release-refresh scenarios below; the candidate passes.
- Regression coverage includes pinned-base acquisition, release/test-merge ancestry, initially shallow checkouts, history beyond the former fixed depth, exact-head force-push recovery, and unavailable source.
- Precommit and committed-branch managed Codex reviews are scoped-clean at the required P0 scope.
- AWS `pnpm run check` passed: 4,290 tests, 14 skipped, zero failures, plus 13 changed-file coverage tests; builds, static checks, formatting and lint passed.
- The remote working candidate ran over the pinned baseline. Its production source hashes match committed head `dc4d13758d11d45c16b32d267046e5eaceb23a83`; hosted CI qualifies the published branch separately.

## Real Behavior Proof

Claim: the compiled production Git acquisition and metadata owners preserve complete ancestry and the original source identities through the complete preparation sequence.

Provider: AWS Crabbox; lease `cbx_230f25a88811`, image `ami-0461d919be7deb53c`, Linux `c7a.8xlarge`; Node24.18.1, pnpm11.10.0, Git2.53.0.

[Native proof and full gate](https://crabbox.openclaw.ai/portal/runs/run_6262e7007597).

The same standalone script ran against separately compiled main `5121370cfadc58069ebf4194cfbbbc138bd1e7a4` and the candidate. It creates a real blobless Git remote, captures the base, advances main, prepares the exact base/head, refreshes a historical release, fetches the pinned test merge, and reads the delta after making the origin unavailable.

| Scenario | Baseline | Candidate |
| --- | --- | --- |
| Pinned base after main advances | Missing; checkout becomes shallow | Acquired; complete history retained |
| Branch and historical release refresh | Checkout becomes shallow | Complete history retained |
| Full base/head/release/test-merge sequence | Stops at missing base | Original identities, clean unchanged checkout, 138-byte offline patch |
| Initially shallow checkout | Not used as passing evidence | Full sequence passes after unshallowing |
| Unavailable source | Existing refusal | Refuses the missing pinned base |

All fixture checkouts were removed. Synthetic release metadata and local Git object sizes replace the GitHub metadata service only; actual Git processes, blobless transport, compiled owners and offline reads execute. This is controlled source-preparation proof, not a model review, production queue mutation, fleet-wide deployment measurement, or a claim about any particular historical failed review.

The first local fixture attempt inherited tag signing and failed before the bug. The first AWS candidate run omitted the required remote blob-size resolver and stopped after its ancestry assertions. Those harness failures are not counted as passing proof; the linked corrected run contains the full trace.

Reproduce after `pnpm install --frozen-lockfile` and `pnpm run build`:

```sh
node source-proof.mjs "$PWD" sequence
node source-proof.mjs "$PWD" shallow
node source-proof.mjs "$PWD" runtime
node source-proof.mjs "$PWD" unavailable
```

<details>
<summary>Standalone controlled Git proof</summary>

```js
import assert from 'node:assert/strict';
import {execFileSync} from 'node:child_process';
import {createHash} from 'node:crypto';
import {mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync} from 'node:fs';
import {tmpdir} from 'node:os';
import {join, resolve} from 'node:path';
import {pathToFileURL} from 'node:url';

const repo = resolve(process.argv[2]);
const mode = process.argv[3] ?? 'sequence';
const {ensureReviewTreeCommit, ensurePullRequestReviewHead, hydratePullRequestReviewHistory,
  hydratePullRequestReviewBlobs} = await import(pathToFileURL(join(repo, 'dist/clawsweeper-review-blobs.js')));
const {createReviewRuntime} = await import(pathToFileURL(join(repo, 'dist/clawsweeper-review-runtime.js')));
const root = mkdtempSync(join(tmpdir(), 'clawsweeper-ancestry-proof-'));
const source = join(root, 'source');
const origin = join(root, 'origin.git');
const target = join(root, 'target');
const git = (cwd, ...args) => execFileSync('git', args, {cwd, encoding:'utf8', stdio:['pipe','pipe','pipe']}).trim();
const trace = [];
const result = {mode, node:process.version, git:git(repo,'--version'), sourceRevision:git(repo,'rev-parse','HEAD'),
  sourceHashes:Object.fromEntries(['src/clawsweeper-review-blobs.ts','src/clawsweeper-review-runtime.ts'].map(p=>
    [p,createHash('sha256').update(readFileSync(join(repo,p))).digest('hex')])),
  compiledHashes:Object.fromEntries(['dist/clawsweeper-review-blobs.js','dist/clawsweeper-review-runtime.js'].map(p=>
    [p,createHash('sha256').update(readFileSync(join(repo,p))).digest('hex')])), trace};
const record = stage => trace.push({stage, shallow:git(target,'rev-parse','--is-shallow-repository'),
  checkout:git(target,'rev-parse','HEAD'), dirty:git(target,'status','--porcelain')});
try {
  mkdirSync(source);
  git(root,'init','--bare','-q',origin);
  git(origin,'config','uploadpack.allowFilter','true');
  git(source,'init','-q','-b','main');
  git(source,'config','user.name','ClawSweeper proof');
  git(source,'config','user.email','proof@example.invalid');
  git(source,'config','commit.gpgsign','false');
  git(source,'config','tag.gpgsign','false');
  git(source,'remote','add','origin',origin);
  const commit = (value, file='main.txt') => {
    writeFileSync(join(source,file),value+'\n');
    git(source,'add',file);
    git(source,'commit','-qm',value);
    return git(source,'rev-parse','HEAD');
  };
  commit('root');
  const release = commit('release');
  git(source,'tag','proof-v1',release);
  const checkout = commit('initial checkout');
  git(source,'push','-q','origin','main','refs/tags/proof-v1');
  git(root,'clone','-q','--filter=blob:none','--single-branch','--branch','main',
    ...(mode==='shallow' ? ['--depth=1'] : []),`file://${origin}`,target);
  const base = commit('pinned REST base');
  git(source,'checkout','-qb','feature');
  const head = commit('feature','feature.txt');
  git(source,'push','-q','origin','HEAD:refs/pull/1342/head');
  git(source,'checkout','-q','main');
  git(source,'merge','-q','--no-ff','feature','-m','test merge');
  const merge = git(source,'rev-parse','HEAD');
  git(source,'push','-q','origin','HEAD:refs/pull/1342/merge');
  // Restore only this synthetic branch ref to model the unmerged base branch.
  git(source,'checkout','-q','--detach',base);
  git(source,'branch','-f','main',base);
  git(source,'checkout','-q','main');
  const advanced = commit('main advanced after REST capture');
  git(source,'push','-q','origin','main');
  Object.assign(result,{base,head,merge,release,checkout,advanced});
  record('initial');
  if(mode==='unavailable') rmSync(origin,{recursive:true,force:true});
  if(mode!=='runtime') {
    result.baseReady = ensureReviewTreeCommit({targetDir:target,sha:base,
      sourceRef:'refs/heads/main',destinationRef:'refs/clawsweeper/review-cache/base-1342'});
    record('base acquired');
    if(mode==='unavailable') {
      assert.equal(result.baseReady,false);
      result.pass=true;
    } else {
      assert.equal(result.baseReady,true,'pinned base acquired after branch advance');
      assert.equal(trace.at(-1).shallow,'false','base acquisition preserves full ancestry');
      assert.equal(ensurePullRequestReviewHead({targetDir:target,itemNumber:1342,headSha:head}),true);
      record('head acquired');
    }
  }
  if(mode!=='unavailable') {
    const runtime = createReviewRuntime({run:(command,args,options={})=>
      execFileSync(command,args,{cwd:options.cwd,encoding:'utf8',timeout:options.timeoutMs,stdio:['pipe','pipe','pipe']}).trim(),
      ghJson:()=>[{tagName:'proof-v1',name:'Synthetic release',publishedAt:'2026-01-01T00:00:00Z',isLatest:true}]});
    const info = runtime.gitInfo(target,{targetBranch:'main'});
    record('branch and release refreshed');
    assert.equal(info.mainSha,advanced);
    assert.equal(info.latestRelease.sha,release);
    assert.equal(trace.at(-1).shallow,'false','metadata refresh preserves full ancestry');
    if(mode!=='runtime') {
      result.mergeBase = hydratePullRequestReviewHistory({targetDir:target,baseSha:base,headSha:head,itemNumber:1342,testMergeSha:merge});
      record('test merge prepared');
      assert.equal(result.mergeBase,base);
      assert.equal(trace.at(-1).shallow,'false','test-merge acquisition preserves full ancestry');
      result.hydration = hydratePullRequestReviewBlobs({targetDir:target,baseSha:base,headSha:head,
        resolveBlobSizes:ids=>new Map(execFileSync('git',['cat-file','--batch-check=%(objectname) %(objectsize)'],
          {cwd:source,input:ids.join('\n')+'\n',encoding:'utf8'}).trim().split('\n').map(line=>{
            const [oid,bytes]=line.split(' '); return [oid,Number(bytes)];
          }))});
      assert.equal(result.hydration.hydrated,true);
      git(target,'remote','set-url','origin',join(root,'offline.git'));
      const patch = execFileSync('git',['diff','--binary',base,head],{cwd:target,env:{...process.env,GIT_NO_LAZY_FETCH:'1'}});
      result.offlinePatchBytes=patch.length;
      assert.match(patch.toString(),/\+feature/);
      result.mergeParents=git(target,'show','-s','--format=%P',merge).split(' ');
      assert.deepEqual(result.mergeParents,[base,head]);
    }
    assert.equal(git(target,'rev-parse','HEAD'),checkout);
    assert.equal(git(target,'status','--porcelain'),'');
    result.pass=true;
  }
} catch(error) {
  result.pass=false;
  result.error=error.message;
  process.exitCode=1;
} finally {
  rmSync(root,{recursive:true,force:true});
  result.fixtureRemoved=true;
  console.log(JSON.stringify(result,null,2));
}
```

</details>
