### PR TITLE
fix(review): preserve fixture references through prompt admission

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,6 +621,12 @@ must qualify under the same digest's exact path and mode `100644` policy before
 any source is eligible for classification or an audit notice.
 The policy does not trust checkout ignore rules, domain patterns, fixture words,
 test names, or unchanged-line inference; no nearby fixture is implicitly approved.
+When review evidence quotes an exact reviewed synthetic URI, prompt preparation
+replaces the complete token with a visible reference to its source
+file. The original context is preserved, and changed tokens or additional query
+text remain untouched. This omission does not classify a native finding or prove
+its verification status. Source blobs, introduced patches, and scanner admission
+retain their existing checks.
 Findings attributed to prompt, schema, diff, additional-input, other-path, or
 encoded-only blobs remain blocking, as do other findings, verified findings,
 and incomplete scans. Unverified findings alone never qualify: every finding must

--- a/README.md
+++ b/README.md
@@ -622,9 +622,9 @@ any source is eligible for classification or an audit notice.
 The policy does not trust checkout ignore rules, domain patterns, fixture words,
 test names, or unchanged-line inference; no nearby fixture is implicitly approved.
 When review evidence quotes an exact reviewed synthetic URI, prompt preparation
-replaces the complete token with a visible reference to its source
-file. The original context is preserved, and changed tokens or additional query
-text remain untouched. This omission does not classify a native finding or prove
+replaces the URI with a visible reference to its source file, preserving closing
+Markdown and sentence punctuation. The original context is preserved, and changed
+paths, credentials, or additional query text remain untouched. This omission does not classify a native finding or prove
 its verification status. Source blobs, introduced patches, and scanner admission
 retain their existing checks.
 Findings attributed to prompt, schema, diff, additional-input, other-path, or

