### PR TITLE
fix: avoid false storage warnings for metadata helpers

### DIFF
--- a/docs/pr-review-comments.md
+++ b/docs/pr-review-comments.md
@@ -171,8 +171,9 @@ production source or documented storage contracts, not setup in test, fixture,
 or example source paths. Colocated `*.test-support.*` and Go `*_test.go` files
 are test code too, even when their guards or setup mention metadata,
 serialization, or SQL. Generic words such as `metadata`, `chunkId`, `documentId`,
-`collection`, and `dimension` alone do not establish vector storage. Known
-storage paths, explicit vector/embedding contracts, and same-hunk persistence
+`collection`, and `dimension` alone do not establish vector storage, including
+generic metadata or identifier filenames. Known storage paths, explicit
+vector/embedding contracts, and same-hunk persistence
 evidence still require review; diagnostic logging does not exempt real storage
 changes in the same patch.
 Markdown beside source is still documentation: ordinary

--- a/src/clawsweeper-change-detection.ts
+++ b/src/clawsweeper-change-detection.ts
@@ -557,11 +557,7 @@ function dataModelPathHint(path: string): string {
   if (/(^|\/)persistence(?:\/|[-_.])|(?:serialized|persisted?)[-_.]?(?:state|json)/i.test(path)) {
     return "serialized state";
   }
-  if (
-    /(^|\/)(?:vector|embedding|embeddings|memory)(?:\/|[-_.])|(?:vector|embedding|metadata|row-id|document-id|chunk-id)/i.test(
-      path,
-    )
-  ) {
+  if (/vector|embedding|(?:^|\/)memory(?:\/|[-_.])/i.test(path)) {
     return "vector/embedding metadata";
   }
   if (

--- a/test/fixtures/persistence-classifier-132839.json
+++ b/test/fixtures/persistence-classifier-132839.json
@@ -1,0 +1,20 @@
+{
+  "repository": "openclaw/openclaw",
+  "headSha": "61d7719d833eb6684fc603a5c3659d1ba17f0595",
+  "baseSha": "4e36c68976a9474e6c7bf6dc55e2aedb4321d54d",
+  "sourceSha256": "95951deb7c4cc78ff35fa3376fa9fd792a3f1787213eb7205178dd1318bb89fc",
+  "provenance": "Git-derived review-context pullFiles from exact reviewed committed source diff; not the unavailable archived worker JSON. No PR-body text is an input. Every patch is the full unified hunk body at these immutable endpoints. Minimal fixture selects the one path named by the captured public stored-data warning; full 43-file context is retained separately.",
+  "pullFilesTruncated": false,
+  "pullRequest": "https://github.com/openclaw/openclaw/pull/132839",
+  "sourceComment": "https://github.com/openclaw/openclaw/pull/132839#issuecomment-5464924250",
+  "pullFiles": [
+    {
+      "filename": "src/agents/embedded-agent-runner/run/prompt-image-metadata.ts",
+      "status": "modified",
+      "additions": 48,
+      "deletions": 0,
+      "changes": 48,
+      "patch": "@@ -1,3 +1,5 @@\n+import { isImageMediaFact, type MediaFact } from \"../../../media/media-facts.js\";\n+import type { PromptImageOrderEntry } from \"../../../media/prompt-image-order.js\";\n import type { AgentMessage } from \"../../runtime/index.js\";\n \n export type ImageFactIndex = number | null;\n@@ -7,6 +9,52 @@ export type MediaImageLayout = {\n   suppressedFactIndexes?: number[];\n };\n \n+/** Resolves image ownership before independent media arrays are combined. */\n+export function resolveMediaImageLayout(params: {\n+  media: readonly MediaFact[];\n+  imageOrder?: readonly PromptImageOrderEntry[];\n+  mediaImageLayout?: MediaImageLayout;\n+  inlineImageCount: number;\n+}): MediaImageLayout {\n+  const suppressed = new Set([\n+    ...(params.mediaImageLayout?.suppressedFactIndexes ?? []),\n+    ...params.media.flatMap((fact, index) => (fact.hydrationSuppressed === true ? [index] : [])),\n+  ]);\n+  const imageFactIndexes = params.media.flatMap((fact, factIndex) =>\n+    isImageMediaFact(fact) && !suppressed.has(factIndex) ? [factIndex] : [],\n+  );\n+  const slots = (() => {\n+    // Keep suppressed inline slots for byte-to-fact alignment; consumers filter\n+    // them only after associating the original inline image array.\n+    if (params.mediaImageLayout?.slots.length) {\n+      return params.mediaImageLayout.slots;\n+    }\n+    if (params.imageOrder?.length === imageFactIndexes.length) {\n+      return params.imageOrder.map((kind, index) => ({ kind, factIndex: imageFactIndexes[index] }));\n+    }\n+    if (params.imageOrder?.length) {\n+      const pending = [...imageFactIndexes];\n+      return [\n+        ...params.imageOrder.map((kind) => ({\n+          kind,\n+          ...(kind === \"offloaded\" && pending.length ? { factIndex: pending.shift() } : {}),\n+        })),\n+        ...pending.map((factIndex) => ({ kind: \"offloaded\" as const, factIndex })),\n+      ];\n+    }\n+    return imageFactIndexes.map((factIndex, imageIndex) => ({\n+      factIndex,\n+      kind:\n+        !params.media[factIndex]?.path &&\n+        !params.media[factIndex]?.url &&\n+        imageIndex < params.inlineImageCount\n+          ? (\"inline\" as const)\n+          : (\"offloaded\" as const),\n+    }));\n+  })();\n+  return { slots, suppressedFactIndexes: [...suppressed] };\n+}\n+\n export function readPersistedImageBlockFactIndexes(\n   message: AgentMessage,\n ): ImageFactIndex[] | undefined {"
+    }
+  ]
+}

--- a/test/pr-surface-policy.test.ts
+++ b/test/pr-surface-policy.test.ts
@@ -196,6 +196,7 @@ for (const [name, fixturePath, normalizationTruncates] of [
   ["pane-local diagnostics", "./fixtures/persistence-classifier-132718.json", true],
   ["test-support workspace guard", "./fixtures/persistence-classifier-133209.json", true],
   ["Go chunk diagnostics", "./fixtures/persistence-classifier-134934.json", false],
+  ["retained image runtime fields", "./fixtures/persistence-classifier-132839.json", true],
 ] as const) {
   for (const normalized of [false, true]) {
     test(`${name} creates no stored-data warning or migration gate (${normalized ? "production-normalized" : "full"} patch)`, () => {
@@ -230,8 +231,16 @@ for (const [name, fixturePath, normalizationTruncates] of [
 test("runtime state names and typed parameters alone do not establish stored data", () => {
   const patch =
     "@@\n+function show(\n+  state: ViewState,\n+  session: string,\n+) { return state; }";
-  for (const filename of ["ui/src/state.ts", "src/runtime/session.ts", "ui/src/history/merge.ts"]) {
-    for (const evidence of [patch, `${patch}\n\n[truncated 90 chars]`, undefined]) {
+  for (const filename of [
+    "ui/src/state.ts",
+    "src/runtime/session.ts",
+    "ui/src/history/merge.ts",
+    "src/runtime/metadata.ts",
+    "src/runtime/row-id.ts",
+    "src/runtime/document-id.ts",
+    "src/runtime/chunk-id.ts",
+  ]) {
+    for (const evidence of [patch, "", `${patch}\n\n[truncated 90 chars]`, undefined]) {
       const detection = dataModelChangeFromPullFilesForTest({
         pullFiles: [{ filename, previous_filename: "ui/src/session-view.ts", patch: evidence }],
       });
@@ -358,6 +367,31 @@ test("storage evidence still warns and gates browser, runtime, and schema change
       patch: "@@\n-  ttl: 86400,\n+  ttl: 3600,",
       surface: "persistent cache schema",
     },
+    {
+      filename: "src/runtime/metadata.ts",
+      patch: '@@\n localStorage.setItem("preferences", JSON.stringify({\n+  revision: 2,\n }));',
+      surface: "serialized state",
+    },
+    {
+      filename: "src/runtime/row-id.ts",
+      patch: "@@\n CREATE TABLE sessions (\n+  revision INTEGER,\n );",
+      surface: "database schema",
+    },
+    {
+      filename: "src/runtime/document-id.ts",
+      patch: '@@\n await state.storage.put("snapshot", {\n+  revision: nextRevision,\n });',
+      surface: "durable storage schema",
+    },
+    {
+      filename: "src/runtime/chunk-id.ts",
+      patch: "@@\n-  embeddingDimension: 768,\n+  embeddingDimension: 1024,",
+      surface: "vector/embedding metadata",
+    },
+    ...["vector", "embedding", "embeddings", "memory"].map((owner) => ({
+      filename: `src/${owner}/records.ts`,
+      patch: "@@\n+  metadata: row.metadata,",
+      surface: "vector/embedding metadata",
+    })),
   ];
   for (const { surface, ...file } of cases) {
     const pullFiles = hydratePrimaryBody("", "pull_request", { pullFiles: [file] }).context
@@ -382,6 +416,12 @@ test("strong persistence evidence remains unknown when production normalization 
     { filename: "ui/src/display.ts", previous_filename: "ui/src/storage/state.ts" },
     { filename: "ui/src/storage/state.ts", previous_filename: "ui/src/display.ts" },
     { filename: "ui/src/display.ts", patch: '@@\n localStorage.getItem("preferences");\n' },
+    { filename: "src/vector/records.ts" },
+    { filename: "src/embedding/records.ts" },
+    { filename: "src/embeddings/records.ts" },
+    { filename: "src/memory/records.ts" },
+    { filename: "src/runtime/metadata.ts", previous_filename: "src/vector/records.ts" },
+    { filename: "src/vector/records.ts", previous_filename: "src/runtime/metadata.ts" },
   ]) {
     const patch = `${file.patch ?? "@@\n"}${" // retained context\n".repeat(110)}+  revision: 2,`;
     const pullFiles = hydratePrimaryBody("", "pull_request", { pullFiles: [{ ...file, patch }] })


### PR DESCRIPTION
## What Problem This Solves

Fixes false stored-data warnings on runtime helpers whose filenames contain `metadata`, `row-id`, `document-id`, or `chunk-id`. In https://github.com/openclaw/openclaw/pull/132839, an image-ownership helper was classified as vector storage and received a migration gate despite having no storage contract.

## Why This Change Was Made

Remove those four weak filename hints at the classifier that owns them, and simplify the equivalent vector/embedding expression. Explicit vector, embedding and bounded memory paths still count as storage evidence. SQL, serialization and durable-storage operations still trigger review under generic filenames; rename-side evidence and incomplete file lists keep their existing gates.

The regression fixture comes from the actual Git diff for the image-history PR, with both full and production-normalized variants. The PR description is not an input to the detector. Production code shrinks by four lines (+1/-5); tests and fixture add 60 net lines (+62/-2), and docs add one (+3/-2).

## User Impact

Contributors no longer receive migration requirements solely because an ordinary runtime helper has a metadata or identifier filename. Real storage changes retain their warnings and maintainer gates.

## OpenClaw Bay Impact

No Bay change is needed. This corrects existing review classification and rendered warning content; it does not change events, queue lifecycle, persisted report shape, dashboard contracts, or action authority.

## Documentation Impact

Updated the active `docs/pr-review-comments.md` contract to state that generic metadata and identifier filenames alone are insufficient storage evidence. The source of truth remains `dataModelPathHint` and the same-hunk detector in `src/clawsweeper-change-detection.ts`; the review maintainers own this contract. Verified against this PR's source tree. Future path-hint or storage-evidence changes must keep these examples and controls aligned.

## Evidence

`pnpm run check` passed on Node 24.19.0 / pnpm 11.10.0: all static checks, all three TypeScript builds, lint, 13 targeted coverage cases, and the full suite (4,446 passed, 14 platform skips, zero failures or cancellations). The exact source tree is `52b65852a24c6eb74be33bd3c85afcabf7127ed1`.

Before the repair, all 70 focused cases ran with exactly three intended failures and 67 passes. The unchanged regressions pass after the repair. The formatter made no byte changes. An initial full-check attempt failed in temporary Git fixture setup because the proof runner overrode global config and lazy-fetch behavior; removing those two runner-only overrides made the unchanged full suite pass. No test assertion, coverage threshold, or product code changed to resolve those setup failures.

Independent Codex reviews found no actionable P0–P2 findings both before commit and on committed branch `b3aff8875f3989cb28d123df50bb5ef7d17a8b96` against its base. The committed review did not rerun candidate code.

## Real Behavior Proof

**Claim and surface:** the compiled production detector, production patch compactor, public review renderer, and automation marker builder reject weak filename-only storage evidence while retaining real storage gates.

**Scenario and command:** replayed 15 exact inputs through the built `dist/clawsweeper.js` surface using a standalone Node driver after `pnpm run check`, on an isolated Linux AWS worker without credentials or an IAM role. The original image-helper input is derived from Git head `61d7719d833eb6684fc603a5c3659d1ba17f0595`. The same driver and inputs ran before and after the repair.

| Scenario group | Observed result after repair |
| --- | --- |
| Actual image-helper diff, full and production-normalized | No stored-data warning or migration gate |
| Generic metadata path with missing, empty, or truncated patch | No filename-only storage warning |
| Explicit vector/embedding/memory paths | Storage warning and maintainer gate retained |
| SQL, serialization, durable storage, or explicit vector fields under generic filenames | Correct storage surface and gate retained |
| Renames into or out of vector paths; globally truncated file inventory | Incomplete-storage evidence remains gated |

**Observed trace:** the baseline reproduced eight failing scenarios and retained seven passing controls. After the repair, all 15 scenarios, all 15 prerequisites, and all 45 classification/warning/automation assertions passed. Complete source, index, refs, dependency inventory and built root `dist` inventory remained identical across check and replay. The private proof HOME was removed and its absence verified independently.

```json
{"selected":15,"actual":15,"passed":true,"failures":[],"infrastructureError":null}
```

The retained replay result has SHA-256 `9baa13d1636af164ff23a00087e5313f01f22ed42a51e05702dfaf16879521d1`; the complete native evidence archive is `91fd7ef07f10a62577cf644f216bebf807be885af4497c2d48bcc633e2c11ca7`. Driver SHA-256: `ab889da77d4d99cb23f5ddd9ab44a279b845c51c032c32e541d9f62d59b78696`.

**Limits:** the driver uses synthetic completed-review fields to exercise the real renderer and marker builder. It does not claim a live model verdict, GitHub publication, queue execution, Bay update, or execution of the target OpenClaw PR. The original and repaired source trees and raw output are retained separately.
