### PR TITLE
fix(review): stop showing non-actions as remaining merge work

### DIFF
--- a/docs/pr-review-comments.md
+++ b/docs/pr-review-comments.md
@@ -105,6 +105,33 @@ PR comments use a human-first shape:
 8. `## Findings` appears only when actionable review or security findings need
    a little more visible detail.
 
+New reviewer output requires a producer-owned `nextStep` assessment. Issues use
+none and retain their existing next-action guidance in `workReason`; only PR
+checklists consume this new intent. Canonical report frontmatter stores `next_step` as JSON: `{"kind":"none","text":""}` means
+no additional required next step; `{"kind":"required","text":"..."}` carries
+nonempty trimmed action text. Explanatory routing prose stays in `workReason`.
+Only the Before merge next-step checkbox and its readiness count consume this
+intent: explicit none suppresses that derived item, while required actions survive
+negation, contrast, routine-sounding prose, or lack of action keywords. Human-owned
+actions may be required even when `workCandidate` is none. Contributor changelog
+requests remain subject to OpenClaw's release-owned changelog normalization.
+
+Historical Decisions may omit the assessment, and reports are not migrated or
+rewritten. Missing, malformed, duplicated, or ambiguous metadata retains the
+conservative legacy prose fallback, never an inferred none. Only a unique valid
+value in leading canonical frontmatter counts; body or fenced examples cannot
+supply it. This compatibility limit means old false-positive prose needs a fresh
+producer assessment, not a guess from its summary, rating, or automation markers.
+Independent findings, security concerns, risks, contributor proof, historical
+verification, decisions, failed reviews, and low-quality remediation still render
+and count. Scores and marker/repair/automerge eligibility are unchanged: `nextStep`
+is presentation intent, not mutation authority. OpenClaw Bay needs no code change
+because its observer projection does not consume this checklist.
+
+The [next-step intent proof recipe](proof/review-next-step-intent/README.md)
+compares identical synthetic reports against pinned baseline and candidate
+renderers and exercises producer-to-report persistence without live publication.
+
 Everything primarily useful to agents or deep reviewers lives under one
 collapsed `Agent review details` section: security evidence, PR surface,
 review metrics, stored-data warnings, root-cause clusters, proof suggestions,

