### PR TITLE
fix: unblock browser reviews on approved auth fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,16 +586,18 @@ the [remote-CDP coverage](https://github.com/openclaw/openclaw/blob/58da2f5897fe
 the [server-context redaction test](https://github.com/openclaw/openclaw/blob/4b5987829d0f82ea44ae50f2f418ffe5ea445e7f/extensions/browser/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts),
 the [remote-CDP documentation example](https://github.com/openclaw/openclaw/blob/bf15c87d2b1223610b42775b8154b8eec60b541d/docs/tools/browser.md),
 the [credentialed-page rejection fixtures](https://github.com/openclaw/openclaw/blob/d5fb4903f1b13a4309d479f1011d995b1fc706ae/extensions/browser/src/browser-tool.test.ts),
+the [guarded CDP authentication fixtures](https://github.com/openclaw/openclaw/blob/1cf6ff3bdc08a6ac08facb1006b1d7aabc0eaff4/extensions/browser/src/browser/cdp.helpers.test.ts),
+the [MCP endpoint-redaction fixture](https://github.com/openclaw/openclaw/blob/ac21e89c13e42f6a7d152bf9be143e67edd44ed3/extensions/browser/src/browser/chrome-mcp.test.ts),
 and the [Mattermost slash-error sanitization fixtures](https://github.com/openclaw/openclaw/blob/9c0975c1c20ed635532c7aa0f510154224adee7f/extensions/mattermost/src/mattermost/slash-http.test.ts)
 after a complete scan. Static host policy associates each
 exact detector-matched URI SHA-256 with only its approved source paths and exact
 scanner `Raw` digest, including when `Raw` omits a path retained by `RawV2`. The
 matched value must be a literal in a host-staged Git blob from mode `100644`.
-The four Mattermost entries cover only the reviewed `/api` and `/hooks` URI
-prefixes and their authorities. TruffleHog's pinned URI detector excludes query
-text; this classification makes no claim about surrounding query values. The
-table binds exact values and paths across revisions, not entire enclosing URLs
-or particular commits.
+The three guarded-CDP/MCP entries and four Mattermost entries also bind complete
+reviewed source lines, including surrounding query text that TruffleHog's URI
+detector does not match. Changes to those lines or additional literal occurrences
+refuse classification. These witnesses do not expand native query detection.
+The table binds exact values and paths across revisions, not particular commits.
 The host locates that exact literal independently in the staged blob. Decoder
 coordinates can shift, and TruffleHog can omit a companion plain-text finding,
 so admission does not depend on another finding or a reported line matching the
@@ -603,6 +605,11 @@ original source. Repeated literals remain eligible unless an entry is bound to
 an approved complete-line digest; those entries require exactly one occurrence
 in the staged blob. Finding order and duplicate records do not change the exact
 value, path, and mode checks.
+Findings must use `PLAIN` or `HTML`, except the two guarded-CDP fixtures also
+permit `BASE64`. The pinned Base64 decoder preserves the rest of a chunk after
+decoding another token, so an unchanged literal can acquire that decoder label
+and win cross-decoder deduplication. Those entries still require the literal in
+its exact original source line; encoded-only content remains blocking.
 One source path may contain multiple independently reviewed fixtures; each
 digest/path/mode tuple must match exactly, so source membership alone never
 qualifies a finding.

--- a/src/agent-input-scan-fixtures.ts
+++ b/src/agent-input-scan-fixtures.ts
@@ -5,6 +5,7 @@ interface ReviewedFixture {
   fixtureSha256: string;
   rawSha256?: string;
   lineSha256s?: readonly string[];
+  decoders?: readonly ("PLAIN" | "HTML" | "BASE64")[];
   sources: readonly string[];
 }
 
@@ -46,6 +47,29 @@ const REVIEWED_FIXTURES: readonly ReviewedFixture[] = [
     fixtureSha256: "d8996b8fdec57910e379c720611bc37f9433f1cb7027b6f6262d785f1506e9ff",
     rawSha256: "8d3331ee208c72c30fba199e4e2b8a65d69a5034e49875a2f20dbea3a4f2f976",
     sources: ["extensions/browser/src/browser-tool.test.ts"],
+  },
+  {
+    // Decoding a neighboring Basic-auth token can label these unchanged CDP
+    // literals BASE64. Each match still requires its exact original source line.
+    fixtureSha256: "24bd2ee9856630ff773868d946a3b3159e1bb04b297adf4d42b916218a0195d7",
+    rawSha256: "d15184614e748450d49a726f84955ca7745b87d0728afbd6bb6b50d84cce4fe0",
+    lineSha256s: ["89bc2aa05769a4016fb19125143188f20b91807aa5c47918133a119b5a91d341"],
+    decoders: ["PLAIN", "HTML", "BASE64"],
+    sources: ["extensions/browser/src/browser/cdp.helpers.test.ts"],
+  },
+  {
+    fixtureSha256: "973f5bd82def987cc78ac1211ce5f32debb1284687fc325aa3b9101879c19228",
+    rawSha256: "886f9c4f784d3bccb1899db732a298b1d10db8ffdb2b88f76435ea346956e83f",
+    lineSha256s: ["8cf15179943a1e0f6610e8bd8677c07cd69c4f9241709527c735d7a1e50ee9cf"],
+    decoders: ["PLAIN", "HTML", "BASE64"],
+    sources: ["extensions/browser/src/browser/cdp.helpers.test.ts"],
+  },
+  {
+    // Bind the complete MCP redaction fixture, including its unmatched query.
+    fixtureSha256: "1723ec81bae6840c6acfb126d527fa9cd7727764c93846424fc6136fa5dbb860",
+    rawSha256: "a89a1a50188bbcb017bc52d1d2683ea0c06d8805919c89d4813fc3ee0050061b",
+    lineSha256s: ["30136a0d64f0e22bd059dd81cc6a07cad9af26be47d7979a314dee7093011f1f"],
+    sources: ["extensions/browser/src/browser/chrome-mcp.test.ts"],
   },
   {
     // Mattermost slash-error sanitization fixtures introduced by 9c0975c1c20e.
@@ -288,7 +312,7 @@ export function classifyReviewedFixtureScan(
       finding.DetectorName !== "URI" ||
       finding.SourceType !== 15 ||
       finding.Verified !== false ||
-      (finding.DecoderName !== "PLAIN" && finding.DecoderName !== "HTML") ||
+      typeof finding.DecoderName !== "string" ||
       typeof finding.VerificationError !== "string" ||
       !finding.VerificationError ||
       typeof finding.Raw !== "string" ||
@@ -305,6 +329,8 @@ export function classifyReviewedFixtureScan(
         entry.fixtureSha256 === digest && (entry.rawSha256 ?? entry.fixtureSha256) === rawDigest,
     );
     if (!fixture) return refuse("literal_not_reviewed");
+    if (!(fixture.decoders ?? ["PLAIN", "HTML"]).some((decoder) => decoder === finding.DecoderName))
+      return refuse("finding_not_reviewed");
     if (typeof file !== "string" || scannerLine === null) return refuse("metadata_mismatch");
     if (staged?.kind !== "blob" || !staged.bytes) return refuse("material_not_reviewed");
     if (

--- a/test/agent-input-scan.test.ts
+++ b/test/agent-input-scan.test.ts
@@ -548,6 +548,8 @@ const browserServerContextSource =
   "extensions/browser/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts";
 const browserDocsSource = "docs/tools/browser.md";
 const browserToolSource = "extensions/browser/src/browser-tool.test.ts";
+const browserCdpHelpersSource = "extensions/browser/src/browser/cdp.helpers.test.ts";
+const browserMcpSource = "extensions/browser/src/browser/chrome-mcp.test.ts";
 const mattermostSource = "extensions/mattermost/src/mattermost/slash-http.test.ts";
 const ledgerFixtureSha256 = "a728de5dbbef23b8aa5ef2d99060835f4f2fb5a0fa2abb9fe249d08aa09bd09e";
 const nativeContractFailures = new Map([
@@ -575,6 +577,27 @@ for (const scenario of [
   "browser local server mismatch",
   "browser docs fixture",
   "browser page URL fixture",
+  "browser CDP relay fixture",
+  "browser CDP relay shifted HTML without companion",
+  "browser CDP encoded fixture",
+  "browser CDP encoded HTML fixture",
+  "browser MCP endpoint fixture",
+  "browser MCP endpoint shifted HTML without companion",
+  "browser CDP relay changed username",
+  "browser CDP encoded changed password",
+  "browser MCP endpoint changed host",
+  "browser CDP relay source mismatch",
+  "browser MCP endpoint source mismatch",
+  "browser CDP relay query mutation",
+  "browser MCP endpoint query mutation",
+  "browser CDP relay unapproved line",
+  "browser CDP encoded duplicate on unapproved line",
+  "browser MCP endpoint duplicate on approved line",
+  "browser MCP endpoint encoded-only",
+  "browser CDP relay BASE64 fixture",
+  "browser CDP encoded shifted BASE64 without companion",
+  "browser CDP encoded BASE64 encoded-only",
+  "browser MCP endpoint BASE64 fixture",
   "mattermost api input fixture",
   "mattermost api redacted fixture",
   "mattermost hooks input fixture",
@@ -671,7 +694,39 @@ for (const scenario of [
     const mattermostFixture = scenario.startsWith("mattermost ");
     const browserDocsFixture = scenario.startsWith("browser docs");
     const browserPageFixture = scenario.startsWith("browser page URL");
-    if (scenario.startsWith("browser ")) {
+    const browserCdpFixture = scenario.startsWith("browser CDP ");
+    const browserMcpFixture = scenario.startsWith("browser MCP ");
+    const browserExactFixture = browserCdpFixture || browserMcpFixture;
+    const encodedCdpFixture = browserCdpFixture && scenario.includes("encoded");
+    // Preserve the literal witnesses captured from the native OpenClaw scan.
+    const literalLine = browserCdpFixture
+      ? encodedCdpFixture
+        ? 406
+        : 293
+      : browserMcpFixture
+        ? 1339
+        : 42;
+    const scannerLine = scenario.includes("shifted BASE64") ? literalLine - 4 : literalLine;
+    const primaryDecoder = scenario.includes("BASE64")
+      ? "BASE64"
+      : scenario === "browser CDP encoded HTML fixture"
+        ? "HTML"
+        : "PLAIN";
+    if (browserExactFixture) {
+      const url = new URL(
+        browserCdpFixture ? "http://127.0.0.1:9222/json/version" : "https://example.com/chrome",
+      );
+      url.username = browserCdpFixture && !encodedCdpFixture ? "openclaw" : "alice";
+      url.password = browserCdpFixture
+        ? encodedCdpFixture
+          ? "p@ss word"
+          : "relay-token"
+        : "supersecretpasswordvalue1234";
+      if (scenario.endsWith("changed username")) url.username += "changed";
+      if (scenario.endsWith("changed password")) url.password += "changed";
+      if (scenario.endsWith("changed host")) url.hostname = "other.example.com";
+      uri = url.href;
+    } else if (scenario.startsWith("browser ")) {
       const local = scenario.includes("local");
       const url = new URL(
         browserDocsFixture
@@ -713,7 +768,10 @@ for (const scenario of [
       authority.username = "redacted";
       authority.password = "redacted";
     }
-    const raw = browserPageFixture || mattermostFixture ? authority.href.slice(0, -1) : uri;
+    const raw =
+      browserPageFixture || browserExactFixture || mattermostFixture
+        ? authority.href.slice(0, -1)
+        : uri;
     let otherReviewedUri: string | undefined;
     if (scenario.endsWith("different approved literal")) {
       if (mattermostFixture) {
@@ -744,13 +802,21 @@ for (const scenario of [
                   ? scenario.endsWith("source mismatch")
                     ? browserToolSource
                     : browserDocsSource
-                  : browserPageFixture
+                  : browserExactFixture
                     ? scenario.endsWith("source mismatch")
-                      ? browserDocsSource
-                      : browserToolSource
-                    : scenario.includes("server")
-                      ? browserServerContextSource
-                      : browserChromeSource,
+                      ? browserCdpFixture
+                        ? browserMcpSource
+                        : browserCdpHelpersSource
+                      : browserCdpFixture
+                        ? browserCdpHelpersSource
+                        : browserMcpSource
+                    : browserPageFixture
+                      ? scenario.endsWith("source mismatch")
+                        ? browserDocsSource
+                        : browserToolSource
+                      : scenario.includes("server")
+                        ? browserServerContextSource
+                        : browserChromeSource,
               ]
             : scenario === "shared approved path OIDs"
               ? [...autoreviewSources, ledgerSource]
@@ -769,8 +835,20 @@ for (const scenario of [
                     ];
     const value =
       scenario === "decoded only" || scenario.endsWith("encoded-only")
-        ? uri.replace(":", "&#58;")
+        ? primaryDecoder === "BASE64"
+          ? Buffer.from(uri).toString("base64")
+          : uri.replace(":", "&#58;")
         : uri;
+    const sourceValue = browserMcpFixture
+      ? `${value}?token=supersecrettokenvalue1234567890${scenario.endsWith("query mutation") ? "changed" : ""}`
+      : `${value}${browserCdpFixture && scenario.endsWith("query mutation") ? "?changed=1" : ""}`;
+    const reviewedBrowserLine = browserExactFixture
+      ? scenario === "browser CDP relay unapproved line"
+        ? JSON.stringify(sourceValue)
+        : browserCdpFixture
+          ? `      fetchOk(${JSON.stringify(sourceValue)}, 250),`
+          : `          ${JSON.stringify(sourceValue)},`
+      : undefined;
     const reviewedMattermostLine =
       mattermostFixture && scenario.includes("fixture")
         ? scenario.includes("redacted")
@@ -779,15 +857,18 @@ for (const scenario of [
             ? `        ${JSON.stringify(`fallback\r\nsecond-line botToken: secret-bot ${uri}?token=secret-query`)},`
             : `        ${JSON.stringify(`primary\ntoken=secret-token ${uri}?access_token=secret-access&client_secret=secret-client`)},`
         : undefined;
+    const reviewedFixtureLine = reviewedBrowserLine ?? reviewedMattermostLine;
     const contents =
-      "// context\n".repeat(40) +
-      (reviewedMattermostLine ?? JSON.stringify(otherReviewedUri ?? value)) +
+      "// context\n".repeat(literalLine - 2) +
+      (reviewedFixtureLine ?? JSON.stringify(otherReviewedUri ?? value)) +
       "\n" +
       (scenario.includes("duplicate on unapproved line")
-        ? reviewedMattermostLine + "\n"
-        : scenario.endsWith("repeated literal")
-          ? JSON.stringify(value) + "\n"
-          : "");
+        ? (browserExactFixture ? JSON.stringify(sourceValue) : reviewedMattermostLine) + "\n"
+        : scenario.includes("duplicate on approved line")
+          ? reviewedFixtureLine + "\n"
+          : scenario.endsWith("repeated literal")
+            ? JSON.stringify(value) + "\n"
+            : "");
     const fixtureContent = (prefix: string) =>
       Buffer.concat([
         Buffer.from(prefix + contents),
@@ -855,6 +936,8 @@ for (const scenario of [
 const uri = ${JSON.stringify(uri)};
 const raw = ${JSON.stringify(raw)};
 const scenario = ${JSON.stringify(scenario)};
+const literalLine = ${literalLine};
+const scannerLine = ${scannerLine};
 fs.writeFileSync(${JSON.stringify(receipt)}, path.dirname(inputDir));
 const parsed = new URL(uri);
 const blobs = inputs.filter(({name}) => /^[a-f0-9]{40}$/.test(name));
@@ -868,9 +951,9 @@ let findings = inputs.filter(({name, bytes}) =>
   (scenario === 'raw diff' && name === '0') ||
   (scenario === 'normalized worktree' && /^\d+$/.test(name) && bytes.includes('\r\n'))
 ).map(({name, bytes}) => ({
-  SourceType: 15, DetectorType: 17, DetectorName: 'URI', DecoderName: 'PLAIN', Verified: false,
+  SourceType: 15, DetectorType: 17, DetectorName: 'URI', DecoderName: ${JSON.stringify(primaryDecoder)}, Verified: false,
   VerificationError: 'synthetic verification error', Raw: raw, RawV2: uri,
-  SourceMetadata: {Data: {Filesystem: {file: path.join(inputDir, name), line: /^[a-f0-9]{40}$/.test(name) ? 42 : scenario === 'raw diff' ? 1 : bytes.toString().split('\n').findIndex(line => line.includes(uri)) + 1}}},
+  SourceMetadata: {Data: {Filesystem: {file: path.join(inputDir, name), line: /^[a-f0-9]{40}$/.test(name) ? scannerLine : scenario === 'raw diff' ? 1 : bytes.toString().split('\n').findIndex(line => line.includes(uri)) + 1}}},
   SecretParts: {host: parsed.host, username: parsed.username, password: parsed.password},
   ExtraData: null, StructuredData: null,
 }));
@@ -878,7 +961,7 @@ if (scenario.includes('shifted HTML')) {
   const plain = findings;
   const html = plain.map(finding => ({
     ...finding, DecoderName: 'HTML',
-    SourceMetadata: {Data: {Filesystem: {...finding.SourceMetadata.Data.Filesystem, line: 38}}},
+    SourceMetadata: {Data: {Filesystem: {...finding.SourceMetadata.Data.Filesystem, line: literalLine - 4}}},
   }));
   findings = scenario.endsWith('first') ? [...html, ...plain] : [...plain, ...html];
   if (scenario.endsWith('without companion')) findings = [html[0], plain[1], html[1]];
@@ -956,6 +1039,14 @@ process.exit(scenario === 'unexpected successful output' ? 0 : 183);
         "browser remote server fixture",
         "browser docs fixture",
         "browser page URL fixture",
+        "browser CDP relay fixture",
+        "browser CDP relay shifted HTML without companion",
+        "browser CDP encoded fixture",
+        "browser CDP encoded HTML fixture",
+        "browser MCP endpoint fixture",
+        "browser MCP endpoint shifted HTML without companion",
+        "browser CDP relay BASE64 fixture",
+        "browser CDP encoded shifted BASE64 without companion",
         "mattermost api input fixture",
         "mattermost api redacted fixture",
         "mattermost hooks input fixture",
@@ -988,25 +1079,31 @@ process.exit(scenario === 'unexpected successful output' ? 0 : 183);
       const expectedLocations = (
         shiftedHtml
           ? [
-              { scannerLine: 42, decoder: "PLAIN" },
+              { scannerLine: literalLine, decoder: "PLAIN" },
               ...(scenario.endsWith("without companion")
                 ? []
-                : [{ scannerLine: 42, decoder: "PLAIN" }]),
+                : [{ scannerLine: literalLine, decoder: "PLAIN" }]),
               ...(scenario.endsWith("repeated literal")
                 ? [
                     { scannerLine: 43, decoder: "PLAIN" },
                     { scannerLine: 43, decoder: "PLAIN" },
                   ]
                 : []),
-              { scannerLine: 38, decoder: "HTML" },
-              { scannerLine: 38, decoder: "HTML" },
+              { scannerLine: literalLine - 4, decoder: "HTML" },
+              { scannerLine: literalLine - 4, decoder: "HTML" },
             ]
           : [
-              { scannerLine: scenario === "shifted PLAIN" ? 43 : 42, decoder: "PLAIN" },
-              { scannerLine: scenario === "shifted PLAIN" ? 43 : 42, decoder: "PLAIN" },
+              {
+                scannerLine: scenario === "shifted PLAIN" ? 43 : scannerLine,
+                decoder: primaryDecoder,
+              },
+              {
+                scannerLine: scenario === "shifted PLAIN" ? 43 : scannerLine,
+                decoder: primaryDecoder,
+              },
               ...(scenario === "HTML duplicate" ? [{ scannerLine: 42, decoder: "HTML" }] : []),
             ]
-      ).map((location) => ({ ...location, literalLine: 42 }));
+      ).map((location) => ({ ...location, literalLine }));
       const expectedFindings = expectedLocations.length;
       assert.equal(
         notice.findings.reduce(


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where an OpenClaw Browser PR cannot receive its required ClawSweeper review because complete before/after blobs contain existing synthetic CDP-authentication and MCP-redaction fixtures. The exact review for https://github.com/openclaw/openclaw/pull/135857 stopped before inference: https://github.com/openclaw/clawsweeper/actions/runs/33588830096.

## Why This Change Was Made

The trusted host policy now recognizes three independently reviewed fixture tuples, bound to exact `Raw`/`RawV2` hashes, source paths, regular-file mode, complete source-line hashes, and exactly one literal occurrence per blob. The two guarded-CDP entries additionally recognize native `BASE64` findings; every other entry, including the new MCP entry, retains `PLAIN`/`HTML` only.

TruffleHog 3.97.1's Base64 decoder retains surrounding plaintext after decoding a neighboring token. Its concurrent cross-decoder deduplication can therefore retain a `BASE64` finding for an unchanged literal and omit its `PLAIN` counterpart. Both CDP tuples were observed this way in complete native scans. Pinned upstream contract: [decoder](https://github.com/trufflesecurity/trufflehog/blob/20652fbbdefffcdaa493a5bf57ab2ac6b1db715b/pkg/decoders/base64.go), [cross-decoder deduplication](https://github.com/trufflesecurity/trufflehog/blob/20652fbbdefffcdaa493a5bf57ab2ac6b1db715b/pkg/engine/engine.go#L1339). The old hosted diagnostic's `OTHER` label is lossy and is not presented as proof of its exact decoder.

No scanner suppression, target-owned allowlist, broad path/domain exception, URI rewrite, password normalization, or changed detector/verification flags. Complete-scan validation, all-reference path/mode checks, original-literal witnesses, source fences, cleanup, and redacted notices remain in the same owner.

## User Impact

Maintainers can review the affected Browser change without rewriting historical test blobs or bypassing the input scanner. Altered or unapproved input remains blocking. No OpenClaw runtime, public configuration, dependency, protocol, database, or schema changes.

## OpenClaw Bay Impact

None. This changes only trusted pre-inference fixture classification; queue/lifecycle states, review publication, telemetry schemas, and Bay's observer-only contract are unchanged.

## Documentation Impact

Updated the active README Safety Model, owned by the host scanner policy in `src/agent-input-scan-fixtures.ts`. It names the newly reviewed source fixtures, the per-fixture decoder restriction, and complete-line witnesses. The contract remains pinned to native TruffleHog 3.97.1; scanner upgrades or fixture/policy changes require requalification.

## Evidence

- Regression-before-fix: the six initial PLAIN/HTML positive cases failed against host revision `43553c96ab2fcd03b7599eb67cd49e2507bb92ea`; all 11 rejection controls in that run passed. The later BASE64 acceptance cases are included in the 108-case candidate run below.
- Candidate: all 108 fixture-admission cases passed, including existing verified/mixed finding, malformed/incomplete scan, source drift, shared-blob, file-mode, and diagnostic-redaction checks.
- Full repository check: passed, including changed coverage (13/13) and 4,440 passing tests with nine platform skips and zero failures.
- Required Codex reviews: passed before commit and on committed head `062297f5da11475cff804240ea2fb0785fc7cca4` against `43553c96ab2fcd03b7599eb67cd49e2507bb92ea`; no accepted/actionable P0 findings. Both runs retained native input scanning, isolated review, and final source verification. The reviewer did not independently execute the reported tests.
- Production delta: +26 net lines. The growth encodes three independent fixture contracts and scopes decoder eligibility to individual entries. Tests: +97 net lines; documentation: +7.

## Real Behavior Proof

**Claim and surface:** the actual compiled `scanAgentInput` owner, real Git staging, and native TruffleHog accept the unchanged reviewed Browser source only after this narrow host-policy repair; unapproved source remains refused.

**Scenario:** OpenClaw head `5020996064bd19c5f3a32d91623d926544a87dd7` against base `7de6d2a8fb1da7519586565b930b1c42849085d3`. The owner scanned the complete before/after blobs, raw diff, patch, and fixed review prompt. Baseline ClawSweeper revision: `43553c96ab2fcd03b7599eb67cd49e2507bb92ea`. Candidate ClawSweeper head: `062297f5da11475cff804240ea2fb0785fc7cca4`. The tested source bytes remain identical: SHA-256 `e73d566597052e47df87da98e0436819f468743d4d6e71d779020448f117a970` for `src/agent-input-scan-fixtures.ts`.

**Environment:** macOS arm64, Node 24.19.0, native TruffleHog 3.97.1 (executable SHA-256 `4b7cfc5e0759ca5eec3c4aaa360e35baaa5177668b95fb4150a784423620da95`). The process inherited an all-network-deny sandbox; every worker confirmed loopback connection denial with `EPERM`. No credential environment, operator browser/Gateway, provider, or model process was used.

**Commands run:** after `pnpm run build` for the respective host revision, the task-local harness ran `node proof.mjs before`, `node proof.mjs after`, and `node controls.mjs run`. The harness supplied only a controlled `PATH`, private temporary `HOME`/`TMP` directories, and locale variables. It launched each worker through `sandbox-exec` with `(version 1)(allow default)(deny network*)`, asserted loopback denial before scanning, mapped the owner's typed refusal through `agentInputScanFailureExitCode`, and checked source identities and cleanup afterward. Proof harness SHA-256: `5c7446a226a76b60944b19c1feeee9e5e3ac1439c005f9039e5dd620fea0fc1e`; controls harness: `4ca68c649c8f78034ccbd97769d5adbcca3292b172e4f8a8de9e14f235309712`.

The essential owner-call/error-adapter logic is shown below as an excerpt, not as the complete harness or a standalone reproduction:

```js
try {
  owner.scanAgentInput({
    cwd: targetRoot,
    prompt: params.prompt,
    source: { kind: 'committed', baseSha, headSha },
    timeoutMs: 180000,
  });
  outcome = { accepted: true, exitCode: 0 };
} catch (error) {
  if (!(error instanceof owner.AgentInputScanError)) throw error;
  outcome = {
    accepted: false,
    reason: error.reason,
    exitCode: owner.agentInputScanFailureExitCode(error),
  };
}
process.exitCode = outcome.exitCode;
```

**Observed result:** baseline admission refused with exit 79 and 10 native findings; candidate admission succeeded and classified all 10 findings across four fixture/source groups. The candidate run itself observed both CDP tuples as `BASE64`. The production scanner arguments were unchanged, including `--results=verified,unknown`, `--fail`, and `--fail-on-scan-errors`.

Eight additional controls exercised the real owner and native scanner against isolated temporary Git fixtures; all matched their exact expected outcome:

| Control | Native result |
| --- | --- |
| Exact approved source lines | Accepted |
| MCP query-only mutation | `literal_mismatch` |
| Approved literal at an unapproved path | `source_not_reviewed` |
| Changed synthetic credential | `literal_not_reviewed` |
| Encoded-only CDP URI | `literal_mismatch` |
| One blob with approved and unapproved source references | `source_not_reviewed` |
| Executable file mode | `source_not_reviewed` |
| Reviewed URI in prompt material | `material_not_reviewed` |

All seven negative controls produced native findings and exit 79, not an arbitrary scanner error. All processes were joined; scanner staging and controlled Git fixtures were removed; source/checkouts remained unchanged during each run.

**Trace:** redacted before/after/control reports retained locally. SHA-256: before `2e553b49878d0f700fbe5597b199c6eb9b20138fd8263057a429fe0e4f41fe50`; after `9691724624da3dc746ee98decaa593ec504a0ed62009405cf617c62f693c3930`; controls `7f3ff21dacc91bb720191979789f1b8ef7fad1fe4bccec0dd2dcba4c69c22229`.

**Limits:** native macOS proof, not Linux/Windows hosted-runner parity or a model-backed review. Network denial prevented real credential verification. Verified and incomplete-scan rejection are separately covered by the existing unit contracts, not fabricated as live outcomes.
