### PR TITLE
fix(fanout): list installation-accessible repositories

### DIFF
--- a/src/repair/target-fanout.ts
+++ b/src/repair/target-fanout.ts
@@ -111,6 +111,11 @@ interface FanoutOptions {
   owners: readonly string[] | undefined;
 }
 
+interface InventoryAccess {
+  env: NodeJS.ProcessEnv;
+  kind: "installation" | "public";
+}
+
 const PUBLIC_INVENTORY_TOKEN = "__public__";
 export const SCHEDULED_REVIEW_PLAN_BATCH_SIZE = 50;
 
@@ -540,10 +545,13 @@ export function allocateReviewCandidateCapacity(
 }
 
 function listOwnerRepositories(owner: string): ListedRepository[] {
-  const env = inventoryEnv(owner);
-  if (!env) {
+  const access = inventoryAccess(owner);
+  if (!access) {
     console.error(`[target-fanout] skipping ${owner}: missing inventory token`);
     return [];
+  }
+  if (access.kind === "installation") {
+    return listInstallationRepositories(owner, access.env);
   }
   const output = runGh(
     [
@@ -555,11 +563,32 @@ function listOwnerRepositories(owner: string): ListedRepository[] {
       "--json",
       "nameWithOwner,isArchived,isFork,hasIssuesEnabled,visibility,defaultBranchRef",
     ],
-    env,
+    access.env,
   );
   const parsed = JSON.parse(output) as unknown;
   if (!Array.isArray(parsed)) throw new Error(`gh repo list ${owner} did not return an array`);
   return parsed.map((entry, index) => listedRepository(entry, `${owner}[${index}]`));
+}
+
+function listInstallationRepositories(owner: string, env: NodeJS.ProcessEnv): ListedRepository[] {
+  const output = runGh(
+    [
+      "api",
+      "--paginate",
+      "-H",
+      "Accept: application/vnd.github+json",
+      "--jq",
+      'if (.repositories | type) != "array" then error("repositories must be an array") else .repositories[] end',
+      "/installation/repositories?per_page=100",
+    ],
+    env,
+  );
+  const ownerPrefix = `${owner.toLowerCase()}/`;
+  return (output === "" ? [] : output.split(/\r?\n/))
+    .map((entry, index) =>
+      listedInstallationRepository(JSON.parse(entry), `${owner}.repositories[${index}]`),
+    )
+    .filter((repository) => repository.nameWithOwner.toLowerCase().startsWith(ownerPrefix));
 }
 
 function listedRepository(value: unknown, label: string): ListedRepository {
@@ -576,6 +605,19 @@ function listedRepository(value: unknown, label: string): ListedRepository {
     hasIssuesEnabled: booleanValue(repo.hasIssuesEnabled, false),
     visibility: stringValue(repo.visibility, `${label}.visibility`).toUpperCase(),
     defaultBranch: typeof branch.name === "string" ? branch.name : "",
+  };
+}
+
+function listedInstallationRepository(value: unknown, label: string): ListedRepository {
+  const repo = record(value, label);
+  return {
+    nameWithOwner: stringValue(repo.full_name, `${label}.full_name`),
+    isArchived: booleanValue(repo.archived, false),
+    isDisabled: booleanValue(repo.disabled, false),
+    isFork: booleanValue(repo.fork, false),
+    hasIssuesEnabled: booleanValue(repo.has_issues, false),
+    visibility: stringValue(repo.visibility, `${label}.visibility`).toUpperCase(),
+    defaultBranch: typeof repo.default_branch === "string" ? repo.default_branch : "",
   };
 }
 
@@ -704,13 +746,17 @@ function runGh(args: readonly string[], env: NodeJS.ProcessEnv): string {
   }).trimEnd();
 }
 
