### PR TITLE
fix(review): stop retrying deterministic input refusals

### DIFF
--- a/.github/actions/setup-openclaw-codex-source/action.yml
+++ b/.github/actions/setup-openclaw-codex-source/action.yml
@@ -33,8 +33,16 @@ runs:
       if: ${{ steps.target.outputs.repository == 'openclaw/openclaw' && env.CLAWSWEEPER_RUNNER != 'openclaw' }}
       shell: bash
       run: |
+        set +e
         "$GITHUB_ACTION_PATH/install.sh" \
           "${{ steps.target.outputs.repository }}" \
           "${{ inputs.target-dir }}" \
           "${{ inputs.review-artifact-dir }}" \
           "${{ inputs.target-dir }}-codex-cache.git"
+        setup_status=$?
+        set -e
+        if [ "$setup_status" -eq 80 ]; then
+          echo "::notice::The base checkout has no eligible Codex pin; deferring the decision to the materialized review tree."
+          exit 0
+        fi
+        exit "$setup_status"

--- a/.github/actions/setup-openclaw-codex-source/install.sh
+++ b/.github/actions/setup-openclaw-codex-source/install.sh
@@ -60,6 +60,16 @@ if [[ "$pin_root" != "$target_root" ]] &&
   exit 1
 fi
 
+if [[ -n "${GITHUB_ENV:-}" ]]; then
+  {
+    echo "CLAWSWEEPER_OPENCLAW_CODEX_SETUP_SCRIPT=$setup_script"
+    echo "CLAWSWEEPER_OPENCLAW_CODEX_TARGET_DIR=$target_root"
+    echo "CLAWSWEEPER_OPENCLAW_CODEX_ARTIFACT_DIR=$review_artifact_root"
+    echo "CLAWSWEEPER_OPENCLAW_CODEX_CACHE_DIR=$cache_dir"
+    echo "CLAWSWEEPER_OPENCLAW_CODEX_SOURCE_URL=$source_url"
+  } >> "$GITHUB_ENV"
+fi
+
 package_json_input="$pin_root/extensions/codex/package.json"
 if [[ ! -f "$package_json_input" || -L "$package_json_input" ]]; then
   echo "OpenClaw Codex version pin must be a regular file." >&2
@@ -164,15 +174,5 @@ elif [[ -e "$review_sibling" ]]; then
   exit 1
 fi
 ln -s "$source_dir" "$review_sibling"
-
-if [[ -n "${GITHUB_ENV:-}" ]]; then
-  {
-    echo "CLAWSWEEPER_OPENCLAW_CODEX_SETUP_SCRIPT=$setup_script"
-    echo "CLAWSWEEPER_OPENCLAW_CODEX_TARGET_DIR=$target_root"
-    echo "CLAWSWEEPER_OPENCLAW_CODEX_ARTIFACT_DIR=$review_artifact_root"
-    echo "CLAWSWEEPER_OPENCLAW_CODEX_CACHE_DIR=$cache_dir"
-    echo "CLAWSWEEPER_OPENCLAW_CODEX_SOURCE_URL=$source_url"
-  } >> "$GITHUB_ENV"
-fi
 
 echo "Prepared Codex $version source for OpenClaw review at $source_dir."

--- a/.github/actions/setup-openclaw-codex-source/install.sh
+++ b/.github/actions/setup-openclaw-codex-source/install.sh
@@ -8,6 +8,7 @@ cache_dir_input="${4:-}"
 source_url="${5:-https://github.com/openai/codex.git}"
 pin_dir_input="${6:-$target_dir_input}"
 setup_script="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)/$(basename "${BASH_SOURCE[0]}")"
+source_incompatible_exit=80
 
 target_repo="$(printf '%s' "$target_repo" | tr '[:upper:]' '[:lower:]')"
 if [[ "$target_repo" != "openclaw/openclaw" ]]; then
@@ -62,7 +63,7 @@ fi
 package_json_input="$pin_root/extensions/codex/package.json"
 if [[ ! -f "$package_json_input" || -L "$package_json_input" ]]; then
   echo "OpenClaw Codex version pin must be a regular file." >&2
-  exit 1
+  exit "$source_incompatible_exit"
 fi
 package_json="$(node -e 'process.stdout.write(require("node:fs").realpathSync(process.argv[1]))' "$package_json_input")"
 case "$package_json/" in
@@ -72,18 +73,7 @@ case "$package_json/" in
     exit 1
     ;;
 esac
-version="$(node - "$package_json" <<'NODE'
-const fs = require("node:fs");
-const file = process.argv[2];
-const manifest = JSON.parse(fs.readFileSync(file, "utf8"));
-const version = manifest.dependencies?.["@openai/codex"];
-if (typeof version !== "string" || !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
-  console.error("OpenClaw must pin @openai/codex to one exact version.");
-  process.exit(1);
-}
-process.stdout.write(version);
-NODE
-)"
+version="$(node "$(dirname "$setup_script")/validate-pin.mjs" "$package_json")"
 tag="rust-v$version"
 source_dir="$workspace_root/codex"
 

--- a/.github/actions/setup-openclaw-codex-source/validate-pin.mjs
+++ b/.github/actions/setup-openclaw-codex-source/validate-pin.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+
+const SOURCE_INCOMPATIBLE_EXIT_CODE = 80;
+const exactVersion = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
+
+function refuse() {
+  console.error("OpenClaw must pin @openai/codex to one exact version.");
+  process.exit(SOURCE_INCOMPATIBLE_EXIT_CODE);
+}
+
+let manifest;
+try {
+  manifest = JSON.parse(readFileSync(process.argv[2], "utf8"));
+} catch {
+  refuse();
+}
+
+const version = manifest?.dependencies?.["@openai/codex"];
+if (typeof version !== "string" || !exactVersion.test(version)) refuse();
+process.stdout.write(version);

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1335,6 +1335,10 @@ jobs:
           # unchanged source tuple is terminal, while the workflow stays red.
           if [ "$review_exit_code" -eq 78 ]; then
             echo "failure_reason=incomplete_source" >> "$GITHUB_OUTPUT"
+          # Keep 79 aligned with AGENT_INPUT_FINDINGS_EXIT_CODE. A scanner
+          # refusal is terminal for the unchanged source tuple.
+          elif [ "$review_exit_code" -eq 79 ]; then
+            echo "failure_reason=findings" >> "$GITHUB_OUTPUT"
           elif [ "$review_exit_code" -ne 0 ] && [ -f artifacts/event/failure-diagnostics/manifest.json ] &&
             jq -e '
               .classification == "source_preparation" and