--- a/src/agent-input-scan-fixtures.ts
+++ b/src/agent-input-scan-fixtures.ts
@@ -123,12 +123,12 @@ export function serializeReviewContext(context: object): string {
 }
 
 export function omitReviewedFixtureReferences(text: string): string {
-  // Prose quotations have no Git source binding. Match the complete URI before
-  // stripping closing punctuation; path, query, and credential changes stay visible.
+  // Apostrophes are URI characters, so only terminal quotation punctuation can
+  // be stripped; internal punctuation must not hide a changed path or query.
   return text.replace(
-    /(^|[\s<>"'\x60([{])([A-Za-z][A-Za-z0-9+.-]*:\/\/[^\s<>"'\x60]+)/g,
+    /(^|[\s<>"'\x60([{])([A-Za-z][A-Za-z0-9+.-]*:\/\/[^\s<>"\x60]+)/g,
     (match, boundary: string, uri: string) => {
-      for (const candidate of [uri, uri.replace(/[)\]},.;!]+$/, "")]) {
+      for (const candidate of [uri, uri.replace(/[)\]},.;!']+$/, "")]) {
         const digest = createHash("sha256").update(candidate).digest("hex");
         const fixture = REVIEWED_FIXTURES.find((entry) => entry.fixtureSha256 === digest);
         if (fixture) {

--- a/src/agent-input-scan-fixtures.ts
+++ b/src/agent-input-scan-fixtures.ts
@@ -123,27 +123,27 @@ export function serializeReviewContext(context: object): string {
 }
 
 export function omitReviewedFixtureReferences(text: string): string {
-  // Apostrophes are URI characters, so only terminal quotation punctuation can
-  // be stripped; internal punctuation must not hide a changed path or query.
-  return text.replace(
-    /(^|[\s<>"'\x60([{])([A-Za-z][A-Za-z0-9+.-]*:\/\/[^\s<>"\x60]+)/g,
-    (match, boundary: string, uri: string) => {
-      for (const candidate of [uri, uri.replace(/[)\]},.;!']+$/, "")]) {
-        const digest = createHash("sha256").update(candidate).digest("hex");
-        const fixture = REVIEWED_FIXTURES.find((entry) => entry.fixtureSha256 === digest);
-        if (fixture) {
-          return (
-            boundary +
-            "[reviewed synthetic URI omitted; inspect " +
-            fixture.sources.join(", ") +
-            "]" +
-            uri.slice(candidate.length)
-          );
-        }
+  // Match whole scheme tokens once; retrying at every character is quadratic.
+  // Strip only terminal punctuation; internal punctuation may belong to a URI.
+  return text.replace(/(?<![A-Za-z0-9+.-])[A-Za-z0-9+.-]+:\/\/[^\s<>"\x60]+/g, (uri) => {
+    let end = uri.length;
+    while (end > 0 && ")]}.,;!'".includes(uri.charAt(end - 1))) {
+      end -= 1;
+    }
+    for (const candidate of [uri, uri.slice(0, end)]) {
+      const digest = createHash("sha256").update(candidate).digest("hex");
+      const fixture = REVIEWED_FIXTURES.find((entry) => entry.fixtureSha256 === digest);
+      if (fixture) {
+        return (
+          "[reviewed synthetic URI omitted; inspect " +
+          fixture.sources.join(", ") +
+          "]" +
+          uri.slice(candidate.length)
+        );
       }
-      return match;
-    },
-  );
+    }
+    return uri;
+  });
 }
 
 export interface ScanSourceReference {

--- a/src/agent-input-scan-fixtures.ts
+++ b/src/agent-input-scan-fixtures.ts
@@ -114,6 +114,29 @@ const REVIEWED_FIXTURES: readonly ReviewedFixture[] = [
   },
 ];
 
+export function serializeReviewContext(context: object): string {
+  return JSON.stringify(
+    context,
+    (_key, value) => (typeof value === "string" ? omitReviewedFixtureReferences(value) : value),
+    2,
+  );
+}
+
+export function omitReviewedFixtureReferences(text: string): string {
+  // Prose quotations do not carry a Git source binding. Omit the complete
+  // reviewed token; a prefix match could conceal changed credentials or a query.
+  return text.replace(
+    /(^|[\s<>"'\x60(])([A-Za-z][A-Za-z0-9+.-]*:\/\/[^\s<>"'\x60]+)/g,
+    (match, boundary: string, uri: string) => {
+      const digest = createHash("sha256").update(uri).digest("hex");
+      const fixture = REVIEWED_FIXTURES.find((entry) => entry.fixtureSha256 === digest);
+      return fixture
+        ? boundary + "[reviewed synthetic URI omitted; inspect " + fixture.sources.join(", ") + "]"
+        : match;
+    },
+  );
+}
+
 export interface ScanSourceReference {
   source: string;
   mode: string;

--- a/src/agent-input-scan-fixtures.ts
+++ b/src/agent-input-scan-fixtures.ts
@@ -123,16 +123,25 @@ export function serializeReviewContext(context: object): string {
 }
 
 export function omitReviewedFixtureReferences(text: string): string {
-  // Prose quotations do not carry a Git source binding. Omit the complete
-  // reviewed token; a prefix match could conceal changed credentials or a query.
+  // Prose quotations have no Git source binding. Match the complete URI before
+  // stripping closing punctuation; path, query, and credential changes stay visible.
   return text.replace(
-    /(^|[\s<>"'\x60(])([A-Za-z][A-Za-z0-9+.-]*:\/\/[^\s<>"'\x60]+)/g,
+    /(^|[\s<>"'\x60([{])([A-Za-z][A-Za-z0-9+.-]*:\/\/[^\s<>"'\x60]+)/g,
     (match, boundary: string, uri: string) => {
-      const digest = createHash("sha256").update(uri).digest("hex");
-      const fixture = REVIEWED_FIXTURES.find((entry) => entry.fixtureSha256 === digest);
-      return fixture
-        ? boundary + "[reviewed synthetic URI omitted; inspect " + fixture.sources.join(", ") + "]"
-        : match;
+      for (const candidate of [uri, uri.replace(/[)\]},.;!]+$/, "")]) {
+        const digest = createHash("sha256").update(candidate).digest("hex");
+        const fixture = REVIEWED_FIXTURES.find((entry) => entry.fixtureSha256 === digest);
+        if (fixture) {
+          return (
+            boundary +
+            "[reviewed synthetic URI omitted; inspect " +
+            fixture.sources.join(", ") +
+            "]" +
+            uri.slice(candidate.length)
+          );
+        }
+      }
+      return match;
     },
   );
 }

--- a/src/clawsweeper-review-command-workflow.ts
+++ b/src/clawsweeper-review-command-workflow.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { ACTION_EVENT_REASON_CODES, ACTION_EVENT_STATUSES } from "./action-ledger.js";
 import { AgentInputScanError, agentInputScanFailureExitCode } from "./agent-input-scan.js";
+import { serializeReviewContext } from "./agent-input-scan-fixtures.js";
 import type { Args } from "./clawsweeper-args.js";
 import {
   isBulkFilerExemptRepositoryPermission as isVerifiedMaintainerRepositoryPermission,
@@ -415,7 +416,7 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
             const inspection = runReviewCheckoutInspection({
               // Structural reuse has no model payload. Hydrated reuse scans the
               // current context too, including source comments.
-              initialPrompt: JSON.stringify(context ?? item),
+              initialPrompt: serializeReviewContext(context ?? item),
               scanSource: item.kind === "pull_request"
                 ? { kind: "committed", baseSha: typeof baseSha === "string" ? baseSha : "", headSha: headSha ?? "" }
                 : { kind: "prompt" },

--- a/src/clawsweeper-review-runtime.ts
+++ b/src/clawsweeper-review-runtime.ts
@@ -495,6 +495,7 @@ export function createReviewRuntime({
       runtimeHints.mediaProofSummary,
       runtimeHints.mediaProofManifestPath,
     );
+    // Keep raw maintainer input scanner-visible; omit fixtures only from sourced GitHub fields.
     const extra = additionalPrompt.trim()
       ? `
 
@@ -503,7 +504,7 @@ export function createReviewRuntime({
 ${additionalPrompt.trim()}
 `
       : "";
-    const text = omitReviewedFixtureReferences(`${prompt}
+    const text = `${prompt}
 
 ## Repository State
 
@@ -511,7 +512,7 @@ ${additionalPrompt.trim()}
 - Repository policy: ${profile.promptNote}
 - Item: #${item.number}
 - Type: ${item.kind}
-- Title: ${item.title}
+- Title: ${omitReviewedFixtureReferences(item.title)}
 - URL: ${item.url}
 - Author: ${item.author}
 - Author association: ${item.authorAssociation}
@@ -536,7 +537,7 @@ Primary-body \`bodyCoverage\` describes separate untrusted excerpts and omitted 
 ${contextJson}
 \`\`\`
 ${extra}
-`);
+`;
     return {
       text,
       telemetry: {

--- a/src/clawsweeper-review-runtime.ts
+++ b/src/clawsweeper-review-runtime.ts
@@ -10,6 +10,10 @@ import {
 import { dirname, join, relative, resolve } from "node:path";
 import { runAgentCheckoutInspection, runAgentProcess } from "./agent-runner.js";
 import { AgentInputScanError, type AgentScanSource } from "./agent-input-scan.js";
+import {
+  omitReviewedFixtureReferences,
+  serializeReviewContext,
+} from "./agent-input-scan-fixtures.js";
 import { stringArg, type Args } from "./clawsweeper-args.js";
 import {
   mediaProofRuntimeHints,
@@ -462,7 +466,7 @@ export function createReviewRuntime({
 
   function contextJsonForPrompt(context: ItemContext): string {
     const { pullCommitsRevision: __, prHydrationSnapshot: ___, ...promptContext } = context;
-    return JSON.stringify(promptContext, null, 2);
+    return serializeReviewContext(promptContext);
   }
 
   function buildReviewPrompt(
@@ -476,14 +480,12 @@ export function createReviewRuntime({
     const contextJson = contextJsonForPrompt(context);
     const introductionEvidence =
       item.kind === "pull_request"
-        ? `\n\n## PR Introduction Evidence\n\n\`\`\`json\n${JSON.stringify(
+        ? `\n\n## PR Introduction Evidence\n\n\`\`\`json\n${serializeReviewContext(
             buildPullRequestReviewEvidence({
               ...(runtimeHints.targetDir ? { targetDir: runtimeHints.targetDir } : {}),
               context,
               mainSha: git.mainSha,
             }),
-            null,
-            2,
           )}\n\`\`\`\n`
         : "";
     const schema = reviewDecisionSchemaText();
@@ -501,7 +503,7 @@ export function createReviewRuntime({
 ${additionalPrompt.trim()}
 `
       : "";
-    const text = `${prompt}
+    const text = omitReviewedFixtureReferences(`${prompt}
 
 ## Repository State
 
@@ -534,7 +536,7 @@ Primary-body \`bodyCoverage\` describes separate untrusted excerpts and omitted 
 ${contextJson}
 \`\`\`
 ${extra}
-`;
+`);
     return {
       text,
       telemetry: {

--- a/test/review-command-workflow.test.ts
+++ b/test/review-command-workflow.test.ts
@@ -65,7 +65,7 @@ const reviewedUri = readFileSync("test/action-ledger-runtime.test.ts", "utf8")
     (uri) => digest(uri) === "a728de5dbbef23b8aa5ef2d99060835f4f2fb5a0fa2abb9fe249d08aa09bd09e",
   );
 assert.ok(reviewedUri);
-const fixtureQuote = `Reference \`${reviewedUri}\` and changed \`${reviewedUri}?unreviewed\`.`;
+const fixtureQuote = `Reference [fixture](${reviewedUri}). Changed [fixture](${reviewedUri}?unreviewed).`;
 const safeFixtureQuote = fixtureQuote.replace(
   reviewedUri,
   "[reviewed synthetic URI omitted; inspect test/action-ledger-runtime.test.ts]",

--- a/test/review-command-workflow.test.ts
+++ b/test/review-command-workflow.test.ts
@@ -59,6 +59,18 @@ function digest(value: string): string {
   return createHash("sha256").update(value).digest("hex");
 }
 
+const reviewedUri = readFileSync("test/action-ledger-runtime.test.ts", "utf8")
+  .match(/[A-Za-z][A-Za-z0-9+.-]*:\/\/[^\s"'`]+/g)
+  ?.find(
+    (uri) => digest(uri) === "a728de5dbbef23b8aa5ef2d99060835f4f2fb5a0fa2abb9fe249d08aa09bd09e",
+  );
+assert.ok(reviewedUri);
+const fixtureQuote = `Reference \`${reviewedUri}\` and changed \`${reviewedUri}?unreviewed\`.`;
+const safeFixtureQuote = fixtureQuote.replace(
+  reviewedUri,
+  "[reviewed synthetic URI omitted; inspect test/action-ledger-runtime.test.ts]",
+);
+
 function replaceFrontMatterValue(markdown: string, key: string, value: string): string {
   const line = `${key}: ${value}`;
   const pattern = new RegExp(`^${key}:\\s*.*$`, "m");
@@ -249,7 +261,7 @@ for (const scenario of [
     const currentRecord = structuralRecord(RESERVED_AT, pull);
     const patch = "@@ -1 +1 @@\n-const value = 1;\n+const value = 2; // sensitive-comment-marker";
     const context = {
-      issue: { updatedAt: RESERVED_AT },
+      issue: { updatedAt: RESERVED_AT, body: fixtureQuote },
       sourceRevision: priorRecord.sourceRevision,
       comments: [],
       timeline: [],
@@ -314,7 +326,7 @@ for (const scenario of [
       repo: REPO,
       number: ITEM_NUMBER,
       kind: isPullRequest ? ("pull_request" as const) : ("issue" as const),
-      title: "Scheduled cache proof",
+      title: `Scheduled cache proof. ${fixtureQuote}`,
       url: `https://github.com/${REPO}/issues/${ITEM_NUMBER}`,
       createdAt: "2026-08-01T00:00:00Z",
       updatedAt: PRIOR_ACTIVITY_AT,
@@ -334,6 +346,7 @@ for (const scenario of [
     let structuralFetches = 0;
     let cachedCompletions = 0;
     let checkoutInspectionCalls = 0;
+    let inspectedPrompt = "";
     let reviewTreeAttempts = 0;
     let reviewTreeCleanupCalls = 0;
     let blobMetadataCalls = 0;
@@ -556,6 +569,7 @@ for (const scenario of [
       reviewPolicyHash: () => POLICY,
       runReviewCheckoutInspection: (options) => {
         checkoutInspectionCalls += 1;
+        inspectedPrompt = options.initialPrompt;
         if (refuseScan)
           return runAgentCheckoutInspection({
             cwd: options.openclawDir,
@@ -828,6 +842,13 @@ for (const scenario of [
       assert.ok(structuralFetches >= 2);
       assert.equal(cachedCompletions, 1);
       assert.equal(checkoutInspectionCalls, 1);
+      const inspectedContext = JSON.parse(inspectedPrompt);
+      assert.equal(
+        hydrated ? inspectedContext.issue.body : inspectedContext.title,
+        hydrated ? safeFixtureQuote : `Scheduled cache proof. ${safeFixtureQuote}`,
+      );
+      assert.equal(context.issue.body, fixtureQuote);
+      assert.equal(item.title, `Scheduled cache proof. ${fixtureQuote}`);
       const carriedReportPath = join(artifactDir, `${ITEM_NUMBER}.md`);
       assert.equal(existsSync(carriedReportPath), true);
       const carriedReport = readFileSync(carriedReportPath, "utf8");

--- a/test/review-prompt-context.test.ts
+++ b/test/review-prompt-context.test.ts
@@ -53,13 +53,15 @@ test("GitHub review context omits complete reviewed URI quotations and preserves
     uri + "/changed).",
     uri + ")?new-secret=changed",
     uri + ".)/changed",
+    uri + "'/changed",
+    uri + "'?new-secret=changed",
     uri + "\\changed",
     uri.replace("://", "://changed"),
     "https://docs.example.test/proof",
   ];
   const reference = "[reviewed synthetic URI omitted; inspect test/action-ledger-runtime.test.ts]";
   const quote = (value: string) =>
-    `Backticks \x60${value}\x60; Markdown [fixture](${value}). Sentence ${value}. Wrapped (${value}); [${value}], {${value}}!`;
+    `Backticks \x60${value}\x60; Markdown [fixture](${value}). Sentence ${value}. Wrapped (${value}); [${value}], {${value}}! Quoted '${value}'.`;
   const body = quote(uri);
   const context = {
     issue: { body },

--- a/test/review-prompt-context.test.ts
+++ b/test/review-prompt-context.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 
@@ -34,6 +35,55 @@ import {
   longProofBody,
   scriptSentinel,
 } from "./primary-body-fixture.ts";
+
+test("GitHub review context omits complete reviewed URI quotations and preserves other evidence", () => {
+  const source = readFileSync(new URL("./action-ledger-runtime.test.ts", import.meta.url), "utf8");
+  const uri = [...source.matchAll(/"([^"\n]+)"/g)]
+    .map((match) => match[1]!)
+    .find(
+      (value) =>
+        createHash("sha256").update(value).digest("hex") ===
+        "a728de5dbbef23b8aa5ef2d99060835f4f2fb5a0fa2abb9fe249d08aa09bd09e",
+    );
+  assert.ok(uri, "existing reviewed URI fixture");
+  const controls = [
+    uri + "?new-secret=changed",
+    uri + "/changed",
+    uri + "\\changed",
+    uri.replace("://", "://changed"),
+    "https://docs.example.test/proof",
+  ];
+  const body = "Existing fixture \x60" + uri + "\x60; inspect the test before judging.";
+  const context = {
+    issue: { body },
+    comments: [{ id: 12, body }],
+    timeline: [],
+    pullReviewComments: controls.map((body, id) => ({ id, body })),
+  };
+  const original = JSON.stringify(context);
+  const target = item({ kind: "pull_request", title: body });
+  const prompt = reviewPromptForTest(target, context, git);
+  const jsonText = prompt
+    .split("## GitHub Context\n")[1]!
+    .match(/\x60{3}json\n([\s\S]*?)\n\x60{3}/)![1]!;
+  const rendered = JSON.parse(jsonText);
+  const omitted =
+    "Existing fixture \x60[reviewed synthetic URI omitted; inspect test/action-ledger-runtime.test.ts]\x60; inspect the test before judging.";
+  assert.equal(rendered.issue.body, omitted);
+  assert.equal(rendered.comments[0].body, omitted);
+  assert.ok(prompt.includes("- Title: " + omitted));
+  assert.deepEqual(
+    rendered.pullReviewComments.map(({ body }: { body: string }) => body),
+    controls,
+  );
+  assert.equal(JSON.stringify(context), original);
+  const introduction =
+    prompt.match(/\n\n## PR Introduction Evidence\n[\s\S]*?\n\x60{3}\n/)?.[0] ?? "";
+  assert.equal(
+    reviewPromptTelemetryForTest(target, context, git).contextChars,
+    jsonText.length + introduction.length,
+  );
+});
 
 for (const kind of ["issue", "pull_request"] as const) {
   test(`raw ${kind} body reaches real review JSON with exact bounded late proof coverage`, () => {

--- a/test/review-prompt-context.test.ts
+++ b/test/review-prompt-context.test.ts
@@ -77,7 +77,8 @@ test("GitHub review context omits complete reviewed URI quotations and preserves
   };
   const original = JSON.stringify(context);
   const target = item({ kind: "pull_request", title: body });
-  const prompt = reviewPromptForTest(target, context, git);
+  const additionalPrompt = "Inspect the supplied request: " + body;
+  const prompt = reviewPromptForTest(target, context, git, additionalPrompt);
   const jsonText = prompt
     .split("## GitHub Context\n")[1]!
     .match(/\x60{3}json\n([\s\S]*?)\n\x60{3}/)![1]!;
@@ -91,6 +92,7 @@ test("GitHub review context omits complete reviewed URI quotations and preserves
     controls,
   );
   assert.equal(JSON.stringify(context), original);
+  assert.equal(prompt.split("## Maintainer Request\n\n")[1]?.trim(), additionalPrompt);
   const introduction =
     prompt.match(/\n\n## PR Introduction Evidence\n[\s\S]*?\n\x60{3}\n/)?.[0] ?? "";
   assert.equal(

--- a/test/review-prompt-context.test.ts
+++ b/test/review-prompt-context.test.ts
@@ -49,11 +49,18 @@ test("GitHub review context omits complete reviewed URI quotations and preserves
   const controls = [
     uri + "?new-secret=changed",
     uri + "/changed",
+    uri + "?new-secret=changed).",
+    uri + "/changed).",
+    uri + ")?new-secret=changed",
+    uri + ".)/changed",
     uri + "\\changed",
     uri.replace("://", "://changed"),
     "https://docs.example.test/proof",
   ];
-  const body = "Existing fixture \x60" + uri + "\x60; inspect the test before judging.";
+  const reference = "[reviewed synthetic URI omitted; inspect test/action-ledger-runtime.test.ts]";
+  const quote = (value: string) =>
+    `Backticks \x60${value}\x60; Markdown [fixture](${value}). Sentence ${value}. Wrapped (${value}); [${value}], {${value}}!`;
+  const body = quote(uri);
   const context = {
     issue: { body },
     comments: [{ id: 12, body }],
@@ -67,8 +74,7 @@ test("GitHub review context omits complete reviewed URI quotations and preserves
     .split("## GitHub Context\n")[1]!
     .match(/\x60{3}json\n([\s\S]*?)\n\x60{3}/)![1]!;
   const rendered = JSON.parse(jsonText);
-  const omitted =
-    "Existing fixture \x60[reviewed synthetic URI omitted; inspect test/action-ledger-runtime.test.ts]\x60; inspect the test before judging.";
+  const omitted = quote(reference);
   assert.equal(rendered.issue.body, omitted);
   assert.equal(rendered.comments[0].body, omitted);
   assert.ok(prompt.includes("- Title: " + omitted));

--- a/test/review-prompt-context.test.ts
+++ b/test/review-prompt-context.test.ts
@@ -57,11 +57,17 @@ test("GitHub review context omits complete reviewed URI quotations and preserves
     uri + "'?new-secret=changed",
     uri + "\\changed",
     uri.replace("://", "://changed"),
+    "changed" + uri,
+    "9" + uri,
+    "+" + uri,
+    "-" + uri,
+    "." + uri,
+    "https://docs.example.test/?next=" + uri,
     "https://docs.example.test/proof",
-  ];
+  ].flatMap((value) => [value, `url=${value}`, `source:${value}`]);
   const reference = "[reviewed synthetic URI omitted; inspect test/action-ledger-runtime.test.ts]";
   const quote = (value: string) =>
-    `Backticks \x60${value}\x60; Markdown [fixture](${value}). Sentence ${value}. Wrapped (${value}); [${value}], {${value}}! Quoted '${value}'.`;
+    `Backticks \x60${value}\x60; Markdown [fixture](${value}). Sentence ${value}. Wrapped (${value}); [${value}], {${value}}! Quoted '${value}'. Assigned url=${value}; labelled source:${value}. Pipe|${value}.`;
   const body = quote(uri);
   const context = {
     issue: { body },


### PR DESCRIPTION
Quoting an already reviewed synthetic URI in a PR discussion could stop ClawSweeper before review. This reproduced on [OpenClaw PR 135798](https://github.com/openclaw/openclaw/pull/135798) in [the failed review run](https://github.com/openclaw/clawsweeper/actions/runs/33639350172): prompt material lacked the Git source binding required by native finding classification.

One shared serializer now replaces complete, exact reviewed URI quotations with visible references to their approved source files. Transformation is limited to GitHub-sourced title/context and PR introduction quotations, including cached-context preflights. JSON string values are handled before escaping, and original discussion objects retain their bytes. Raw `additionalPrompt`, maintainer requests and supplied `--body-file` material remain scanner-visible; the assembled prompt is no longer transformed as a whole. Source blobs, patches, schemas and independently staged additional inputs retain their existing admission checks.

Matching consumes the complete scheme and URI. Assignment and label values such as `url=` and `source:` work without a list of prose prefixes; altered schemes, nested URLs, credentials, paths and queries stay intact. Only terminal presentation punctuation may be removed for a second exact digest match, after the full URI is checked. Internal apostrophes remain part of the token. Matching starts at scheme boundaries and trims punctuation backwards to keep work linear on untrusted text.

The final public commit is [801df5eb90cab1c2d78c84c3439622e8b11992ec](https://github.com/openclaw/clawsweeper/commit/801df5eb90cab1c2d78c84c3439622e8b11992ec), with tree `14e86bc6d5ec68e5a942bc530625f8bdddc20953`. Native run `run_a2ad8bcef5be` tested that exact index tree before commit: the worker's checkout HEAD was still `8ae09e334c6ac75f36360c5231971ffca67a2ec0`. All 1,343 captured source entries, modes, Git blob IDs and byte hashes match the later committed tree. The captured source was applied without further changes, then reviewed both before and after commit. This updates the obsolete commit/tree references identified by [the latest review and rank-up moves](https://github.com/openclaw/clawsweeper/pull/1356#issuecomment-5512219720).

Controlled runtime proof used the compiled production renderer and `scanAgentInput`, Node 24.19.0, pnpm 11.10.0 and real pinned TruffleHog 3.97.1 on an isolated Linux worker:

- The four-case raw-input before probe exposed two incorrect admissions: a raw maintainer request and supplied authoritative body lost their URI text before scanning. The context/title and independently staged raw-input controls behaved correctly. The strengthened renderer regression also failed before the repair. Afterward, the same raw request and supplied body remained in the assembled prompt and both received native refusal, exit 79.
- All 26 final native cases matched their expected outcomes: the four raw-input cases above, plus all 22 retained cases. Those 22 include eight exact quotation/value forms admitted, eleven changed-URI forms refused with exit 79, an independently staged raw input refused, the three original public comments admitted as one scenario, and ordinary Markdown links preserved and admitted. The renderer regression also protects altered numeric/symbol scheme prefixes and nested URLs.
- The retained linear-scaling proof measured both plain alphanumeric text and a URI with a long nonterminal punctuation run at 15, 30 and 60 KB. Before the matcher repair, the largest inputs took 3,966 ms and 3,034 ms; quadrupling either input took about 16 times as long. The identical repaired probes took 1.157 ms and 1.231 ms. Every sample preserved its input and every child exited normally. The matcher file is byte-identical in the final commit, so these earlier measurements remain applicable without claiming a new performance run.
- `pnpm run check` passed 4,447 tests with 14 platform skips, zero failures or cancellations, plus all 13 required coverage tests. Formatting matched the planned tree. Source, dependency, index/ref and captured build inventories were verified; temporary HOME absence was independently checked after execution.
- Earlier native controls admitted an exact fixture at its approved source path and refused it at another path or in an introduced raw patch. That source/blob classification policy is unchanged. Independent Codex reviews before and after the final commit reported no actionable P0–P2 findings; both reviews were static and separate from the native runtime proof.

The final runtime result and archive are bound by SHA256 `a98732878fa4192496c4643e0e59e28e61d13db605de650c81d353941e922f83` and `907393b5ff6b6d1f6cb95aae34629b497406794d8066e7e8ef08706495d01c94`. The committed-review report is bound by SHA256 `e1ff55ac57b73ff309c1c923611dfb0fc6ba7de7375d2d3ee8ef645acc64f2a8`.

This proves controlled compiled-runtime/native-scanner behavior, including the original public-comment inputs. The original hosted review remains a post-landing canary. Final-head [CI](https://github.com/openclaw/clawsweeper/actions/runs/33668556086) and [CodeQL](https://github.com/openclaw/clawsweeper/actions/runs/33668554731) passed.

Production +42/-6 (net +36), tests +89/-2 (net +87), documentation +6. The production addition owns one shared quotation serializer and its prompt/preflight wiring. No configuration, schema, dependency or persistence changes. OpenClaw Bay's observer and navigation contracts are unaffected.
