### PR TITLE
fix: unblock reviews containing config redaction fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,7 +588,9 @@ the [remote-CDP documentation example](https://github.com/openclaw/openclaw/blob
 the [credentialed-page rejection fixtures](https://github.com/openclaw/openclaw/blob/d5fb4903f1b13a4309d479f1011d995b1fc706ae/extensions/browser/src/browser-tool.test.ts),
 the [guarded CDP authentication fixtures](https://github.com/openclaw/openclaw/blob/1cf6ff3bdc08a6ac08facb1006b1d7aabc0eaff4/extensions/browser/src/browser/cdp.helpers.test.ts),
 the [MCP endpoint-redaction fixture](https://github.com/openclaw/openclaw/blob/ac21e89c13e42f6a7d152bf9be143e67edd44ed3/extensions/browser/src/browser/chrome-mcp.test.ts),
-and the [Mattermost slash-error sanitization fixtures](https://github.com/openclaw/openclaw/blob/9c0975c1c20ed635532c7aa0f510154224adee7f/extensions/mattermost/src/mattermost/slash-http.test.ts)
+the [Mattermost slash-error sanitization fixtures](https://github.com/openclaw/openclaw/blob/9c0975c1c20ed635532c7aa0f510154224adee7f/extensions/mattermost/src/mattermost/slash-http.test.ts),
+and the OpenClaw config [URL-redaction](https://github.com/openclaw/openclaw/blob/5fe22a7d88919f260e7999fc775733feff3cb1fa/src/config/redact-snapshot.test.ts)
+and [restoration fixtures](https://github.com/openclaw/openclaw/blob/5fe22a7d88919f260e7999fc775733feff3cb1fa/src/config/redact-snapshot.restore.test.ts)
 after a complete scan. Static host policy associates each
 exact detector-matched URI SHA-256 with only its approved source paths and exact
 scanner `Raw` digest, including when `Raw` omits a path retained by `RawV2`. The

--- a/src/agent-input-scan-fixtures.ts
+++ b/src/agent-input-scan-fixtures.ts
@@ -96,6 +96,22 @@ const REVIEWED_FIXTURES: readonly ReviewedFixture[] = [
     lineSha256s: ["ae6d199d9d7983df3024f5615dc243efd1e6988e1afddb79da0b99183cab8552"],
     sources: ["extensions/mattermost/src/mattermost/slash-http.test.ts"],
   },
+  {
+    // OpenClaw config endpoint redaction and restoration fixtures.
+    fixtureSha256: "a2e43ebb989e154a5cfde0e9f67d0e7465adffdba2c8be60394f35e7797149a3",
+    rawSha256: "6b167ea4a777545dcca0e4d425aafccd750a6c6fca8a5b2b370f16491f3a8a4d",
+    sources: ["src/config/redact-snapshot.restore.test.ts", "src/config/redact-snapshot.test.ts"],
+  },
+  {
+    // OpenClaw media and provider request proxy redaction fixture.
+    fixtureSha256: "cee9438f4c98a2b27c3aa4bab25b071a4fa9511252ffce86ebf38f302c151e5b",
+    sources: ["src/config/redact-snapshot.test.ts"],
+  },
+  {
+    // OpenClaw browser CDP credential redaction and restoration fixture.
+    fixtureSha256: "f11c92a245b2308a02f08759cdc5952b4ebe9af5225923807769267fce35f464",
+    sources: ["src/config/redact-snapshot.test.ts"],
+  },
 ];
 
 export interface ScanSourceReference {


### PR DESCRIPTION
Related: [OpenClaw Control UI refactor](https://github.com/openclaw/openclaw/pull/135851).

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Resolves a problem where ClawSweeper refuses to review OpenClaw config-redaction changes because existing synthetic URI fixtures trigger its input scanner. The recorded hosted attempt stopped before inference. A controlled scan identified three fixture identities in two config-redaction test files; recognizing those exact identities lets the normal review admission process continue.

## Why This Change Was Made

The change adds 16 production lines and changes the README by +3/−1 lines. Classifier logic and tests are unchanged. It is based on `904579a319c4393f18c8d42c25e840b74dbab2c0`, including its separate decoder-specific fixture policy; these three new entries retain the default PLAIN/HTML restriction.

| Fixture | Full URI SHA-256 | Approved source paths |
| --- | --- | --- |
| Endpoint redaction/restoration | `a2e43ebb989e154a5cfde0e9f67d0e7465adffdba2c8be60394f35e7797149a3` | `src/config/redact-snapshot.test.ts`; `src/config/redact-snapshot.restore.test.ts` |
| Request-proxy redaction | `cee9438f4c98a2b27c3aa4bab25b071a4fa9511252ffce86ebf38f302c151e5b` | `src/config/redact-snapshot.test.ts` |
| Browser CDP redaction | `f11c92a245b2308a02f08759cdc5952b4ebe9af5225923807769267fce35f464` | `src/config/redact-snapshot.test.ts` |

The endpoint entry separately binds the scanner's Raw SHA-256 to `6b167ea4a777545dcca0e4d425aafccd750a6c6fca8a5b2b370f16491f3a8a4d`. The other entries require Raw to match the full-URI digest. Admission still requires complete TruffleHog 3.97.1 output, URI detector 17, an unverified finding with matching metadata and literal bytes, and exclusively approved Git-blob references with mode `100644`. A test filename, example domain, or unverified result alone never permits admission. Structured fixture notices remain present.

## User Impact

Reviews can proceed past these specific source fixtures. A fresh trusted review still needs to scan its actual complete inputs; the original prompt, schema, and additional inputs remain unavailable for replay.

## OpenClaw Bay Impact

Bay is unaffected: no queue, lifecycle, publication, status, telemetry, or dashboard contract changes.

## Documentation Impact

The active README Safety Model links both approved source files at the recorded OpenClaw base `5fe22a7d88919f260e7999fc775733feff3cb1fa`. ClawSweeper maintainers own this documentation and the host fixture table is its source of truth; update the policy and links together if fixture identities or source scope change.

## Evidence

Canonical Linux CI passed on `1dc7cf26c7e2937e97fa9bc15a3aa4def38f6ead`: [CI 33606456905](https://github.com/openclaw/clawsweeper/actions/runs/33606456905), including the unchanged `pnpm run check`, sparse repair builds, and Windows Codex launcher. The full check selected all 286 files and reported 4,444 passes, 14 platform skips, and zero failures; coverage was 83.47% lines, 76.26% branches, and 88.59% functions, above the existing 49/66/57 floors. It ran on Node 24.19.0 with pnpm 11.10.0 and four test-file workers. The locale, concurrent-import, and terminal-cleanup cases that failed locally passed here.

This resolves both before-merge validation items in the [first ClawSweeper review](https://github.com/openclaw/clawsweeper/pull/1351#issuecomment-5506475358). That review accepted the controlled behavior proof and found no introduced correctness defect. The source remains unchanged; the local macOS limitations below remain separate, explicitly unresolved observations.

Precommit and committed-branch Codex reviews completed with no accepted findings in their P0 scope, both exit 0 with source hashes unchanged. The local commit is `1dc7cf26c7e2937e97fa9bc15a3aa4def38f6ead`; all 1,342 source entries match the checked candidate based on `904579a3`.

Static checks, all three builds, lint, and the dedicated 13-case coverage check passed. The complete canonical phases, using the existing runner's supported four test-file workers and unchanged coverage settings, finished with exit 1 after 21m35s. All 286 files were selected: 4,448 tests passed, one failed, and nine skipped. The failure was `candidate sv-SE: ETIMEDOUT` at the existing 60-second locale-child deadline in `docs/proof/label-sync-identity-determinism/run-proof.mjs:217`, surfaced by `test/label-mutation-batch.test.ts:496`. Coverage reporting also failed on an empty native coverage file, so the aggregate 49/66/57 coverage floors remain unverified. The relationship between that empty file and the timeout is not established. No retry or assertion, deadline, or coverage relaxation was used.

All 346 pre-existing emitted files remained byte-identical. The whole-dist integrity receipt records a change because the docs-site tests produced 168 new files under `dist/docs-site/`; no existing production JavaScript changed. The unresolved follow-up is the macOS locale-proof timeout and native coverage collection failure. That macOS execution did not pass; the separate canonical Linux full check above did.

A focused current-head diagnostic reran the complete 14-case label-mutation file in its original order with the existing deadlines: 13 passed and the locale case failed because the macOS process-incarnation helper could not complete. A single native helper probe then reached its unchanged 2,000 ms deadline before returning identity data. Its cause remains unestablished; no retry, timeout increase, weaker identity check, or speculative production change is included. All four retained coverage files from the focused run were valid and nonempty, which does not establish the cause of the earlier empty coverage file.

The earlier 16-worker full check on the same logical two-file change against `43553c96` failed: 4,415 passed, four failed, nine skipped. Its failures were a concurrent-import readiness timeout, process-incarnation lookup failure, terminal-cleanup timeout, and a pinned-checkout wall-time assertion. Ordered scoped baseline diagnostics passed 106 executed cases and skipped two platform-specific ledger cases; none reproduced the original failures. Those diagnostics excluded other declarations according to their recorded scopes and did not recreate the concurrent full-suite load. The failures' cause and any relationship to the proposal remain unestablished. A later four-worker pass would not establish that those failures were preexisting or flaky.

## Real Behavior Proof

The controlled probe scans the complete OpenClaw `5fe22a7d88919f260e7999fc775733feff3cb1fa` → `369bd13494d8cf5aa49ad43102c8b90429581e1e` raw diff, patch, and 69 distinct before/after blobs across 35 paths. The 3,104,507 staged bytes have source identity SHA-256 `6e7f8eec23257ac7986b8b4df5b11ff3665bfce8de23293761c7d083f733cb49`.

On macOS with Node 26.8.1 and the external TruffleHog 3.97.1 binary, one complete native scan produced seven unverified URI findings, all PLAIN. Feeding that identical output and source-material map to both classifiers caused the `904579a3` baseline classifier to refuse `literal_not_reviewed` and the proposal to return four digest/path notice groups. All 22 negative controls remained refused, including wrong paths/modes/shared references, every non-blob input kind, verified results, changed literals, Raw/RawV2 mismatches, inconsistent metadata, absent literal bytes, wrong detector/decoder, mixed findings, and incomplete scan output. Proxy and CDP findings remain refused from the endpoint-restore-only path.

A separate scan of the actual head test blob produced three native findings. Selecting the proxy finding, changing its native PLAIN decoder field to HTML, and adjusting completion counts passed the HTML-only classifier control without a PLAIN companion. This is a native-derived control, not an additional complete review.

Commands use `$PROOF_DIR` for the retained proof directory:

```sh
env -i PATH=/opt/homebrew/bin:/usr/bin:/bin /opt/homebrew/bin/node "$PROOF_DIR/controlled-native-proof.mjs"
env -i PATH=/opt/homebrew/bin:/usr/bin:/bin /opt/homebrew/bin/node "$PROOF_DIR/html-only-classifier-probe.mjs"
```

The scanner receives only private task HOME/TMP directories. Raw scanner output remains in memory, and both probes exited 0 and verified cleanup; their native scanner returned 183 with findings. These probes do not invoke a model; the managed Codex review is separate.

| Evidence | SHA-256 |
| --- | --- |
| Exact two-file patch | `d4774d8e132151e8f90178ecc57e4007fe5724262ed3cccfe529cbdc81c74506` |
| Proposed classifier | `f8f4a95d231d0ab82f8532332b0bbef66bb9d8ba5333c708160eb377b1870ff6` |
| Controlled native result | `ef2b4aac909c54472ffb25c790bc29b035647cbf8e158238819b77049384a126` |
| HTML-only control result | `b2575779d8f4cbaf0f512cf8461ebf8e26a48540c9c73db17f33cb4115380872` |
| Scanner binary | `f6899e5521ff060634a9599e02215195d29d330e9a902feb3f5322eedcb7ba21` |

The original hosted review retained only its first safe finding diagnostic. Its original prompt, schema, and additional inputs are unavailable. Earlier native scans also varied in finding count and decoder while identifying the same three literal identities. These results therefore establish the source-fixture behavior, not byte-identical reproduction of the hosted scan or a guarantee that all future review inputs pass. A fresh trusted review must scan its actual complete inputs.

The aggregate results and SHA-256 table above retain the safe trace without exposing raw findings. Hosted validation is complete; the updated proof and validation disposition are submitted for current ClawSweeper review before landing.
