### PR TITLE
fix(review): unblock Mac dashboard synthetic fixture admission

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,6 +588,7 @@ the [remote-CDP documentation example](https://github.com/openclaw/openclaw/blob
 the [credentialed-page rejection fixtures](https://github.com/openclaw/openclaw/blob/d5fb4903f1b13a4309d479f1011d995b1fc706ae/extensions/browser/src/browser-tool.test.ts),
 the [guarded CDP authentication fixtures](https://github.com/openclaw/openclaw/blob/1cf6ff3bdc08a6ac08facb1006b1d7aabc0eaff4/extensions/browser/src/browser/cdp.helpers.test.ts),
 the [MCP endpoint-redaction fixture](https://github.com/openclaw/openclaw/blob/ac21e89c13e42f6a7d152bf9be143e67edd44ed3/extensions/browser/src/browser/chrome-mcp.test.ts),
+the [Mac dashboard credentialed-subframe rejection fixture](https://github.com/openclaw/openclaw/blob/9ba01d6c7b1c308e7b41eac11ba6f43e0fd0393d/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift#L273),
 the [Mattermost slash-error sanitization fixtures](https://github.com/openclaw/openclaw/blob/9c0975c1c20ed635532c7aa0f510154224adee7f/extensions/mattermost/src/mattermost/slash-http.test.ts),
 and the OpenClaw config [URL-redaction](https://github.com/openclaw/openclaw/blob/5fe22a7d88919f260e7999fc775733feff3cb1fa/src/config/redact-snapshot.test.ts)
 and [restoration fixtures](https://github.com/openclaw/openclaw/blob/5fe22a7d88919f260e7999fc775733feff3cb1fa/src/config/redact-snapshot.restore.test.ts)
@@ -595,7 +596,7 @@ after a complete scan. Static host policy associates each
 exact detector-matched URI SHA-256 with only its approved source paths and exact
 scanner `Raw` digest, including when `Raw` omits a path retained by `RawV2`. The
 matched value must be a literal in a host-staged Git blob from mode `100644`.
-The three guarded-CDP/MCP entries and four Mattermost entries also bind complete
+The three guarded-CDP/MCP entries, Mac dashboard entry, and four Mattermost entries also bind complete
 reviewed source lines, including surrounding query text that TruffleHog's URI
 detector does not match. Changes to those lines or additional literal occurrences
 refuse classification. These witnesses do not expand native query detection.
@@ -607,8 +608,9 @@ original source. Repeated literals remain eligible unless an entry is bound to
 an approved complete-line digest; those entries require exactly one occurrence
 in the staged blob. Finding order and duplicate records do not change the exact
 value, path, and mode checks.
-Findings must use `PLAIN` or `HTML`, except the two guarded-CDP fixtures also
-permit `BASE64`. The pinned Base64 decoder preserves the rest of a chunk after
+Findings must use `PLAIN` or `HTML`, except the Mac dashboard entry permits only
+its observed `PLAIN` decoder and the two guarded-CDP fixtures also permit `BASE64`.
+The pinned Base64 decoder preserves the rest of a chunk after
 decoding another token, so an unchanged literal can acquire that decoder label
 and win cross-decoder deduplication. Those entries still require the literal in
 its exact original source line; encoded-only content remains blocking.

--- a/src/agent-input-scan-fixtures.ts
+++ b/src/agent-input-scan-fixtures.ts
@@ -72,6 +72,14 @@ const REVIEWED_FIXTURES: readonly ReviewedFixture[] = [
     sources: ["extensions/browser/src/browser/chrome-mcp.test.ts"],
   },
   {
+    // Approved Mac dashboard subframe rejection witness in OpenClaw 9ba01d6c7b1c.
+    fixtureSha256: "97c60d02f5114db97718cfe1c3686c0a36fb5138840611c8793c7abbd9c64f71",
+    rawSha256: "43690a8c13d4028ed731bc4dfeb37f83adaa4e5849d2e0fa13f746843adec333",
+    lineSha256s: ["87f28bc6a5b0037cfd2ecc94349d5c9bfff572776c25d5e713ae7d83144f5f98"],
+    decoders: ["PLAIN"],
+    sources: ["apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift"],
+  },
+  {
     // Mattermost slash-error sanitization fixtures introduced by 9c0975c1c20e.
     fixtureSha256: "f2c5cfd2b711577ed9048f9bd0e6c97ae88097b8eba8c1ff37deb33ed910f5a7",
     rawSha256: "7d765bfa6e81c336a916aaf71eab28f5c0c4ae47a359ec3adf2d4f175645456d",

--- a/test/agent-input-scan.test.ts
+++ b/test/agent-input-scan.test.ts
@@ -550,6 +550,7 @@ const browserDocsSource = "docs/tools/browser.md";
 const browserToolSource = "extensions/browser/src/browser-tool.test.ts";
 const browserCdpHelpersSource = "extensions/browser/src/browser/cdp.helpers.test.ts";
 const browserMcpSource = "extensions/browser/src/browser/chrome-mcp.test.ts";
+const macDashboardSource = "apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift";
 const mattermostSource = "extensions/mattermost/src/mattermost/slash-http.test.ts";
 const ledgerFixtureSha256 = "a728de5dbbef23b8aa5ef2d99060835f4f2fb5a0fa2abb9fe249d08aa09bd09e";
 const nativeContractFailures = new Map([
@@ -569,7 +570,7 @@ const nativeContractFailures = new Map([
   ["unexpected successful output", "unexpected_exit"],
 ]);
 
-for (const scenario of [
+for (const scenarioName of [
   "reviewed fixture",
   "browser local Chrome fixture",
   "browser remote Chrome fixture",
@@ -678,8 +679,32 @@ for (const scenario of [
   "malformed output",
   "unexpected successful output",
   "source drift",
+  ...[
+    "reviewed fixture",
+    "changed raw",
+    "changed full URI",
+    "changed matching raw values",
+    "other file",
+    "unapproved line",
+    "duplicate on approved line",
+    "executable source",
+    "prompt",
+    "diff",
+    "verified",
+    "mixed findings",
+    "wrong detector",
+    "wrong source type",
+    "wrong decoder",
+    "unreviewed HTML",
+    "wrong secret parts",
+    "missing verification error",
+    "wrong version",
+    "missing completion",
+  ].map((scenario) => `mac dashboard ${scenario}`),
 ]) {
-  test(`reviewed synthetic fixture admission: ${scenario}`, (t) => {
+  const macDashboardFixture = scenarioName.startsWith("mac dashboard ");
+  const scenario = macDashboardFixture ? scenarioName.slice("mac dashboard ".length) : scenarioName;
+  test(`reviewed synthetic fixture admission: ${scenarioName}`, (t) => {
     const notices: unknown[][] = [];
     t.mock.method(console, "error", (...args: unknown[]) => notices.push(args));
     // Read the existing malformed-configuration fixture without reproducing its
@@ -699,17 +724,19 @@ for (const scenario of [
     const browserExactFixture = browserCdpFixture || browserMcpFixture;
     const encodedCdpFixture = browserCdpFixture && scenario.includes("encoded");
     // Preserve the literal witnesses captured from the native OpenClaw scan.
-    const literalLine = browserCdpFixture
-      ? encodedCdpFixture
-        ? 406
-        : 293
-      : browserMcpFixture
-        ? 1339
-        : 42;
+    const literalLine = macDashboardFixture
+      ? 273
+      : browserCdpFixture
+        ? encodedCdpFixture
+          ? 406
+          : 293
+        : browserMcpFixture
+          ? 1339
+          : 42;
     const scannerLine = scenario.includes("shifted BASE64") ? literalLine - 4 : literalLine;
     const primaryDecoder = scenario.includes("BASE64")
       ? "BASE64"
-      : scenario === "browser CDP encoded HTML fixture"
+      : scenario === "browser CDP encoded HTML fixture" || scenario === "unreviewed HTML"
         ? "HTML"
         : "PLAIN";
     if (browserExactFixture) {
@@ -759,6 +786,13 @@ for (const scenario of [
       if (scenario === "mattermost changed path") url.pathname = "/changed";
       uri = url.href;
     }
+    if (macDashboardFixture) {
+      // Native 3.97.1 witness from OpenClaw 9ba01d6c7b1c, line 273.
+      const url = new URL("http://localhost:18890/embed/channel/T01/C01");
+      url.username = "user";
+      url.password = "pass";
+      uri = url.href;
+    }
     assert.ok(uri, "reviewed synthetic fixture is present");
     const authority = new URL(uri);
     authority.pathname = "";
@@ -769,7 +803,7 @@ for (const scenario of [
       authority.password = "redacted";
     }
     const raw =
-      browserPageFixture || browserExactFixture || mattermostFixture
+      macDashboardFixture || browserPageFixture || browserExactFixture || mattermostFixture
         ? authority.href.slice(0, -1)
         : uri;
     let otherReviewedUri: string | undefined;
@@ -787,7 +821,7 @@ for (const scenario of [
     }
     const findingValues = [uri, raw, ...(otherReviewedUri ? [otherReviewedUri] : [])];
     const f = fixture(t, scenario === "prompt" ? uri : undefined);
-    const files =
+    let files =
       scenario === "many source references"
         ? Array.from({ length: 8 }, (_, index) => `unapproved-${index}.test.ts`)
         : mattermostFixture
@@ -833,6 +867,8 @@ for (const scenario of [
                             ? "other.test.ts"
                             : ledgerSource,
                     ];
+    if (macDashboardFixture)
+      files = [scenario === "other file" ? "other.test.swift" : macDashboardSource];
     const value =
       scenario === "decoded only" || scenario.endsWith("encoded-only")
         ? primaryDecoder === "BASE64"
@@ -857,7 +893,13 @@ for (const scenario of [
             ? `        ${JSON.stringify(`fallback\r\nsecond-line botToken: secret-bot ${uri}?token=secret-query`)},`
             : `        ${JSON.stringify(`primary\ntoken=secret-token ${uri}?access_token=secret-access&client_secret=secret-client`)},`
         : undefined;
-    const reviewedFixtureLine = reviewedBrowserLine ?? reviewedMattermostLine;
+    const reviewedMacDashboardLine = macDashboardFixture
+      ? scenario === "unapproved line"
+        ? JSON.stringify(value)
+        : `        let credentialedFrame = try #require(URL(string: "${value}"))`
+      : undefined;
+    const reviewedFixtureLine =
+      reviewedMacDashboardLine ?? reviewedBrowserLine ?? reviewedMattermostLine;
     const contents =
       "// context\n".repeat(literalLine - 2) +
       (reviewedFixtureLine ?? JSON.stringify(otherReviewedUri ?? value)) +


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where ClawSweeper refuses review of the Mac browser sidebar-width change in https://github.com/openclaw/openclaw/pull/136168 because a pre-existing synthetic navigation-rejection fixture appears in both complete scanned Swift blobs.

The refusal occurred before reviewer execution in https://github.com/openclaw/clawsweeper/actions/runs/33614457592/job/100196969182 at deployed source `521f1ab5ca8c099b25d546baaa7a88ceedfd0174`. Its value-free diagnostic was `agent_input_scan / findings / unclassified_finding / literal_not_reviewed`, finding count 2, detector 17 (URI), decoder `PLAIN`, verified false, scanner line 273.

## Why This Change Was Made

Peter explicitly approved a narrowly scoped host fixture-policy correction for this verified synthetic fixture, regression tests, independent review, and a normal policy PR. This adds exactly one entry to the existing host-owned table: one native Raw/RawV2 hash pair, one complete source-line witness, one exact source path, and only the observed `PLAIN` decoder. No classifier, scanner, version, verification, staging, schema, or runtime behavior is otherwise changed. The existing mode `100644` and provenance gates and unsuppressible classification notice remain intact.

The source constructs a URL and asserts that `shouldAllowNavigation` rejects a credentialed subframe; it makes no network request. [Pinned source and rejection assertion](https://github.com/openclaw/openclaw/blob/9ba01d6c7b1c308e7b41eac11ba6f43e0fd0393d/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift#L267). The complete fixture line is identical in the original and candidate blobs. Neither the OpenClaw branch nor the fixture placement was changed. Prompt/patch findings, verified findings, unrelated findings, other paths/modes, changed literals/lines, duplicate occurrences, HTML/Base64 records, and incomplete or incompatible native scans still refuse admission.

## User Impact

Once merged and deployed, this exact synthetic fixture no longer blocks admission for the browser resizing review. This is not an OpenClaw review verdict or evidence that the browser PR has landed.

## OpenClaw Bay Impact

Bay is unaffected: no dashboard, queue, lifecycle projection, or data-contract changes.

## Documentation Impact

Updated the active README admission-policy section with the pinned source and this entry's stricter PLAIN-only decoder scope. The host policy table remains the source of truth. No changelog change; release-note context is retained here.

## Evidence

The admission suite passed **162/162** tests, including 20 new cases reusing the existing native-metadata/scanner harness. Against pre-fix policy, the new matrix was **18 passed / 2 failed**: the positive admission case failed with `literal_not_reviewed`, and the prompt case could not reach its expected prompt refusal because the earlier unapproved blob blocked first. After the change, positive admission and all refusal controls passed.

Fresh isolated Codex autoreview returned `scoped-clean`, no findings, at its default P0 scope; it did not run tests. `PATH="/opt/homebrew/opt/node@24/bin:/opt/homebrew/opt/bash/bin:$PATH" pnpm run check` passed: static checks, all builds, lint, changed-coverage tests (13/13), and full coverage tests (4,471 passed, 9 skipped, 0 failed; 513 seconds). Overall coverage: 83.40% lines / 76.28% branches / 88.53% functions. `git diff --check` passed. Production delta: 8 added table-entry lines; tests: +55/-13 lines; README: +5/-3 lines. No classifier code changed.

Exact-head CI passed: https://github.com/openclaw/clawsweeper/actions/runs/33644717400 (head `8559db2a84eca401837f0850e961f0561a39bbb5`).

## Real Behavior Proof

**Claim and exercised surface:** The built host `scanAgentInput` path admits only the approved fixture after a complete real native scan, preserving its audit notice. Baseline host policy and candidate policy were run against the same clean, unchanged OpenClaw checkout, with committed source base `93f1bb84f9522e357c9709ff717b4642fc5485ec`, head `9ba01d6c7b1c308e7b41eac11ba6f43e0fd0393d`, and a harmless synthetic review prompt. No model/provider was invoked by this proof.

**Environment and command:** macOS, Node 24.20.0, TruffleHog 3.97.1. Both direct native scans and the complete host admission ran under a task-scoped `sandbox-exec` profile `(version 1) (allow default) (deny network*)`. Independently verified IPv4 and IPv6 task-owned loopback controls connected outside the sandbox and returned EPERM inside it, with zero sandboxed connections received. No operator Gateway was contacted. Verification remained enabled. Native invocation used `filesystem <private-staging> --results=verified,unknown --fail --fail-on-scan-errors --no-update --json --no-color`.

**Observed trace:** Both policies received two native unverified PLAIN URI findings at line 273, exit 183. Baseline returned `findings / literal_not_reviewed`; candidate classified the same identities and completed host admission. The host emitted one `agent_input_scan_classified` notice containing both blob witnesses with scanner/literal line 273 and occurrence count 1 each. This is classification of reviewed synthetic findings, not a claim of zero scanner findings.

| Provenance | Exact identity |
| --- | --- |
| Source | `apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift` |
| Before blob | `fea2bed8ba0e1374b19128416fc2d61a5a68999b` |
| Candidate blob | `a8e577bd05b7e999ec0673481e7c888327748d16` |
| Path SHA-256 | `f042d529fd3af41da12f94fe46495571109b04ff2986f61422209efd7bdad8b4` |
| Native Raw SHA-256 | `43690a8c13d4028ed731bc4dfeb37f83adaa4e5849d2e0fa13f746843adec333` |
| Native RawV2 SHA-256 | `97c60d02f5114db97718cfe1c3686c0a36fb5138840611c8793c7abbd9c64f71` |
| Complete source-line SHA-256 | `87f28bc6a5b0037cfd2ecc94349d5c9bfff572776c25d5e713ae7d83144f5f98` |
| Both modes | `100644` |

Native identities were obtained from real scanner output and checked against the [pinned URI detector](https://github.com/trufflesecurity/trufflehog/blob/v3.97.1/pkg/detectors/uri/uri.go#L85) and [native JSON serializer](https://github.com/trufflesecurity/trufflehog/blob/v3.97.1/pkg/output/json.go#L68), rather than guessed from URL parsing. Raw findings, matched values, secret parts, and verification messages are deliberately excluded from this public proof.

**Limits:** This proves the exact fixture and the local built host admission over the full committed diff/blobs, not the failed run's complete assembled prompt, a deployed policy rollout, another reviewer execution, or browser UI behavior. The table binds exact values/lines/path across revisions, not a commit allowlist. Existing scanner coverage limitations remain.

The original OpenClaw PR https://github.com/openclaw/openclaw/pull/136168 must still receive its own successful ClawSweeper review and pass its normal native landing gates; this policy correction does not approve or land that PR.