@@ -1763,6 +1767,8 @@ jobs:
           detail="The exact review did not produce a publishable artifact. The durable queue will retry it."
           if [ "$REVIEW_FAILURE_REASON" = "incomplete_source" ]; then
             detail="The exact review could not verify the complete source. The durable queue will not retry this unchanged revision."
+          elif [ "$REVIEW_FAILURE_REASON" = "findings" ]; then
+            detail="The input scanner refused the reviewed source. The durable queue will not retry this unchanged revision."
           elif [ "$REVIEW_FAILURE_REASON" = "source_incompatible" ]; then
             detail="The reviewed source does not contain a valid exact Codex version pin. The durable queue will not retry this unchanged revision; update or rebase it before requesting review again."
           elif [ "$RESERVATION_STATUS" = "superseded" ] || [ "$REVIEW_SUPERSEDED" = "true" ]; then

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1335,6 +1335,13 @@ jobs:
           # unchanged source tuple is terminal, while the workflow stays red.
           if [ "$review_exit_code" -eq 78 ]; then
             echo "failure_reason=incomplete_source" >> "$GITHUB_OUTPUT"
+          elif [ "$review_exit_code" -ne 0 ] && [ -f artifacts/event/failure-diagnostics/manifest.json ] &&
+            jq -e '
+              .classification == "source_preparation" and
+              .retryable == false and
+              .failure.reason_code == "source_incompatible"
+            ' artifacts/event/failure-diagnostics/manifest.json >/dev/null; then
+            echo "failure_reason=source_incompatible" >> "$GITHUB_OUTPUT"
           fi
           if [ "$review_exit_code" -ne 0 ]; then
             exit "$review_exit_code"
@@ -1756,6 +1763,8 @@ jobs:
           detail="The exact review did not produce a publishable artifact. The durable queue will retry it."
           if [ "$REVIEW_FAILURE_REASON" = "incomplete_source" ]; then
             detail="The exact review could not verify the complete source. The durable queue will not retry this unchanged revision."
+          elif [ "$REVIEW_FAILURE_REASON" = "source_incompatible" ]; then
+            detail="The reviewed source does not contain a valid exact Codex version pin. The durable queue will not retry this unchanged revision; update or rebase it before requesting review again."
           elif [ "$RESERVATION_STATUS" = "superseded" ] || [ "$REVIEW_SUPERSEDED" = "true" ]; then
             state="Waiting"
             detail="A newer exact-review queue owner superseded this run. This run completed as a no-op."

--- a/README.md
+++ b/README.md
@@ -599,8 +599,10 @@ or particular commits.
 The host locates that exact literal independently in the staged blob. Decoder
 coordinates can shift, and TruffleHog can omit a companion plain-text finding,
 so admission does not depend on another finding or a reported line matching the
-original source. Repeated literals remain eligible; finding order and duplicate
-records do not change the exact value, path, and mode checks.
+original source. Repeated literals remain eligible unless an entry is bound to
+an approved complete-line digest; those entries require exactly one occurrence
+in the staged blob. Finding order and duplicate records do not change the exact
+value, path, and mode checks.
 One source path may contain multiple independently reviewed fixtures; each
 digest/path/mode tuple must match exactly, so source membership alone never
 qualifies a finding.

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -314,7 +314,7 @@ export type ExactReviewReviewRecoveryReason =
   | "workflow_cancelled"
   | "workflow_failed";
 type ExactReviewRetryKind = "coordination" | "throttle";
-type ExactReviewFailureReason = "incomplete_source" | "source_incompatible";
+type ExactReviewFailureReason = "findings" | "incomplete_source" | "source_incompatible";
 type ExactReviewPublicationFailureKind = "github_rate_limit" | "github_transient";
 type ExactReviewDispatchFailureClass =
   | "permanent_rejection"
