### PR TITLE
fix(fanout): preflight canonical coverage identities

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -3680,12 +3680,12 @@ jobs:
           hydrate-state-blobs: "false"
 
       - uses: actions/setup-node@v6
-        if: ${{ github.event.schedule != '37 */6 * * *' }}
+        if: ${{ github.event.schedule == '41/10 * * * *' }}
         with:
           node-version: 24
 
       - name: Prepare canonical coverage identities
-        if: ${{ github.event.schedule != '37 */6 * * *' }}
+        if: ${{ github.event.schedule == '41/10 * * * *' }}
         env:
           CLAWSWEEPER_RECORDS_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           CLAWSWEEPER_RECORDS_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -3671,12 +3671,25 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/setup-state
+        if: ${{ github.event.schedule == '37 */6 * * *' }}
         with:
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           hydrate-git-state: "false"
           hydrate-state-blobs: "false"
+
+      - uses: actions/setup-node@v6
+        if: ${{ github.event.schedule != '37 */6 * * *' }}
+        with:
+          node-version: 24
+
+      - name: Prepare canonical coverage identities
+        if: ${{ github.event.schedule != '37 */6 * * *' }}
+        env:
+          CLAWSWEEPER_RECORDS_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          CLAWSWEEPER_RECORDS_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+        run: node scripts/prepare-worker-coverage-manifest.ts
 
       - uses: ./.github/actions/setup-pnpm
         with:
@@ -3723,6 +3736,7 @@ jobs:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           FANOUT_MODE: ${{ github.event.schedule == '41/10 * * * *' && 'normal-review' || (github.event.schedule == '37 */6 * * *' && 'audit' || 'hot-intake') }}
           FANOUT_LIMIT: ${{ github.event.schedule == '41/10 * * * *' && '12' || (github.event.schedule == '37 */6 * * *' && '12' || '20') }}
+          COVERAGE_MANIFEST: ${{ github.event.schedule == '37 */6 * * *' && '.artifacts/worker-records-manifest.json' || '.artifacts/worker-coverage-manifest.json' }}
           REVIEW_COVERAGE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
         run: |
           set -euo pipefail
@@ -3733,7 +3747,7 @@ jobs:
             --workflow sweep.yml \
             --ref main \
             --cursor-store-url "$REVIEW_COVERAGE_URL" \
-            --coverage-tracked-items-manifest .artifacts/worker-records-manifest.json \
+            --coverage-tracked-items-manifest "$COVERAGE_MANIFEST" \
             --publish-url "$REVIEW_COVERAGE_URL"
 
       - name: Summarize trailing weekly review coverage