-function inventoryEnv(owner: string): NodeJS.ProcessEnv | null {
+function inventoryAccess(owner: string): InventoryAccess | null {
   const key = `CLAWSWEEPER_INVENTORY_TOKEN_${owner.replace(/[^A-Za-z0-9]/g, "_").toUpperCase()}`;
   const token = process.env[key] || process.env.CLAWSWEEPER_INVENTORY_TOKEN;
-  if (token === PUBLIC_INVENTORY_TOKEN) return publicInventoryEnv();
-  if (token) return { GH_TOKEN: token, GITHUB_TOKEN: token };
+  if (token === PUBLIC_INVENTORY_TOKEN) {
+    return { env: publicInventoryEnv(), kind: "public" };
+  }
+  if (token) {
+    return { env: { GH_TOKEN: token, GITHUB_TOKEN: token }, kind: "installation" };
+  }
   if (process.env.GITHUB_ACTIONS === "true") return null;
-  return publicInventoryEnv();
+  return { env: publicInventoryEnv(), kind: "public" };
 }
 
 function publicInventoryEnv(): NodeJS.ProcessEnv {

--- a/test/repair/target-fanout.test.ts
+++ b/test/repair/target-fanout.test.ts
@@ -482,18 +482,16 @@ test("target fanout dispatches generic public inventory after central visibility
 const fs = require("node:fs");
 const args = process.argv.slice(2);
 fs.appendFileSync(${JSON.stringify(logPath)}, JSON.stringify({args, ghToken: process.env.GH_TOKEN || ""}) + "\\n");
-if (args[0] === "repo" && args[1] === "list" && args[2] === "openclaw") {
-  process.stdout.write(JSON.stringify([
-    {nameWithOwner:"openclaw/clawhub",isArchived:false,isFork:false,hasIssuesEnabled:true,visibility:"PUBLIC",defaultBranchRef:{name:"main"}},
-    {nameWithOwner:"openclaw/example-tool",isArchived:false,isFork:false,hasIssuesEnabled:true,visibility:"PUBLIC",defaultBranchRef:{name:"trunk"}},
-    {nameWithOwner:"openclaw/private-tool",isArchived:false,isFork:false,hasIssuesEnabled:true,visibility:"PRIVATE",defaultBranchRef:{name:"main"}}
-  ]));
-  process.exit(0);
-}
-if (args[0] === "repo" && args[1] === "list" && args[2] === "steipete") {
-  process.stdout.write(JSON.stringify([
-    {nameWithOwner:"steipete/camsnap",isArchived:false,isFork:false,hasIssuesEnabled:true,visibility:"PUBLIC",defaultBranchRef:{name:"master"}}
-  ]));
+if (args[0] === "api" && args.includes("/installation/repositories?per_page=100")) {
+  const repositories = process.env.GH_TOKEN === "inventory-openclaw" ? [
+      {full_name:"openclaw/clawhub",archived:false,disabled:false,fork:false,has_issues:true,visibility:"public",default_branch:"main"},
+      {full_name:"openclaw/example-tool",archived:false,disabled:false,fork:false,has_issues:true,visibility:"public",default_branch:"trunk"},
+      {full_name:"openclaw/private-tool",archived:false,disabled:false,fork:false,has_issues:true,visibility:"private",default_branch:"main"},
+      {full_name:"outside/inaccessible",archived:false,disabled:false,fork:false,has_issues:true,visibility:"public",default_branch:"main"}
+  ] : [
+    {full_name:"steipete/camsnap",archived:false,disabled:false,fork:false,has_issues:true,visibility:"public",default_branch:"master"}
+  ];
+  process.stdout.write(repositories.map((repository) => JSON.stringify(repository)).join("\\n"));
   process.exit(0);
 }
 if (args[0] === "api" && args[1] === "graphql") {
@@ -561,12 +559,16 @@ globalThis.fetch = async (input, init) => {
     .map((line) => JSON.parse(line) as { args: string[]; ghToken: string });
   assert.deepEqual(
     calls
-      .filter((call) => call.args[0] === "repo" && call.args[1] === "list")
-      .map((call) => [call.args[2], call.ghToken]),
-    [
-      ["openclaw", "inventory-openclaw"],
-      ["steipete", "inventory-steipete"],
-    ],
+      .filter(
+        (call) =>
+          call.args[0] === "api" && call.args.includes("/installation/repositories?per_page=100"),
+      )
+      .map((call) => call.ghToken),
+    ["inventory-openclaw", "inventory-steipete"],
+  );
+  assert.equal(
+    calls.some((call) => call.args[0] === "repo" && call.args[1] === "list"),
+    false,
   );
   assert.deepEqual(
     calls
@@ -613,10 +615,10 @@ test("target fanout retryable probe exits before dispatch or cursor advancement"
 const fs = require("node:fs");
 const args = process.argv.slice(2);
 fs.appendFileSync(${JSON.stringify(logPath)}, JSON.stringify({args, ghToken: process.env.GH_TOKEN || ""}) + "\\n");
-if (args[0] === "repo" && args[1] === "list" && args[2] === "openclaw") {
-  process.stdout.write(JSON.stringify([
-    {nameWithOwner:"openclaw/retry-later",isArchived:false,isFork:false,hasIssuesEnabled:true,visibility:"PUBLIC",defaultBranchRef:{name:"main"}}
-  ]));
+if (args[0] === "api" && args.includes("/installation/repositories?per_page=100")) {
+  process.stdout.write(JSON.stringify(
+    {full_name:"openclaw/retry-later",archived:false,disabled:false,fork:false,has_issues:true,visibility:"public",default_branch:"main"}
+  ));
   process.exit(0);
 }
 if (args[0] === "api" && args[1] === "graphql") {
@@ -705,7 +707,7 @@ globalThis.fetch = async (input, init) => {
 
 test("target fanout uses explicit inventory and central metadata tokens in Actions", () => {
   const source = readFileSync("src/repair/target-fanout.ts", "utf8");
-  const inventoryStart = source.indexOf("function inventoryEnv(");
+  const inventoryStart = source.indexOf("function inventoryAccess(");
   const inventoryEnd = source.indexOf("function publicInventoryEnv(", inventoryStart);
   const metadataStart = source.indexOf("function hostedTargetMetadataToken(");
   const metadataEnd = source.indexOf("function dispatchEnv(", metadataStart);
@@ -717,7 +719,8 @@ test("target fanout uses explicit inventory and central metadata tokens in Actio
   const inventoryHelper = source.slice(inventoryStart, inventoryEnd);
   assert.match(inventoryHelper, /CLAWSWEEPER_INVENTORY_TOKEN_/);
   assert.match(inventoryHelper, /if \(process\.env\.GITHUB_ACTIONS === "true"\) return null;/);
-  assert.match(inventoryHelper, /return publicInventoryEnv\(\);/);
+  assert.match(inventoryHelper, /kind: "installation"/);
+  assert.match(inventoryHelper, /kind: "public"/);
   const metadataHelper = source.slice(metadataStart, metadataEnd);
   assert.match(metadataHelper, /CLAWSWEEPER_HOSTED_TARGET_METADATA_TOKEN/);
   assert.match(
@@ -832,16 +835,11 @@ test("normal target fanout dispatches even when canonical storage is unavailable
 const fs = require("node:fs");
 const args = process.argv.slice(2);
 fs.appendFileSync(${JSON.stringify(logPath)}, JSON.stringify({args, ghToken: process.env.GH_TOKEN || ""}) + "\\n");
-if (args[0] === "repo" && args[1] === "list" && args[2] === "openclaw") {
-  process.stdout.write(JSON.stringify([
-    {nameWithOwner:"openclaw/clawhub",isArchived:false,isFork:false,hasIssuesEnabled:true,visibility:"PUBLIC",defaultBranchRef:{name:"main"}}
-  ]));
-  process.exit(0);
-}
-if (args[0] === "repo" && args[1] === "list" && args[2] === "steipete") {
-  process.stdout.write(JSON.stringify([
-    {nameWithOwner:"steipete/camsnap",isArchived:false,isFork:false,hasIssuesEnabled:true,visibility:"PUBLIC",defaultBranchRef:{name:"master"}}
-  ]));
+if (args[0] === "api" && args.includes("/installation/repositories?per_page=100")) {
+  const repository = process.env.GH_TOKEN === "inventory-openclaw"
+    ? {full_name:"openclaw/clawhub",archived:false,disabled:false,fork:false,has_issues:true,visibility:"public",default_branch:"main"}
+    : {full_name:"steipete/camsnap",archived:false,disabled:false,fork:false,has_issues:true,visibility:"public",default_branch:"master"};
+  process.stdout.write(JSON.stringify(repository));
   process.exit(0);
 }
 if (args[0] === "api" && args[1] === "graphql") {
@@ -927,12 +925,12 @@ globalThis.fetch = async (input, init) => {
     .map((line) => JSON.parse(line) as { args: string[]; ghToken: string });
   assert.deepEqual(
     calls
-      .filter((call) => call.args[0] === "repo" && call.args[1] === "list")
-      .map((call) => [call.args[2], call.ghToken]),
-    [
-      ["openclaw", "inventory-openclaw"],
-      ["steipete", "inventory-steipete"],
-    ],
+      .filter(
+        (call) =>
+          call.args[0] === "api" && call.args.includes("/installation/repositories?per_page=100"),
+      )
+      .map((call) => call.ghToken),
+    ["inventory-openclaw", "inventory-steipete"],
   );
   assert.deepEqual(
     calls
@@ -979,11 +977,11 @@ test("target fanout dry-run does not persist its selected cursor", () => {
 const fs = require("node:fs");
 const args = process.argv.slice(2);
 fs.appendFileSync(${JSON.stringify(logPath)}, JSON.stringify(args) + "\\n");
-if (args[0] === "repo" && args[1] === "list" && args[2] === "openclaw") {
-  process.stdout.write(JSON.stringify([
-    {nameWithOwner:"openclaw/clawhub",isArchived:false,isFork:false,hasIssuesEnabled:true,visibility:"PUBLIC",defaultBranchRef:{name:"main"}},
-    {nameWithOwner:"openclaw/fs-safe",isArchived:false,isFork:false,hasIssuesEnabled:true,visibility:"PUBLIC",defaultBranchRef:{name:"main"}}
-  ]));
+if (args[0] === "api" && args.includes("/installation/repositories?per_page=100")) {
+  process.stdout.write([
+    {full_name:"openclaw/clawhub",archived:false,disabled:false,fork:false,has_issues:true,visibility:"public",default_branch:"main"},
+    {full_name:"openclaw/fs-safe",archived:false,disabled:false,fork:false,has_issues:true,visibility:"public",default_branch:"main"}
+  ].map((repository) => JSON.stringify(repository)).join("\\n"));
   process.exit(0);
 }
 if (args[0] === "api" && args[1] === "graphql") {


### PR DESCRIPTION
## Summary

- list repositories through the GitHub App installation-scoped REST inventory when fanout receives an explicit inventory token
- preserve the existing unauthenticated/public organization fallback
- keep malformed responses, API failures, and missing default branches fail-closed before dispatch

## Problem

After the bounded canonical-state read repair in #1340, scheduled fanout reached repository discovery and failed at the next boundary. [Run 33601434699](https://github.com/openclaw/clawsweeper/actions/runs/33601434699) shows `gh repo list openclaw` returning 18 `Resource not accessible by integration` errors at `repositoryOwner.repositories.nodes.*.defaultBranchRef`.

A read-only follow-up found the same 18 first-page field errors in five completed observations across regenerated installation tokens and two deployed heads. The repository nodes were visible to GraphQL, but their default-branch refs were not. Broader maintainer access returned valid default branches for the full organization inventory, which isolates this to the GitHub App installation-token field boundary rather than missing branches or repository-state corruption.

## Implementation

- distinguish explicit installation-token inventory from the existing `__public__` fallback
- call `gh api --paginate /installation/repositories?per_page=100` for installation inventory
- validate every page as an array and emit one compact repository object per line through `--jq`
- map REST repository metadata and `default_branch` into the existing fanout model
- retain only repositories owned by the requested owner before applying the existing archive/fork/issues/default-branch eligibility policy

The public fallback still uses the existing organization listing. Installation API or payload failures still throw before selection, dispatch, or cursor advancement.

## Security boundary

This changes only which read endpoint consumes the already-minted installation token.

- no GitHub App permission or token scope changes
- no workflow, repository configuration, secret, token-lifetime, or token-revocation changes
- no token values, private repository names, or repository content are logged
- no dispatch, queue, state, deployment, or production mutation is part of this PR
- the endpoint returns only repositories accessible to that installation; the existing owner filter provides an additional containment check

Production fanout already mints these explicit values with `actions/create-github-app-token`. A non-installation token supplied manually through the same explicit environment variable will fail closed at the installation endpoint. The `__public__` sentinel remains the supported public/local fallback.

## Validation

Exact head: `345e2f9a75aaf5cd0752e589c9c313aff2e78107`  
Base: `521f1ab5ca8c099b25d546baaa7a88ceedfd0174`

- `pnpm run build:repair`
- `node --test test/repair/target-fanout.test.ts` — 23/23 passed
- `pnpm run lint:repair`
- `pnpm exec oxfmt --check src/repair/target-fanout.ts test/repair/target-fanout.test.ts`
- `git diff --check origin/main...HEAD`
- Docker-backed local-container static checks, `build:all`, and all lint groups passed in Crabbox run `run_8dd25d8e76e6`

The all-file formatter/full-suite container path inherits Windows CRLF bytes through raw sync. The unrelated `sweep-workflow` shell-fixture failures reproduced on untouched `origin/main` in Crabbox run `run_9d57c325c5aa`, including explicit `$'\r': command not found` errors. Changed-file formatting and the complete touched-surface suite are clean.

### Codex review

- `codex review --uncommitted` before commit: no actionable correctness issues
- after rebasing onto the exact base, `codex review --base origin/main`: clean; the reviewer independently reran the focused build and 23-test suite
- no accepted correctness or security findings remain

## Real Behavior Proof

**Claim:** an explicit GitHub App installation token enumerates only installation-accessible repositories across pagination, preserves their exact default branches, and never falls back to the GraphQL `defaultBranchRef` query.

**Exercised surface:** production `dist/repair/target-fanout.js list --owners openclaw`, invoked through the real Ubuntu `gh` 2.45 CLI.

**Scenario:** a local HTTPS GitHub-shaped API returned two paginated installation inventory pages. The fixture included accessible `main` and `trunk` repositories; the legacy GraphQL path was configured to fail if called.

**Environment and command:** Docker-backed Crabbox `local-container`, image `mcr.microsoft.com/playwright:v1.60.0-noble`, run `run_dc72ec345e85`, lease `cbx_63e15cd9935f` (stopped), at exact head `345e2f9a75aaf5cd0752e589c9c313aff2e78107`.

**Observed result:**

```json
{"marker":"installation_inventory_paginated","total":2,"repositories":[["openclaw/accessible-main","main"],["openclaw/accessible-trunk","trunk"]],"dispatches":0,"result":"pass"}
{"marker":"csw147_fanout_inventory_proof","result":"pass"}
```

Both page requests carried authorization, the second page was consumed, the GraphQL path was not called, and dispatch count remained zero.

**Limits:** this controlled proof uses a local HTTPS API fixture and no production credentials. It proves the CLI/endpoint/pagination/parsing contract, not future GitHub availability or the outcome of a live scheduled run. Historical production logs provide the separate evidence for the installation-token GraphQL failure boundary.

## Risks and rollout

- blast radius is limited to repository discovery for explicit fanout inventory tokens
- public/local fallback behavior is unchanged
- deterministic API and payload errors remain fail-closed before dispatch
- no deployment or runtime gate change is included; normal CI and maintainer-facing ClawSweeper review should validate the exact head before merge consideration

## Related

- #1340
- [post-#1340 fanout failure](https://github.com/openclaw/clawsweeper/actions/runs/33601434699)
