### PR TITLE
fix(review): identify refused inputs and recognize reviewed Mattermost fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,6 +567,13 @@ review. The scan stages at most 256 MiB in private external temporary files and
 uses the remaining review deadline; it never silently truncates or bypasses.
 Diagnostics omit scanner output and source values. Restore prerequisites or
 remove sensitive input before retrying a refusal.
+Exact-review failure manifests distinguish a native output/scan-contract failure
+from an unclassified finding. The latter records the first blocking finding's
+bounded detector metadata and host-staged material identity: prompt, schema,
+additional input, raw diff, patch, raw working bytes, or Git blob. Source
+references contain Git revisions and hashed paths, with at most four references
+and their total count. No raw paths, matched values, literal digests, or
+verification messages are retained; this provenance does not authorize a finding.
 
 The host classifies the reviewed synthetic malformed-configuration URI in
 `test/action-ledger-runtime.test.ts` and the explicitly approved autoreview
@@ -578,11 +585,17 @@ the reviewed OpenClaw Browser CDP authentication and credential-redaction fixtur
 the [remote-CDP coverage](https://github.com/openclaw/openclaw/blob/58da2f5897feb6840937d8e50cf7ee6f26aa57d7/extensions/browser/src/browser/chrome.test.ts),
 the [server-context redaction test](https://github.com/openclaw/openclaw/blob/4b5987829d0f82ea44ae50f2f418ffe5ea445e7f/extensions/browser/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts),
 the [remote-CDP documentation example](https://github.com/openclaw/openclaw/blob/bf15c87d2b1223610b42775b8154b8eec60b541d/docs/tools/browser.md),
-and the [credentialed-page rejection fixtures](https://github.com/openclaw/openclaw/blob/d5fb4903f1b13a4309d479f1011d995b1fc706ae/extensions/browser/src/browser-tool.test.ts)
+the [credentialed-page rejection fixtures](https://github.com/openclaw/openclaw/blob/d5fb4903f1b13a4309d479f1011d995b1fc706ae/extensions/browser/src/browser-tool.test.ts),
+and the [Mattermost slash-error sanitization fixtures](https://github.com/openclaw/openclaw/blob/9c0975c1c20ed635532c7aa0f510154224adee7f/extensions/mattermost/src/mattermost/slash-http.test.ts)
 after a complete scan. Static host policy associates each
-exact full-URI SHA-256 with only its approved source paths and exact scanner `Raw`
-digest, including when `Raw` omits a path retained by `RawV2`. The complete value
-must be a literal in a host-staged Git blob from mode `100644`.
+exact detector-matched URI SHA-256 with only its approved source paths and exact
+scanner `Raw` digest, including when `Raw` omits a path retained by `RawV2`. The
+matched value must be a literal in a host-staged Git blob from mode `100644`.
+The four Mattermost entries cover only the reviewed `/api` and `/hooks` URI
+prefixes and their authorities. TruffleHog's pinned URI detector excludes query
+text; this classification makes no claim about surrounding query values. The
+table binds exact values and paths across revisions, not entire enclosing URLs
+or particular commits.
 The host locates that exact literal independently in the staged blob. Decoder
 coordinates can shift, and TruffleHog can omit a companion plain-text finding,
 so admission does not depend on another finding or a reported line matching the

--- a/docs/review-cache.md
+++ b/docs/review-cache.md
@@ -100,7 +100,16 @@ admission. The manifest records the failure stage, reason, retryability, and
 the observed PR head. Native Git failures also retain process exit status, signal,
 error code, and bounded redacted stderr. Public errors omit raw process output;
 scanner output and verification details are never retained. Scan refusals
-preserve their original terminal classification and exit code.
+remain terminal and retain their workflow exit code. Incomplete or inconsistent
+native output uses `scanner_failed`; a complete scan with an unclassified finding
+uses `findings`. The manifest's optional `failure.scan` carries closed diagnostic
+reason codes. Finding diagnostics identify only the first blocking record, with
+the total finding count, bounded detector/decoder/line metadata, and a host-staged
+material ID. Git blobs and raw working files include up to four source references
+with exact Git revisions, modes, and SHA-256 path hashes plus the total reference
+count; patches and raw diffs identify their Git endpoints. Unknown scanner paths
+never become material identities. Raw paths, matched values, and literal digests
+are excluded. Diagnostic metadata never authorizes a finding or removes scanned input.
 
 Blob-size metadata uses batches of at most 160 objects; one explicit fetch per
 delta retrieves missing blobs only after the complete set fits the scanner's

--- a/src/agent-input-scan-fixtures.ts
+++ b/src/agent-input-scan-fixtures.ts
@@ -46,11 +46,91 @@ const REVIEWED_FIXTURES: readonly ReviewedFixture[] = [
     rawSha256: "8d3331ee208c72c30fba199e4e2b8a65d69a5034e49875a2f20dbea3a4f2f976",
     sources: ["extensions/browser/src/browser-tool.test.ts"],
   },
+  {
+    // Mattermost slash-error sanitization fixtures introduced by 9c0975c1c20e.
+    fixtureSha256: "f2c5cfd2b711577ed9048f9bd0e6c97ae88097b8eba8c1ff37deb33ed910f5a7",
+    rawSha256: "7d765bfa6e81c336a916aaf71eab28f5c0c4ae47a359ec3adf2d4f175645456d",
+    sources: ["extensions/mattermost/src/mattermost/slash-http.test.ts"],
+  },
+  {
+    fixtureSha256: "fd79d243a5d942979882ca621cfa8bd240a2fce9ca400cdd6b2b1bfab4c5cf6a",
+    rawSha256: "014a5653f93da5c53f9a09313e7aa32753fbdf0de02314af39a65af9a1dde664",
+    sources: ["extensions/mattermost/src/mattermost/slash-http.test.ts"],
+  },
+  {
+    fixtureSha256: "14947662dc4356637571038e47cd3f37a8911d37d41688a2f6c6b2b54c209c41",
+    rawSha256: "7d765bfa6e81c336a916aaf71eab28f5c0c4ae47a359ec3adf2d4f175645456d",
+    sources: ["extensions/mattermost/src/mattermost/slash-http.test.ts"],
+  },
+  {
+    fixtureSha256: "0c2d147cb7b70169ceb0302b40bceaa60abc15263c4dcfb7f1746cc93e3c87d3",
+    rawSha256: "014a5653f93da5c53f9a09313e7aa32753fbdf0de02314af39a65af9a1dde664",
+    sources: ["extensions/mattermost/src/mattermost/slash-http.test.ts"],
+  },
 ];
 
-export interface ReviewedFixtureBlob {
-  bytes: Buffer;
-  references: readonly { source: string; mode: string }[];
+export interface ScanSourceReference {
+  source: string;
+  mode: string;
+  revision: string;
+}
+
+export type ScanInputOrigin =
+  | { kind: "prompt" | "schema" | "additional" }
+  | { kind: "raw_diff" | "patch"; from: string; to: string }
+  | { kind: "worktree" | "blob"; references: readonly ScanSourceReference[] };
+
+export type StagedScanInput = ScanInputOrigin & { id: string; bytes?: Buffer };
+
+interface ScanMaterialDiagnostic {
+  kind: ScanInputOrigin["kind"];
+  id: string;
+  from?: string;
+  to?: string;
+  referenceCount?: number;
+  references?: { revision: string; pathSha256: string; mode: string }[];
+}
+
+export type ScanRefusalDiagnostic =
+  | {
+      kind: "native_contract";
+      reason:
+        | "invalid_stdout"
+        | "invalid_stderr"
+        | "scan_error"
+        | "incomplete_scan"
+        | "completion_mismatch"
+        | "unexpected_exit";
+    }
+  | {
+      kind: "unclassified_finding";
+      reason:
+        | "finding_not_reviewed"
+        | "literal_not_reviewed"
+        | "material_not_reviewed"
+        | "source_not_reviewed"
+        | "metadata_mismatch"
+        | "literal_mismatch";
+      findingCount: number;
+      findingIndex: number;
+      detectorType: number | null;
+      decoder: "PLAIN" | "HTML" | "OTHER";
+      verified: boolean | null;
+      scannerLine: number | null;
+      material?: ScanMaterialDiagnostic;
+    };
+
+export interface ReviewedFixtureNotice {
+  fixtureSha256: string;
+  source: string;
+  detector: string;
+  findings: ClassifiedFinding[];
+}
+
+interface RefusedScan {
+  kind: "refused";
+  reason: "scanner_failed" | "findings";
+  diagnostic: ScanRefusalDiagnostic;
 }
 
 interface ClassifiedFinding {
@@ -61,157 +141,232 @@ interface ClassifiedFinding {
   occurrences: number;
 }
 
-function object(value: unknown): Record<string, unknown> {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error("invalid scanner object");
-  }
-  return value as Record<string, unknown>;
+function object(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
 }
 
-function records(bytes: Buffer): Record<string, unknown>[] {
-  const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
-  if (!text.endsWith("\n")) throw new Error("incomplete scanner output");
-  return text
-    .slice(0, -1)
-    .split("\n")
-    .map((line) => object(JSON.parse(line)));
+function records(bytes: Buffer): Record<string, unknown>[] | undefined {
+  try {
+    if (!bytes.length) return [];
+    const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    if (!text.endsWith("\n")) return undefined;
+    return text
+      .slice(0, -1)
+      .split("\n")
+      .map((line) => {
+        const value = object(JSON.parse(line));
+        if (!value) throw new Error("invalid scanner object");
+        return value;
+      });
+  } catch {
+    // Parser errors can contain credential-shaped input; retain only a closed reason.
+    return undefined;
+  }
+}
+
+function materialDiagnostic(input: StagedScanInput): ScanMaterialDiagnostic {
+  // Only host-staged identities leave the scanner boundary. Bound reference
+  // fanout and hash paths; raw finding values and provider strings never leave.
+  return {
+    kind: input.kind,
+    id: input.id,
+    ...("from" in input ? { from: input.from, to: input.to } : {}),
+    ...("references" in input
+      ? {
+          referenceCount: input.references.length,
+          references: input.references.slice(0, 4).map(({ source, mode, revision }) => ({
+            revision,
+            pathSha256: createHash("sha256").update(source).digest("hex"),
+            mode,
+          })),
+        }
+      : {}),
+  };
 }
 
 /** Classify only complete native scans whose every finding matches host fixture policy. */
 export function classifyReviewedFixtureScan(
+  status: number,
   stdout: Buffer,
   stderr: Buffer,
-  sourceBlobs: ReadonlyMap<string, ReviewedFixtureBlob>,
-):
-  | { fixtureSha256: string; source: string; detector: string; findings: ClassifiedFinding[] }[]
-  | undefined {
-  try {
-    const findings = records(stdout);
-    const logs = records(stderr);
-    // TruffleHog can log detector failures and still exit 183. Its exit status
-    // alone therefore cannot establish that all detectors finished successfully.
-    if (
-      logs.some(
-        (entry) =>
-          entry.level !== "info-0" ||
-          typeof entry.logger !== "string" ||
-          typeof entry.msg !== "string" ||
-          entry.error !== undefined ||
-          entry.errors !== undefined,
-      ) ||
-      logs.filter((entry) => entry.msg === "finished scanning").length !== 1
+  inputs: ReadonlyMap<string, StagedScanInput>,
+): { kind: "classified"; notices: ReviewedFixtureNotice[] } | RefusedScan {
+  const nativeFailure = (
+    reason: Extract<ScanRefusalDiagnostic, { kind: "native_contract" }>["reason"],
+  ): RefusedScan => ({
+    kind: "refused",
+    reason: "scanner_failed",
+    diagnostic: { kind: "native_contract", reason },
+  });
+  if (status !== 183) return nativeFailure("unexpected_exit");
+  const findings = records(stdout);
+  if (!findings?.length) return nativeFailure("invalid_stdout");
+  const logs = records(stderr);
+  if (!logs) return nativeFailure("invalid_stderr");
+  // TruffleHog can log detector failures and still exit 183. Its exit status
+  // alone therefore cannot establish that all detectors finished successfully.
+  if (
+    logs.some(
+      (entry) =>
+        entry.level !== "info-0" ||
+        typeof entry.logger !== "string" ||
+        typeof entry.msg !== "string" ||
+        entry.error !== undefined ||
+        entry.errors !== undefined,
     )
-      return undefined;
-    const completion = logs.at(-1)!;
-    if (
-      completion.logger !== "trufflehog" ||
-      completion.msg !== "finished scanning" ||
-      completion.trufflehog_version !== "3.97.1" ||
-      typeof completion.chunks !== "number" ||
-      !Number.isSafeInteger(completion.chunks) ||
-      completion.chunks <= 0 ||
-      typeof completion.bytes !== "number" ||
-      !Number.isSafeInteger(completion.bytes) ||
-      completion.bytes <= 0 ||
-      completion.verified_secrets !== 0 ||
-      completion.unverified_secrets !== findings.length
-    )
-      return undefined;
+  )
+    return nativeFailure("scan_error");
+  const completion = logs.at(-1)!;
+  if (
+    logs.filter((entry) => entry.msg === "finished scanning").length !== 1 ||
+    completion?.logger !== "trufflehog" ||
+    completion.msg !== "finished scanning"
+  )
+    return nativeFailure("incomplete_scan");
+  const verifiedCount = findings.filter((finding) => finding.Verified === true).length;
+  if (
+    completion.trufflehog_version !== "3.97.1" ||
+    typeof completion.chunks !== "number" ||
+    !Number.isSafeInteger(completion.chunks) ||
+    completion.chunks <= 0 ||
+    typeof completion.bytes !== "number" ||
+    !Number.isSafeInteger(completion.bytes) ||
+    completion.bytes <= 0 ||
+    completion.verified_secrets !== verifiedCount ||
+    completion.unverified_secrets !== findings.length - verifiedCount
+  )
+    return nativeFailure("completion_mismatch");
 
-    const literalLines = new Map<string, number>();
-    const classified = new Map<
-      string,
-      { fixtureSha256: string; source: string; findings: Map<string, ClassifiedFinding> }
-    >();
-    for (const finding of findings) {
-      if (
-        finding.DetectorType !== 17 ||
-        finding.DetectorName !== "URI" ||
-        finding.SourceType !== 15 ||
-        finding.Verified !== false ||
-        (finding.DecoderName !== "PLAIN" && finding.DecoderName !== "HTML") ||
-        typeof finding.VerificationError !== "string" ||
-        !finding.VerificationError ||
-        typeof finding.Raw !== "string" ||
-        typeof finding.RawV2 !== "string" ||
-        finding.ExtraData !== null ||
-        finding.StructuredData !== null
+  const literalLines = new Map<string, number>();
+  const classified = new Map<
+    string,
+    { fixtureSha256: string; source: string; findings: Map<string, ClassifiedFinding> }
+  >();
+  for (const [findingIndex, finding] of findings.entries()) {
+    const source = object(object(object(finding.SourceMetadata)?.Data)?.Filesystem);
+    const file = source?.file;
+    const staged = typeof file === "string" ? inputs.get(file) : undefined;
+    const scannerLine =
+      typeof source?.line === "number" && Number.isSafeInteger(source.line) && source.line > 0
+        ? source.line
+        : null;
+    const refuse = (
+      reason: Extract<ScanRefusalDiagnostic, { kind: "unclassified_finding" }>["reason"],
+    ): RefusedScan => ({
+      kind: "refused",
+      reason: "findings",
+      diagnostic: {
+        kind: "unclassified_finding",
+        reason,
+        findingCount: findings.length,
+        findingIndex,
+        detectorType:
+          typeof finding.DetectorType === "number" &&
+          Number.isInteger(finding.DetectorType) &&
+          finding.DetectorType >= 0 &&
+          finding.DetectorType <= 2_147_483_647
+            ? finding.DetectorType
+            : null,
+        decoder:
+          finding.DecoderName === "PLAIN" || finding.DecoderName === "HTML"
+            ? finding.DecoderName
+            : "OTHER",
+        verified: typeof finding.Verified === "boolean" ? finding.Verified : null,
+        scannerLine,
+        ...(staged ? { material: materialDiagnostic(staged) } : {}),
+      },
+    });
+    if (
+      finding.DetectorType !== 17 ||
+      finding.DetectorName !== "URI" ||
+      finding.SourceType !== 15 ||
+      finding.Verified !== false ||
+      (finding.DecoderName !== "PLAIN" && finding.DecoderName !== "HTML") ||
+      typeof finding.VerificationError !== "string" ||
+      !finding.VerificationError ||
+      typeof finding.Raw !== "string" ||
+      typeof finding.RawV2 !== "string" ||
+      finding.ExtraData !== null ||
+      finding.StructuredData !== null
+    )
+      return refuse("finding_not_reviewed");
+    // URI Raw omits the path; bind both native outputs to the reviewed match.
+    const digest = createHash("sha256").update(finding.RawV2).digest("hex");
+    const rawDigest = createHash("sha256").update(finding.Raw).digest("hex");
+    const fixture = REVIEWED_FIXTURES.find(
+      (entry) =>
+        entry.fixtureSha256 === digest && (entry.rawSha256 ?? entry.fixtureSha256) === rawDigest,
+    );
+    if (!fixture) return refuse("literal_not_reviewed");
+    if (typeof file !== "string" || scannerLine === null) return refuse("metadata_mismatch");
+    if (staged?.kind !== "blob" || !staged.bytes) return refuse("material_not_reviewed");
+    if (
+      !staged.references.length ||
+      staged.references.some(
+        ({ source, mode }) => mode !== "100644" || !fixture.sources.some((path) => path === source),
       )
-        return undefined;
-      // URI Raw omits the path; bind both outputs to the complete reviewed value.
-      const digest = createHash("sha256").update(finding.RawV2).digest("hex");
-      const rawDigest = createHash("sha256").update(finding.Raw).digest("hex");
-      const fixture = REVIEWED_FIXTURES.find(
-        (entry) =>
-          entry.fixtureSha256 === digest && (entry.rawSha256 ?? entry.fixtureSha256) === rawDigest,
-      );
-      if (!fixture) return undefined;
-      const source = object(object(object(finding.SourceMetadata).Data).Filesystem);
-      const file = source.file;
-      if (typeof file !== "string") return undefined;
-      const staged = sourceBlobs.get(file);
-      if (
-        !staged ||
-        !staged.references.length ||
-        staged.references.some(
-          ({ source, mode }) =>
-            mode !== "100644" || !fixture.sources.some((path) => path === source),
-        ) ||
-        typeof source.line !== "number" ||
-        !Number.isSafeInteger(source.line) ||
-        source.line <= 0
-      )
-        return undefined;
-      const uri = new URL(finding.RawV2);
-      const parts = object(finding.SecretParts);
-      if (
-        Object.keys(parts).length !== 3 ||
-        parts.host !== uri.host ||
-        parts.username !== uri.username ||
-        parts.password !== uri.password
-      )
-        return undefined;
-      const valueKey = `${file}:${digest}`;
-      let literalLine = literalLines.get(valueKey);
-      if (literalLine === undefined) {
-        // Decoding can shift coordinates, and deduplication can drop the plain
-        // finding. Bind to staged bytes and record one literal witness separately
-        // from the scanner's location, without allocating unbounded line lists.
-        const text = new TextDecoder("utf-8", { fatal: true }).decode(staged.bytes);
-        const offset = text.indexOf(finding.RawV2);
-        if (offset < 0) return undefined;
-        literalLine = 1;
-        for (
-          let newline = text.indexOf("\n");
-          newline !== -1 && newline < offset;
-          newline = text.indexOf("\n", newline + 1)
-        ) {
-          literalLine++;
-        }
-        literalLines.set(valueKey, literalLine);
+    )
+      return refuse("source_not_reviewed");
+    const uri = new URL(finding.RawV2);
+    const parts = object(finding.SecretParts);
+    if (
+      !parts ||
+      Object.keys(parts).length !== 3 ||
+      parts.host !== uri.host ||
+      parts.username !== uri.username ||
+      parts.password !== uri.password
+    )
+      return refuse("metadata_mismatch");
+    const valueKey = `${file}:${digest}`;
+    let literalLine = literalLines.get(valueKey);
+    if (literalLine === undefined) {
+      // Decoding can shift coordinates, and deduplication can drop the plain
+      // finding. Bind to staged bytes and record one literal witness separately
+      // from the scanner's location, without allocating unbounded line lists.
+      let text;
+      try {
+        text = new TextDecoder("utf-8", { fatal: true }).decode(staged.bytes);
+      } catch {
+        return refuse("literal_mismatch");
       }
-      const blob = basename(file);
-      const key = `${blob}:${source.line}:${finding.DecoderName}`;
-      const sources = new Set(staged.references.map(({ source }) => source));
-      for (const path of sources) {
-        const groupKey = `${digest}:${path}`;
-        const group = classified.get(groupKey) ?? {
-          fixtureSha256: digest,
-          source: path,
-          findings: new Map<string, ClassifiedFinding>(),
-        };
-        const previous = group.findings.get(key);
-        group.findings.set(key, {
-          blob,
-          scannerLine: source.line,
-          literalLine,
-          decoder: finding.DecoderName,
-          occurrences: (previous?.occurrences ?? 0) + 1,
-        });
-        classified.set(groupKey, group);
+      const offset = text.indexOf(finding.RawV2);
+      if (offset < 0) return refuse("literal_mismatch");
+      literalLine = 1;
+      for (
+        let newline = text.indexOf("\n");
+        newline !== -1 && newline < offset;
+        newline = text.indexOf("\n", newline + 1)
+      ) {
+        literalLine++;
       }
+      literalLines.set(valueKey, literalLine);
     }
-    return [...classified.entries()]
+    const blob = basename(file);
+    const key = `${blob}:${scannerLine}:${finding.DecoderName}`;
+    const sources = new Set(staged.references.map(({ source }) => source));
+    for (const path of sources) {
+      const groupKey = `${digest}:${path}`;
+      const group = classified.get(groupKey) ?? {
+        fixtureSha256: digest,
+        source: path,
+        findings: new Map<string, ClassifiedFinding>(),
+      };
+      const previous = group.findings.get(key);
+      group.findings.set(key, {
+        blob,
+        scannerLine,
+        literalLine,
+        decoder: finding.DecoderName,
+        occurrences: (previous?.occurrences ?? 0) + 1,
+      });
+      classified.set(groupKey, group);
+    }
+  }
+  return {
+    kind: "classified",
+    notices: [...classified.entries()]
       .sort(([a], [b]) => a.localeCompare(b))
       .map(([, group]) => ({
         fixtureSha256: group.fixtureSha256,
@@ -220,9 +375,6 @@ export function classifyReviewedFixtureScan(
         findings: [...group.findings.entries()]
           .sort(([a], [b]) => a.localeCompare(b))
           .map(([, value]) => value),
-      }));
-  } catch {
-    // Scanner output includes credential-shaped bytes; never expose parse errors.
-    return undefined;
-  }
+      })),
+  };
 }

--- a/src/agent-input-scan.ts
+++ b/src/agent-input-scan.ts
@@ -22,7 +22,11 @@ import { reviewToolCacheRoot } from "./review-tool-bootstrap.js";
 import { readReviewGit, reviewMergeBase, type ReviewGitReadOptions } from "./pr-review-evidence.js";
 import {
   classifyReviewedFixtureScan,
-  type ReviewedFixtureBlob,
+  type ReviewedFixtureNotice,
+  type ScanInputOrigin,
+  type ScanRefusalDiagnostic,
+  type ScanSourceReference,
+  type StagedScanInput,
 } from "./agent-input-scan-fixtures.js";
 
 export type AgentScanSource =
@@ -52,6 +56,7 @@ export class AgentInputScanError extends Error {
       | "source_drift"
       | "unsafe_path"
       | "unsupported_content",
+    readonly scanDiagnostic?: ScanRefusalDiagnostic,
   ) {
     super(
       `Agent input scan refused: ${reason}. Restore trusted scan prerequisites or remove sensitive input before retrying.`,
@@ -245,7 +250,7 @@ export function scanAgentInput(options: {
   };
   let root: string | undefined;
   let failure: AgentInputScanError | undefined;
-  let classified: ReturnType<typeof classifyReviewedFixtureScan>;
+  let classified: ReviewedFixtureNotice[] | undefined;
   try {
     const cwd = realpathSync(options.cwd);
     const scanner = trustedScanner(cwd, options.cwd, remaining());
@@ -254,22 +259,27 @@ export function scanAgentInput(options: {
       throw new AgentInputScanError("unsafe_path");
     const inputDir = join(root, "input");
     mkdirSync(inputDir, { mode: 0o700 });
-    const reviewedFixtureBlobs = new Map<string, ReviewedFixtureBlob>();
+    const inputs = new Map<string, StagedScanInput>();
     let staged = 0;
     let ordinal = 0;
-    const stage = (bytes: Buffer, name = String(ordinal++)) => {
+    const stage = (bytes: Buffer, origin: ScanInputOrigin, name = String(ordinal++)) => {
       remaining();
       staged += bytes.length;
       if (staged > MAX_SCAN_BYTES) throw new AgentInputScanError("staging_limit");
       writeFileSync(join(inputDir, name), bytes, { mode: 0o600, flag: "wx" });
+      inputs.set(join(inputDir, name), {
+        ...origin,
+        id: name,
+        ...(origin.kind === "blob" ? { bytes } : {}),
+      });
     };
-    stage(Buffer.from(options.prompt), "prompt");
+    stage(Buffer.from(options.prompt), { kind: "prompt" }, "prompt");
     if (options.schemaPath) {
       if (statSync(options.schemaPath).size > MAX_SCAN_BYTES - staged)
         throw new AgentInputScanError("staging_limit");
-      stage(readFileSync(options.schemaPath), "schema");
+      stage(readFileSync(options.schemaPath), { kind: "schema" }, "schema");
     }
-    for (const bytes of options.additionalBytes ?? []) stage(bytes);
+    for (const bytes of options.additionalBytes ?? []) stage(bytes, { kind: "additional" });
     const source = options.source;
     let assertCurrent = () => {};
     if (source.kind !== "prompt") {
@@ -462,12 +472,16 @@ export function scanAgentInput(options: {
             )
               throw new AgentInputScanError("source_drift");
             rawIdentities.set(entry.path, oid);
-            if (oid !== entry.oid) stage(bytes);
+            if (oid !== entry.oid)
+              stage(bytes, {
+                kind: "worktree",
+                references: [{ source: entry.path, mode: entry.mode, revision: source.headSha }],
+              });
           }
         };
       }
       assertCurrent();
-      const blobs = new Map<string, { source: string; mode: string }[]>();
+      const blobs = new Map<string, ScanSourceReference[]>();
       const endpoints =
         source.kind === "snapshot"
           ? [mergeBase.sha, source.headSha, source.indexTreeSha, source.treeSha]
@@ -486,7 +500,7 @@ export function scanAgentInput(options: {
           to,
         ];
         const raw = git([...args, "--raw", "--no-abbrev", "-z", "--"]);
-        stage(raw);
+        stage(raw, { kind: "raw_diff", from, to });
         const fields = new TextDecoder("utf-8", { fatal: true }).decode(raw).split("\0");
         if (fields.pop() !== "" || fields.length % 2 !== 0)
           throw new AgentInputScanError("incomplete_source");
@@ -504,9 +518,9 @@ export function scanAgentInput(options: {
           if (!match) throw new AgentInputScanError("incomplete_source");
           if (source.kind === "committed")
             currentFiles.push({ path, mode: match[2]!, oid: match[4]! });
-          for (const [mode, oid] of [
-            [match[1]!, match[3]!],
-            [match[2]!, match[4]!],
+          for (const [mode, oid, revision] of [
+            [match[1]!, match[3]!, from],
+            [match[2]!, match[4]!, to],
           ]) {
             if (mode === "000000") continue;
             if (!["100644", "100755", "120000"].includes(mode!))
@@ -514,11 +528,15 @@ export function scanAgentInput(options: {
             if (!OBJECT_ID.test(oid!)) throw new AgentInputScanError("incomplete_source");
             // An OID identifies bytes, not each scanned endpoint's path/mode eligibility.
             const references = blobs.get(oid!) ?? [];
-            references.push({ source: path, mode: mode! });
+            references.push({ source: path, mode: mode!, revision: revision! });
             blobs.set(oid!, references);
           }
         }
-        stage(git([...args, "--patch", "--binary", "--full-index", "--"]));
+        stage(git([...args, "--patch", "--binary", "--full-index", "--"]), {
+          kind: "patch",
+          from,
+          to,
+        });
       }
       // Only live committed checkouts need normalized raw files staged here;
       // snapshot objects were already captured and fenced before preparation.
@@ -535,8 +553,7 @@ export function scanAgentInput(options: {
         )
           throw new AgentInputScanError("unsupported_content");
         // OID names preserve multiline bytes and make symlinks ordinary scan files.
-        stage(bytes, oid);
-        reviewedFixtureBlobs.set(join(inputDir, oid), { bytes, references });
+        stage(bytes, { kind: "blob", references }, oid);
       }
     }
     const result = spawnSync(
@@ -570,13 +587,15 @@ export function scanAgentInput(options: {
     if (result.error || result.signal || (result.status !== 0 && result.status !== 183))
       throw new AgentInputScanError("scanner_failed");
     if (result.status === 183 || result.stdout?.length) {
-      if (result.status === 183)
-        classified = classifyReviewedFixtureScan(
-          result.stdout,
-          result.stderr,
-          reviewedFixtureBlobs,
-        );
-      if (!classified) throw new AgentInputScanError("findings");
+      const classification = classifyReviewedFixtureScan(
+        result.status!,
+        result.stdout,
+        result.stderr,
+        inputs,
+      );
+      if (classification.kind === "refused")
+        throw new AgentInputScanError(classification.reason, classification.diagnostic);
+      classified = classification.notices;
     }
     remaining();
     assertCurrent();

--- a/src/clawsweeper-review-failure-diagnostics.ts
+++ b/src/clawsweeper-review-failure-diagnostics.ts
@@ -42,7 +42,7 @@ export function writeExactReviewFailureDiagnostics(options: {
   env?: NodeJS.ProcessEnv;
 }): string {
   const error = record(options.error);
-  const scanFailure = options.error instanceof AgentInputScanError;
+  const scanFailure = options.error instanceof AgentInputScanError ? options.error : undefined;
   const diagnosticStage = scanFailure
     ? "agent_input_scan"
     : safeCode(error.diagnosticStage, /^source_preparation$/);
@@ -81,6 +81,7 @@ export function writeExactReviewFailureDiagnostics(options: {
       failure: {
         stage: diagnosticStage ?? "unknown",
         reason_code: diagnosticReason ?? "unknown",
+        ...(scanFailure?.scanDiagnostic ? { scan: scanFailure.scanDiagnostic } : {}),
       },
       process: {
         status: Number.isInteger(error.status) && Number(error.status) >= 0 ? error.status : null,

--- a/test/agent-input-scan.test.ts
+++ b/test/agent-input-scan.test.ts
@@ -31,6 +31,7 @@ import {
   withTargetReviewSnapshot,
 } from "../dist/repair/target-validation.js";
 import { useFakeScanner } from "./agent-input-scan-helpers.ts";
+import { writeExactReviewFailureDiagnostics } from "../dist/clawsweeper-review-failure-diagnostics.js";
 
 test("only incomplete source scan failures receive the terminal review exit code", () => {
   assert.equal(
@@ -138,7 +139,7 @@ if (inputs.some(({bytes}) => bytes.includes(${JSON.stringify(needle)}))) {
       () => f.run({ kind: "committed", baseSha, headSha }),
       (error) => {
         assert.ok(error instanceof AgentInputScanError);
-        assert.equal(error.reason, "findings");
+        assert.equal(error.reason, "scanner_failed");
         assert.doesNotMatch(String(error), /must-not-escape/);
         return true;
       },
@@ -342,7 +343,7 @@ test("repair admission includes staged bytes when working bytes were restored", 
   const expected = captureTargetCheckoutBinding(f.cwd);
   assert.throws(
     () => withTargetReviewSnapshot({ cwd: f.cwd, baseSha, expected, timeoutMs: 30_000 }, f.run),
-    /findings/,
+    /scanner_failed/,
   );
   assert.equal(existsSync(f.calls), false);
 });
@@ -466,7 +467,7 @@ ${failure === "signal" ? "process.kill(process.pid, 'SIGTERM');" : failure === "
                 ? "scanner_unavailable"
                 : failure === "deadline"
                   ? "deadline"
-                  : "findings",
+                  : "scanner_failed",
         );
         assert.doesNotMatch(String(error), /synthetic-sensitive-value/);
         return true;
@@ -542,7 +543,24 @@ const browserServerContextSource =
   "extensions/browser/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts";
 const browserDocsSource = "docs/tools/browser.md";
 const browserToolSource = "extensions/browser/src/browser-tool.test.ts";
+const mattermostSource = "extensions/mattermost/src/mattermost/slash-http.test.ts";
 const ledgerFixtureSha256 = "a728de5dbbef23b8aa5ef2d99060835f4f2fb5a0fa2abb9fe249d08aa09bd09e";
+const nativeContractFailures = new Map([
+  ["missing completion", "incomplete_scan"],
+  ["detector error", "scan_error"],
+  ["info error", "scan_error"],
+  ["info errors", "scan_error"],
+  ["wrong count", "completion_mismatch"],
+  ["verified count", "completion_mismatch"],
+  ["wrong version", "completion_mismatch"],
+  ["duplicate completion", "incomplete_scan"],
+  ["trailing log", "incomplete_scan"],
+  ["unterminated output", "invalid_stdout"],
+  ["unterminated stderr", "invalid_stderr"],
+  ["malformed stderr", "invalid_stderr"],
+  ["malformed output", "invalid_stdout"],
+  ["unexpected successful output", "unexpected_exit"],
+]);
 
 for (const scenario of [
   "reviewed fixture",
@@ -552,10 +570,21 @@ for (const scenario of [
   "browser local server mismatch",
   "browser docs fixture",
   "browser page URL fixture",
+  "mattermost api input fixture",
+  "mattermost api redacted fixture",
+  "mattermost hooks input fixture",
+  "mattermost hooks redacted fixture",
+  "mattermost changed username",
+  "mattermost changed password",
+  "mattermost changed host",
+  "mattermost changed path",
+  "mattermost mismatched authority raw",
+  "mattermost source mismatch",
+  "mattermost different approved literal",
   "browser docs source mismatch",
   "browser page URL source mismatch",
   "browser page URL changed path",
-  "browser page URL changed query",
+  "browser page URL synthetic query record",
   "browser docs shifted HTML",
   "browser docs shifted HTML first",
   "browser docs shifted HTML without companion",
@@ -588,10 +617,14 @@ for (const scenario of [
   "invalid line",
   "invalid UTF-8 literal blob",
   "other file",
+  "many source references",
+  "untrusted finding metadata",
   "prompt",
   "schema",
   "additional",
   "diff",
+  "raw diff",
+  "normalized worktree",
   "decoded only",
   "wrong detector",
   "wrong source type",
@@ -628,6 +661,7 @@ for (const scenario of [
     let uri = [...existing.matchAll(/"([^"\n]+)"/g)]
       .map((match) => match[1]!)
       .find((value) => createHash("sha256").update(value).digest("hex") === ledgerFixtureSha256);
+    const mattermostFixture = scenario.startsWith("mattermost ");
     const browserDocsFixture = scenario.startsWith("browser docs");
     const browserPageFixture = scenario.startsWith("browser page URL");
     if (scenario.startsWith("browser ")) {
@@ -644,53 +678,88 @@ for (const scenario of [
       url.username = local ? "browser-user" : "user";
       url.password = browserPageFixture ? "secret" : local ? "browser-password" : "pass";
       if (scenario === "browser page URL changed path") url.pathname = "/changed";
-      if (scenario === "browser page URL changed query") url.search = "?changed=1";
+      // Parser-only control: native URI matching excludes query text.
+      if (scenario === "browser page URL synthetic query record") url.search = "?changed=1";
       uri = browserPageFixture ? url.href : url.href.slice(0, -1);
+    }
+    if (mattermostFixture) {
+      // Native URI output stops before query text in these reviewed sanitization fixtures.
+      const url = new URL(
+        scenario.includes("hooks")
+          ? "https://chat.example.com/hooks"
+          : "https://chat.example.com/api",
+      );
+      url.username = scenario.includes("redacted") ? "redacted" : "user";
+      url.password = scenario.includes("redacted") ? "redacted" : "pass";
+      if (scenario === "mattermost changed username") url.username += "changed";
+      if (scenario === "mattermost changed password") url.password += "changed";
+      if (scenario === "mattermost changed host") url.hostname = "other.example.com";
+      if (scenario === "mattermost changed path") url.pathname = "/changed";
+      uri = url.href;
     }
     assert.ok(uri, "reviewed synthetic fixture is present");
     const authority = new URL(uri);
     authority.pathname = "";
     authority.search = "";
     authority.hash = "";
-    const raw = browserPageFixture ? authority.href.slice(0, -1) : uri;
+    if (scenario === "mattermost mismatched authority raw") {
+      authority.username = "redacted";
+      authority.password = "redacted";
+    }
+    const raw = browserPageFixture || mattermostFixture ? authority.href.slice(0, -1) : uri;
     let otherReviewedUri: string | undefined;
     if (scenario.endsWith("different approved literal")) {
-      const other = new URL("http://127.0.0.1");
-      other.username = "browser-user";
-      other.password = "browser-password";
-      otherReviewedUri = other.href.slice(0, -1);
+      if (mattermostFixture) {
+        const other = new URL(uri);
+        other.pathname = "/hooks";
+        otherReviewedUri = other.href;
+      } else {
+        const other = new URL("http://127.0.0.1");
+        other.username = "browser-user";
+        other.password = "browser-password";
+        otherReviewedUri = other.href.slice(0, -1);
+      }
     }
     const findingValues = [uri, raw, ...(otherReviewedUri ? [otherReviewedUri] : [])];
     const f = fixture(t, scenario === "prompt" ? uri : undefined);
-    const files = scenario.startsWith("browser ")
-      ? [
-          browserDocsFixture
-            ? scenario.endsWith("source mismatch")
-              ? browserToolSource
-              : browserDocsSource
-            : browserPageFixture
-              ? scenario.endsWith("source mismatch")
-                ? browserDocsSource
-                : browserToolSource
-              : scenario.includes("server")
-                ? browserServerContextSource
-                : browserChromeSource,
-        ]
-      : scenario === "shared approved path OIDs"
-        ? [...autoreviewSources, ledgerSource]
-        : scenario === "shared approved and unapproved path OIDs"
-          ? [ledgerSource, "other.test.ts"]
-          : scenario === "both autoreview paths"
-            ? autoreviewSources
-            : [
-                scenario === "canonical autoreview path"
-                  ? autoreviewSources[0]!
-                  : scenario === "vendored autoreview path"
-                    ? autoreviewSources[1]!
-                    : scenario === "other file"
-                      ? "other.test.ts"
-                      : ledgerSource,
-              ];
+    const files =
+      scenario === "many source references"
+        ? Array.from({ length: 8 }, (_, index) => `unapproved-${index}.test.ts`)
+        : mattermostFixture
+          ? [
+              scenario === "mattermost source mismatch"
+                ? "extensions/mattermost/src/slash-http.test.ts"
+                : mattermostSource,
+            ]
+          : scenario.startsWith("browser ")
+            ? [
+                browserDocsFixture
+                  ? scenario.endsWith("source mismatch")
+                    ? browserToolSource
+                    : browserDocsSource
+                  : browserPageFixture
+                    ? scenario.endsWith("source mismatch")
+                      ? browserDocsSource
+                      : browserToolSource
+                    : scenario.includes("server")
+                      ? browserServerContextSource
+                      : browserChromeSource,
+              ]
+            : scenario === "shared approved path OIDs"
+              ? [...autoreviewSources, ledgerSource]
+              : scenario === "shared approved and unapproved path OIDs"
+                ? [ledgerSource, "other.test.ts"]
+                : scenario === "both autoreview paths"
+                  ? autoreviewSources
+                  : [
+                      scenario === "canonical autoreview path"
+                        ? autoreviewSources[0]!
+                        : scenario === "vendored autoreview path"
+                          ? autoreviewSources[1]!
+                          : scenario === "other file"
+                            ? "other.test.ts"
+                            : ledgerSource,
+                    ];
     const value =
       scenario === "decoded only" || scenario.endsWith("encoded-only")
         ? uri.replace(":", "&#58;")
@@ -714,6 +783,8 @@ for (const scenario of [
       if (scenario === "executable source" || scenario === "shared endpoint OID 755 to 644")
         chmodSync(join(f.cwd, file), 0o755);
     }
+    if (scenario === "normalized worktree")
+      writeFileSync(join(f.cwd, ".gitattributes"), "*.ts text eol=crlf\n");
     const baseSha = f.commit();
     for (const file of files) {
       if (scenario === "shared endpoint OID 644 to 755" || scenario === "executable head snapshot")
@@ -728,6 +799,11 @@ for (const scenario of [
         );
     }
     const headSha = f.commit();
+    if (scenario === "normalized worktree")
+      writeFileSync(
+        join(f.cwd, files[0]!),
+        fixtureContent("// after\n").toString().replaceAll("\n", "\r\n"),
+      );
     const modeOnly =
       scenario.startsWith("shared endpoint OID") || scenario === "executable head snapshot";
     if (modeOnly) {
@@ -769,11 +845,13 @@ let findings = inputs.filter(({name, bytes}) =>
   (scenario === 'prompt' && name === 'prompt') ||
   (scenario === 'schema' && name === 'schema') ||
   (scenario === 'additional' && name === '0') ||
-  (scenario === 'diff' && /^\d+$/.test(name) && bytes.includes(uri))
+  (scenario === 'diff' && /^\d+$/.test(name) && bytes.includes(uri)) ||
+  (scenario === 'raw diff' && name === '0') ||
+  (scenario === 'normalized worktree' && /^\d+$/.test(name) && bytes.includes('\r\n'))
 ).map(({name, bytes}) => ({
   SourceType: 15, DetectorType: 17, DetectorName: 'URI', DecoderName: 'PLAIN', Verified: false,
   VerificationError: 'synthetic verification error', Raw: raw, RawV2: uri,
-  SourceMetadata: {Data: {Filesystem: {file: path.join(inputDir, name), line: /^[a-f0-9]{40}$/.test(name) ? 42 : bytes.toString().split('\n').findIndex(line => line.includes(uri)) + 1}}},
+  SourceMetadata: {Data: {Filesystem: {file: path.join(inputDir, name), line: /^[a-f0-9]{40}$/.test(name) ? 42 : scenario === 'raw diff' ? 1 : bytes.toString().split('\n').findIndex(line => line.includes(uri)) + 1}}},
   SecretParts: {host: parsed.host, username: parsed.username, password: parsed.password},
   ExtraData: null, StructuredData: null,
 }));
@@ -808,6 +886,11 @@ if (scenario === 'missing verification error') findings[0].VerificationError = '
 if (scenario === 'unexpected extra data') findings[0].ExtraData = {};
 if (scenario === 'unexpected structured data') findings[0].StructuredData = {};
 if (scenario === 'wrong secret parts') findings[0].SecretParts.host = 'mismatch';
+if (scenario === 'untrusted finding metadata') {
+  findings[0].DetectorType = findings[0].DetectorName = findings[0].DecoderName = uri;
+  findings[0].SourceMetadata.Data.Filesystem.file = '/outside/' + uri;
+  findings[0].SourceMetadata.Data.Filesystem.line = Number.MAX_VALUE;
+}
 if (scenario === 'source drift') fs.appendFileSync(${JSON.stringify(join(f.cwd, files[0]!))}, '// drift');
 process.stdout.write(findings.map(value => JSON.stringify(value)).join('\n') + (scenario === 'unterminated output' ? '' : '\n'));
 if (scenario === 'malformed output') process.stdout.write('{');
@@ -816,7 +899,7 @@ if (scenario === 'info error') process.stderr.write(JSON.stringify({level:'info-
 if (scenario === 'info errors') process.stderr.write(JSON.stringify({level:'info-0', logger:'trufflehog', msg:'detector failed', errors:[]}) + '\n');
 const completion = JSON.stringify({
   level:'info-0', logger:'trufflehog', msg:'finished scanning', trufflehog_version:scenario === 'wrong version' ? 'changed' : '3.97.1',
-  chunks:2, bytes:1000, verified_secrets:scenario === 'verified count' ? 1 : 0, unverified_secrets:findings.length + (scenario === 'wrong count' ? 1 : 0),
+  chunks:2, bytes:1000, verified_secrets:findings.filter(value => value.Verified).length + (scenario === 'verified count' ? 1 : 0), unverified_secrets:findings.filter(value => !value.Verified).length + (scenario === 'wrong count' ? 1 : 0),
 }) + (scenario === 'unterminated stderr' ? '' : '\n');
 if (scenario !== 'missing completion') process.stderr.write(completion);
 if (scenario === 'duplicate completion') process.stderr.write(completion);
@@ -854,6 +937,10 @@ process.exit(scenario === 'unexpected successful output' ? 0 : 183);
         "browser remote server fixture",
         "browser docs fixture",
         "browser page URL fixture",
+        "mattermost api input fixture",
+        "mattermost api redacted fixture",
+        "mattermost hooks input fixture",
+        "mattermost hooks redacted fixture",
         "browser docs shifted HTML",
         "browser docs shifted HTML first",
         "browser docs shifted HTML without companion",
@@ -924,11 +1011,123 @@ process.exit(scenario === 'unexpected successful output' ? 0 : 183);
     } else {
       assert.throws(run, (error) => {
         assert.ok(error instanceof AgentInputScanError);
-        assert.equal(error.reason, scenario === "source drift" ? "source_drift" : "findings");
+        const contractFailure = nativeContractFailures.get(scenario);
         assert.equal(
-          findingValues.some((candidate) => String(error).includes(candidate)),
+          error.reason,
+          scenario === "source drift"
+            ? "source_drift"
+            : contractFailure
+              ? "scanner_failed"
+              : "findings",
+        );
+        const outputDir = writeExactReviewFailureDiagnostics({
+          artifactDir: join(f.root, "artifacts"),
+          error,
+          prompt: "Review the change.",
+          model: "internal",
+          classification: "codex_execution",
+          repo: "openclaw/clawsweeper",
+          itemKind: "pull_request",
+          itemNumber: 1,
+          sourceSha: headSha,
+          retryable: error.retryable,
+          workflowExit: 1,
+          env: {},
+        });
+        const manifest = JSON.parse(readFileSync(join(outputDir, "manifest.json"), "utf8"));
+        assert.equal(manifest.failure.stage, "agent_input_scan");
+        assert.equal(manifest.failure.reason_code, error.reason);
+        assert.equal(manifest.source.sha, headSha);
+        assert.equal(manifest.retryable, false);
+        const diagnostic = manifest.failure.scan;
+        if (scenario !== "source drift") {
+          assert.equal(
+            diagnostic?.kind,
+            contractFailure ? "native_contract" : "unclassified_finding",
+          );
+          if (contractFailure) assert.equal(diagnostic.reason, contractFailure);
+          else {
+            if (mattermostFixture) {
+              assert.equal(
+                diagnostic.reason,
+                scenario === "mattermost different approved literal"
+                  ? "literal_mismatch"
+                  : scenario === "mattermost source mismatch"
+                    ? "source_not_reviewed"
+                    : "literal_not_reviewed",
+              );
+            }
+            assert.ok(diagnostic.findingCount > diagnostic.findingIndex);
+            if (scenario === "untrusted finding metadata") {
+              assert.equal(diagnostic.detectorType, null);
+              assert.equal(diagnostic.decoder, "OTHER");
+              assert.equal(diagnostic.scannerLine, null);
+              assert.equal(diagnostic.material, undefined);
+            }
+            const kind = new Map([
+              ["prompt", "prompt"],
+              ["schema", "schema"],
+              ["additional", "additional"],
+              ["diff", "patch"],
+              ["raw diff", "raw_diff"],
+              ["normalized worktree", "worktree"],
+              ["other file", "blob"],
+              ["many source references", "blob"],
+            ]).get(scenario);
+            if (kind) {
+              assert.equal(diagnostic.material.kind, kind);
+              if (kind === "patch" || kind === "raw_diff") {
+                assert.equal(diagnostic.material.from, baseSha);
+                assert.equal(diagnostic.material.to, headSha);
+              } else if (kind === "blob") {
+                assert.ok(
+                  [baseSha, headSha].some(
+                    (revision) =>
+                      f.git("rev-parse", `${revision}:${files[0]!}`) === diagnostic.material.id,
+                  ),
+                );
+                assert.equal(
+                  diagnostic.material.referenceCount,
+                  scenario === "many source references" ? 8 : 1,
+                );
+                assert.equal(
+                  diagnostic.material.references.length,
+                  scenario === "many source references" ? 4 : 1,
+                );
+                assert.equal(
+                  diagnostic.material.references[0].pathSha256,
+                  createHash("sha256").update(files[0]!).digest("hex"),
+                );
+                assert.equal(diagnostic.material.references[0].mode, "100644");
+              } else if (kind === "worktree") {
+                assert.equal(diagnostic.material.references[0].revision, headSha);
+                assert.equal(
+                  diagnostic.material.references[0].pathSha256,
+                  createHash("sha256").update(files[0]!).digest("hex"),
+                );
+              }
+            }
+          }
+        }
+        const diagnosticBytes = [
+          "manifest.json",
+          "error.txt",
+          "stdout.error.txt",
+          "stderr.tail.txt",
+        ]
+          .map((name) => readFileSync(join(outputDir, name), "utf8"))
+          .join("\n");
+        assert.equal(
+          [...findingValues, f.root, ...files].some((candidate) =>
+            (String(error) + diagnosticBytes).includes(candidate),
+          ),
           false,
-          "finding bytes stay private",
+          "finding bytes and raw source paths stay private",
+        );
+        assert.equal(
+          diagnosticBytes.includes(createHash("sha256").update(uri).digest("hex")),
+          false,
+          "refusal diagnostics do not publish literal digests",
         );
         return true;
       });

--- a/test/assist-artifact.test.ts
+++ b/test/assist-artifact.test.ts
@@ -29,7 +29,7 @@ const request: AssistRequestBinding = {
   reasoningEffort: "high",
 };
 
-for (const admission of ["clean", "finding"]) {
+for (const admission of ["clean", "invalid-output"]) {
   test(`assist generation ${admission} leaves no diagnostic prompt copy`, (t) => {
     const root = mkdtempSync(join(tmpdir(), "clawsweeper-assist-prompt-"));
     t.after(() => rmSync(root, { recursive: true, force: true }));
@@ -41,7 +41,7 @@ for (const admission of ["clean", "finding"]) {
       t,
       `
 assert.equal(fs.existsSync(${JSON.stringify(promptPath)}), false);
-${admission === "finding" ? "process.exit(183);" : ""}
+${admission === "invalid-output" ? "process.exit(183);" : ""}
 `,
     );
     const binary = join(root, "codex");
@@ -90,8 +90,8 @@ fs.writeFileSync(process.argv[process.argv.indexOf('--output-last-message') + 1]
         artifact: artifactPath,
         work_dir: root,
       });
-    if (admission === "finding") {
-      assert.throws(run, /Agent input scan refused: findings/);
+    if (admission === "invalid-output") {
+      assert.throws(run, /Agent input scan refused: scanner_failed/);
       assert.equal(existsSync(providerInput), false);
       assert.equal(existsSync(artifactPath), false);
     } else {

--- a/test/local-review.test.ts
+++ b/test/local-review.test.ts
@@ -62,7 +62,7 @@ function runLocalReview(
   return { status: result.status, out: `${result.stderr ?? ""}${result.stdout ?? ""}` };
 }
 
-for (const admission of ["clean", "finding"])
+for (const admission of ["clean", "invalid-output"])
   test(
     `local-review ${admission} preserves GitHub isolation without diagnostic prompt copies`,
     { skip: process.platform === "win32" },
@@ -74,7 +74,7 @@ for (const admission of ["clean", "finding"])
         t,
         `
 assert.equal(fs.readdirSync(${JSON.stringify(reportDir)}, {recursive: true}).some(name => String(name).endsWith('.prompt.md')), false);
-${admission === "finding" ? "process.exit(183);" : ""}
+${admission === "invalid-output" ? "process.exit(183);" : ""}
 `,
       );
       try {
@@ -136,9 +136,9 @@ fs.writeFileSync(output, "---\\nresult: success\\n---\\n\\nOffline local review 
           ),
           false,
         );
-        if (admission === "finding") {
+        if (admission === "invalid-output") {
           assert.equal(result.status, 1, result.out);
-          assert.match(result.out, /Agent input scan refused: findings/);
+          assert.match(result.out, /Agent input scan refused: scanner_failed/);
           assert.equal(existsSync(capture), false);
           return;
         }

--- a/test/pr-close-coverage-proof.test.ts
+++ b/test/pr-close-coverage-proof.test.ts
@@ -460,7 +460,7 @@ test("PR close coverage proof prompt requires concrete coverage proof", () => {
   assert.doesNotMatch(prompt, /patchSignature/);
 });
 
-for (const admission of ["clean", "finding"])
+for (const admission of ["clean", "invalid-output"])
   test(
     `PR close coverage proof ${admission} leaves no prompt copies in the proof tree`,
     { skip: process.platform === "win32" },
@@ -475,7 +475,7 @@ for (const admission of ["clean", "finding"])
           t,
           `
 assert.equal(fs.existsSync(${JSON.stringify(promptPath)}), false);
-${admission === "finding" ? "process.exit(183);" : ""}
+${admission === "invalid-output" ? "process.exit(183);" : ""}
 `,
         );
         const binDir = join(root, "bin");
@@ -522,7 +522,8 @@ ${admission === "finding" ? "process.exit(183);" : ""}
                 promptTemplate: "Prove close coverage.",
               },
             });
-          if (admission === "finding") assert.throws(run, /Agent input scan refused: findings/);
+          if (admission === "invalid-output")
+            assert.throws(run, /Agent input scan refused: scanner_failed/);
           else assert.equal(run().decision, "covered");
         } finally {
           if (previousCodexBin === undefined) delete process.env.CODEX_BIN;

--- a/test/repair/run-worker.test.ts
+++ b/test/repair/run-worker.test.ts
@@ -33,7 +33,7 @@ test("repair output schema keeps every strict object property required", () => {
   visit(schema, "schema");
 });
 
-for (const admission of ["clean", "finding", "dry-run"])
+for (const admission of ["clean", "invalid-output", "dry-run"])
   test(`run-worker ${admission} preserves the target and prompt artifact contract`, () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-run-worker-"));
     const fakeBin = path.join(tmp, "bin");
@@ -52,7 +52,7 @@ const runs = fs.readdirSync(${JSON.stringify(path.join(repoRoot, ".clawsweeper-r
 for (const run of runs.filter(name => name.startsWith(${JSON.stringify(`${jobName}-plan-`)}))) {
   assert.equal(fs.existsSync(path.join(${JSON.stringify(path.join(repoRoot, ".clawsweeper-repair/runs"))}, run, 'prompt.md')), false);
 }
-${admission === "finding" ? "process.exit(183);" : admission === "dry-run" ? "throw new Error('dry run must not invoke scanner');" : ""}
+${admission === "invalid-output" ? "process.exit(183);" : admission === "dry-run" ? "throw new Error('dry run must not invoke scanner');" : ""}
 `,
     );
     fs.mkdirSync(targetCheckout, { recursive: true });
@@ -159,7 +159,8 @@ ${admission === "finding" ? "process.exit(183);" : admission === "dry-run" ? "th
             stdio: "pipe",
           },
         );
-      if (admission === "finding") assert.throws(run, /Agent input scan refused: findings/);
+      if (admission === "invalid-output")
+        assert.throws(run, /Agent input scan refused: scanner_failed/);
       else run();
       assert.equal(fs.readFileSync(jobPath, "utf8"), originalJob);
       const runDirs = fs.globSync(
@@ -169,7 +170,7 @@ ${admission === "finding" ? "process.exit(183);" : admission === "dry-run" ? "th
       const runDir = runDirs[0];
       assert.ok(runDir);
       const diagnosticPromptPath = path.join(runDir, "prompt.md");
-      if (admission === "finding") {
+      if (admission === "invalid-output") {
         assert.equal(fs.existsSync(cwdFile), false);
         assert.equal(fs.existsSync(diagnosticPromptPath), false);
         return;

--- a/test/review-command-workflow.test.ts
+++ b/test/review-command-workflow.test.ts
@@ -659,7 +659,7 @@ for (const scenario of [
         );
 
       if (refuseScan) {
-        const reason = incompleteSource ? "incomplete_source" : "findings";
+        const reason = incompleteSource ? "incomplete_source" : "scanner_failed";
         assert.throws(execute, (error) => {
           assert.ok(error instanceof AgentInputScanError);
           assert.equal(error.reason, reason);
@@ -686,7 +686,13 @@ for (const scenario of [
           const manifest = JSON.parse(
             readFileSync(join(artifactDir, "failure-diagnostics", "manifest.json"), "utf8"),
           );
-          assert.deepEqual(manifest.failure, { stage: "agent_input_scan", reason_code: reason });
+          assert.deepEqual(manifest.failure, {
+            stage: "agent_input_scan",
+            reason_code: reason,
+            ...(!incompleteSource
+              ? { scan: { kind: "native_contract", reason: "invalid_stdout" } }
+              : {}),
+          });
           assert.equal(manifest.retryable, false);
           assert.equal(manifest.process.workflow_exit, incompleteSource ? 78 : 1);
           assert.equal(


### PR DESCRIPTION
Related: [the refused OpenClaw canary](https://github.com/openclaw/openclaw/pull/126818) and [source-preparation repair](https://github.com/openclaw/clawsweeper/pull/1344).

## What Problem This Solves

A refused source scan left maintainers with a generic `findings` failure and no safe way to identify the blocked input. Malformed native output was also reported as findings. A live canary exposed four unreviewed synthetic URI patterns in the existing Mattermost slash-error redaction tests.

## Why This Change Was Made

The existing scanner classifier now returns one explicit success/refusal result. The staging owner records bounded input provenance, and the existing failure manifest carries closed diagnostic codes and host-owned identifiers before private inputs are removed. A malformed, incomplete, or inconsistent native scan remains `scanner_failed`; an unclassified finding remains `findings`. Matched values, raw paths, arbitrary scanner strings, stdout, and stderr are excluded.

Four exact detector-value/Raw digest pairs were added to the existing reviewed-fixture table after reading the original redaction tests, their introducing commit and parent, shipped history, and pinned detector source. Each pair requires the exact Mattermost test path, mode, staged literal witness, and the existing complete-scan/all-findings checks. This adds policy data rather than a general exception for domains or tests.

## User Impact

Maintainers can locate a blocked material kind and Git endpoint without publishing the material or a suspected credential. The reviewed Mattermost fixtures can proceed through admission. Unknown literals, wrong sources or modes, verified findings, mismatched parts, and incomplete native output still refuse the entire input batch.

The URI detector's matched value ends before the query. These entries bind the matched prefix and authority at the reviewed source path across revisions; they do not pin an entire enclosing URL, its query, or a single revision. This limit is documented explicitly.

## OpenClaw Bay Impact

No Bay change is needed. The optional diagnostic belongs to the existing private failure artifact, not a Bay API or projection. Queue, retry, lifecycle, storage, and public dashboard contracts are unchanged.

## Documentation Impact

Active `README.md` and `docs/review-cache.md` now describe the diagnostic boundary and the detector-prefix, path, and revision limits. Their existing maintainer ownership and source-triggered update contract remain in place.

## Evidence

Candidate: `10adaf807313080b4000d1c5b1a5a3a73c61af65`, based on `311b985611cf2036bd23ca54420996f0ce5b81c5`. The frozen patch is `87cefc9de7af7932ca148360c48d5b4025de1e2e72f25034ab16005d182500c2`; all exercised source and compiled-module hashes were unchanged before and after proof.

- Final full `pnpm run check`: **4,412 passed, nine skipped, zero failures or cancellations** (1,106 seconds). Node 24.19.0, pinned pnpm 11.10.0, Bash 4+, macOS arm64.
- Focused scanner/writer suite: 113 passed. Caller/ledger regressions: 30 passed. The actual nested npm child fixture passed. Updated-main target validation: 209 passed, three platform skips.
- Four new fixture positives first refused with `literal_not_reviewed`; after the table update, all eleven new owner cases passed, including seven refusal/exactness controls.
- Fresh independent Codex precommit review: scoped-clean at P0–P2; no findings. The reviewer inspected code but did not execute tests. Committed-branch review and exact-head CI are separate landing gates.

The first full check found eleven outdated assertions expecting empty exit-183 output to mean findings; they now require native-contract refusal while retaining provider, ledger, prompt, and cleanup assertions. A separate npm-discovery failure was reproduced and resolved by exposing the installed Node runtime's real bin directory in the task launcher. No production installer, test assertion, or repository configuration was weakened for that environment fix.

Final delta: production **+340/-168 (net +172)**, tests **+269/-62 (net +207)**, docs **+27/-5 (net +22)**. Production growth comprises the closed diagnostic capability (+151) and four policy entries (+21); one classifier and one input map replace the collapsed failure path.

## Real Behavior Proof

**Native scanner and failure-manifest path: eight cases passed.** The actual `scanAgentInput` owner ran pinned TruffleHog 3.97.1 with its normal verification flags and wrote through the existing failure-diagnostic owner. A clean prompt and an approved source blob were admitted. An unapproved source, prompt, schema, additional input, and patch were refused with the correct material provenance. The final case removed only the terminal newline from real native output and correctly produced `scanner_failed/invalid_stdout`. Each run verified native completion, binary identity, source/build invariance, and temporary-input cleanup; no raw output was retained.

```sh
node "$PROOF_DIR/native-proof.mjs" "$CLAW_WORKTREE" "$PROOF_DIR/native-result"
```

Harness SHA-256: `22846664aee4bdfcd33ca309b5ca280b51ecd9f0c536d3f165f301b7256d60ac`. Final result SHA-256: `48aeb9bd0679e0f65a7ac927b60bc586d56a1ca962048997214a2638f663e719`. The initial attempt stopped at an output-directory preflight before native execution; the successful run used a fresh directory and the unchanged harness.

**Mattermost native comparison: one scan, identical buffers, opposite classification.** The probe read exact public base/head blobs `0f48e6fe11e85a4cad32fd13bc5dd5e83794e38c` and `5b7bce6545dce0556c172382ad6443536f90f081` from [the canary test source](https://github.com/openclaw/openclaw/blob/d172b7b36f472452d526abd921b6759c698cbc50/extensions/mattermost/src/mattermost/slash-http.test.ts#L609). A fresh HOME and `env -i` forwarded no credentials or proxies. The native scan exited 183 with four unknown URI rows, one completion record, and no scan errors. The unchanged native status/stdout/stderr buffers were passed to both classifiers: the pre-table-update classifier refused `literal_not_reviewed`; the candidate classified every row into three fixture notices. A shifted scanner line retained its separate staged literal witness.

The four literals originate in [the redaction-test introduction](https://github.com/openclaw/openclaw/commit/9c0975c1c20ed635532c7aa0f510154224adee7f); its raw parent lacks them. They remain identical through stable `v2026.8.2` and both canary endpoints. The [pinned URI detector](https://github.com/trufflesecurity/trufflehog/blob/v3.97.1/pkg/detectors/uri/uri.go) supplies the matched-prefix and Raw contract. No enclosing query bytes are claimed as native match evidence.

Command: `node probe-mattermost-verifying-ab.mjs candidate-spec.json` under an empty environment. Harness SHA-256: `5f23594f0c8ca1a3659e28c188804b5226cca459297584f48b3928c6c5e5f53b`. Result SHA-256: `ab1e24d63a39b30ce7ba2560114883751a09cd5d23bf6b479f778e2744eb070d`. Native binary SHA-256: `f6899e5521ff060634a9599e02215195d29d330e9a902feb3f5322eedcb7ba21`.

These proofs exercise compiled owners and the native scanner. The Mattermost comparison covers two source blobs, not the full hosted prompt/diff or a completed canary review. No model or contributor code executed. A fresh normal hosted canary after deployment will verify end-to-end admission separately.