--- a/scripts/prepare-worker-coverage-manifest.ts
+++ b/scripts/prepare-worker-coverage-manifest.ts
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+import { mkdirSync, mkdtempSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { WORKER_RECORDS_MANIFEST_SCHEMA_VERSION } from "../src/review-coverage-manifest.ts";
+import { discoverWorkerRecordRepoSlugs, fetchWorkerCanonicalItemIds } from "./worker-records.ts";
+
+// A coverage-only artifact: this does not materialize or certify a records tree.
+export async function prepareWorkerCoverageManifest(options: {
+  worktreeRoot: string;
+  baseUrl: string;
+  webhookSecret: string;
+  fetch?: typeof globalThis.fetch;
+}) {
+  const artifactRoot = path.join(options.worktreeRoot, ".artifacts");
+  const manifestPath = path.join(artifactRoot, "worker-coverage-manifest.json");
+  mkdirSync(artifactRoot, { recursive: true });
+  // A failed refresh must not leave a previous manifest available to consumers.
+  rmSync(manifestPath, { force: true });
+  const slugs = await discoverWorkerRecordRepoSlugs(options);
+  if (!slugs.length || new Set(slugs.map((entry) => entry.repoSlug)).size !== slugs.length) {
+    throw new Error("Canonical coverage requires a nonempty, unique repository listing");
+  }
+  const repositories: Record<string, { coverageTrackedItemIds: number[] }> = {};
+  for (const { repoSlug } of slugs) {
+    repositories[repoSlug] = {
+      coverageTrackedItemIds: await fetchWorkerCanonicalItemIds({ ...options, repoSlug }),
+    };
+  }
+  const stagingRoot = mkdtempSync(path.join(artifactRoot, ".worker-coverage-"));
+  try {
+    const stagedPath = path.join(stagingRoot, "manifest.json");
+    writeFileSync(
+      stagedPath,
+      `${JSON.stringify({ schemaVersion: WORKER_RECORDS_MANIFEST_SCHEMA_VERSION, source: "worker", purpose: "coverage-identities", repositories })}\n`,
+      "utf8",
+    );
+    renameSync(stagedPath, manifestPath);
+  } finally {
+    rmSync(stagingRoot, { recursive: true, force: true });
+  }
+  return { manifestPath, repositoryCount: slugs.length };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  try {
+    const result = await prepareWorkerCoverageManifest({
+      worktreeRoot: process.cwd(),
+      baseUrl: process.env.CLAWSWEEPER_RECORDS_URL ?? "https://clawsweeper.openclaw.ai",
+      webhookSecret:
+        process.env.CLAWSWEEPER_RECORDS_SECRET ?? process.env.CLAWSWEEPER_WEBHOOK_SECRET ?? "",
+    });
+    console.log(`[worker-coverage] complete repositories=${result.repositoryCount}`);
+  } catch {
+    // Request diagnostics are allowlisted by the read client; do not print remote bodies.
+    console.error("[worker-coverage] canonical identity preflight failed; refusing fanout");
+    process.exitCode = 1;
+  }
+}

--- a/scripts/worker-records.ts
+++ b/scripts/worker-records.ts
@@ -694,17 +694,19 @@ export async function fetchWorkerCanonicalItemIds(options: {
           Array.isArray(candidate.records)
         ) {
           const pageIds: number[] = [];
+          let previousId = cursor;
           for (const record of candidate.records) {
-            const itemId = Number((record as { id?: unknown } | null)?.id);
+            const itemId = (record as { id?: unknown } | null)?.id;
             if (
+              typeof itemId !== "number" ||
               !Number.isSafeInteger(itemId) ||
-              itemId <= cursor ||
-              seen.has(itemId) ||
-              pageIds.includes(itemId)
+              itemId <= previousId ||
+              seen.has(itemId)
             ) {
               return false;
             }
             pageIds.push(itemId);
+            previousId = itemId;
           }
           return (
             candidate.nextCursor === null ||
@@ -878,6 +880,16 @@ async function fetchWorkerSnapshotChunk(options: {
   fetch?: typeof globalThis.fetch;
 }) {
   const expectedRange = `bytes ${options.offset}-${options.offset + options.length - 1}/${options.snapshot.bytes}`;
+  const startedAt = Date.now();
+  const diagnosticOptions = {
+    path: "/internal/state/records/snapshots/chunk",
+    body: {
+      repoSlug: options.snapshot.repoSlug,
+      revisionWatermark: options.snapshot.revisionWatermark,
+      offset: options.offset,
+      length: options.length,
+    },
+  };
   for (let attempt = 1; ; attempt += 1) {
     let response: Response;
     try {
@@ -898,6 +910,13 @@ async function fetchWorkerSnapshotChunk(options: {
         1,
       );
     } catch (error) {
+      recordReadDiagnostic(
+        diagnosticOptions,
+        attempt,
+        startedAt,
+        error instanceof RetryableSignedRequestError ? "transport" : "configuration",
+        error instanceof RetryableSignedRequestError && attempt < SIGNED_REQUEST_MAX_ATTEMPTS,
+      );
       if (!(error instanceof RetryableSignedRequestError)) throw error;
       if (attempt >= SIGNED_REQUEST_MAX_ATTEMPTS) throw error.cause;
       await signedRequestBackoff(attempt, WORKER_RECORD_READ_RETRY_DELAYS_MS);
@@ -905,6 +924,14 @@ async function fetchWorkerSnapshotChunk(options: {
     }
 
     if (!response.ok) {
+      recordReadDiagnostic(
+        diagnosticOptions,
+        attempt,
+        startedAt,
+        "http_error",
+        response.status >= 500 && attempt < SIGNED_REQUEST_MAX_ATTEMPTS,
+        response.status,
+      );
       const bodyText = await response.text().catch(() => "");
       if (response.status >= 500 && attempt < SIGNED_REQUEST_MAX_ATTEMPTS) {
         await signedRequestBackoff(attempt, WORKER_RECORD_READ_RETRY_DELAYS_MS);
@@ -933,6 +960,14 @@ async function fetchWorkerSnapshotChunk(options: {
     }
 
     if (protocolError === undefined && bytes !== undefined) return bytes;
+    recordReadDiagnostic(
+      diagnosticOptions,
+      attempt,
+      startedAt,
+      "invalid_response",
+      attempt < SIGNED_REQUEST_MAX_ATTEMPTS,
+      response.status,
+    );
     await response.body?.cancel().catch(() => {});
     if (attempt >= SIGNED_REQUEST_MAX_ATTEMPTS) throw protocolError;
     await signedRequestBackoff(attempt, WORKER_RECORD_READ_RETRY_DELAYS_MS);
@@ -999,6 +1034,58 @@ function signedWorkerRecordReadPost<T>(options: SignedPostOptions): Promise<T> {
   );
 }
 
+function recordReadDiagnostic(
+  options: { path: string; body?: unknown },
+  attempt: number,
+  startedAt: number,
+  category: "transport" | "configuration" | "http_error" | "invalid_response",
+  retry: boolean,
+  status?: number,
+) {
+  const endpoints: Record<string, string> = {
+    "/internal/state/records/slugs": "records_slugs",
+    "/internal/state/records/list": "records_list",
+    "/internal/state/records/export": "records_export",
+    "/internal/state/records/snapshots/latest": "snapshots_latest",
+    "/internal/state/records/snapshots/chunk": "snapshots_chunk",
+  };
+  const item =
+    /^\/internal\/state\/records\/([a-z0-9-]+)\/(?:items|closed|plans|decision-packets)\/[1-9]\d*$/.exec(
+      options.path,
+    );
+  const endpoint = endpoints[options.path] ?? (item ? "records_item" : undefined);
+  if (!endpoint) return;
+  const body =
+    options.body !== null && typeof options.body === "object"
+      ? (options.body as Record<string, unknown>)
+      : {};
+  const repoSlug = body.repoSlug ?? item?.[1];
+  const coordinates: Record<string, string | number> = {};
+  if (typeof repoSlug === "string" && repoSlug.length <= 200 && isRepoSlug(repoSlug)) {
+    coordinates.repoSlug = repoSlug;
+  }
+  for (const key of ["cursor", "sinceRevision", "revisionWatermark", "offset", "length"] as const) {
+    const value = body[key];
+    if (typeof value === "number" && Number.isSafeInteger(value) && value >= 0) {
+      coordinates[key] = value;
+    }
+  }
+  // At most three events per read; never include remote text, URLs or credentials.
+  console.error(
+    `[worker-record-read] ${JSON.stringify({
+      event: retry ? "retry" : "failure",
+      endpoint,
+      ...coordinates,
+      attempt,
+      maxAttempts: SIGNED_REQUEST_MAX_ATTEMPTS,
+      elapsedMs: Math.max(0, Date.now() - startedAt),
+      category,
+      ...(status === undefined ? {} : { status }),
+      delayMs: retry ? WORKER_RECORD_READ_RETRY_DELAYS_MS[attempt - 1] : 0,
+    })}`,
+  );
+}
+
 export async function signedPost<T>(options: SignedPostOptions): Promise<T> {
   return signedPostWithRetryMode<T>(options, false);
 }
@@ -1007,6 +1094,7 @@ async function signedPostWithRetryMode<T>(
   options: SignedPostOptions,
   unifiedAttemptBudget: boolean,
 ): Promise<T> {
+  const startedAt = Date.now();
   for (let attempt = 1; ; attempt += 1) {
     let response: Response;
     try {
@@ -1014,6 +1102,15 @@ async function signedPostWithRetryMode<T>(
         ? await signedRequestWithMaxAttempts(options, 1)
         : await signedRequest(options);
     } catch (error) {
+      if (unifiedAttemptBudget) {
+        recordReadDiagnostic(
+          options,
+          attempt,
+          startedAt,
+          error instanceof RetryableSignedRequestError ? "transport" : "configuration",
+          error instanceof RetryableSignedRequestError && attempt < SIGNED_REQUEST_MAX_ATTEMPTS,
+        );
+      }
       if (!(error instanceof RetryableSignedRequestError) || !unifiedAttemptBudget) throw error;
       if (attempt >= SIGNED_REQUEST_MAX_ATTEMPTS) throw error.cause;
       await signedRequestBackoff(attempt, options.retryDelaysMs);
@@ -1023,6 +1120,16 @@ async function signedPostWithRetryMode<T>(
     // later clone() of a consumed response throws, masking the real failure.
     const bodyText = await response.text().catch(() => "");
     if (!response.ok) {
+      if (unifiedAttemptBudget) {
+        recordReadDiagnostic(
+          options,
+          attempt,
+          startedAt,
+          "http_error",
+          response.status >= 500 && attempt < SIGNED_REQUEST_MAX_ATTEMPTS,
+          response.status,
+        );
+      }
       if (unifiedAttemptBudget && response.status >= 500 && attempt < SIGNED_REQUEST_MAX_ATTEMPTS) {
         await signedRequestBackoff(attempt, options.retryDelaysMs);
         continue;
@@ -1045,6 +1152,16 @@ async function signedPostWithRetryMode<T>(
       value === null ||
       (options.validateResponse !== undefined && !options.validateResponse(value))
     ) {
+      if (unifiedAttemptBudget) {
+        recordReadDiagnostic(
+          options,
+          attempt,
+          startedAt,
+          "invalid_response",
+          attempt < SIGNED_REQUEST_MAX_ATTEMPTS,
+          response.status,
+        );
+      }
       if (attempt < SIGNED_REQUEST_MAX_ATTEMPTS) {
         await signedRequestBackoff(attempt, options.retryDelaysMs);
         continue;
@@ -1065,6 +1182,7 @@ async function signedGet<T>(options: {
   webhookSecret: string;
   fetch?: typeof globalThis.fetch;
 }): Promise<T> {
+  const startedAt = Date.now();
   for (let attempt = 1; ; attempt += 1) {
     let response: Response;
     try {
@@ -1078,6 +1196,13 @@ async function signedGet<T>(options: {
         1,
       );
     } catch (error) {
+      recordReadDiagnostic(
+        options,
+        attempt,
+        startedAt,
+        error instanceof RetryableSignedRequestError ? "transport" : "configuration",
+        error instanceof RetryableSignedRequestError && attempt < SIGNED_REQUEST_MAX_ATTEMPTS,
+      );
       if (!(error instanceof RetryableSignedRequestError)) throw error;
       if (attempt >= SIGNED_REQUEST_MAX_ATTEMPTS) throw error.cause;
       await signedRequestBackoff(attempt, WORKER_RECORD_READ_RETRY_DELAYS_MS);
@@ -1085,6 +1210,14 @@ async function signedGet<T>(options: {
     }
     const bodyText = await response.text().catch(() => "");
     if (!response.ok) {
+      recordReadDiagnostic(
+        options,
+        attempt,
+        startedAt,
+        "http_error",
+        response.status >= 500 && attempt < SIGNED_REQUEST_MAX_ATTEMPTS,
+        response.status,
+      );
       if (response.status >= 500 && attempt < SIGNED_REQUEST_MAX_ATTEMPTS) {
         await signedRequestBackoff(attempt, WORKER_RECORD_READ_RETRY_DELAYS_MS);
         continue;
@@ -1110,6 +1243,14 @@ async function signedGet<T>(options: {
       !Number.isSafeInteger(envelope.revision) ||
       Number(envelope.revision) < 1
     ) {
+      recordReadDiagnostic(
+        options,
+        attempt,
+        startedAt,
+        "invalid_response",
+        attempt < SIGNED_REQUEST_MAX_ATTEMPTS,
+        response.status,
+      );
       if (attempt < SIGNED_REQUEST_MAX_ATTEMPTS) {
         await signedRequestBackoff(attempt, WORKER_RECORD_READ_RETRY_DELAYS_MS);
         continue;

--- a/test/repair/fanout-hydration-routing.test.ts
+++ b/test/repair/fanout-hydration-routing.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 import { parse } from "yaml";
 
-test("only non-audit fanout uses the identities preflight; audit and downstream retain hydration", () => {
+test("only normal-review fanout uses identities; hot intake skips preflight and audit retains hydration", () => {
   const workflow = parse(readFileSync(".github/workflows/sweep.yml", "utf8"));
   const fanout = workflow.jobs["target-fanout"];
   const full = fanout.steps.find(
@@ -16,7 +16,17 @@ test("only non-audit fanout uses the identities preflight; audit and downstream 
     (step: { name?: string }) => step.name === "Dispatch selected targets",
   );
   assert.equal(full.if, "${{ github.event.schedule == '37 */6 * * *' }}");
-  assert.equal(identity.if, "${{ github.event.schedule != '37 */6 * * *' }}");
+  assert.equal(identity.if, "${{ github.event.schedule == '41/10 * * * *' }}");
+  const nodeSetup = fanout.steps.find(
+    (step: { uses?: string }) => step.uses === "actions/setup-node@v6",
+  );
+  assert.equal(nodeSetup.if, identity.if);
+  for (const schedule of ["41/10 * * * *", "4/20 * * * *", "37 */6 * * *"]) {
+    const matches = (condition: string) =>
+      condition === "${{ github.event.schedule == '" + schedule + "' }}";
+    assert.equal(matches(identity.if), schedule === "41/10 * * * *");
+    assert.equal(matches(full.if), schedule === "37 */6 * * *");
+  }
   assert.equal(identity.run, "node scripts/prepare-worker-coverage-manifest.ts");
   assert.equal(identity["continue-on-error"], undefined);
   assert.equal(dispatch.if, undefined); // ordinary success() dependency, not always()

--- a/test/repair/fanout-hydration-routing.test.ts
+++ b/test/repair/fanout-hydration-routing.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { parse } from "yaml";
+
+test("only non-audit fanout uses the identities preflight; audit and downstream retain hydration", () => {
+  const workflow = parse(readFileSync(".github/workflows/sweep.yml", "utf8"));
+  const fanout = workflow.jobs["target-fanout"];
+  const full = fanout.steps.find(
+    (step: { uses?: string }) => step.uses === "./.github/actions/setup-state",
+  );
+  const identity = fanout.steps.find(
+    (step: { name?: string }) => step.name === "Prepare canonical coverage identities",
+  );
+  const dispatch = fanout.steps.find(
+    (step: { name?: string }) => step.name === "Dispatch selected targets",
+  );
+  assert.equal(full.if, "${{ github.event.schedule == '37 */6 * * *' }}");
+  assert.equal(identity.if, "${{ github.event.schedule != '37 */6 * * *' }}");
+  assert.equal(identity.run, "node scripts/prepare-worker-coverage-manifest.ts");
+  assert.equal(identity["continue-on-error"], undefined);
+  assert.equal(dispatch.if, undefined); // ordinary success() dependency, not always()
+  assert.ok(fanout.steps.indexOf(identity) < fanout.steps.indexOf(dispatch));
+  assert.equal(fanout["timeout-minutes"], 30);
+  assert.equal(full.with["hydrate-git-state"], "false");
+  assert.equal(full.with["hydrate-state-blobs"], "false");
+  assert.equal(
+    dispatch.env.COVERAGE_MANIFEST,
+    "${{ github.event.schedule == '37 */6 * * *' && '.artifacts/worker-records-manifest.json' || '.artifacts/worker-coverage-manifest.json' }}",
+  );
+  assert.match(dispatch.run, /--coverage-tracked-items-manifest "\$COVERAGE_MANIFEST"/);
+  const otherHydrations = Object.entries(workflow.jobs).flatMap(([name, job]) =>
+    name === "target-fanout"
+      ? []
+      : ((job as { steps?: Array<{ uses?: string; name?: string }> }).steps ?? []).filter((step) =>
+          step.uses?.endsWith("/.github/actions/setup-state"),
+        ),
+  );
+  assert.ok(otherHydrations.length >= 5);
+  assert.ok(otherHydrations.every((step) => step.name !== "Prepare canonical coverage identities"));
+});

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -6154,8 +6154,9 @@ test("target fanout uses the canonical cursor store without a git publisher", ()
   assert.match(fanoutBlock, /--cursor-store-url "\$REVIEW_COVERAGE_URL"/);
   assert.match(
     fanoutBlock,
-    /--coverage-tracked-items-manifest \.artifacts\/worker-records-manifest\.json/,
+    /COVERAGE_MANIFEST: \$\{\{ github\.event\.schedule == '37 \*\/6 \* \* \*' && '\.artifacts\/worker-records-manifest\.json' \|\| '\.artifacts\/worker-coverage-manifest\.json' \}\}/,
   );
+  assert.match(fanoutBlock, /--coverage-tracked-items-manifest "\$COVERAGE_MANIFEST"/);
   assert.doesNotMatch(fanoutBlock, /Create state token/);
   assert.doesNotMatch(fanoutBlock, /repair:publish-main/);
   assert.doesNotMatch(fanoutBlock, /results\/target-fanout-cursors/);

--- a/test/worker-coverage-manifest.test.ts
+++ b/test/worker-coverage-manifest.test.ts
@@ -1,0 +1,301 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createHash, createHmac } from "node:crypto";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import test, { type TestContext } from "node:test";
+
+import { prepareWorkerCoverageManifest } from "../scripts/prepare-worker-coverage-manifest.ts";
+import { materializeWorkerRecords } from "../scripts/worker-records.ts";
+import { coverageTrackedCountsFromManifest } from "../src/review-coverage-manifest.ts";
+
+const secret = "coverage-fixture-secret";
+const slugs = ["fixture-empty", "fixture-large", "fixture-small"];
+const identities = new Map(
+  slugs.map((slug, index) => [
+    slug,
+    index === 1 ? Array.from({ length: 501 }, (_, i) => i + 1) : index === 2 ? [7, 9] : [],
+  ]),
+);
+
+function temporaryRoot(t: TestContext) {
+  const root = mkdtempSync(join(tmpdir(), "worker-coverage-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  return root;
+}
+
+async function fixture(t: TestContext, options: { full?: boolean; failSlug?: string } = {}) {
+  const requests: Array<{ endpoint: string; repoSlug?: string; cursor?: number }> = [];
+  const server = createServer(async (request, response) => {
+    const chunks: Buffer[] = [];
+    for await (const chunk of request) chunks.push(Buffer.from(chunk));
+    const text = Buffer.concat(chunks).toString("utf8");
+    assert.equal(request.method, "POST");
+    assert.equal(
+      request.headers["x-clawsweeper-exact-review-signature"],
+      "sha256=" + createHmac("sha256", secret).update(text).digest("hex"),
+    );
+    const body = JSON.parse(text);
+    const endpoint = request.url ?? "";
+    requests.push({ endpoint, repoSlug: body.repoSlug, cursor: body.cursor });
+    const send = (status: number, value: unknown) => {
+      response.writeHead(status, { "content-type": "application/json" });
+      response.end(JSON.stringify(value));
+    };
+    if (endpoint.endsWith("/slugs")) {
+      send(200, { repositories: slugs.map((repoSlug) => ({ repoSlug, revision: 1 })) });
+    } else if (endpoint.endsWith("/list")) {
+      assert.equal(body.section, "items");
+      assert.equal(body.limit, 500);
+      if (body.repoSlug === options.failSlug) {
+        send(403, { error: "BODY_SENTINEL_DO_NOT_LOG" });
+      } else {
+        const ids = (identities.get(body.repoSlug) ?? [])
+          .filter((id) => id > body.cursor)
+          .slice(0, 500);
+        send(200, {
+          repoSlug: body.repoSlug,
+          section: "items",
+          records: ids.map((id) => ({ id })),
+          nextCursor: ids.length === 500 ? ids.at(-1) : null,
+        });
+      }
+    } else if (options.full && endpoint.endsWith("/snapshots/latest")) {
+      send(404, { error: "snapshot_not_found" });
+    } else if (options.full && endpoint.endsWith("/export")) {
+      const records = [
+        ...(identities.get(body.repoSlug) ?? []).map((id) => ({
+          section: "items",
+          id: String(id),
+          content: "fixture",
+          digest: createHash("sha256").update("fixture").digest("hex"),
+          revision: 1,
+          storeRevision: id,
+          deleted: false,
+        })),
+        {
+          section: "closed",
+          id: "800",
+          content: "closed",
+          digest: createHash("sha256").update("closed").digest("hex"),
+          revision: 1,
+          storeRevision: 800,
+          deleted: false,
+        },
+        {
+          section: "items",
+          id: "900",
+          content: null,
+          digest: null,
+          revision: 1,
+          storeRevision: 900,
+          deleted: true,
+        },
+      ];
+      const page = records
+        .filter((record) => record.storeRevision > body.cursor)
+        .slice(0, body.limit);
+      send(200, {
+        repoSlug: body.repoSlug,
+        revision: 1000,
+        records: page,
+        nextCursor: page.length === body.limit ? page.at(-1)?.storeRevision : null,
+      });
+    } else {
+      send(403, { error: "UNEXPECTED_SNAPSHOT_OR_EXPORT" });
+    }
+  });
+  await new Promise<void>((done) => server.listen(0, "127.0.0.1", done));
+  t.after(() => new Promise<void>((done) => server.close(() => done())));
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  return { baseUrl: "http://127.0.0.1:" + address.port, webhookSecret: secret, requests };
+}
+
+function runCli(root: string, baseUrl: string) {
+  const child = spawn(process.execPath, [resolve("scripts/prepare-worker-coverage-manifest.ts")], {
+    cwd: root,
+    env: {
+      PATH: process.env.PATH,
+      SystemRoot: process.env.SystemRoot,
+      CLAWSWEEPER_RECORDS_URL: baseUrl,
+      CLAWSWEEPER_RECORDS_SECRET: secret,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (chunk) => {
+    stdout += String(chunk);
+  });
+  child.stderr.on("data", (chunk) => {
+    stderr += String(chunk);
+  });
+  return new Promise<{ code: number | null; stdout: string; stderr: string }>((done, reject) => {
+    child.on("error", reject);
+    child.on("close", (code) => done({ code, stdout, stderr }));
+  });
+}
+
+test("coverage CLI uses signed paginated identities without snapshot/export or record writes", async (t) => {
+  const root = temporaryRoot(t);
+  const service = await fixture(t);
+  const result = await runCli(root, service.baseUrl);
+  assert.equal(result.code, 0, result.stderr);
+  const manifestPath = join(root, ".artifacts", "worker-coverage-manifest.json");
+  assert.deepEqual(
+    [...coverageTrackedCountsFromManifest(manifestPath)],
+    [
+      ["fixture-empty", 0],
+      ["fixture-large", 501],
+      ["fixture-small", 2],
+    ],
+  );
+  assert.equal(JSON.parse(readFileSync(manifestPath, "utf8")).purpose, "coverage-identities");
+  assert.equal(existsSync(join(root, "records")), false);
+  assert.equal(existsSync(join(root, ".artifacts", "worker-records-manifest.json")), false);
+  assert.deepEqual(
+    service.requests.map((request) => [request.endpoint.split("/").at(-1), request.cursor]),
+    [
+      ["slugs", undefined],
+      ["list", 0],
+      ["list", 0],
+      ["list", 500],
+      ["list", 0],
+    ],
+  );
+});
+
+test("identities preflight matches full cold hydration coverage without closed/deleted records", async (t) => {
+  t.mock.method(console, "error", () => {});
+  const service = await fixture(t, { full: true });
+  const full = await materializeWorkerRecords({
+    ...service,
+    worktreeRoot: temporaryRoot(t),
+    repoSlugs: slugs,
+  });
+  const identity = await prepareWorkerCoverageManifest({
+    ...service,
+    worktreeRoot: temporaryRoot(t),
+  });
+  assert.deepEqual(
+    [...coverageTrackedCountsFromManifest(identity.manifestPath)],
+    [...coverageTrackedCountsFromManifest(full.manifestPath)],
+  );
+  const { reviewPlanningRepositories, planReviewFanout } =
+    await import("../dist/repair/target-fanout.js");
+  const repositories = slugs.map((slug) => ({
+    targetRepo: slug.replace("-", "/"),
+    defaultBranch: "main",
+    visibility: "PUBLIC",
+  }));
+  const openCounts = new Map(
+    repositories.map((repo, index) => [
+      repo.targetRepo,
+      { issues: index * 260, pullRequests: index },
+    ]),
+  );
+  const plan = (manifest: string) =>
+    planReviewFanout(
+      reviewPlanningRepositories({
+        repositories,
+        openCounts,
+        coverageTrackedCounts: coverageTrackedCountsFromManifest(manifest),
+        recordsRoot: join(temporaryRoot(t), "absent-records"),
+      }),
+      { limit: 2, cursor: 1, candidateCapacity: 51 },
+    );
+  assert.deepEqual(plan(identity.manifestPath), plan(full.manifestPath));
+});
+
+test("late CLI failure removes stale output without publishing partial identities or remote text", async (t) => {
+  const root = temporaryRoot(t);
+  mkdirSync(join(root, ".artifacts"));
+  const output = join(root, ".artifacts", "worker-coverage-manifest.json");
+  writeFileSync(output, "stale manifest");
+  const service = await fixture(t, { failSlug: "fixture-small" });
+  const result = await runCli(root, service.baseUrl);
+  assert.equal(result.code, 1);
+  assert.equal(existsSync(output), false);
+  assert.equal(existsSync(join(root, "records")), false);
+  assert.match(result.stderr, /"endpoint":"records_list"/);
+  assert.match(result.stderr, /"repoSlug":"fixture-small"/);
+  assert.match(result.stderr, /"status":403/);
+  assert.doesNotMatch(result.stderr, /BODY_SENTINEL|coverage-fixture-secret|https?:/);
+  assert.equal(
+    service.requests.filter((request) => request.repoSlug === "fixture-small").length,
+    1,
+  );
+});
+
+test("empty or duplicate discovery refuses coverage", async (t) => {
+  for (const repositories of [
+    [],
+    [
+      { repoSlug: "fixture-empty", revision: 1 },
+      { repoSlug: "fixture-empty", revision: 1 },
+    ],
+  ]) {
+    const root = temporaryRoot(t);
+    await assert.rejects(
+      prepareWorkerCoverageManifest({
+        worktreeRoot: root,
+        baseUrl: "http://127.0.0.1:1",
+        webhookSecret: secret,
+        fetch: async () => Response.json({ repositories }),
+      }),
+      /nonempty, unique/,
+    );
+    assert.equal(existsSync(join(root, ".artifacts", "worker-coverage-manifest.json")), false);
+  }
+});
+
+test("persistent late read failure exhausts existing delays without exposing an artifact", async (t) => {
+  const root = temporaryRoot(t);
+  const delays: number[] = [];
+  const original = globalThis.setTimeout;
+  t.mock.method(globalThis, "setTimeout", ((callback: () => void, delay: number) => {
+    delays.push(delay);
+    queueMicrotask(callback);
+    return 0 as unknown as ReturnType<typeof original>;
+  }) as typeof setTimeout);
+  t.mock.method(console, "error", () => {});
+  let lateRequests = 0;
+  await assert.rejects(
+    prepareWorkerCoverageManifest({
+      worktreeRoot: root,
+      baseUrl: "http://127.0.0.1:1",
+      webhookSecret: secret,
+      fetch: async (input, init) => {
+        if (String(input).endsWith("/slugs"))
+          return Response.json({
+            repositories: [
+              { repoSlug: "fixture-first", revision: 1 },
+              { repoSlug: "fixture-last", revision: 1 },
+            ],
+          });
+        const body = JSON.parse(String(init?.body));
+        if (body.repoSlug === "fixture-first") {
+          assert.equal(
+            existsSync(join(root, ".artifacts", "worker-coverage-manifest.json")),
+            false,
+          );
+          return Response.json({
+            repoSlug: body.repoSlug,
+            section: "items",
+            records: [{ id: 1 }],
+            nextCursor: null,
+          });
+        }
+        lateRequests++;
+        return Response.json({ error: "exact_review_queue_unavailable" }, { status: 500 });
+      },
+    }),
+    /exact_review_queue_unavailable/,
+  );
+  assert.equal(lateRequests, 3);
+  assert.deepEqual(delays, [30_000, 60_000]);
+  assert.equal(existsSync(join(root, ".artifacts", "worker-coverage-manifest.json")), false);
+});

--- a/test/worker-records-request.test.ts
+++ b/test/worker-records-request.test.ts
@@ -567,3 +567,96 @@ test("fetchWorkerCanonicalItemIds pages the exact coverage identity set", async 
     [0, 500],
   );
 });
+
+test("canonical identity pagination refuses reordered, duplicate, string and nonadvancing rows", async (t) => {
+  const delays = captureRetryDelays(t);
+  t.mock.method(console, "error", () => {});
+  for (const [records, nextCursor] of [
+    [[{ id: 2 }, { id: 1 }], 1],
+    [[{ id: 1 }, { id: 1 }], 1],
+    [[{ id: "1" }], null],
+    [[{ id: 1 }], 0],
+    [[], 1],
+  ]) {
+    const { calls, fetchImpl } = fetchStub(
+      Array.from({ length: 3 }, () =>
+        jsonResponse(200, { repoSlug: "openclaw-openclaw", section: "items", records, nextCursor }),
+      ),
+    );
+    await assert.rejects(
+      fetchWorkerCanonicalItemIds({
+        baseUrl,
+        webhookSecret,
+        repoSlug: "openclaw-openclaw",
+        fetch: fetchImpl,
+      }),
+      /invalid_json_body/,
+    );
+    assert.equal(calls.length, 3);
+  }
+  assert.deepEqual(delays, Array.from({ length: 5 }, () => [30_000, 60_000]).flat());
+});
+
+test("record diagnostics allow only bounded metadata and preserve final failure identity", async (t) => {
+  const delays = captureRetryDelays(t);
+  const messages: string[] = [];
+  t.mock.method(console, "error", (message: string) => {
+    messages.push(message);
+  });
+  const { fetchImpl } = fetchStub([
+    new Error("SECRET_NETWORK_SENTINEL"),
+    jsonResponse(500, { error: "SECRET_BODY_SENTINEL", objectKey: "SECRET_OBJECT_SENTINEL" }),
+    jsonResponse(500, { error: "exact_review_queue_unavailable" }),
+  ]);
+  await assert.rejects(
+    exportWorkerRecords({
+      baseUrl,
+      webhookSecret: "SECRET_AUTH_SENTINEL",
+      repoSlug: "openclaw-openclaw",
+      sinceRevision: 19,
+      fetch: fetchImpl,
+    }),
+    (error: Error & { code?: string }) =>
+      error.name === "WorkerRecordRequestError" && error.code === "exact_review_queue_unavailable",
+  );
+  assert.deepEqual(delays, [30_000, 60_000]);
+  assert.equal(messages.length, 3);
+  assert.ok(messages.every((message) => message.length < 600));
+  assert.doesNotMatch(messages.join(""), /SECRET_|https?:|objectKey|signature|bodySnippet/);
+  const events = messages.map((message) =>
+    JSON.parse(message.slice("[worker-record-read] ".length)),
+  );
+  assert.deepEqual(
+    events.map(({ event, attempt, category, delayMs }) => ({ event, attempt, category, delayMs })),
+    [
+      { event: "retry", attempt: 1, category: "transport", delayMs: 30_000 },
+      { event: "retry", attempt: 2, category: "http_error", delayMs: 60_000 },
+      { event: "failure", attempt: 3, category: "http_error", delayMs: 0 },
+    ],
+  );
+  for (const event of events) {
+    assert.equal(event.endpoint, "records_export");
+    assert.equal(event.repoSlug, "openclaw-openclaw");
+    assert.equal(event.cursor, 0);
+    assert.equal(event.sinceRevision, 19);
+    assert.equal(event.maxAttempts, 3);
+    assert.ok(Number.isSafeInteger(event.elapsedMs) && event.elapsedMs >= 0);
+  }
+});
+
+test("ordinary signed POST callers do not emit canonical read diagnostics", async (t) => {
+  captureRetryDelays(t);
+  const messages: string[] = [];
+  t.mock.method(console, "error", (message: string) => {
+    messages.push(message);
+  });
+  const { fetchImpl } = fetchStub([jsonResponse(500, {}), jsonResponse(200, {})]);
+  await signedPost({
+    baseUrl,
+    webhookSecret,
+    path: "/internal/state/records/export",
+    body: { repoSlug: "openclaw-openclaw" },
+    fetch: fetchImpl,
+  });
+  assert.deepEqual(messages, []);
+});


### PR DESCRIPTION
## Summary

- Prepare normal-review fanout from complete canonical item identities instead of downloading every repository's record snapshots and export journal; hot-intake keeps its existing live GitHub open-count planning without a canonical record preflight.
- Keep full setup-state hydration for audit fanout and every downstream review/apply job.
- Add bounded, allowlisted canonical-read retry/failure context without changing the existing three-attempt, 30-second/60-second, fail-closed policy.

## Problem

Scheduled fanout still encounters sanitized `exact_review_queue_unavailable` failures after the bounded record-export repair and canonical-read retry repair. The full record-content hydration is an unnecessary availability dependency for non-audit target selection: its coverage input is canonical item identities, not report content. Audit remains content-dependent.

The incident is not isolated to one deterministic repository/export failure. Observed failures include both snapshot-latest and export reads; comparable scheduled runs completed all repositories. The underlying Worker/Durable Object exception is not visible in the permitted evidence. This PR removes the unnecessary heavy-read dependency; it does not claim to repair or identify the hidden server exception.

Related: https://github.com/openclaw/clawsweeper/pull/1299 and https://github.com/openclaw/clawsweeper/pull/1340 (CSW-147).

## Implementation

The new `scripts/prepare-worker-coverage-manifest.ts` discovers canonical repository slugs and pages the existing signed item-list endpoint. It rejects empty/duplicate discovery and malformed, duplicate, reordered, or nonadvancing identity pages. All repository reads must succeed before the coverage-only artifact is atomically published. A failed refresh removes any stale coverage artifact and exits nonzero; the workflow's ordinary success dependency prevents fanout.

The separate `.artifacts/worker-coverage-manifest.json` uses the existing coverage-reader fields with `purpose: coverage-identities`. It neither writes a records tree nor claims one was hydrated. Only the normal-review schedule runs its preflight. Hot-intake does not consume the manifest and does not run this preflight; its existing live GitHub open-count planning is unchanged. The audit schedule still uses `.artifacts/worker-records-manifest.json` from setup-state. No downstream hydration call is replaced, and no partial/skip fallback is introduced.

Canonical read diagnostics contain only a fixed endpoint category, validated bounded repository slug, allowlisted numeric pagination/range coordinates, attempt/count, elapsed time, fixed error category, HTTP status, and retry delay. They contain no response body, exception text/stack, URL, credential, or snapshot object key. There are at most three failure/retry events per logical read. Generic signed POST behavior is unchanged.

## Real Behavior Proof

**Claim:** normal-review fanout can obtain the same canonical coverage identities and planner result without snapshots/exports or a materialized records tree, and incomplete required canonical reads remain fail-closed. Hot-intake bypasses this unused preflight without changing its planning; audit and downstream jobs retain hydration.

**Surface and scenario:** executed the real Node CLI as a child process against an HMAC-verifying loopback HTTP server. The fixture contains three repositories (empty, 501 identities requiring pagination, and two identities); closed records and a tombstone are present in the full cold-hydration comparison. The comparison invokes the existing materializer and compiled `reviewPlanningRepositories`/`planReviewFanout` functions. A late 403 exercises the CLI's refusal and stale-artifact removal. Focused deterministic failure fixtures cover mixed transient/protocol failures, persistent 500, invalid pagination, and diagnostic redaction.

**Observed result:** the CLI requests only slug discovery and item-list pages, produces counts `0/501/2`, matches full hydration's coverage and planner output, and writes no records tree/full-hydration manifest. Late failure exits 1 with no stale/partial coverage output and no sentinel body/secret in diagnostics. Retry exhaustion preserves three attempts with delays `[30000, 60000]` and no successful artifact. Workflow assertions retain audit and downstream hydration and success-only dispatch dependency.

**Exact revision/environment:** head `1ec0149ed24394b10b1277715b9349643cd67834`, base `ff071968ca4e3fa62c364f9642e10a03c2fda025`, tree `4a2fc810faaa0fbc5eb8e3873bcaf30b1ef79691`. Docker-backed Crabbox `provider=local-container`, image `node:24-bookworm`, Node 24.20.0. Run `run_29b8782c071a`, lease `cbx_7b06d470525c`: exit 0; build:all, 66 focused cases plus 3 workflow-contract cases, isolated terminal-fixture recheck, and CI-pinned actionlint 1.7.12 passed. The clean unpublished commit was supplied as a local Git bundle and checked out with canonical LF content/executable modes; the output confirmed the exact head above. Captured author-retained artifacts: `csw-147-narrow-recheck-2.stdout.log` / `csw-147-narrow-recheck-2.stderr.log`, ending `CSW_147_PROOF_COMPLETE`.

**Reproduction commands:**

```sh
pnpm install --frozen-lockfile
pnpm run build:all
node --test test/worker-coverage-manifest.test.ts test/worker-records-request.test.ts test/review-coverage-manifest.test.ts test/repair/fanout-hydration-routing.test.ts test/repair/target-fanout.test.ts test/repair/focused-state-hydration.test.ts
node --test --test-name-pattern 'target fanout uses|scheduled reviews feed' test/sweep-workflow.test.ts
pnpm run check
```

**Artifact/trace:** the executable fixture and assertions are committed in `test/worker-coverage-manifest.test.ts`, the retry/redaction assertions in `test/worker-records-request.test.ts`, and routing assertions in `test/repair/fanout-hydration-routing.test.ts` / `test/sweep-workflow.test.ts`. The author retains captured Crabbox stdout/stderr; run IDs and sanitized outcome are recorded here once final proof completes.

**Limits:** this is a controlled local HTTP boundary, not live Cloudflare or GitHub dispatch. Retry delay values are asserted with a deterministic timer; the proof does not wait 90 wall-clock seconds per failing fixture. It does not prove production capacity, reproduce the hidden DO exception, or establish cross-repository transactional consistency. No production credentials or data are used. Metadata reads can still fail and must still block fanout. Audit and downstream content hydration retain their existing availability dependency and aggregate timeout risk.

## Validation and review

- `git diff --check`: passed.
- `codex review --uncommitted`: first pass found an obsolete literal-manifest workflow assertion; accepted and repaired. Focused proof rerun; second dirty review clean.
- The accepted hot-intake narrowing passed 29 affected tests, another `codex review --uncommitted`, and a fresh `codex review --base ff071968ca4e3fa62c364f9642e10a03c2fda025`: clean; no actionable findings. No code changes after this review.
- Actionlint 1.7.12, same pinned archive/checksum and invocation as CI: passed for all workflows.
- Final-head `pnpm run check`, Crabbox `run_0fe9728b1e49` / `cbx_43d7ce98c1a9`: static checks, formatting, all builds, lint and focused coverage (13 tests) passed. The full suite completed 4,492 tests: 4,477 pass, 14 skip, 1 failure. The sole failure was the unchanged `terminal proof stays pinned to its original pane after another window is selected` cleanup assertion at `test/live-proof-review-environment.test.ts:1180` (`Missing expected exception`, expected `ESRCH`). That isolated test passed unchanged on recheck in `run_29b8782c071a`. The terminal implementation/test have no diff from base; no terminal-code change, retry-policy change, or test bypass was made. This local full-suite invocation is not reported as green.
- Historical supporting result: before the two-condition hot-intake narrowing, head `d86a72d40f5310336f067cc73e50263cf4f83f50` passed full `pnpm run check` in Crabbox `run_63936eac8637` / `cbx_2a3afa16572e` (4,478 pass, 14 skip, 0 fail), and all hosted CI passed. This is not substituted for final-head hosted CI.
- Initial broad check had 59 prerequisite failures in the minimal image. Installing `jq` and `tmux` and enabling pnpm on the standard sanitized child PATH **inside the disposable container only** resolved them. No product/test bypass or repository prerequisite-policy change was made.
- Final-head hosted CI: pending after this push; required before readiness handoff.

Initial raw Windows-to-Linux sync introduced CRLF-only formatting noise in untouched files. Linux proof uses a fresh worktree from canonical Git blobs, applying only the task delta with Git's Windows line-ending normalization and preserving Git executable modes. No repository-wide line-ending/platform policy or unrelated files were changed. Hosted Bash contracts are validated in Linux, not ported to native Windows.

### ClawSweeper finding disposition — accepted with maintainer approval

The 2026-09-02 20:44:46 UTC review of this head accepted real-behavior proof as sufficient and requested skipping the identity preflight for hot-intake. The underlying observation is correct: hot-intake selects from live GitHub open counts and does not consume the coverage manifest. Restricting this preflight to normal-review would remove an unnecessary dependency for hot-intake.

Historical context: this was not a newly introduced canonical-read gate. On the base revision, both scheduled modes ran full setup-state, whose `materializeWorkerRecords` already calls `fetchWorkerCanonicalItemIds` after each snapshot/export. The initial revision retained that gate in both modes. The maintainer has now expressly approved removing the unused preflight from hot-intake. The follow-up restricts both dedicated Node setup and identity preparation to the normal-review schedule, with assertions for all three schedules. Audit and every downstream review/apply hydration stay unchanged; there is no new partial/skip fallback. This addresses the actionable dependency/routing concern without claiming the old dependency was introduced by this PR. Both applicable Rank-up moves are included: normal-only routing and refreshed proof/review.

## Risks / rollout

Repository-side workflow/client scope only. No Worker/DO, auth, queue, publication, retry-delay, concurrency, timeout, or public API/schema changes. No live rerun/dispatch/cancel or production diagnostic settings were changed. This workflow-file change requires the usual GitHub workflow-scoped push capability. Merge/deploy is not authorized by this task.

OpenClaw Bay is unaffected: this changes internal preparation and operator failure context, not public schemas, display, links, or controls. No Bay code/proof update is needed.

Release-note context: normal-review avoids unnecessary full record downloads; hot-intake avoids an unused canonical-record preflight. Failed required canonical identity reads still stop normal-review selection; operational logs identify the failing read category and bounded coordinates.