--- a/docs/proof/review-next-step-intent/README.md
+++ b/docs/proof/review-next-step-intent/README.md
@@ -1,0 +1,89 @@
+# PR next-step intent renderer proof
+
+- Status: historical proof recipe, not an operator runbook
+- Owner: ClawSweeper review maintainers
+- Source: [replay](replay.mjs), [report producer](../../../src/clawsweeper-report-document.ts),
+  [intent reader](../../../src/clawsweeper-next-step.ts), and
+  [checklist renderer](../../../src/clawsweeper-report-comment-helpers.ts)
+- Baseline: `39592f04448bdc34d37b9e7f8d5c5d7c828b73f2`
+- Update when: next-step serialization, checklist projection, ratings, or markers change
+
+## Claim and limits
+
+Explicit `nextStep: {kind: "none", text: ""}` removes the spurious PR checklist
+item and readiness count for “No concrete repair remains after this review.”
+Required actions survive contrast, negation, and missing action keywords.
+Independent findings and security blockers remain visible; legacy or malformed
+intent retains conservative inference. Scores and automation markers stay identical.
+
+The trigger was the [public review comment](https://github.com/openclaw/clawsweeper/pull/1341#issuecomment-5499517784)
+reviewed at `2026-09-01T21:41:39.976Z` on
+`a9455acae0abc0f3025d5944e0cd1db7fc9ddd92`. **Its historical raw structured record
+was not recovered.** All inputs here are synthetic, including the 5/6 ratings,
+proof assessment, source IDs, and typed intent. This does not claim the original
+review contained the new field or reconstruct its missing data.
+
+## Run
+
+Use Node 24+ and this repository's installed, pinned pnpm dependencies. From
+the repository root, build the pinned baseline in a new temporary directory
+without switching or editing any checkout:
+
+```sh
+REPLAY_ROOT="$(git rev-parse --show-toplevel)"
+BASELINE_SHA=39592f04448bdc34d37b9e7f8d5c5d7c828b73f2
+BASELINE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/clawsweeper-next-step-baseline.XXXXXX")"
+git archive --output="$BASELINE_DIR/source.tar" "$BASELINE_SHA"
+tar -xf "$BASELINE_DIR/source.tar" -C "$BASELINE_DIR"
+cmp pnpm-lock.yaml "$BASELINE_DIR/pnpm-lock.yaml"
+ln -s "$REPLAY_ROOT/node_modules" "$BASELINE_DIR/node_modules"
+"$REPLAY_ROOT/node_modules/.bin/tsc" -p "$BASELINE_DIR/tsconfig.json"
+"$REPLAY_ROOT/node_modules/.bin/tsc" -p "$BASELINE_DIR/tsconfig.repair.json"
+pnpm run build:node
+node docs/proof/review-next-step-intent/replay.mjs \
+  --baseline-dist "$BASELINE_DIR/dist" --baseline-sha "$BASELINE_SHA"
+```
+
+Stop if any command fails. The baseline needs its archived `package.json` and
+`config/` beside `dist/`, with dependencies resolvable through `node_modules/`.
+No install, toolchain changes, network, model calls, or GitHub operations are
+needed. The temporary baseline can be removed after inspection.
+The baseline invokes the same installed compiler/configurations as
+`build:node` directly because pnpm's automatic dependency check may otherwise
+try to reinstall through the shared dependency symlink in a temporary archive.
+
+`--baseline-dist` accepts another trusted compiled baseline with its full
+`--baseline-sha`. That SHA is a declared provenance reference, not proof that
+arbitrary supplied build bytes came from it; the receipt records compiled hashes.
+The candidate always comes from `dist/` in the script's repository.
+`--output-dir` defaults to `.artifacts/next-step-intent/proof` relative to that
+repository; absolute paths are also accepted. Keep generated output locally ignored.
+
+## Observable proof
+
+Ten paired cases feed the **same serialized report bytes directly to both real
+compiled renderers**, not to different schemas or different input versions. Each
+asserts checkbox and readiness counts, all three 5/6 scores, identical score
+text, and identical nonempty automation markers. The six original cases cover
+the reported phrase with explicit none, legacy required action, required
+contrast, keyword-free required human action, an independent finding, and the
+legacy none sentinel. Four controls add required negation, the reported phrase
+without metadata, malformed none metadata, and an independent security concern.
+
+A separate producer roundtrip runs the real decision parser, report writer,
+intent reader, and renderer. Only surrounding context/formatting dependencies
+use synthetic wiring; no model or reviewer runs. The resulting report must
+preserve explicit none and render no next-step item or remaining count.
+
+Inspect `result.json`, `before.md`, `after.md`, per-case `.report.md` / `.before.md`
+/ `.after.md`, and `producer-roundtrip.report.md` / `.after.md`. The receipt
+records current Git SHA and dirty state, fixture and source hashes, compiled
+owner hashes, baseline SHA/provenance, runtime, and each observable assertion.
+The provider is local Node, with no container image or lease. Rebuild and rerun
+after committing before using the receipt as committed-head evidence.
+
+This proves local producer/persistence/rendering behavior, not live publication
+or repair/automerge eligibility. No old records are migrated. Other independent
+blockers have focused regression coverage, not an exhaustive replay here.
+OpenClaw Bay needs no change: its observer projection does not consume this
+checklist, and no observer routes or controls change.

--- a/docs/proof/review-next-step-intent/replay.mjs
+++ b/docs/proof/review-next-step-intent/replay.mjs
@@ -1,0 +1,356 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { parseArgs } from "node:util";
+
+const root = fileURLToPath(new URL("../../../", import.meta.url));
+const { values } = parseArgs({
+  options: {
+    "baseline-dist": { type: "string" },
+    "baseline-sha": { type: "string" },
+    "output-dir": { type: "string", default: ".artifacts/next-step-intent/proof" },
+  },
+});
+assert.ok(
+  values["baseline-dist"],
+  "Pass --baseline-dist (see README.md for the pinned build recipe)",
+);
+assert.match(values["baseline-sha"] ?? "", /^[a-f0-9]{40}$/, "Pass the full --baseline-sha");
+assert.ok(Number(process.versions.node.split(".")[0]) >= 24, "Node 24 or newer is required");
+const baselineDist = resolve(values["baseline-dist"]);
+const candidateDist = join(root, "dist");
+assert.notEqual(baselineDist, candidateDist, "Baseline and candidate must be separate builds");
+const proofDir = resolve(root, values["output-dir"]);
+mkdirSync(proofDir, { recursive: true });
+const from = (path) => import(pathToFileURL(path).href);
+const hash = (bytes) => createHash("sha256").update(bytes).digest("hex");
+const git = (...args) => execFileSync("git", args, { cwd: root, encoding: "utf8" }).trim();
+const baselineSha = git("rev-parse", "--verify", `${values["baseline-sha"]}^{commit}`);
+const before = await from(join(baselineDist, "clawsweeper.js"));
+const after = await from(join(candidateDist, "clawsweeper.js"));
+const { nextStepFromReport } = await from(join(candidateDist, "clawsweeper-next-step.js"));
+const {
+  reportFrontMatter,
+  prRatingReportSection,
+  realBehaviorProofReportSection,
+  closeDecision,
+  item,
+} = await from(join(root, "test/helpers.ts"));
+
+const none = { kind: "none", text: "" };
+const reportedText = "No concrete repair remains after this review.";
+const section = (comment, title) =>
+  comment
+    .split(`## ${title}\n\n`)[1]
+    ?.split(/\n## |\n<details>/)[0]
+    ?.trim() ?? "";
+const observation = (comment) => ({
+  checklist: section(comment, "Before merge"),
+  checkboxCount: (section(comment, "Before merge").match(/^- \[ \]/gm) ?? []).length,
+  remainingCount: Number(
+    section(comment, "Merge readiness").match(/(\d+) items? remain/)?.[1] ?? 0,
+  ),
+  scores: section(comment, "Review scores"),
+  markers: comment.match(/<!-- clawsweeper-[^\n]+/g) ?? [],
+});
+const rating = { proofTier: "A", patchTier: "A", overallTier: "A" };
+const proofSummary = "Synthetic local renderer fixture; no historical proof record is asserted.";
+function serializedReport(reason, nextStep, extra = "") {
+  return `${reportFrontMatter({
+    type: "pull_request",
+    number: "123",
+    review_status: "complete",
+    local_checkout_access: "verified",
+    author_association: "MEMBER",
+    work_candidate: "none",
+    pull_head_sha: "c".repeat(40),
+    ...(nextStep === undefined ? {} : { next_step: JSON.stringify(nextStep) }),
+  })}\n## Summary\n\nThe retry guard is ready for review.\n\n## What This Changes\n\nKeeps retry ownership bounded.\n\n${prRatingReportSection(
+    {
+      ...rating,
+      overallLabel: "🦞 diamond lobster",
+      patchLabel: "🦞 diamond lobster",
+      summary: "Synthetic 5/6 readiness assessment.",
+    },
+  )}\n${realBehaviorProofReportSection({ summary: proofSummary })}\n## Work Candidate\n\nCandidate: none\n\nReason: ${reason}\n\n${extra}`;
+}
+const finding =
+  "## Review Findings\n\nOverall correctness: patch is incorrect\n\nFull review comments:\n\n- **[P1] Retry race:** `src/retry.ts:12`\n  - body: Repair concurrent retry handling.\n  - confidence: 0.9\n";
+const security =
+  "## Security Review\n\nStatus: needs_attention\n\nSummary: Confirm ownership.\n\nConcerns:\n\n- **[high] Ownership boundary:** `src/retry.ts:12`\n  - body: Restore the authorization guard.\n  - confidence: 0.9\n";
+const contrast = "No schema change is needed, but repair the retry guard before merge.";
+const negation = "Do not merge until the owner approves the compatibility contract.";
+const scenarios = [
+  {
+    name: "reported-text-explicit-none",
+    report: serializedReport(reportedText, none),
+    beforeCount: 1,
+    afterCount: 0,
+  },
+  {
+    name: "legacy-required-action",
+    report: serializedReport("Repair the retry guard before merge.", undefined),
+    beforeCount: 1,
+    afterCount: 1,
+    retained: "Repair the retry guard before merge.",
+  },
+  {
+    name: "required-contrast",
+    report: serializedReport(contrast, { kind: "required", text: contrast }),
+    beforeCount: 1,
+    afterCount: 1,
+    retained: contrast,
+  },
+  {
+    name: "required-human-action-without-keywords",
+    report: serializedReport("None.", { kind: "required", text: "Owner approval." }),
+    beforeCount: 0,
+    afterCount: 1,
+    retained: "Owner approval.",
+  },
+  {
+    name: "independent-finding-with-none",
+    report: serializedReport("None.", none, finding),
+    beforeCount: 1,
+    afterCount: 1,
+    retained: "Repair concurrent retry handling.",
+  },
+  {
+    name: "legacy-none-sentinel",
+    report: serializedReport("None.", undefined),
+    beforeCount: 0,
+    afterCount: 0,
+  },
+  {
+    name: "required-negation",
+    report: serializedReport("None.", { kind: "required", text: negation }),
+    beforeCount: 0,
+    afterCount: 1,
+    retained: negation,
+  },
+  {
+    name: "legacy-reported-text",
+    report: serializedReport(reportedText, undefined),
+    beforeCount: 1,
+    afterCount: 1,
+    retained: reportedText,
+  },
+  {
+    name: "malformed-none-fallback",
+    report: serializedReport(reportedText, { kind: "none", text: "ambiguous" }),
+    beforeCount: 1,
+    afterCount: 1,
+    retained: reportedText,
+  },
+  {
+    name: "independent-security-with-none",
+    report: serializedReport("None.", none, security),
+    beforeCount: 1,
+    afterCount: 1,
+    retained: "Restore the authorization guard.",
+  },
+];
+const results = [];
+for (const fixture of scenarios) {
+  // Identical serialized bytes enter both real renderers, bypassing producer-schema validation.
+  const baselineMarkdown = before.renderReviewCommentFromReport(fixture.report, "none");
+  const candidateMarkdown = after.renderReviewCommentFromReport(fixture.report, "none");
+  const baseline = observation(baselineMarkdown);
+  const candidate = observation(candidateMarkdown);
+  assert.equal(baseline.checkboxCount, fixture.beforeCount, `${fixture.name}: baseline checklist`);
+  assert.equal(candidate.checkboxCount, fixture.afterCount, `${fixture.name}: candidate checklist`);
+  assert.equal(baseline.remainingCount, fixture.beforeCount, `${fixture.name}: baseline count`);
+  assert.equal(candidate.remainingCount, fixture.afterCount, `${fixture.name}: candidate count`);
+  assert.equal(
+    (baseline.scores.match(/\(5\/6\)/g) ?? []).length,
+    3,
+    `${fixture.name}: all three scores`,
+  );
+  assert.equal(candidate.scores, baseline.scores, `${fixture.name}: scores unchanged`);
+  assert.ok(baseline.markers.length > 0, `${fixture.name}: automation markers present`);
+  assert.deepEqual(candidate.markers, baseline.markers, `${fixture.name}: markers unchanged`);
+  if (fixture.retained) assert.ok(candidate.checklist.includes(fixture.retained), fixture.name);
+  if (fixture.afterCount === 0) assert.equal(candidate.checklist, "None.", fixture.name);
+  writeFileSync(join(proofDir, `${fixture.name}.report.md`), fixture.report);
+  writeFileSync(join(proofDir, `${fixture.name}.before.md`), baselineMarkdown);
+  writeFileSync(join(proofDir, `${fixture.name}.after.md`), candidateMarkdown);
+  if (fixture.name === "reported-text-explicit-none") {
+    assert.ok(baseline.checklist.includes(reportedText));
+    assert.doesNotMatch(candidateMarkdown, /Complete next step|1 item remains/);
+    writeFileSync(join(proofDir, "before.md"), baselineMarkdown);
+    writeFileSync(join(proofDir, "after.md"), candidateMarkdown);
+  }
+  results.push({
+    name: fixture.name,
+    fixtureSha256: hash(fixture.report),
+    baseline,
+    candidate,
+    passed: true,
+  });
+}
+
+// Separately exercise the real producer -> canonical report -> reader -> renderer path.
+const { createReportDocumentRendering } = await from(
+  join(candidateDist, "clawsweeper-report-document.js"),
+);
+const { createReportContextRendering } = await from(
+  join(candidateDist, "clawsweeper-report-context.js"),
+);
+const { createDashboardPresentation } = await from(join(candidateDist, "clawsweeper-dashboard.js"));
+const { createRepositoryLinks } = await from(join(candidateDist, "clawsweeper-links.js"));
+const { normalizeRepo, repositoryProfileFor } = await from(
+  join(candidateDist, "repository-profiles.js"),
+);
+const document = createReportDocumentRendering({
+  ...createRepositoryLinks({
+    reportRepo: "openclaw/clawsweeper-state",
+    normalizeRepo,
+    targetRepo: () => "openclaw/openclaw",
+    targetProfile: () => repositoryProfileFor("openclaw/openclaw"),
+  }),
+  ...createReportContextRendering({}),
+  ...createDashboardPresentation({}),
+  prSurfaceFilesFromContext: () => [],
+  compactPullFilePaths: () => [],
+  confidenceText: String,
+  fixedInText: () => "unknown",
+  formatTimestamp: String,
+  labelJustificationsMarkdown: () => "- none",
+  publicLikelyOwnerRole: String,
+  pullHeadShaFromContext: () => "c".repeat(40),
+  reviewStructuralPullStateFromContext: () => null,
+  sentence: String,
+  sha256: hash,
+});
+const producerInput = closeDecision({
+  decision: "keep_open",
+  closeReason: "none",
+  nextStep: none,
+  workReason: reportedText,
+  summary: "Synthetic retry guard assessment.",
+  changeSummary: "Keeps retry ownership bounded.",
+  bestSolution: "None.",
+  risks: [],
+  overallCorrectness: "patch is correct",
+  evidence: [],
+  likelyOwners: [
+    {
+      person: "@synthetic-owner",
+      role: "introduced behavior",
+      reason: "Synthetic owner for this local fixture.",
+      commits: ["c".repeat(40)],
+      files: ["src/retry.ts"],
+      confidence: "low",
+    },
+  ],
+  realBehaviorProof: {
+    status: "sufficient",
+    evidenceKind: "terminal",
+    needsContributorAction: false,
+    summary: proofSummary,
+  },
+  prRating: { ...rating, summary: "Synthetic 5/6 readiness assessment.", nextSteps: [] },
+});
+const producer = after.parseDecision(producerInput);
+const durable = document.markdownFor({
+  item: item({
+    kind: "pull_request",
+    authorAssociation: "MEMBER",
+    url: "https://github.com/openclaw/openclaw/pull/123",
+  }),
+  decision: { ...producer, localCheckoutAccess: "verified" },
+  context: { issue: {}, comments: [], timeline: [] },
+  git: { mainSha: "a".repeat(40), latestRelease: null, releaseStateComplete: true },
+  action: { actionTaken: "kept_open" },
+  reviewMode: "propose",
+  snapshotHash: "synthetic-snapshot",
+  contentDigest: "synthetic-content",
+  reviewPolicy: "synthetic-policy",
+  runtime: { model: "Codex", reasoningEffort: "high" },
+});
+assert.deepEqual(nextStepFromReport(durable), none);
+const roundTripComment = after.renderReviewCommentFromReport(durable, "none");
+const roundTrip = observation(roundTripComment);
+assert.equal(roundTrip.checklist, "None.");
+assert.equal(roundTrip.remainingCount, 0);
+assert.equal((roundTrip.scores.match(/\(5\/6\)/g) ?? []).length, 3);
+writeFileSync(join(proofDir, "producer-input.json"), JSON.stringify(producerInput, null, 2) + "\n");
+writeFileSync(join(proofDir, "producer-roundtrip.report.md"), durable);
+writeFileSync(join(proofDir, "producer-roundtrip.after.md"), roundTripComment);
+
+const owners = [
+  "clawsweeper",
+  "clawsweeper-decision-parser",
+  "clawsweeper-policy",
+  "clawsweeper-next-step",
+  "clawsweeper-report-comment-helpers",
+  "clawsweeper-report-comment-presentation",
+  "clawsweeper-report-document",
+  "clawsweeper-report-context",
+  "clawsweeper-dashboard",
+  "clawsweeper-links",
+  "report-front-matter",
+  "repository-profiles",
+];
+const compiledHashes = (dir) =>
+  Object.fromEntries(
+    owners.map((owner) => {
+      const path = join(dir, `${owner}.js`);
+      if (owner === "clawsweeper-next-step" && !existsSync(path)) return [`${owner}.js`, null];
+      return [`${owner}.js`, hash(readFileSync(path))];
+    }),
+  );
+const sourcePaths = [
+  ...owners.map((owner) => `src/${owner}.ts`),
+  "src/clawsweeper-types.ts",
+  "schema/clawsweeper-decision.schema.json",
+  "prompts/review-item.md",
+  "test/helpers.ts",
+  "pnpm-lock.yaml",
+  "docs/proof/review-next-step-intent/replay.mjs",
+];
+const result = {
+  passed: true,
+  provider: "local-node",
+  image: null,
+  lease: null,
+  runtime: {
+    node: process.version,
+    platform: process.platform,
+    arch: process.arch,
+    packageManager: JSON.parse(readFileSync(join(root, "package.json"), "utf8")).packageManager,
+  },
+  candidate: {
+    head: git("rev-parse", "HEAD"),
+    dirty: git("status", "--porcelain", "--untracked-files=normal").length > 0,
+    build: "pnpm run build:node",
+    compiledOwnerSha256: compiledHashes(candidateDist),
+    sourceSha256: Object.fromEntries(
+      sourcePaths.map((path) => [path, hash(readFileSync(join(root, path)))]),
+    ),
+  },
+  baseline: {
+    sha: baselineSha,
+    compiledOwnerSha256: compiledHashes(baselineDist),
+    provenance:
+      "Caller-supplied compiled dist. SHA names the declared source revision, not a verified build attestation; use the pinned git-archive build recipe in README.md.",
+  },
+  command:
+    "node docs/proof/review-next-step-intent/replay.mjs --baseline-dist <baseline-dist> --baseline-sha <full-sha> [--output-dir <output-dir>]",
+  scenarios: results,
+  producerRoundTrip: {
+    passed: true,
+    inputSha256: hash(JSON.stringify(producerInput)),
+    fixtureSha256: hash(durable),
+    observation: roundTrip,
+  },
+  limits:
+    "Synthetic local replay only; the historical raw structured record was not recovered. No model execution, network, publication, deploy, apply, repair, or merge. Scores and markers match in every paired replay; live eligibility is not exercised. Old records without valid next-step intent retain conservative inference. Rebuild and rerun after source or HEAD changes before citing committed proof.",
+};
+writeFileSync(join(proofDir, "result.json"), JSON.stringify(result, null, 2) + "\n");
+console.log(
+  JSON.stringify({ passed: true, scenarios: results.length, producerRoundTrip: true, proofDir }),
+);

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -217,7 +217,8 @@ Keep user-visible fields non-overlapping. `summary` is the verdict and
 rationale, `changeSummary` is only the requested change or PR diff,
 `systemContext` and `architectureDiagram` explain how that change fits into the
 surrounding system,
-`workReason` is the routing or next-action reason, `bestSolution` is the desired
+`workReason` is the routing reason (or existing issue next-action guidance),
+`nextStep` records required PR action intent, `bestSolution` is the desired
 end state, `reproductionAssessment` answers whether the issue has a
 high-confidence reproduction path, `solutionAssessment` answers whether the
 current/proposed path is the best fix, and `risks` are only unresolved
@@ -228,6 +229,24 @@ one short sentence for `changeSummary`, `workReason`, `bestSolution`, and
 `securityReview.concerns`, `evidence`, and `likelyOwners`. Do not turn
 `changeSummary` or `workReason` into an automerge/autofix status update; merge
 automation is reported by the command/status comment and hidden markers.
+
+For pull requests, follow this next-step contract. Always fill `nextStep` with
+`{ "kind": "none", "text": "" }` when no additional required next step remains,
+including routine CI or ordinary maintainer look.
+Otherwise use `{ "kind": "required", "text": "<nonempty trimmed action>" }`.
+Keep explanatory routing prose in `workReason`. A genuine blocker stays required
+even if its prose includes no, not, but, unless, or until: for example, "No schema
+change is needed, but repair the retry guard before merge" or "Do not merge until
+the owner approves the compatibility contract." Human-owned actions can be
+required even with `workCandidate: "none"`. Do not rely on action keywords to
+communicate intent. Independent findings, security concerns, risks, contributor
+proof, historical verification, decisions, failed reviews, and low-quality
+remediation remain blockers regardless of `nextStep`. This field is presentation
+intent for the Before merge checklist/count only, not authority to auto-fix or
+merge; the automation meaning of `workCandidate` is unchanged. Existing repository
+policies still apply: do not request contributor changelog entries for OpenClaw.
+For issues, use `nextStep` kind none with empty text and keep existing next-action
+guidance in `workReason`; issue rendering is unchanged.
 
 Put maintainer-intent reasoning in `maintainerDecision`; do not expect labels,
 report prose, or deterministic code to reconstruct it later. Set `required:

--- a/schema/clawsweeper-decision.schema.json
+++ b/schema/clawsweeper-decision.schema.json
@@ -57,6 +57,7 @@
     "workConfidence",
     "workPriority",
     "workReason",
+    "nextStep",
     "workPrompt",
     "workClusterRefs",
     "workValidation",
@@ -1134,7 +1135,30 @@
     },
     "workReason": {
       "type": "string",
-      "description": "Short reason this item is or is not a safe fix-PR candidate. For pull requests that need human handling, make this the maintainer next action and do not restate bestSolution."
+      "description": "Short routing explanation for why this item is or is not a safe fix-PR candidate. For pull requests, keep required action intent in nextStep, not in this rationale. For issues, retain existing routing or next-action guidance here."
+    },
+    "nextStep": {
+      "description": "Producer-owned presentation intent for the PR Before merge next step only, never authority to auto-fix or merge. Issues use none and retain next-action guidance in workReason. None means no additional required action (including routine CI or ordinary maintainer look); required states the concrete action, including human-owned blockers even when workCandidate is none or the text contains no/not/but/unless/until. Independent findings, security, proof, risks, decisions, and low-quality remediation remain separate blockers.",
+      "anyOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "text"],
+          "properties": {
+            "kind": { "type": "string", "enum": ["none"] },
+            "text": { "type": "string", "enum": [""] }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "text"],
+          "properties": {
+            "kind": { "type": "string", "enum": ["required"] },
+            "text": { "type": "string", "pattern": "^\\S(?:[\\s\\S]*\\S)?$" }
+          }
+        }
+      ]
     },
     "workPrompt": {
       "type": "string",

--- a/src/clawsweeper-decision-parser.ts
+++ b/src/clawsweeper-decision-parser.ts
@@ -87,6 +87,7 @@ import type {
   TelegramVisibleProof,
 } from "./clawsweeper-types.js";
 import { derivedPrRating, normalizePrRating } from "./clawsweeper-rating.js";
+import { parseNextStep } from "./clawsweeper-next-step.js";
 import { parseMaintainerDecision } from "./decision-packets.js";
 import { DEFAULT_TARGET_REPO, normalizeRepo } from "./repository-profiles.js";
 
@@ -495,10 +496,33 @@ export function createDecisionParser({
   const CLEAN_OPENCLAW_PR_REVIEW_NEXT_STEP =
     "Continue normal maintainer review; ClawSweeper found no patch-correctness issue.";
 
+  const STANDALONE_CHANGELOG_ENTRY_REQUEST =
+    /^(?:please\s+)?(?:add|include)\s+(?:(?:a|an|the)\s+)?(?:(?:missing|required)\s+)?(?:changelog(?:\.md)?\s+entr(?:y|ies)|release[- ]notes?)(?:\s+before\s+merge)?[.!]?\s*$/i;
+  const NEXT_STEP_CLAUSE_SEPARATOR =
+    /([.;]\s+|\n+|\s+(?:and|but)\s+(?=(?:add|include|repair|fix|verify|confirm|resolve|prove|run)\s+(?:the|a|an|this|that)\s+\S))/i;
+
   function normalizeDecisionForItem(
     decision: Decision,
     item: DecisionNormalizationItem | undefined,
   ): Decision {
+    if (decision.nextStep?.kind === "required" && isOpenClawContributorPullRequest(item)) {
+      // Unlike findings, action prose must directly request only a changelog entry;
+      // mentions in a different or ambiguous instruction retain required intent.
+      // Split conjunctions only before clear imperative clauses, not compound
+      // objects such as "a changelog entry and repair notes". Unrecognized forms
+      // stay together so an ambiguous additional action cannot be stripped.
+      const parts = decision.nextStep.text.split(NEXT_STEP_CLAUSE_SEPARATOR);
+      const retained = parts.flatMap((text, index) =>
+        index % 2 === 0 && !STANDALONE_CHANGELOG_ENTRY_REQUEST.test(text) ? [index] : [],
+      );
+      if (retained.length !== (parts.length + 1) / 2) {
+        const text = retained
+          .map((index, position) => `${position === 0 ? "" : parts[index - 1]}${parts[index]}`)
+          .join("")
+          .trim();
+        decision = { ...decision, nextStep: { kind: text ? "required" : "none", text } };
+      }
+    }
     const reviewFindings = decision.reviewFindings.filter(
       (finding) => !isContributorChangelogEntryFinding(item, finding),
     );
@@ -1001,6 +1025,10 @@ export function createDecisionParser({
       record.maintainerDecision,
       "decision.maintainerDecision",
     );
+    const nextStep =
+      record.nextStep === undefined
+        ? undefined
+        : parseNextStep(record.nextStep, "decision.nextStep");
     const decision: Decision = {
       decision: requireEnum(record.decision, DECISIONS, "decision.decision"),
       closeReason: requireEnum(record.closeReason, ALL_REASONS, "decision.closeReason"),
@@ -1138,6 +1166,14 @@ export function createDecisionParser({
       workConfidence: requireEnum(record.workConfidence, CONFIDENCES, "decision.workConfidence"),
       workPriority: requireEnum(record.workPriority, CONFIDENCES, "decision.workPriority"),
       workReason: requireReportText(record.workReason, "decision.workReason"),
+      ...(nextStep === undefined
+        ? {}
+        : {
+            nextStep: {
+              ...nextStep,
+              text: requireReportText(nextStep.text, "decision.nextStep.text"),
+            },
+          }),
       workPrompt: requireReportText(record.workPrompt, "decision.workPrompt"),
       workClusterRefs: requireSingleLineStringArray(
         record.workClusterRefs,

--- a/src/clawsweeper-next-step.ts
+++ b/src/clawsweeper-next-step.ts
@@ -1,0 +1,49 @@
+import type { NextStepAssessment } from "./clawsweeper-types.js";
+import { parseDocument } from "yaml";
+import { parseReportFrontMatter, readReportFrontMatterField } from "./report-front-matter.js";
+
+export function parseNextStep(value: unknown, path = "nextStep"): NextStepAssessment {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${path} must be an object`);
+  }
+  const record = value as Record<string, unknown>;
+  if (Object.keys(record).some((key) => key !== "kind" && key !== "text")) {
+    throw new Error(`${path} has unexpected keys`);
+  }
+  if (record.kind !== "none" && record.kind !== "required") {
+    throw new Error(`${path}.kind must be none or required`);
+  }
+  if (typeof record.text !== "string") throw new Error(`${path}.text must be a string`);
+  if (record.kind === "none" && record.text !== "") {
+    throw new Error(`${path}.text must be empty for none`);
+  }
+  const text = record.text.trim();
+  if (record.kind === "required" && !text) {
+    throw new Error(`${path}.text must not be empty for required`);
+  }
+  return { kind: record.kind, text };
+}
+
+export function nextStepFromReport(markdown: string): NextStepAssessment | undefined {
+  const field = readReportFrontMatterField(markdown, "next_step");
+  if (field.status !== "value") return undefined;
+  const header = markdown.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/)?.[1] ?? "";
+  const frontmatter = parseReportFrontMatter(markdown)!;
+  // Noncanonical spellings must not hide a competing value beside the literal key.
+  if (
+    [...frontmatter.fields.keys(), ...frontmatter.competingKeys].some(
+      (key) => key !== "next_step" && key.trim().replace(/^["']|["']$/g, "") === "next_step",
+    )
+  )
+    return undefined;
+  try {
+    // Validate the header as well as the JSON value: repeated (including quoted)
+    // keys, fenced examples, or malformed continuations cannot supply intent.
+    if (parseDocument(header, { uniqueKeys: true }).errors.length) return undefined;
+    const value: unknown = JSON.parse(field.value);
+    return parseNextStep(value, "next_step");
+  } catch {
+    // Malformed historical metadata retains the legacy conservative projection.
+    return undefined;
+  }
+}

--- a/src/clawsweeper-policy.ts
+++ b/src/clawsweeper-policy.ts
@@ -774,6 +774,7 @@ export const DECISION_SCHEMA_KEYS = new Set([
   "workConfidence",
   "workPriority",
   "workReason",
+  "nextStep",
   "workPrompt",
   "workClusterRefs",
   "workValidation",

--- a/src/clawsweeper-report-comment-helpers.ts
+++ b/src/clawsweeper-report-comment-helpers.ts
@@ -8,6 +8,7 @@ import type {
   ItemKind,
   LikelyOwner,
   MergeRiskOption,
+  NextStepAssessment,
   PublicBeforeMergeItem,
   PublicPriority,
   RegressionAssessment,
@@ -298,6 +299,7 @@ export function createReportCommentHelpers(
     securityReview: SecurityReview;
     risks: string;
     nextStep: string;
+    nextStepAssessment: NextStepAssessment | undefined;
     decisionPending: boolean;
     patchQualityBlocked: boolean;
     requiredRatingSteps: readonly string[];
@@ -370,10 +372,14 @@ export function createReportCommentHelpers(
       add("Resolve security review attention item", options.securityReview.summary);
     }
     if (!isReportNoneList(options.risks)) addPrioritized(options.risks, "P1", "Resolve merge risk");
-    // Only actionable next-step text enters the checklist: routing rationale or other
-    // explanatory prose is not remaining merge work, and decision questions are
-    // already represented by the decision packet.
-    if (
+    // Producer intent controls only this item; older reports retain prose inference.
+    if (options.nextStepAssessment?.kind === "required") {
+      add(
+        `Complete next step (${publicPriorityFromText(options.nextStepAssessment.text, "P2")})`,
+        options.nextStepAssessment.text,
+      );
+    } else if (
+      options.nextStepAssessment === undefined &&
       !isRoutineBeforeMergeStep(options.nextStep) &&
       !isRoutineCiOrReviewText(options.nextStep) &&
       isActionablePriorityText(options.nextStep) &&

--- a/src/clawsweeper-report-comment-presentation.ts
+++ b/src/clawsweeper-report-comment-presentation.ts
@@ -12,6 +12,7 @@ import { neutralizeReviewControlMarkers, renderReviewHistorySection } from "./re
 import type { CreateReportRenderingDependencies } from "./clawsweeper-report-rendering-dependencies.js";
 import type { createReportContextRendering } from "./clawsweeper-report-context.js";
 import type { createReportCommentHelpers } from "./clawsweeper-report-comment-helpers.js";
+import { nextStepFromReport } from "./clawsweeper-next-step.js";
 
 export function createReportCommentPresentation(
   dependencies: CreateReportRenderingDependencies &
@@ -317,6 +318,7 @@ export function createReportCommentPresentation(
         securityReview,
         risks,
         nextStep: nextStepLine,
+        nextStepAssessment: nextStepFromReport(markdown),
         decisionPending: Boolean(decisionPacketBlock),
         patchQualityBlocked,
         requiredRatingSteps: patchQualityBlocked ? prRating.nextSteps : [],

--- a/src/clawsweeper-report-document.ts
+++ b/src/clawsweeper-report-document.ts
@@ -37,6 +37,7 @@ import {
   fitPrHydrationSnapshotToPublicationLimit,
   serializePrHydrationSnapshot,
 } from "./pr-hydration-snapshot.js";
+import { parseNextStep } from "./clawsweeper-next-step.js";
 
 export function localCheckoutAccessForDecision(
   decision: Pick<Decision, "localCheckoutAccess">,
@@ -663,7 +664,7 @@ decision: ${options.decision.decision}
 close_reason: ${options.decision.closeReason}
 confidence: ${options.decision.confidence}
 action_taken: ${options.action.actionTaken}
-work_candidate: ${options.decision.workCandidate}
+${options.decision.nextStep === undefined ? "" : `next_step: ${JSON.stringify(parseNextStep(options.decision.nextStep))}\n`}work_candidate: ${options.decision.workCandidate}
 work_confidence: ${options.decision.workConfidence}
 work_priority: ${options.decision.workPriority}
 work_status: ${workStatusForDecision(options.decision)}

--- a/src/clawsweeper-types.ts
+++ b/src/clawsweeper-types.ts
@@ -17,6 +17,7 @@ export type ItemKind = "issue" | "pull_request";
 export type ApplyKind = ItemKind | "all";
 export type DecisionKind = "close" | "keep_open";
 export type WorkCandidateKind = "none" | "manual_review" | "queue_fix_pr";
+export type NextStepAssessment = { kind: "none" | "required"; text: string };
 export type FailedReviewRetryRevisionKind = "pull_head_sha" | "item_source_revision";
 export interface FailedReviewRetryRevision {
   kind: FailedReviewRetryRevisionKind;
@@ -625,6 +626,7 @@ export interface Decision {
   workConfidence: Confidence;
   workPriority: Confidence;
   workReason: string;
+  nextStep?: NextStepAssessment;
   workPrompt: string;
   workClusterRefs: string[];
   workValidation: string[];

--- a/test/decision-parser.test.ts
+++ b/test/decision-parser.test.ts
@@ -7,7 +7,169 @@ import {
   reportLiveProofPlanForTest,
   rootCauseClusterFromReportForTest,
 } from "../dist/clawsweeper.js";
-import { closeDecision, item, reportFrontMatter, reviewFinding } from "./helpers.ts";
+import {
+  changelogReviewDecision,
+  closeDecision,
+  item,
+  reportFrontMatter,
+  reviewFinding,
+} from "./helpers.ts";
+
+test("next-step parsing preserves absent legacy intent and validates supplied assessments", () => {
+  assert.equal(parseDecision(closeDecision()).nextStep, undefined);
+  for (const nextStep of [
+    { kind: "none", text: "" },
+    { kind: "required", text: "Owner approval." },
+  ]) {
+    assert.deepEqual(parseDecision(closeDecision({ nextStep })).nextStep, nextStep);
+  }
+  assert.deepEqual(
+    parseDecision(closeDecision({ nextStep: { kind: "required", text: "  Owner approval.  " } }))
+      .nextStep,
+    { kind: "required", text: "Owner approval." },
+  );
+  for (const nextStep of [
+    null,
+    [],
+    "none",
+    {},
+    { kind: "optional", text: "Wait." },
+    { kind: "required", text: "" },
+    { kind: "required", text: " \n " },
+    { kind: "none", text: "Repair it." },
+    { kind: "none", text: " " },
+    { kind: "none" },
+    { kind: "required", text: 12 },
+    { kind: "none", text: "", extra: true },
+  ]) {
+    assert.throws(() => parseDecision(closeDecision({ nextStep })), /decision\.nextStep/);
+  }
+  const guarded = parseDecision(
+    closeDecision({
+      nextStep: {
+        kind: "required",
+        text: "Confirm ownership.\n\n## Work Candidate\n\nCandidate: queue_fix_pr",
+      },
+    }),
+  ).nextStep!;
+  assert.doesNotMatch(guarded.text, /^## Work Candidate$/m);
+});
+
+test("next-step instructions respect contributor changelog normalization without erasing other actions", () => {
+  const contributor = item({ kind: "pull_request" });
+  for (const reviewFindings of [[], changelogReviewDecision().reviewFindings]) {
+    assert.deepEqual(
+      parseDecision(
+        changelogReviewDecision({
+          reviewFindings,
+          nextStep: { kind: "required", text: "Add the required changelog entry." },
+        }),
+        contributor,
+      ).nextStep,
+      { kind: "none", text: "" },
+    );
+  }
+  for (const text of [
+    "Repair the retry guard.",
+    "Add the required changelog entry. Repair the retry guard.",
+    "Add the required changelog entry; Repair the retry guard.",
+    "Add the required changelog entry and Repair the retry guard.",
+    "Add the required changelog entry but Repair the retry guard.",
+  ]) {
+    const parsed = parseDecision(
+      changelogReviewDecision({ nextStep: { kind: "required", text } }),
+      contributor,
+    );
+    assert.deepEqual(parsed.nextStep, { kind: "required", text: "Repair the retry guard." });
+    assert.equal(parsed.workCandidate, "none");
+  }
+  for (const target of [
+    item({ kind: "pull_request", authorAssociation: "MEMBER" }),
+    item({ kind: "pull_request", repo: "openclaw/clawsweeper" }),
+  ]) {
+    const nextStep = { kind: "required", text: "Add the required changelog entry." };
+    assert.deepEqual(
+      parseDecision(changelogReviewDecision({ nextStep }), target).nextStep,
+      nextStep,
+    );
+  }
+  const nextStep = { kind: "required", text: "Add changelog parser coverage." };
+  assert.deepEqual(
+    parseDecision(changelogReviewDecision({ nextStep }), contributor).nextStep,
+    nextStep,
+  );
+  assert.equal(parseDecision(changelogReviewDecision(), contributor).nextStep, undefined);
+  const finding = reviewFinding({ title: "Retry race", body: "Repair concurrent retry handling." });
+  const parsed = parseDecision(
+    changelogReviewDecision({
+      reviewFindings: [...changelogReviewDecision().reviewFindings, finding],
+      nextStep: { kind: "required", text: "Add the required changelog entry." },
+    }),
+    contributor,
+  );
+  assert.deepEqual(parsed.reviewFindings, [finding]);
+  assert.equal(parsed.workCandidate, "queue_fix_pr");
+});
+
+test("next-step changelog normalization preserves other or ambiguous required instructions verbatim", () => {
+  const contributor = item({ kind: "pull_request" });
+  for (const text of [
+    "Add the missing retry test, not a changelog entry.",
+    "Repair retry ownership rather than add a changelog entry.",
+    "Do not merge until retry ownership is proven.",
+    "Do not merge until retry ownership is proven, not merely a changelog entry added.",
+    "Add a changelog entry rather than repair retry ownership.",
+    "Add a changelog entry only after repairing retry ownership.",
+    "Add a changelog entry documenting the unresolved retry guard defect.",
+    "Add a changelog entry and a retry test.",
+    "Add a changelog entry and retry coverage.",
+    "Add a changelog entry and repair notes.",
+    "Add a changelog entry but ownership approval is still missing.",
+    "No changelog entry is required; repair retry ownership.",
+    "Add the missing retry test, not a changelog entry; confirm owner approval.",
+    "Add the missing retry test, not a changelog entry and confirm owner approval.",
+    "Repair retry ownership rather than add a changelog entry but confirm owner approval.",
+    "Add changelog parser coverage.",
+  ]) {
+    const nextStep = { kind: "required", text };
+    const parsed = parseDecision(
+      changelogReviewDecision({ reviewFindings: [], nextStep }),
+      contributor,
+    );
+    assert.deepEqual(parsed.nextStep, nextStep, text);
+  }
+  for (const separator of ["; ", " and ", " but "]) {
+    for (const action of [
+      "Add the missing retry test, not a changelog entry.",
+      "Repair the retry guard and confirm compatibility; add the missing retry test.",
+    ]) {
+      const parsed = parseDecision(
+        changelogReviewDecision({
+          reviewFindings: [],
+          nextStep: {
+            kind: "required",
+            text: `Add the required changelog entry${separator}${action}`,
+          },
+        }),
+        contributor,
+      );
+      assert.deepEqual(parsed.nextStep, { kind: "required", text: action });
+    }
+  }
+  for (const text of [
+    "Add the required changelog entry.",
+    "Include a release note before merge.",
+  ]) {
+    const parsed = parseDecision(
+      changelogReviewDecision({
+        reviewFindings: [],
+        nextStep: { kind: "required", text },
+      }),
+      contributor,
+    );
+    assert.deepEqual(parsed.nextStep, { kind: "none", text: "" }, text);
+  }
+});
 
 test("evidence requires deliberate repository ownership, including explicit unknown", () => {
   const evidence = { ...closeDecision().evidence[0], repo: "openai/codex" };

--- a/test/review-comment-rendering.test.ts
+++ b/test/review-comment-rendering.test.ts
@@ -18,7 +18,15 @@ import {
   withReviewStartStatusLease,
 } from "../dist/clawsweeper.js";
 import { issueSourceRevisionSha256 } from "../dist/repair/issue-source-guard.js";
-import { closeDecision, detailsBody, item, reportFrontMatter } from "./helpers.ts";
+import {
+  closeDecision,
+  detailsBody,
+  item,
+  prRatingReportSection,
+  realBehaviorProofReportSection,
+  reportFrontMatter,
+} from "./helpers.ts";
+import { nextStepFromReport } from "../dist/clawsweeper-next-step.js";
 import { createRepositoryLinks } from "../dist/clawsweeper-links.js";
 import { createReportDocumentRendering } from "../dist/clawsweeper-report-document.js";
 import { createReportContextRendering } from "../dist/clawsweeper-report-context.js";
@@ -27,7 +35,7 @@ import { createReportParser } from "../dist/clawsweeper-report-parser.js";
 import { createRecordMetadata } from "../dist/clawsweeper-record-metadata.js";
 import { createReportHelpers } from "../dist/clawsweeper-report-helpers.js";
 import { normalizeRepo, repositoryProfileFor } from "../dist/repository-profiles.js";
-import type { DecisionKind, Evidence } from "../dist/clawsweeper-types.js";
+import type { DecisionKind, Evidence, NextStepAssessment } from "../dist/clawsweeper-types.js";
 
 function markdownLinkDestinations(markdown: string): Set<string> {
   const destinations = new Set<string>();
@@ -80,7 +88,11 @@ const evidenceParser = createReportParser({
   }),
 } as Parameters<typeof createReportParser>[0]);
 
-function evidenceReport(evidence: Evidence[], decisionKind: DecisionKind = "close") {
+function evidenceReport(
+  evidence: Evidence[],
+  decisionKind: DecisionKind = "close",
+  nextStep?: NextStepAssessment,
+) {
   const document = createReportDocumentRendering({
     ...evidenceLinks,
     ...createReportContextRendering({} as never),
@@ -105,6 +117,7 @@ function evidenceReport(evidence: Evidence[], decisionKind: DecisionKind = "clos
           evidence,
           decision: decisionKind,
           closeReason: decisionKind === "close" ? "implemented_on_main" : "none",
+          ...(nextStep === undefined ? {} : { nextStep }),
         }),
       ),
       // The host stamps checkout access after parsing model output.
@@ -120,6 +133,244 @@ function evidenceReport(evidence: Evidence[], decisionKind: DecisionKind = "clos
     runtime: { model: "Codex", reasoningEffort: "high" },
   } as Parameters<typeof document.markdownFor>[0]);
 }
+
+function nextStepReport(
+  metadata: Record<string, string> = {},
+  sections = "",
+  reason = "No concrete repair remains after this review.",
+) {
+  return `${reportFrontMatter({
+    type: "pull_request",
+    number: "123",
+    review_status: "complete",
+    local_checkout_access: "verified",
+    author_association: "MEMBER",
+    work_candidate: "none",
+    pull_head_sha: "c".repeat(40),
+    ...metadata,
+  })}
+## Summary
+
+The retry guard is ready for review.
+
+## What This Changes
+
+Keeps retry ownership bounded.
+
+${prRatingReportSection()}
+
+${realBehaviorProofReportSection()}
+
+## Work Candidate
+
+Candidate: none
+
+Reason: ${reason}
+
+${sections}`;
+}
+
+function publicSection(comment: string, title: string): string {
+  return (
+    comment
+      .split(`## ${title}\n\n`)[1]
+      ?.split(/\n## |\n<details>/)[0]
+      ?.trim() ?? ""
+  );
+}
+
+test("explicit next-step none removes the false repair checkbox/count, not scores or markers", () => {
+  const legacy = nextStepReport();
+  const report = nextStepReport({ next_step: JSON.stringify({ kind: "none", text: "" }) });
+  const before = renderReviewCommentFromReport(legacy, "none");
+  const after = renderReviewCommentFromReport(report, "none");
+  assert.match(before, /Complete next step.*No concrete repair remains after this review\./);
+  assert.match(before, /1 item remains/);
+  assert.equal(publicSection(after, "Before merge"), "None.");
+  assert.doesNotMatch(after, /Complete next step|1 item remains/);
+  assert.equal(publicSection(after, "Review scores"), publicSection(before, "Review scores"));
+  assert.equal(
+    reviewAutomationMarkersFromReport(report),
+    reviewAutomationMarkersFromReport(legacy),
+  );
+  assert.deepEqual(
+    after.match(/<!-- clawsweeper-[^\n]+/g),
+    before.match(/<!-- clawsweeper-[^\n]+/g),
+  );
+});
+
+test("explicit required actions bypass prose heuristics even for human-owned workCandidate none", () => {
+  for (const text of [
+    "No schema change is needed, but repair the retry guard before merge.",
+    "Do not merge until the owner approves the compatibility contract.",
+    "Owner approval.",
+    "Wait for CI and ordinary maintainer review.",
+    "A decision on ownership is still outstanding.",
+  ]) {
+    const report = nextStepReport({ next_step: JSON.stringify({ kind: "required", text }) });
+    const comment = renderReviewCommentFromReport(report, "none");
+    assert.ok(publicSection(comment, "Before merge").includes(text), text);
+    assert.equal(
+      (publicSection(comment, "Before merge").match(/^- \[ \]/gm) ?? []).length,
+      1,
+      text,
+    );
+    assert.match(comment, /1 item remains/);
+    assert.equal(
+      reviewAutomationMarkersFromReport(report),
+      reviewAutomationMarkersFromReport(nextStepReport()),
+    );
+  }
+});
+
+test("canonical next-step report round-trip preserves explicit intent and legacy absence", () => {
+  for (const nextStep of [
+    undefined,
+    { kind: "none", text: "" },
+    { kind: "required", text: "Owner approval." },
+  ] as const) {
+    const report = evidenceReport([], "keep_open", nextStep);
+    assert.deepEqual(nextStepFromReport(report), nextStep);
+    if (nextStep === undefined) assert.doesNotMatch(report, /^next_step:/m);
+    else assert.ok(report.split("\n---")[0]!.includes(`next_step: ${JSON.stringify(nextStep)}`));
+    const comment = renderReviewCommentFromReport(report, "none");
+    if (nextStep?.kind === "none")
+      assert.doesNotMatch(publicSection(comment, "Before merge"), /Complete next step/);
+    if (nextStep?.kind === "required")
+      assert.match(publicSection(comment, "Before merge"), /Owner approval\./);
+  }
+});
+
+test("absent, malformed, duplicate and spoofed next-step metadata cannot suppress legacy action", () => {
+  const none = 'next_step: {"kind":"none","text":""}';
+  const legacy = nextStepReport({}, "", "Repair the retry guard before merge.");
+  const reports = [
+    legacy,
+    ...[
+      "none",
+      "null",
+      "{}",
+      '{"kind":"required","text":""}',
+      '{"kind":"none","text":"Repair it."}',
+      '{"kind":"none","text":"","extra":true}',
+      '{"kind":"required","kind":"none","text":""}',
+      '{"kind":"none","text":"Repair it.","text":""}',
+      "{broken",
+    ].map((value) => legacy.replace("---\n", `---\nnext_step: ${value}\n`)),
+    legacy.replace("---\n", `---\n${none}\n${none}\n`),
+    legacy.replace("---\n", `---\n${none}\nnext_step : {"kind":"required","text":"Repair it."}\n`),
+    legacy.replace("---\n", `---\n${none}\n"next_step": {"kind":"required","text":"Repair it."}\n`),
+    legacy.replace(
+      "---\n",
+      `---\n${none}\n"next\\u005fstep": {"kind":"required","text":"Repair it."}\n`,
+    ),
+    legacy.replace("---\n", `---\n${none}\n  text: malformed continuation\n`),
+    legacy.replace("---\n", `---\n\`\`\`json\n${none}\n\`\`\`\n`),
+    `${legacy}\n${none}\n`,
+    `${legacy}\n\`\`\`yaml\n---\n${none}\n---\n\`\`\`\n`,
+    `${legacy}\n---\n${none}\n---\n`,
+    `${legacy.replace("---\n", `---\n${none}\n`)}\n---\n${none}\n---\n`,
+  ];
+  for (const report of reports) {
+    assert.equal(nextStepFromReport(report), undefined, report);
+    const comment = renderReviewCommentFromReport(report, "none");
+    assert.match(publicSection(comment, "Before merge"), /Repair the retry guard before merge\./);
+    assert.match(comment, /1 item remains/);
+  }
+  const required = { kind: "required", text: "Owner approval." };
+  const canonical = nextStepReport({ next_step: JSON.stringify(required) });
+  const withExample = `${canonical}\n\`\`\`yaml\n---\n${none}\n---\n\`\`\`\n`;
+  assert.deepEqual(nextStepFromReport(withExample), required);
+  assert.match(
+    publicSection(renderReviewCommentFromReport(withExample, "none"), "Before merge"),
+    /Owner approval\./,
+  );
+});
+
+test("explicit none leaves independent blockers, decision counts and low ratings intact", () => {
+  const decision = {
+    required: true,
+    kind: "product_direction",
+    question: "Which compatibility contract should ship?",
+    rationale: "This needs an owner ruling.",
+    options: [{ title: "Keep compatibility", body: "Retain the old contract.", recommended: true }],
+    likelyOwner: { person: "@owner", reason: "Owns the contract.", confidence: "high" },
+  };
+  const cases: {
+    metadata?: Record<string, string>;
+    sections?: string;
+    label: string;
+    count?: number;
+  }[] = [
+    {
+      sections:
+        "## Review Findings\n\nOverall correctness: patch is incorrect\n\nFull review comments:\n\n- **[P1] Retry race:** `src/retry.ts:12`\n  - body: Repair concurrent retry handling.\n  - confidence: 0.9",
+      label: "Retry race",
+    },
+    {
+      sections:
+        "## Security Review\n\nStatus: needs_attention\n\nSummary: Confirm ownership.\n\nConcerns:\n\n- **[high] Ownership boundary:** `src/retry.ts:12`\n  - body: Restore the authorization guard.\n  - confidence: 0.9",
+      label: "Resolve security concern",
+    },
+    {
+      sections: "## Risks / Open Questions\n\n- [P1] Repair the compatibility break before merge.",
+      label: "Resolve merge risk",
+    },
+    {
+      metadata: {
+        real_behavior_proof_status: "missing",
+        real_behavior_proof_evidence_kind: "none",
+        real_behavior_proof_needs_contributor_action: "true",
+        author_association: "NONE",
+      },
+      label: "Add real behavior proof",
+    },
+    {
+      sections: "## Live Proof\n\n<!-- clawsweeper-live-verification -->\nResult: invalid",
+      label: "Resolve historical verification",
+    },
+    { metadata: { maintainer_decision: JSON.stringify(decision) }, label: "Decision needed" },
+    {
+      metadata: { pr_rating_patch: "D", pr_rating_proof: "A", pr_rating_overall: "D" },
+      label: "Improve patch quality",
+    },
+    { metadata: { review_status: "failed" }, label: "Retry ClawSweeper review", count: 0 },
+  ];
+  for (const scenario of cases) {
+    const legacy = nextStepReport(scenario.metadata, scenario.sections, "None.");
+    const report = legacy.replace("---\n", '---\nnext_step: {"kind":"none","text":""}\n');
+    const before = renderReviewCommentFromReport(legacy, "none");
+    const after = renderReviewCommentFromReport(report, "none");
+    assert.ok(after.includes(scenario.label), scenario.label);
+    assert.doesNotMatch(publicSection(after, "Before merge"), /Complete next step/);
+    if (scenario.count !== 0) assert.match(after, /1 item remains/, scenario.label);
+    assert.equal(
+      publicSection(after, "Before merge"),
+      publicSection(before, "Before merge"),
+      scenario.label,
+    );
+    assert.equal(
+      publicSection(after, "Review scores"),
+      publicSection(before, "Review scores"),
+      scenario.label,
+    );
+    assert.equal(
+      reviewAutomationMarkersFromReport(report),
+      reviewAutomationMarkersFromReport(legacy),
+      scenario.label,
+    );
+  }
+  const withDecision = nextStepReport({
+    maintainer_decision: JSON.stringify(decision),
+    next_step: JSON.stringify({
+      kind: "required",
+      text: "Record the owner decision in the PR body.",
+    }),
+  });
+  const comment = renderReviewCommentFromReport(withDecision, "none");
+  assert.match(publicSection(comment, "Before merge"), /Record the owner decision/);
+  assert.match(comment, /2 items remain/);
+});
 
 const dependencyEvidence = {
   repo: "openai/codex",

--- a/test/review-prompt-policy.test.ts
+++ b/test/review-prompt-policy.test.ts
@@ -31,6 +31,39 @@ import {
   mediaFixtureUrls,
 } from "./primary-body-fixture.ts";
 
+test("review prompt and generation schema deliver explicit next-step presentation intent", () => {
+  const schema = JSON.parse(readFileSync("schema/clawsweeper-decision.schema.json", "utf8"));
+  assert.ok(schema.required.includes("nextStep"));
+  const [none, required] = schema.properties.nextStep.anyOf;
+  for (const branch of [none, required]) {
+    assert.equal(branch.additionalProperties, false);
+    assert.deepEqual(branch.required, ["kind", "text"]);
+  }
+  assert.deepEqual(none.properties.kind.enum, ["none"]);
+  assert.deepEqual(none.properties.text.enum, [""]);
+  assert.deepEqual(required.properties.kind.enum, ["required"]);
+  const pattern = new RegExp(required.properties.text.pattern);
+  for (const text of ["", " ", "\n", " Owner approval.", "Owner approval. "])
+    assert.equal(pattern.test(text), false);
+  assert.ok(pattern.test("Owner approval."));
+  const prompt = reviewPromptForTest(
+    item({ kind: "pull_request" }),
+    { issue: {}, comments: [], timeline: [] },
+    {
+      mainSha: "a".repeat(40),
+      latestRelease: null,
+    },
+  );
+  assert.match(prompt, /Always fill `nextStep`/);
+  assert.match(prompt, /routine CI or ordinary maintainer look/);
+  assert.match(prompt, /no, not, but, unless, or until/);
+  assert.match(prompt, /Human-owned actions can be\s+required even with `workCandidate: "none"`/);
+  assert.match(prompt, /not authority to auto-fix or\s+merge/);
+  assert.match(prompt, /do not request contributor changelog entries for OpenClaw/);
+  assert.match(prompt, /For issues, use `nextStep` kind none with empty text/);
+  assert.match(prompt, /existing next-action\s+guidance in `workReason`/);
+});
+
 for (const kind of ["issue", "pull_request"] as const) {
   test(`late instruction-like media in ${kind} excerpts never causes host fetches`, () => {
     const lateUrl = mediaFixtureUrls.loopback;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers see a remaining-work checkbox on an otherwise clean ClawSweeper review when its routing explanation says “No concrete repair remains after this review.” The trigger was [the review on PR1341](https://github.com/openclaw/clawsweeper/pull/1341#issuecomment-5499517784): the visible review reported no actionable defect but displayed one remaining item.

## Why This Change Was Made

The renderer was treating routing prose as action intent. This change records a producer-owned `nextStep` assessment, validates and persists it in the canonical report, and consumes it only for the derived Before merge next-step item. `workCandidate: none` remains an automation-routing state, not permission to hide human-owned blockers.

Explicit non-action removes that item; explicit required actions survive negation, contrast, and missing trigger keywords. Findings, security, proof, merge risks, decisions, and rating remediation remain independent. Contributor-changelog normalization preserves mixed or ambiguous required actions. No phrase denylist is added to the general action detector.

## User Impact

New reviews with explicit non-action no longer show the bogus checkbox or inflate the remaining-item count. Genuine required actions stay visible. Issues retain their existing next-action guidance. Scores and repair/automerge markers are unchanged.

Historical reports are not migrated: absent, malformed, or ambiguous intent keeps the conservative legacy fallback. The original review’s raw structured record was not recovered; this is not a claim that it already contained the new field, and this PR does not rewrite that old comment.

## OpenClaw Bay Impact

None. The observer projection does not consume this checklist. No observer routes, controls, workflow mutations, or live repair/merge eligibility change.

## Documentation Impact

Updated the active implementation contract in `docs/pr-review-comments.md`. Added the historical, reproducible recipe `docs/proof/review-next-step-intent/README.md` with its owner, pinned baseline, source references, commands, and explicit proof limits. No changelog edit is included.

## Evidence

- Candidate head: `57de5d52eed4202200b28e10da0a76e21bff5ea8`.
- `pnpm run build:node` and 200 focused parser, renderer/count, risk, labels, prompt-policy, history, and no-op tests passed.
- Codex pre-commit autoreview completed with no accepted findings at its configured P0 threshold.
- An earlier Mac full-check attempt had five unchanged action-ledger timing/fairness failures, all five of which passed in an isolated rerun; the broad run was stopped after approximately 46 minutes. That run is not claimed as a full-check pass. Current-head repository CI must pass before landing.

## Real Behavior Proof

**Claim and exercised surface:** an explicit recorded non-action must not manufacture a PR checkbox/count, while required actions and independent blockers remain visible. The replay calls the compiled production renderers with identical serialized report bytes, then separately runs the real decision parser, report writer, intent reader, and renderer.

**Environment and command:** Node 24+, pinned pnpm dependencies, local Node execution; no container image or lease is claimed for this replay. Baseline source is `39592f04448bdc34d37b9e7f8d5c5d7c828b73f2`, built from `git archive` with the same installed compiler. Candidate is the commit above. Follow the checked-in README to build the baseline, then run:

```bash
node docs/proof/review-next-step-intent/replay.mjs --baseline-dist "$BASELINE_DIR/dist" --baseline-sha 39592f04448bdc34d37b9e7f8d5c5d7c828b73f2
```

**Observed result:** all ten paired cases and the producer/report round-trip passed on the candidate head. The reported sentence produced one checkbox/count on the baseline and zero on the candidate. All three 5/6 score rows and the automation markers matched in every paired case. Controls retain required contrast/negation, keyword-free human action, independent findings/security, and conservative legacy/malformed behavior. The local receipt records exact source/build/fixture hashes and Git state.

**Before / after:** these images show the actual replay’s rendered Markdown in an isolated browser. Both are inspected, synthetic-only local fixtures, not screenshots of a live GitHub comment.

| Before: inferred action | After: explicit non-action |
| --- | --- |
| ![Synthetic baseline review with a false next-step checkbox](https://github.com/user-attachments/assets/7a6ee1cc-5ad4-4209-9959-957557db4430) | ![Synthetic candidate review with no remaining next-step item](https://github.com/user-attachments/assets/80fa6eea-e9bd-4589-9050-54aeff22a95f) |

**Limits:** no live model review, publication, queue, apply, repair, or merge path is exercised by the local replay. The historical raw record is unavailable. Other independent blockers have focused regression coverage rather than exhaustive replay. No unrelated PR or OpenClaw product branch is modified.