@@ -2212,7 +2212,8 @@ export class ExactReviewQueue {
       const reviewFailureReason =
         body.review_failure_reason === undefined
           ? undefined
-          : body.review_failure_reason === "incomplete_source" ||
+          : body.review_failure_reason === "findings" ||
+              body.review_failure_reason === "incomplete_source" ||
               body.review_failure_reason === "source_incompatible"
             ? (body.review_failure_reason as ExactReviewFailureReason)
             : null;

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -314,7 +314,7 @@ export type ExactReviewReviewRecoveryReason =
   | "workflow_cancelled"
   | "workflow_failed";
 type ExactReviewRetryKind = "coordination" | "throttle";
-type ExactReviewFailureReason = "incomplete_source";
+type ExactReviewFailureReason = "incomplete_source" | "source_incompatible";
 type ExactReviewPublicationFailureKind = "github_rate_limit" | "github_transient";
 type ExactReviewDispatchFailureClass =
   | "permanent_rejection"
@@ -2212,7 +2212,8 @@ export class ExactReviewQueue {
       const reviewFailureReason =
         body.review_failure_reason === undefined
           ? undefined
-          : body.review_failure_reason === "incomplete_source"
+          : body.review_failure_reason === "incomplete_source" ||
+              body.review_failure_reason === "source_incompatible"
             ? (body.review_failure_reason as ExactReviewFailureReason)
             : null;
       if (body.review_failure_reason !== undefined && !reviewFailureReason) {

--- a/src/agent-input-scan-fixtures.ts
+++ b/src/agent-input-scan-fixtures.ts
@@ -338,11 +338,17 @@ export function classifyReviewedFixtureScan(
       }
       let lineStart = 0;
       let lineNumber = 1;
+      let literalOccurrences = 0;
       while (lineStart <= text.length) {
         const newline = text.indexOf("\n", lineStart);
         const lineEnd = newline === -1 ? text.length : newline;
         const line = text.slice(lineStart, lineEnd);
         if (line.includes(finding.RawV2)) {
+          let occurrence = line.indexOf(finding.RawV2);
+          while (occurrence !== -1) {
+            literalOccurrences++;
+            occurrence = line.indexOf(finding.RawV2, occurrence + finding.RawV2.length);
+          }
           if (
             fixture.lineSha256s &&
             !fixture.lineSha256s.includes(createHash("sha256").update(line).digest("hex"))
@@ -354,7 +360,11 @@ export function classifyReviewedFixtureScan(
         lineStart = newline + 1;
         lineNumber++;
       }
-      if (literalLine === undefined) return refuse("literal_mismatch");
+      if (
+        literalLine === undefined ||
+        (fixture.lineSha256s !== undefined && literalOccurrences !== 1)
+      )
+        return refuse("literal_mismatch");
       literalLines.set(valueKey, literalLine);
     }
     const blob = basename(file);

--- a/src/agent-input-scan-fixtures.ts
+++ b/src/agent-input-scan-fixtures.ts
@@ -4,6 +4,7 @@ import { basename } from "node:path";
 interface ReviewedFixture {
   fixtureSha256: string;
   rawSha256?: string;
+  lineSha256s?: readonly string[];
   sources: readonly string[];
 }
 
@@ -50,21 +51,25 @@ const REVIEWED_FIXTURES: readonly ReviewedFixture[] = [
     // Mattermost slash-error sanitization fixtures introduced by 9c0975c1c20e.
     fixtureSha256: "f2c5cfd2b711577ed9048f9bd0e6c97ae88097b8eba8c1ff37deb33ed910f5a7",
     rawSha256: "7d765bfa6e81c336a916aaf71eab28f5c0c4ae47a359ec3adf2d4f175645456d",
+    lineSha256s: ["38c08c0f567b2d663fb72a8b41170a233f5baeb499a2205143a873df9e21a43d"],
     sources: ["extensions/mattermost/src/mattermost/slash-http.test.ts"],
   },
   {
     fixtureSha256: "fd79d243a5d942979882ca621cfa8bd240a2fce9ca400cdd6b2b1bfab4c5cf6a",
     rawSha256: "014a5653f93da5c53f9a09313e7aa32753fbdf0de02314af39a65af9a1dde664",
+    lineSha256s: ["0506dfed6fa918c830a5e0d4d1bad503960438d01d5ff9e2cc80cd6654a69033"],
     sources: ["extensions/mattermost/src/mattermost/slash-http.test.ts"],
   },
   {
     fixtureSha256: "14947662dc4356637571038e47cd3f37a8911d37d41688a2f6c6b2b54c209c41",
     rawSha256: "7d765bfa6e81c336a916aaf71eab28f5c0c4ae47a359ec3adf2d4f175645456d",
+    lineSha256s: ["d94c393a7704eab6d2e6ac822bd495a27299d353260c9edc85e852b706a54de3"],
     sources: ["extensions/mattermost/src/mattermost/slash-http.test.ts"],
   },
   {
     fixtureSha256: "0c2d147cb7b70169ceb0302b40bceaa60abc15263c4dcfb7f1746cc93e3c87d3",
     rawSha256: "014a5653f93da5c53f9a09313e7aa32753fbdf0de02314af39a65af9a1dde664",
+    lineSha256s: ["ae6d199d9d7983df3024f5615dc243efd1e6988e1afddb79da0b99183cab8552"],
     sources: ["extensions/mattermost/src/mattermost/slash-http.test.ts"],
   },
 ];
@@ -331,16 +336,25 @@ export function classifyReviewedFixtureScan(
       } catch {
         return refuse("literal_mismatch");
       }
-      const offset = text.indexOf(finding.RawV2);
-      if (offset < 0) return refuse("literal_mismatch");
-      literalLine = 1;
-      for (
-        let newline = text.indexOf("\n");
-        newline !== -1 && newline < offset;
-        newline = text.indexOf("\n", newline + 1)
-      ) {
-        literalLine++;
+      let lineStart = 0;
+      let lineNumber = 1;
+      while (lineStart <= text.length) {
+        const newline = text.indexOf("\n", lineStart);
+        const lineEnd = newline === -1 ? text.length : newline;
+        const line = text.slice(lineStart, lineEnd);
+        if (line.includes(finding.RawV2)) {
+          if (
+            fixture.lineSha256s &&
+            !fixture.lineSha256s.includes(createHash("sha256").update(line).digest("hex"))
+          )
+            return refuse("literal_mismatch");
+          literalLine ??= lineNumber;
+        }
+        if (newline === -1) break;
+        lineStart = newline + 1;
+        lineNumber++;
       }
+      if (literalLine === undefined) return refuse("literal_mismatch");
       literalLines.set(valueKey, literalLine);
     }
     const blob = basename(file);

--- a/src/agent-input-scan.ts
+++ b/src/agent-input-scan.ts
@@ -66,11 +66,12 @@ export class AgentInputScanError extends Error {
 }
 
 export const INCOMPLETE_AGENT_INPUT_SOURCE_EXIT_CODE = 78;
+export const AGENT_INPUT_FINDINGS_EXIT_CODE = 79;
 
 export function agentInputScanFailureExitCode(error: unknown): number | null {
-  return error instanceof AgentInputScanError && error.reason === "incomplete_source"
-    ? INCOMPLETE_AGENT_INPUT_SOURCE_EXIT_CODE
-    : null;
+  if (!(error instanceof AgentInputScanError)) return null;
+  if (error.reason === "incomplete_source") return INCOMPLETE_AGENT_INPUT_SOURCE_EXIT_CODE;
+  return error.reason === "findings" ? AGENT_INPUT_FINDINGS_EXIT_CODE : null;
 }
 
 export const MAX_SCAN_BYTES = 256 * 1024 * 1024;

--- a/src/clawsweeper-review-failure-diagnostics.ts
+++ b/src/clawsweeper-review-failure-diagnostics.ts
@@ -54,7 +54,7 @@ export function writeExactReviewFailureDiagnostics(options: {
     : diagnosticStage
       ? safeCode(
           error.diagnosticReason,
-          /^(?:configuration_missing|setup_script_failed|review_commits_unavailable|review_history_unavailable|review_blob_metadata_unavailable|review_blobs_unavailable|review_checkout_unavailable|review_commit_fetch_failed|review_checkout_failed|review_git_inspection_failed)$/,
+          /^(?:configuration_missing|setup_script_failed|source_incompatible|review_commits_unavailable|review_history_unavailable|review_blob_metadata_unavailable|review_blobs_unavailable|review_checkout_unavailable|review_commit_fetch_failed|review_checkout_failed|review_git_inspection_failed)$/,
         )
       : null;
   const values = exactValues(options.prompt, options.model, options.env ?? process.env);

--- a/src/clawsweeper-review-runtime.ts
+++ b/src/clawsweeper-review-runtime.ts
@@ -47,7 +47,10 @@ import {
 } from "./codex-transient.js";
 import { UserFacingCommandError } from "./command.js";
 import { emptyMaintainerDecision } from "./decision-packets.js";
-import { prepareOpenClawCodexSourceForReview } from "./openclaw-codex-source.js";
+import {
+  openClawCodexSourcePreparationFailureRetryable,
+  prepareOpenClawCodexSourceForReview,
+} from "./openclaw-codex-source.js";
 import { repositoryProfileFor, type RepositoryProfile } from "./repository-profiles.js";
 
 interface ReviewRuntimeDependencies {
@@ -830,6 +833,7 @@ ${extra}
 
   function codexReviewFailureRetryable(error: unknown): boolean {
     if (error instanceof AgentInputScanError) return false;
+    if (!openClawCodexSourcePreparationFailureRetryable(error)) return false;
     return error instanceof CodexReviewError ? error.retryable : true;
   }
 

--- a/src/openclaw-codex-source.ts
+++ b/src/openclaw-codex-source.ts
@@ -9,6 +9,7 @@ type Spawn = (
   args: string[],
 ) => { error?: Error; status: number | null; stderr: string };
 
+export const OPENCLAW_CODEX_SOURCE_INCOMPATIBLE_EXIT_CODE = 80;
 export function prepareOpenClawCodexSourceForReview(options: {
   targetRepo: string;
   reviewDir: string;
@@ -37,10 +38,19 @@ export function prepareOpenClawCodexSourceForReview(options: {
   if (result.error || result.status !== 0) {
     const detail = result.stderr.trim() || result.error?.message || `exit ${result.status}`;
     throw new ReviewSourcePreparationError(
-      "setup_script_failed",
+      result.status === OPENCLAW_CODEX_SOURCE_INCOMPATIBLE_EXIT_CODE
+        ? "source_incompatible"
+        : "setup_script_failed",
       `Could not prepare the PR-pinned Codex source: ${detail}`,
     );
   }
+}
+
+export function openClawCodexSourcePreparationFailureRetryable(error: unknown): boolean {
+  return !(
+    error instanceof ReviewSourcePreparationError &&
+    error.diagnosticReason === "source_incompatible"
+  );
 }
 
 function requiredEnvironmentPath(env: NodeJS.ProcessEnv, name: string): string {

--- a/src/review-source-preparation.ts
+++ b/src/review-source-preparation.ts
@@ -1,6 +1,7 @@
 export type ReviewSourcePreparationFailureReason =
   | "configuration_missing"
   | "setup_script_failed"
+  | "source_incompatible"
   | "review_commits_unavailable"
   | "review_history_unavailable"
   | "review_blob_metadata_unavailable"

--- a/test/agent-input-scan.test.ts
+++ b/test/agent-input-scan.test.ts
@@ -783,9 +783,11 @@ for (const scenario of [
       "// context\n".repeat(40) +
       (reviewedMattermostLine ?? JSON.stringify(otherReviewedUri ?? value)) +
       "\n" +
-      (scenario.endsWith("repeated literal") || scenario.includes("duplicate on unapproved line")
-        ? JSON.stringify(value) + "\n"
-        : "");
+      (scenario.includes("duplicate on unapproved line")
+        ? reviewedMattermostLine + "\n"
+        : scenario.endsWith("repeated literal")
+          ? JSON.stringify(value) + "\n"
+          : "");
     const fixtureContent = (prefix: string) =>
       Buffer.concat([
         Buffer.from(prefix + contents),

--- a/test/agent-input-scan.test.ts
+++ b/test/agent-input-scan.test.ts
@@ -20,6 +20,7 @@ import test from "node:test";
 import { runAgentProcess, runAgentCheckoutInspection } from "../dist/agent-runner.js";
 import {
   AgentInputScanError,
+  AGENT_INPUT_FINDINGS_EXIT_CODE,
   INCOMPLETE_AGENT_INPUT_SOURCE_EXIT_CODE,
   agentInputScanFailureExitCode,
   managedScannerCacheRoot,
@@ -33,10 +34,14 @@ import {
 import { useFakeScanner } from "./agent-input-scan-helpers.ts";
 import { writeExactReviewFailureDiagnostics } from "../dist/clawsweeper-review-failure-diagnostics.js";
 
-test("only incomplete source scan failures receive the terminal review exit code", () => {
+test("unchanged source scan refusals receive terminal review exit codes", () => {
   assert.equal(
     agentInputScanFailureExitCode(new AgentInputScanError("incomplete_source")),
     INCOMPLETE_AGENT_INPUT_SOURCE_EXIT_CODE,
+  );
+  assert.equal(
+    agentInputScanFailureExitCode(new AgentInputScanError("findings")),
+    AGENT_INPUT_FINDINGS_EXIT_CODE,
   );
   assert.equal(agentInputScanFailureExitCode(new AgentInputScanError("scanner_failed")), null);
   assert.equal(agentInputScanFailureExitCode(new Error("review failed")), null);
@@ -574,6 +579,8 @@ for (const scenario of [
   "mattermost api redacted fixture",
   "mattermost hooks input fixture",
   "mattermost hooks redacted fixture",
+  "mattermost hooks input fixture duplicate on unapproved line",
+  "mattermost hooks redacted fixture duplicate on unapproved line",
   "mattermost changed username",
   "mattermost changed password",
   "mattermost changed host",
@@ -764,11 +771,21 @@ for (const scenario of [
       scenario === "decoded only" || scenario.endsWith("encoded-only")
         ? uri.replace(":", "&#58;")
         : uri;
+    const reviewedMattermostLine =
+      mattermostFixture && scenario.includes("fixture")
+        ? scenario.includes("redacted")
+          ? `    expect(message).toContain(${JSON.stringify(uri)});`
+          : scenario.includes("hooks")
+            ? `        ${JSON.stringify(`fallback\r\nsecond-line botToken: secret-bot ${uri}?token=secret-query`)},`
+            : `        ${JSON.stringify(`primary\ntoken=secret-token ${uri}?access_token=secret-access&client_secret=secret-client`)},`
+        : undefined;
     const contents =
       "// context\n".repeat(40) +
-      JSON.stringify(otherReviewedUri ?? value) +
+      (reviewedMattermostLine ?? JSON.stringify(otherReviewedUri ?? value)) +
       "\n" +
-      (scenario.endsWith("repeated literal") ? JSON.stringify(value) + "\n" : "");
+      (scenario.endsWith("repeated literal") || scenario.includes("duplicate on unapproved line")
+        ? JSON.stringify(value) + "\n"
+        : "");
     const fixtureContent = (prefix: string) =>
       Buffer.concat([
         Buffer.from(prefix + contents),
@@ -1050,7 +1067,8 @@ process.exit(scenario === 'unexpected successful output' ? 0 : 183);
             if (mattermostFixture) {
               assert.equal(
                 diagnostic.reason,
-                scenario === "mattermost different approved literal"
+                scenario.includes("duplicate on unapproved line") ||
+                  scenario === "mattermost different approved literal"
                   ? "literal_mismatch"
                   : scenario === "mattermost source mismatch"
                     ? "source_not_reviewed"

--- a/test/dashboard-worker-queue-runtime.test.ts
+++ b/test/dashboard-worker-queue-runtime.test.ts
@@ -10572,7 +10572,7 @@ for (const retryKind of ["coordination", "throttle"] as const) {
   });
 }
 
-test("exact-review queue terminates incomplete source only for the unchanged revision", async () => {
+test("exact-review queue terminates deterministic refusals only for the unchanged revision", async () => {
   const storage = new MemoryDurableStorage();
   const terminal = leasedExactReviewQueueItem(709, "7090");
   const transient = leasedExactReviewQueueItem(710, "7100");
@@ -10626,6 +10626,47 @@ test("exact-review queue terminates incomplete source only for the unchanged rev
   assert.equal(state.items["openclaw/openclaw#711"].state, "pending");
   assert.equal(state.items["openclaw/openclaw#711"].revision, 2);
   assert.equal(state.items["openclaw/openclaw#711"].reviewFailureAttempts, 0);
+  const sourceStorage = new MemoryDurableStorage();
+  const sourceNewer = leasedExactReviewQueueItem(714, "7140");
+  sourceNewer.revision = 2;
+  sourceNewer.decision = { ...sourceNewer.decision, sourceAction: "synchronize" };
+  await sourceStorage.put("exact-review-queue", {
+    deliveries: {},
+    items: {
+      "openclaw/openclaw#713": leasedExactReviewQueueItem(713, "7130"),
+      "openclaw/openclaw#714": sourceNewer,
+    },
+  });
+  const sourceQueue = new ExactReviewQueue({ storage: sourceStorage }, {});
+  const completeSource = (itemNumber: number, runId: string) =>
+    sourceQueue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/complete", {
+        method: "POST",
+        body: JSON.stringify({
+          lease_id: `lease-${itemNumber}`,
+          item_key: `openclaw/openclaw#${itemNumber}`,
+          lease_revision: 1,
+          claim_generation: 1,
+          run_id: runId,
+          run_attempt: 1,
+          outcome: "failure",
+          review_failure_reason: "source_incompatible",
+        }),
+      }),
+    );
+  assert.deepEqual(await (await completeSource(713, "7130")).json(), {
+    ok: true,
+    requeued: false,
+  });
+  assert.deepEqual(await (await completeSource(714, "7140")).json(), {
+    ok: true,
+    requeued: true,
+  });
+  const sourceState = (await sourceStorage.get("exact-review-queue")) as {
+    items: Record<string, { revision: number }>;
+  };
+  assert.equal(sourceState.items["openclaw/openclaw#713"], undefined);
+  assert.equal(sourceState.items["openclaw/openclaw#714"].revision, 2);
 });
 
 test("exact-review queue validates terminal review failure reasons", async () => {

--- a/test/dashboard-worker-queue-runtime.test.ts
+++ b/test/dashboard-worker-queue-runtime.test.ts
@@ -10577,6 +10577,7 @@ test("exact-review queue terminates deterministic refusals only for the unchange
   const terminal = leasedExactReviewQueueItem(709, "7090");
   const transient = leasedExactReviewQueueItem(710, "7100");
   const newer = leasedExactReviewQueueItem(711, "7110");
+  const findingsTerminal = leasedExactReviewQueueItem(712, "7120");
   newer.revision = 2;
   newer.decision = { ...newer.decision, sourceAction: "synchronize" };
   await storage.put("exact-review-queue", {
@@ -10585,6 +10586,7 @@ test("exact-review queue terminates deterministic refusals only for the unchange
       "openclaw/openclaw#709": terminal,
       "openclaw/openclaw#710": transient,
       "openclaw/openclaw#711": newer,
+      "openclaw/openclaw#712": findingsTerminal,
     },
   });
   const queue = new ExactReviewQueue({ storage }, {});
@@ -10617,6 +10619,10 @@ test("exact-review queue terminates deterministic refusals only for the unchange
   assert.equal(newerResponse.status, 200);
   assert.deepEqual(await newerResponse.json(), { ok: true, requeued: true });
 
+  const findingsResponse = await complete(712, "7120", "findings");
+  assert.equal(findingsResponse.status, 200);
+  assert.deepEqual(await findingsResponse.json(), { ok: true, requeued: false });
+
   const state = (await storage.get("exact-review-queue")) as {
     items: Record<string, Record<string, unknown>>;
   };
@@ -10626,6 +10632,7 @@ test("exact-review queue terminates deterministic refusals only for the unchange
   assert.equal(state.items["openclaw/openclaw#711"].state, "pending");
   assert.equal(state.items["openclaw/openclaw#711"].revision, 2);
   assert.equal(state.items["openclaw/openclaw#711"].reviewFailureAttempts, 0);
+  assert.equal(state.items["openclaw/openclaw#712"], undefined);
   const sourceStorage = new MemoryDurableStorage();
   const sourceNewer = leasedExactReviewQueueItem(714, "7140");
   sourceNewer.revision = 2;

--- a/test/exact-review-failure-diagnostics.test.ts
+++ b/test/exact-review-failure-diagnostics.test.ts
@@ -206,6 +206,38 @@ test("scan diagnostics retain refusal identity without scanner output", () => {
   }
 });
 
+test("incompatible source diagnostics retain their structured terminal identity", () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-diagnostics-"));
+  try {
+    const output = writeExactReviewFailureDiagnostics({
+      artifactDir: root,
+      error: Object.assign(new Error("invalid immutable source"), {
+        diagnosticStage: "source_preparation",
+        diagnosticReason: "source_incompatible",
+      }),
+      prompt: "private prompt",
+      model: "private-model",
+      classification: "codex_execution",
+      repo: "openclaw/openclaw",
+      itemKind: "pull_request",
+      itemNumber: 70002,
+      sourceSha: "0".repeat(40),
+      retryable: false,
+      workflowExit: 1,
+      env: {},
+    });
+    const manifest = JSON.parse(readFileSync(join(output, "manifest.json"), "utf8"));
+    assert.equal(manifest.classification, "source_preparation");
+    assert.equal(manifest.retryable, false);
+    assert.deepEqual(manifest.failure, {
+      stage: "source_preparation",
+      reason_code: "source_incompatible",
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("unsafe files are omitted whole and recorded in the readiness manifest", () => {
   const cases = [
     ["control byte", "startup failed\u0000after fork"],

--- a/test/exact-review-failure-diagnostics.test.ts
+++ b/test/exact-review-failure-diagnostics.test.ts
@@ -197,7 +197,7 @@ test("scan diagnostics retain refusal identity without scanner output", () => {
       assert.equal(manifest.classification, "agent_input_scan");
       assert.deepEqual(manifest.failure, { stage: "agent_input_scan", reason_code: reason });
       assert.equal(manifest.retryable, false);
-      assert.equal(manifest.process.workflow_exit, reason === "incomplete_source" ? 78 : 1);
+      assert.equal(manifest.process.workflow_exit, reason === "incomplete_source" ? 78 : 79);
       const text = expectedFiles.map((name) => readFileSync(join(output, name), "utf8")).join("\n");
       assert.doesNotMatch(text, /raw scanner/);
     }

--- a/test/openclaw-codex-source.test.ts
+++ b/test/openclaw-codex-source.test.ts
@@ -1,7 +1,42 @@
 import assert from "node:assert/strict";
-import type { SpawnSyncReturns } from "node:child_process";
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
-import { prepareOpenClawCodexSourceForReview } from "../dist/openclaw-codex-source.js";
+import {
+  OPENCLAW_CODEX_SOURCE_INCOMPATIBLE_EXIT_CODE,
+  openClawCodexSourcePreparationFailureRetryable,
+  prepareOpenClawCodexSourceForReview,
+} from "../dist/openclaw-codex-source.js";
+
+test("Codex source pin validation accepts only one exact version", (t) => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-codex-pin-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const manifest = join(root, "package.json");
+  const validator = join(
+    process.cwd(),
+    ".github",
+    "actions",
+    "setup-openclaw-codex-source",
+    "validate-pin.mjs",
+  );
+  const run = (content: string) => {
+    writeFileSync(manifest, content);
+    return spawnSync(process.execPath, [validator, manifest], { encoding: "utf8" });
+  };
+
+  for (const value of [undefined, "^0.151.0", "*", "workspace:*", "not-a-version"]) {
+    const result = run(JSON.stringify({ dependencies: { "@openai/codex": value } }));
+    assert.equal(result.status, OPENCLAW_CODEX_SOURCE_INCOMPATIBLE_EXIT_CODE, String(value));
+    assert.equal(result.stdout, "");
+  }
+  assert.equal(run("{").status, OPENCLAW_CODEX_SOURCE_INCOMPATIBLE_EXIT_CODE);
+
+  const exact = run(JSON.stringify({ dependencies: { "@openai/codex": "0.151.0" } }));
+  assert.equal(exact.status, 0);
+  assert.equal(exact.stdout, "0.151.0");
+});
 
 test("PR review source preparation invokes the workflow-provisioned setup for the current tree", () => {
   const calls: Array<{ command: string; args: readonly string[] }> = [];
@@ -109,4 +144,32 @@ test("source preparation failures carry safe diagnostic identity", () => {
       return true;
     },
   );
+});
+
+test("only an incompatible immutable source pin is non-retryable", () => {
+  for (const [status, reason, retryable] of [
+    [OPENCLAW_CODEX_SOURCE_INCOMPATIBLE_EXIT_CODE, "source_incompatible", false],
+    [128, "setup_script_failed", true],
+  ] as const) {
+    assert.throws(
+      () =>
+        prepareOpenClawCodexSourceForReview({
+          targetRepo: "openclaw/openclaw",
+          reviewDir: "/workspace/artifacts/review-trees/70002",
+          env: {
+            CLAWSWEEPER_OPENCLAW_CODEX_SETUP_SCRIPT: "/action/install.sh",
+            CLAWSWEEPER_OPENCLAW_CODEX_TARGET_DIR: "/workspace/openclaw",
+            CLAWSWEEPER_OPENCLAW_CODEX_ARTIFACT_DIR: "/workspace/artifacts",
+            CLAWSWEEPER_OPENCLAW_CODEX_CACHE_DIR: "/workspace/openclaw-codex-cache.git",
+          },
+          spawn: () =>
+            ({ status, stderr: "source preparation refused" }) as SpawnSyncReturns<string>,
+        }),
+      (error: unknown) => {
+        assert.equal((error as Error & { diagnosticReason?: string }).diagnosticReason, reason);
+        assert.equal(openClawCodexSourcePreparationFailureRetryable(error), retryable);
+        return true;
+      },
+    );
+  }
 });

--- a/test/review-command-workflow.test.ts
+++ b/test/review-command-workflow.test.ts
@@ -178,13 +178,15 @@ for (const scenario of [
   "changed-pr-exact-codex-failure",
   "changed-pr-exact-fetch-failure",
   "changed-pr-exact-native-checkout-failure",
+  "changed-pr-exact-source-incompatible",
   "changed-pr-clean",
   "content-clean",
   "fresh-refusal",
 ]) {
   test(`scheduled ${scenario} preserves admission and terminal ledger classification`, (t) => {
     const refuseScan = scenario.endsWith("refusal");
-    const codexFailure = scenario.endsWith("codex-failure");
+    const sourceIncompatible = scenario.endsWith("source-incompatible");
+    const codexFailure = scenario.endsWith("codex-failure") || sourceIncompatible;
     const exactFailure = scenario.includes("exact");
     const invalidBase = scenario.endsWith("invalid-base-refusal");
     const missingHead = scenario.endsWith("missing-head-refusal");
@@ -568,7 +570,8 @@ for (const scenario of [
       buildReviewPrompt: () => ({ text: "Review the current item." }),
       itemSnapshotHash: () => digest("snapshot"),
       codexFailureLogKind: () => "codex_execution",
-      codexReviewFailureRetryable: (error: unknown) => !(error instanceof AgentInputScanError),
+      codexReviewFailureRetryable: (error: unknown) =>
+        !(error instanceof AgentInputScanError) && !sourceIncompatible,
       codexFailureDecision: () => {
         if (codexFailure || preparationFailure || checkoutUnavailable)
           return closeDecision({
@@ -600,7 +603,7 @@ for (const scenario of [
         if (codexFailure) {
           throw Object.assign(new Error("Codex source preparation failed"), {
             diagnosticStage: "source_preparation",
-            diagnosticReason: "setup_script_failed",
+            diagnosticReason: sourceIncompatible ? "source_incompatible" : "setup_script_failed",
           });
         }
         if (fresh && refuseScan)
@@ -775,12 +778,16 @@ for (const scenario of [
           const manifest = JSON.parse(
             readFileSync(join(artifactDir, "failure-diagnostics", "manifest.json"), "utf8"),
           );
-          assert.equal(manifest.retryable, true);
+          assert.equal(manifest.retryable, !sourceIncompatible);
           assert.equal(manifest.source.sha, headSha);
           assert.equal(manifest.classification, "source_preparation");
           assert.deepEqual(manifest.failure, {
             stage: "source_preparation",
-            reason_code: preparationFailure ? "configuration_missing" : "setup_script_failed",
+            reason_code: sourceIncompatible
+              ? "source_incompatible"
+              : preparationFailure
+                ? "configuration_missing"
+                : "setup_script_failed",
           });
         }
         return;

--- a/test/setup-openclaw-codex-source-action.test.ts
+++ b/test/setup-openclaw-codex-source-action.test.ts
@@ -165,6 +165,24 @@ test("reuses a complete same-pin cache without network access", (t) => {
   );
 });
 
+test("publishes the runtime contract before deferring an incompatible base pin", (t) => {
+  const fixture = useFixture(t);
+  writePin(fixture.target, "^1.2.3");
+
+  const incompatible = runSetup(fixture);
+  assert.equal(incompatible.status, 80, incompatible.stderr);
+  const environment = readFileSync(fixture.githubEnv, "utf8");
+  for (const name of [
+    "CLAWSWEEPER_OPENCLAW_CODEX_SETUP_SCRIPT",
+    "CLAWSWEEPER_OPENCLAW_CODEX_TARGET_DIR",
+    "CLAWSWEEPER_OPENCLAW_CODEX_ARTIFACT_DIR",
+    "CLAWSWEEPER_OPENCLAW_CODEX_CACHE_DIR",
+    "CLAWSWEEPER_OPENCLAW_CODEX_SOURCE_URL",
+  ]) {
+    assert.match(environment, new RegExp(`^${name}=`, "m"));
+  }
+});
+
 test("retargets to a cached pin offline and replaces a wrong dirty checkout", (t) => {
   const fixture = useFixture(t);
   assert.equal(runSetup(fixture).status, 0);

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1057,6 +1057,10 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
   );
   assert.match(
     step(reviewer, "Review exact event item").run ?? "",
+    /classification == "source_preparation"[\s\S]*retryable == false[\s\S]*reason_code == "source_incompatible"[\s\S]*failure_reason=source_incompatible/,
+  );
+  assert.match(
+    step(reviewer, "Review exact event item").run ?? "",
     /kill -TERM -- "-\$review_pgid"/,
   );
   assert.match(step(reviewer, "Review exact event item").run ?? "", /sleep 60/);
@@ -1337,6 +1341,10 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
   assert.match(
     markUnsuccessful.run ?? "",
     /incomplete_source[\s\S]*will not retry this unchanged revision/,
+  );
+  assert.match(
+    markUnsuccessful.run ?? "",
+    /source_incompatible[\s\S]*will not retry this unchanged revision; update or rebase/,
   );
   assert.match(
     failGeneration.if ?? "",

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1061,6 +1061,10 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
   );
   assert.match(
     step(reviewer, "Review exact event item").run ?? "",
+    /review_exit_code.*-eq 79[\s\S]*failure_reason=findings/,
+  );
+  assert.match(
+    step(reviewer, "Review exact event item").run ?? "",
     /classification == "source_preparation"[\s\S]*retryable == false[\s\S]*reason_code == "source_incompatible"[\s\S]*failure_reason=source_incompatible/,
   );
   assert.match(
@@ -1346,6 +1350,7 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
     markUnsuccessful.run ?? "",
     /incomplete_source[\s\S]*will not retry this unchanged revision/,
   );
+  assert.match(markUnsuccessful.run ?? "", /findings[\s\S]*will not retry this unchanged revision/);
   assert.match(
     markUnsuccessful.run ?? "",
     /source_incompatible[\s\S]*will not retry this unchanged revision; update or rebase/,

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -248,7 +248,7 @@ test("OpenClaw review jobs provision the pinned sibling Codex source before revi
 
 test("Codex source setup normalizes OpenClaw casing and stays out of the OpenClaw runner", () => {
   const action = YAML.parse(readText(".github/actions/setup-openclaw-codex-source/action.yml")) as {
-    runs: { steps: Array<{ id?: string; if?: string; uses?: string }> };
+    runs: { steps: Array<{ id?: string; if?: string; uses?: string; run?: string }> };
   };
   const normalize = action.runs.steps.find((step) => step.id === "target");
   const cache = action.runs.steps.find((step) => step.uses === "actions/cache@v6");
@@ -257,6 +257,10 @@ test("Codex source setup normalizes OpenClaw casing and stays out of the OpenCla
   assert.match(cache?.if ?? "", /env\.CLAWSWEEPER_RUNNER != 'openclaw'/u);
   const setup = action.runs.steps.at(-1);
   assert.match(setup?.if ?? "", /env\.CLAWSWEEPER_RUNNER != 'openclaw'/u);
+  assert.match(
+    setup?.run ?? "",
+    /setup_status.*-eq 80[\s\S]*deferring the decision to the materialized review tree[\s\S]*exit 0/,
+  );
 });
 
 test("automatic OpenClaw bug dispatch uses one gate across direct and deferred publication", () => {


### PR DESCRIPTION
## Summary

- stop retrying deterministic source-preparation refusals when a reviewed PR pins an incompatible Codex version
- admit the four known Mattermost scanner fixtures only when their literal, path, mode, digest, and reviewed source line all match the trusted contract
- terminalize unchanged exact-review scanner findings while preserving fail-closed handling for scanner/runtime contract failures

## Problem

Two different deterministic input refusals could leave review work cycling without making progress:

1. openclaw/openclaw#70002 pins Codex with a non-exact/incompatible range. The base checkout did not expose that PR-specific pin, so preparation could repeatedly retry the same unchanged review tuple.
2. openclaw/openclaw#126818 contains intentional Mattermost redaction fixtures that resemble credentials. The scanner correctly failed closed, but the exact reviewed fixture contract was not precise enough to admit those known test literals or to stop retrying a deterministic finding.

## Implementation

- validate the Codex pin after the PR review tree is materialized and return an explicit `source_incompatible` terminal result for the unchanged tuple
- retain the existing four-fixture path/mode/digest policy and additionally bind every admitted Mattermost literal to its approved reviewed-line SHA-256
- scan every occurrence of each line-bound literal and require exactly one, so a byte-identical clone of an approved fixture line still fails closed
- classify scanner findings separately from scanner availability or native-contract failures; only unchanged deterministic findings become terminal
- propagate the terminal classifications through queue reconciliation, diagnostics, and the maintainer review workflow

## Validation

- `pnpm run check` on the earlier shared-runtime head `6831df2384b5a7fa8950c6f3094b7a16705ff862`
  - formatting, TypeScript builds, lint, changed coverage, and the ordinary 286-file test surface passed
  - live-proof cases requiring `tmux` failed because the standard `node:24-bookworm` image has no `tmux`
- current `main` baseline `39592f04448bdc34d37b9e7f8d5c5d7c828b73f2` reproduced that same live-proof failure (`spawnSync tmux ENOENT`) in the same image
- exact current head `568de8c437468b76afaafbed4ceb3790b2c2de42`: TypeScript build and formatting passed; scanner suite 121/121 passed in Docker-backed Crabbox
- source-preparation focused suite: 10/10 passed
- exact Mattermost behavior proof: 2/2 focused queue tests passed, plus all controlled fixture/refusal assertions
- CI follow-up: the first run exposed one stale test assertion (`findings` expected exit `1` instead of the dedicated exit `79`); the corrected focused diagnostics suite passed 6/6
- `codex review --uncommitted`: clean after accepted fixes
- `codex review --base origin/main`: clean on the committed branch

## Real Behavior Proof

### Claim

For an unchanged exact-review tuple, an incompatible PR-tree Codex pin or a deterministic scanner finding is terminal. The four exact Mattermost redaction fixtures pass only at their approved source lines; changed, duplicated, or mixed findings remain refused.

### Exercised surface

- PR-tree source setup and incompatible-pin exit contract
- agent-input scanner admission and refusal behavior
- review queue terminal/retry classification

### Scenario / fixture

- openclaw/openclaw#70002-style `^0.151.0` PR-tree pin
- openclaw/openclaw#126818 Mattermost API/hooks input and redacted fixtures
- byte-identical clone of an approved complete source line
- changed approved line and mixed finding

### Command / environment

Docker-backed Crabbox `local-container`, image `node:24-bookworm`:

- source proof: run `run_26366d3bff64`, lease `cbx_5dfd68b39a1c`
- current-head Mattermost and queue proof: run `run_2d47d8cdb67b`, lease `cbx_e8745bffc0ba`
- current-head inspectable trace rerun: run `run_073f87e41193`, lease `cbx_ad347126ad31`
- current-head production-boundary proof: run `run_f9950a7c1d6a`, lease `cbx_3287f9874d34`
- current-head full scanner suite: run `run_76340e1d372c`, lease `cbx_f6c298e8480c`
- exact-head broad check: run `run_09c9cfa85827`, lease `cbx_f7cd1fae9a28`
- current-main tmux baseline: run `run_ca2369cdeaff`, lease `cbx_df7b63070a0b`

### Observed result

- incompatible PR pin exited with the dedicated incompatible-source status; exact compatible pin remained eligible
- all four exact Mattermost fixtures were admitted
- a byte-identical cloned approved line, a changed approved line, and a mixed finding were refused
- queue tests confirmed deterministic unchanged refusals do not re-enter the retry loop
- scanner native/runtime contract failures remain fail-closed and are not mislabeled as terminal findings

### Artifact / trace

The Crabbox run and lease IDs above identify the retained execution traces. Proof markers included:

- `initial_checkout_deferred_to_review_tree`
- `pr_70002_incompatible_pin_refused`
- `exact_pin_eligible`
- `csw_149_source_preparation_proof`
- `csw_149_behavior_proof`
- `current_main_tmux_baseline_reproduced`

Redacted exact-head output from `run_073f87e41193` (Docker-backed Crabbox `local-container`, `node:24-bookworm`, exit `0`):

```text
CRABBOX_PHASE:exact-fixture
{"marker":"exact_fixture_allowed","result":"pass"}
{"marker":"verbatim_reviewed_line_clone_refused","result":"pass"}
{"marker":"changed_reviewed_line_refused","result":"pass"}
{"marker":"mixed_finding_refused","result":"pass"}
CRABBOX_PHASE:queue
✔ exact-review queue terminates deterministic refusals only for the unchanged revision
✔ exact-review queue validates terminal review failure reasons
ℹ tests 2
ℹ pass 2
ℹ fail 0
CRABBOX_PHASE:done
{"marker":"csw_149_behavior_proof","result":"pass"}
run details provider=local-container lease=cbx_ad347126ad31 run=run_073f87e41193 type=node_24-bookworm exit=0
```

Redacted production-boundary output from `run_f9950a7c1d6a` (Docker-backed Crabbox `local-container`, `node:24-bookworm`, exit `0`):

```text
CRABBOX_PHASE:native-scanner
{"marker":"native_scanner_ready","scanner":"trufflehog","managed_path":true,"result":"pass"}
CRABBOX_PHASE:source-contract
{"marker":"production_source_setup_refused","reason":"source_incompatible","exit_code":80,"result":"pass"}
CRABBOX_PHASE:worker-queue-boundary
{"marker":"production_worker_queue_terminalized","reason":"findings","worker_runtime":"workerd-local","enqueue_status":202,"claim_status":200,"completion_status":200,"requeued":false,"completed_tuple_claim_status":409,"completed_tuple_claim_error":"lease_not_active","result":"pass"}
{"marker":"production_worker_queue_terminalized","reason":"source_incompatible","worker_runtime":"workerd-local","enqueue_status":202,"claim_status":200,"completion_status":200,"requeued":false,"completed_tuple_claim_status":409,"completed_tuple_claim_error":"lease_not_active","result":"pass"}
{"marker":"csw_149_production_queue_boundary","result":"pass"}
CRABBOX_PHASE:done
{"marker":"csw_149_production_boundary_proof","result":"pass"}
run details provider=local-container lease=cbx_3287f9874d34 run=run_f9950a7c1d6a type=node_24-bookworm exit=0
```

This proof used the production source-setup action and the production dashboard Worker with its real local `workerd` Durable Object binding and signed internal HTTP routes. A loopback GitHub API double supplied only public-repository metadata and accepted the workflow dispatch, avoiding any live GitHub mutation. No queue implementation or in-memory test double was substituted.

### Limits

- proof used deterministic local-container fixtures and the exact reviewed OpenClaw source content; it did not mutate either target PR
- the production-boundary queue proof used a local `workerd` Durable Object and loopback GitHub API double, not the deployed production queue or live GitHub dispatch
- the standard proof image lacks `tmux`, so the unrelated live-terminal proof tests were classified only after reproducing the same failure on current `main`
- GitHub workflow files change in this PR, so pushing/updating the branch may require maintainer OAuth workflow scope

## Risks / rollout

- admission remains fail-closed: any path, mode, digest, line, occurrence count, or scanner-contract mismatch is refused
- terminal state is tied to the unchanged exact-review tuple; new source revisions are evaluated again
- Bay/publication behavior is unchanged
- no changelog entry; release notes remain release-owned

## Links

- openclaw/openclaw#126818
- openclaw/openclaw#70002
