### PR TITLE
fix(review): corroborate reviewed prompt fixtures

### DIFF
--- a/src/agent-input-scan-fixtures.ts
+++ b/src/agent-input-scan-fixtures.ts
@@ -239,6 +239,18 @@ function materialDiagnostic(input: StagedScanInput): ScanMaterialDiagnostic {
   };
 }
 
+function promptLiteralIsDelimited(line: string, index: number, length: number): boolean {
+  const before = line[index - 1];
+  const afterIndex = index + length;
+  const after = line[afterIndex];
+  const beforeIsDelimiter = before === undefined || /[\s"'`([{<,;]/.test(before);
+  const afterIsDelimiter =
+    after === undefined ||
+    /[\s"'`)\]}>;,]/.test(after) ||
+    (after === "\\" && /["'`]/.test(line[afterIndex + 1] ?? ""));
+  return beforeIsDelimiter && afterIsDelimiter;
+}
+
 /** Classify only complete native scans whose every finding matches host fixture policy. */
 export function classifyReviewedFixtureScan(
   status: number,
@@ -293,11 +305,23 @@ export function classifyReviewedFixtureScan(
     return nativeFailure("completion_mismatch");
 
   const literalLines = new Map<string, number>();
+  const approvedBlobFixtures = new Set<string>();
   const classified = new Map<
     string,
     { fixtureSha256: string; source: string; findings: Map<string, ClassifiedFinding> }
   >();
-  for (const [findingIndex, finding] of findings.entries()) {
+  const stagedKind = (finding: Record<string, unknown>): ScanInputOrigin["kind"] | undefined => {
+    const source = object(object(object(finding.SourceMetadata)?.Data)?.Filesystem);
+    return typeof source?.file === "string" ? inputs.get(source.file)?.kind : undefined;
+  };
+  // Validate blob findings first so prompt corroboration is independent of the
+  // scanner's output order. Original indexes remain attached to diagnostics.
+  const orderedFindings = [...findings.entries()].sort(
+    ([leftIndex, left], [rightIndex, right]) =>
+      Number(stagedKind(right) === "blob") - Number(stagedKind(left) === "blob") ||
+      leftIndex - rightIndex,
+  );
+  for (const [findingIndex, finding] of orderedFindings) {
     const source = object(object(object(finding.SourceMetadata)?.Data)?.Filesystem);
     const file = source?.file;
     const staged = typeof file === "string" ? inputs.get(file) : undefined;
@@ -356,14 +380,23 @@ export function classifyReviewedFixtureScan(
     if (!(fixture.decoders ?? ["PLAIN", "HTML"]).some((decoder) => decoder === finding.DecoderName))
       return refuse("finding_not_reviewed");
     if (typeof file !== "string" || scannerLine === null) return refuse("metadata_mismatch");
-    if (staged?.kind !== "blob" || !staged.bytes) return refuse("material_not_reviewed");
-    if (
-      !staged.references.length ||
-      staged.references.some(
-        ({ source, mode }) => mode !== "100644" || !fixture.sources.some((path) => path === source),
+    if (!staged?.bytes || (staged.kind !== "blob" && staged.kind !== "prompt"))
+      return refuse("material_not_reviewed");
+    if (staged.kind === "blob") {
+      if (
+        !staged.references.length ||
+        staged.references.some(
+          ({ source, mode }) =>
+            mode !== "100644" || !fixture.sources.some((path) => path === source),
+        )
       )
-    )
-      return refuse("source_not_reviewed");
+        return refuse("source_not_reviewed");
+    } else if (fixture.lineSha256s !== undefined || !approvedBlobFixtures.has(digest)) {
+      // Prompt text can quote review discussion. Admit only the exact fixture
+      // already established by an approved blob finding in this complete scan.
+      // Fixtures that require a complete source-line witness remain blob-only.
+      return refuse("material_not_reviewed");
+    }
     const uri = new URL(finding.RawV2);
     const parts = object(finding.SecretParts);
     if (
@@ -396,6 +429,11 @@ export function classifyReviewedFixtureScan(
         if (line.includes(finding.RawV2)) {
           let occurrence = line.indexOf(finding.RawV2);
           while (occurrence !== -1) {
+            if (
+              staged.kind === "prompt" &&
+              !promptLiteralIsDelimited(line, occurrence, finding.RawV2.length)
+            )
+              return refuse("literal_mismatch");
             literalOccurrences++;
             occurrence = line.indexOf(finding.RawV2, occurrence + finding.RawV2.length);
           }
@@ -417,6 +455,9 @@ export function classifyReviewedFixtureScan(
         return refuse("literal_mismatch");
       literalLines.set(valueKey, literalLine);
     }
+    if (staged.kind === "prompt") continue;
+    if (staged.kind !== "blob") return refuse("material_not_reviewed");
+    approvedBlobFixtures.add(digest);
     const blob = basename(file);
     const key = `${blob}:${scannerLine}:${finding.DecoderName}`;
     const sources = new Set(staged.references.map(({ source }) => source));

--- a/src/agent-input-scan.ts
+++ b/src/agent-input-scan.ts
@@ -271,7 +271,7 @@ export function scanAgentInput(options: {
       inputs.set(join(inputDir, name), {
         ...origin,
         id: name,
-        ...(origin.kind === "blob" ? { bytes } : {}),
+        ...(origin.kind === "blob" || origin.kind === "prompt" ? { bytes } : {}),
       });
     };
     stage(Buffer.from(options.prompt), { kind: "prompt" }, "prompt");

--- a/test/agent-input-scan.test.ts
+++ b/test/agent-input-scan.test.ts
@@ -553,6 +553,8 @@ const browserMcpSource = "extensions/browser/src/browser/chrome-mcp.test.ts";
 const macDashboardSource = "apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift";
 const mattermostSource = "extensions/mattermost/src/mattermost/slash-http.test.ts";
 const ledgerFixtureSha256 = "a728de5dbbef23b8aa5ef2d99060835f4f2fb5a0fa2abb9fe249d08aa09bd09e";
+const browserCdpRelayLineSha256 =
+  "89bc2aa05769a4016fb19125143188f20b91807aa5c47918133a119b5a91d341";
 const nativeContractFailures = new Map([
   ["missing completion", "incomplete_scan"],
   ["detector error", "scan_error"],
@@ -579,6 +581,7 @@ for (const scenarioName of [
   "browser docs fixture",
   "browser page URL fixture",
   "browser CDP relay fixture",
+  "browser CDP relay line-bound prompt refusal",
   "browser CDP relay shifted HTML without companion",
   "browser CDP encoded fixture",
   "browser CDP encoded HTML fixture",
@@ -650,7 +653,10 @@ for (const scenarioName of [
   "other file",
   "many source references",
   "untrusted finding metadata",
-  "prompt",
+  "prompt with reviewed blob",
+  "prompt first with reviewed blob",
+  "prompt with reviewed blob query suffix",
+  "prompt only",
   "schema",
   "additional",
   "diff",
@@ -820,7 +826,14 @@ for (const scenarioName of [
       }
     }
     const findingValues = [uri, raw, ...(otherReviewedUri ? [otherReviewedUri] : [])];
-    const f = fixture(t, scenario === "prompt" ? uri : undefined);
+    const f = fixture(
+      t,
+      scenario.includes("prompt")
+        ? scenario.endsWith("query suffix")
+          ? `${uri}?unreviewed-query=1`
+          : uri
+        : undefined,
+    );
     let files =
       scenario === "many source references"
         ? Array.from({ length: 8 }, (_, index) => `unapproved-${index}.test.ts`)
@@ -900,6 +913,13 @@ for (const scenarioName of [
       : undefined;
     const reviewedFixtureLine =
       reviewedMacDashboardLine ?? reviewedBrowserLine ?? reviewedMattermostLine;
+    if (scenario === "browser CDP relay line-bound prompt refusal") {
+      assert.equal(
+        createHash("sha256").update(reviewedFixtureLine!).digest("hex"),
+        browserCdpRelayLineSha256,
+        "the corroborating blob retains its approved complete-line witness",
+      );
+    }
     const contents =
       "// context\n".repeat(literalLine - 2) +
       (reviewedFixtureLine ?? JSON.stringify(otherReviewedUri ?? value)) +
@@ -985,8 +1005,8 @@ const parsed = new URL(uri);
 const blobs = inputs.filter(({name}) => /^[a-f0-9]{40}$/.test(name));
 assert.equal(blobs.length, ${modeOnly ? 1 : 2});
 let findings = inputs.filter(({name, bytes}) =>
-  (/^[a-f0-9]{40}$/.test(name) && (scenario !== 'diff' || bytes.includes(uri))) ||
-  (scenario === 'prompt' && name === 'prompt') ||
+  (/^[a-f0-9]{40}$/.test(name) && scenario !== 'prompt only' && (scenario !== 'diff' || bytes.includes(uri))) ||
+  (scenario.includes('prompt') && name === 'prompt') ||
   (scenario === 'schema' && name === 'schema') ||
   (scenario === 'additional' && name === '0') ||
   (scenario === 'diff' && /^\d+$/.test(name) && bytes.includes(uri)) ||
@@ -1015,6 +1035,7 @@ if (scenario.includes('shifted HTML')) {
 if (scenario === 'shifted PLAIN') for (const finding of findings) finding.SourceMetadata.Data.Filesystem.line++;
 if (scenario === 'PLAIN duplicate') findings.push({...findings[0]});
 if (scenario === 'HTML duplicate') findings.push({...findings[0], DecoderName: 'HTML'});
+if (scenario === 'prompt first with reviewed blob') findings.unshift(findings.pop());
 if (scenario === 'changed raw') findings[0].Raw += 'changed';
 if (scenario === 'changed full URI') findings[0].RawV2 += '/changed';
 if (scenario === 'changed matching raw values') findings[0].Raw = findings[0].RawV2 = uri + '/changed';
@@ -1100,6 +1121,8 @@ process.exit(scenario === 'unexpected successful output' ? 0 : 183);
         "shifted PLAIN",
         "PLAIN duplicate",
         "HTML duplicate",
+        "prompt with reviewed blob",
+        "prompt first with reviewed blob",
         "repeated regular snapshot OID",
       ].includes(scenario)
     ) {
@@ -1216,6 +1239,10 @@ process.exit(scenario === 'unexpected successful output' ? 0 : 183);
                     : "literal_not_reviewed",
               );
             }
+            if (scenario === "browser CDP relay line-bound prompt refusal")
+              assert.equal(diagnostic.reason, "material_not_reviewed");
+            if (scenario === "prompt with reviewed blob query suffix")
+              assert.equal(diagnostic.reason, "literal_mismatch");
             assert.ok(diagnostic.findingCount > diagnostic.findingIndex);
             if (scenario === "untrusted finding metadata") {
               assert.equal(diagnostic.detectorType, null);
@@ -1224,7 +1251,7 @@ process.exit(scenario === 'unexpected successful output' ? 0 : 183);
               assert.equal(diagnostic.material, undefined);
             }
             const kind = new Map([
-              ["prompt", "prompt"],
+              ["prompt only", "prompt"],
               ["schema", "schema"],
               ["additional", "additional"],
               ["diff", "patch"],


### PR DESCRIPTION
## Summary

- Admit an approved fixture quoted in the review prompt only when the same exact fixture is independently corroborated by an approved committed blob in the complete scanner result.
- Keep prompt-only, modified, query/path-suffixed, line-bound, source-incompatible, and otherwise unreviewed findings fail-closed.
- Make classification independent of scanner finding order and avoid duplicate audit notices for the prompt copy.

## Problem

The blob-side `literal_not_reviewed` failure reported in ClawSweeper issue 1350 was addressed by pull request 1351, but OpenClaw pull request 135798 still failed before Codex ran. The remaining finding was the same approved fixture quoted later in the assembled review prompt. Treating every prompt finding as unreviewed rejected a complete scan that already contained and validated the exact approved committed-blob witness.

This change fixes that second boundary without allowlisting test paths, downgrading scanner findings, or bypassing scanning.

## Implementation

- Retain prompt bytes for strict fixture classification.
- Validate blob findings before prompt findings while retaining original diagnostic indexes.
- Record a fixture as approved only after its blob origin, source, digest, decoder, literal, and any complete-line witnesses pass existing validation.
- Admit a prompt copy only when its exact fixture digest is already approved by a blob in the same scan, the literal is present exactly, and its boundaries are safe.
- Keep fixtures with `lineSha256s` blob-only because a prompt excerpt cannot prove the approved complete source line.

## Validation

- `pnpm run build`
- Focused scanner scenarios in Docker-backed Crabbox local-container: 8/8 passed.
- `codex review --uncommitted`: first pass identified a query/path suffix ambiguity; fixed with explicit delimiter validation and a regression test. Final dirty review: clean.
- `codex review --base origin/main`: clean at head `9c88dbbda9857fff0a4e5c7ce61b6dbdf9065235` against base `56ccb516ab9d24031ed69bf4449b9916d2153367`.
- `pnpm run review -- --local-range --target-repo openclaw/clawsweeper --base origin/main`: `decision=keep_open`, `confidence=high`.
- `pnpm run review -- --local-only --item-number 135798`: exited 0; the scanner accepted the approved prompt/blob pair and Codex completed the review.

Hosted CI passed on head `9c88dbbda9857fff0a4e5c7ce61b6dbdf9065235`, including `pnpm check`, CodeQL, Windows launcher, and sparse-build smoke checks.

The first hosted exact review of this PR ([run 33653038950](https://github.com/openclaw/clawsweeper/actions/runs/33653038950)) used current-main scanner source `56ccb516ab9d24031ed69bf4449b9916d2153367` and refused before Codex on one HTML-decoded prompt finding with `material_not_reviewed`, exit 79, `retryable: false`. The sanitized diagnostic does not establish which prompt source introduced the finding.

A subsequent managed re-review completed at `2026-09-02T16:20:00.347Z` on the unchanged code head and found no actionable defects, with `proof: sufficient` and `status: ready for maintainer look`. That review used a body from which the source links had temporarily been removed. The full source links are now restored, so that verdict is stale for the current body under the contribution policy. No scanner bypass or retry-reset commit is part of this PR. Maintainer scanner/security disposition is requested before further hosted retries; this record does not claim final full-context readiness.

The broad Linux check passed formatting, build, lint, and the changed scanner surface. Its full-suite phase reproduced the same 59 unrelated workflow/comment-sync failures on both this branch and a clean current-main control (4,387 pass, 59 fail, 14 skip), so those failures are baseline noise rather than a regression from this patch.

## Real Behavior Proof

**Claim:** a fixture copied into the review prompt no longer blocks Codex when—and only when—the complete scan independently validates the exact fixture from an approved committed blob.

**Exercised surface:** the production `scanAgentInput` staging and reviewed-fixture classifier, plus a local replay of the affected OpenClaw PR review.

**Scenario / fixture:**

1. approved prompt copy + approved blob witness → accepted
2. prompt finding emitted before blob finding → accepted
3. prompt copy with a query suffix → refused (`literal_mismatch`)
4. prompt-only fixture → refused (`material_not_reviewed`)
5. line-bound fixture copied into prompt → refused (`material_not_reviewed`)
6. existing reviewed fixture → accepted
7. schema mismatch → refused
8. additional unreviewed material → refused

**Command / environment:** Docker-backed Crabbox `local-container`, image `node:24-bookworm`, lease `cbx_1c2acb8172d9`, run `run_197ec11afb26`, exact head `9c88dbbda9857fff0a4e5c7ce61b6dbdf9065235`.

**Observed result:** all 8 focused scenarios passed. A local-only replay of `openclaw/openclaw#135798` then cleared the input scanner and reached a completed Codex review instead of terminating with `AgentInputScanError`.

**Artifacts / trace:** focused Crabbox timing/result metadata from `run_197ec11afb26`; local replay report `artifacts/local-review-135798/135798.md`; broad branch/control runs `run_96dc2105189d` and `run_9ca8c9a7394c`.

**Limits:** the affected-PR replay was local-only and did not publish or mutate GitHub. Hosted queue/publisher behavior is unchanged; this patch is limited to the pre-Codex scanner classification boundary.

## Risks / rollout

The classifier remains fail-closed. Approval cannot originate from prompt text: it requires an independently validated blob finding in the same complete scan. Line-bound fixtures remain ineligible for prompt corroboration, and any mixed or unreviewed finding still refuses the entire scan.

No queue, lease, publisher, dashboard, or merge-gate behavior changes.

## Related work

- Source report: https://github.com/openclaw/clawsweeper/issues/1350, reported by @SunnyShu0925
- Affected change: https://github.com/openclaw/openclaw/pull/135798 by @SunnyShu0925
