### PR TITLE
fix(repair): time out hung crabfleet action-session fetches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ checkpoint, and status-only commits are intentionally omitted.
 - Retain numeric queue failure source locations inside the Durable Object before remote transport discards the original stack, without logging private error text.
 - Bound shared repair GitHub CLI calls with native process deadlines and honor per-call timeout settings. Thanks @SebTardif.
 - Bound standalone webhook GitHub requests to 15 seconds, including response bodies, so stalled calls return a retryable response. Thanks @SebTardif.
+- Bound CrabFleet action-session register and work-state update fetches to 15 seconds so a hung CrabFleet host cannot stall a GitHub Actions repair job. Thanks @SebTardif.
 - Kept leading report metadata authoritative through ordinary and fenced body quotes across review, repair intake, workflow selection, and decision packets; shared structural parsing rejects competing records and duplicate packet keys while preserving legacy promotion guards. Thanks @dwin-gharibi for the original report and proposed fix in [#1137](https://github.com/openclaw/clawsweeper/pull/1137).
 
 - Completed obsolete exact-review publications when apply verifies a strictly newer durable review for the same revision, preserving retry behavior for unproven results. Thanks @vincentkoc. (#1249)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,6 @@ checkpoint, and status-only commits are intentionally omitted.
 - Retain numeric queue failure source locations inside the Durable Object before remote transport discards the original stack, without logging private error text.
 - Bound shared repair GitHub CLI calls with native process deadlines and honor per-call timeout settings. Thanks @SebTardif.
 - Bound standalone webhook GitHub requests to 15 seconds, including response bodies, so stalled calls return a retryable response. Thanks @SebTardif.
-- Bound CrabFleet action-session register and work-state update fetches to 15 seconds so a hung CrabFleet host cannot stall a GitHub Actions repair job. Thanks @SebTardif.
 - Kept leading report metadata authoritative through ordinary and fenced body quotes across review, repair intake, workflow selection, and decision packets; shared structural parsing rejects competing records and duplicate packet keys while preserving legacy promotion guards. Thanks @dwin-gharibi for the original report and proposed fix in [#1137](https://github.com/openclaw/clawsweeper/pull/1137).
 
 - Completed obsolete exact-review publications when apply verifies a strictly newer durable review for the same revision, preserving retry behavior for unproven results. Thanks @vincentkoc. (#1249)

--- a/docs/steerable-repair-automation.md
+++ b/docs/steerable-repair-automation.md
@@ -320,7 +320,9 @@ Three identities are related but intentionally distinct:
 3. **CrabFleet action session**: one logical interactive session keyed by
    `<repo>:<cluster-id>`.
 
-A new Action attempt registers the same work key with CrabFleet. CrabFleet:
+A new Action attempt registers the same work key with CrabFleet. Register
+and work-state update fetches use a 15-second `AbortSignal` deadline so a
+hung CrabFleet host cannot stall the Action job. CrabFleet:
 
 - returns the existing logical session when one exists;
 - rotates the session-scoped agent token;

--- a/src/repair/action-session.ts
+++ b/src/repair/action-session.ts
@@ -54,6 +54,8 @@ export function actionRunUrl(env: NodeJS.ProcessEnv = process.env): string {
   return repository && runId ? `${server}/${repository}/actions/runs/${runId}` : "";
 }
 
+export const ACTION_SESSION_FETCH_TIMEOUT_MS = 15_000;
+
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
   const command = args._[0];
@@ -75,7 +77,7 @@ async function main(): Promise<void> {
   );
 }
 
-async function registerActionSession(jobPath: string): Promise<void> {
+export async function registerActionSession(jobPath: string): Promise<void> {
   if (!jobPath) throw new Error("action-session register requires a job path");
   const serviceToken = requiredEnv("CLAWSWEEPER_CRABFLEET_SERVICE_TOKEN");
   const baseUrl = String(
@@ -89,6 +91,7 @@ async function registerActionSession(jobPath: string): Promise<void> {
       authorization: `Bearer ${serviceToken}`,
       "content-type": "application/json",
     },
+    signal: AbortSignal.timeout(ACTION_SESSION_FETCH_TIMEOUT_MS),
     body: JSON.stringify({
       workKey: actionWorkKey(job.frontmatter),
       workKind: actionWorkKind(job.frontmatter),
@@ -156,7 +159,7 @@ async function registerActionSession(jobPath: string): Promise<void> {
   console.log(`CrabFleet action session: ${browserUrl}`);
 }
 
-async function updateActionSession({
+export async function updateActionSession({
   state,
   phase,
   summary,
@@ -175,6 +178,7 @@ async function updateActionSession({
       authorization: `Bearer ${token}`,
       "content-type": "application/json",
     },
+    signal: AbortSignal.timeout(ACTION_SESSION_FETCH_TIMEOUT_MS),
     body: JSON.stringify({
       state,
       phase,

--- a/test/repair/action-session.test.ts
+++ b/test/repair/action-session.test.ts
@@ -1,12 +1,19 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
 import {
+  ACTION_SESSION_FETCH_TIMEOUT_MS,
   actionRunUrl,
   actionSessionOwner,
   actionSourceUrl,
   actionWorkKey,
   actionWorkKind,
+  registerActionSession,
+  updateActionSession,
 } from "../../dist/repair/action-session.js";
 
 test("action session classifies issue implementation and PR repair work", () => {
@@ -56,3 +63,119 @@ test("action session prefers the full source URL from the job body", () => {
     "https://github.com/openclaw/openclaw/issues/123",
   );
 });
+
+test(
+  "action session register and update abort hung CrabFleet fetches",
+  { timeout: 3_000 },
+  async (t) => {
+    const previousTimeout = AbortSignal.timeout;
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-action-session-"));
+    const jobPath = path.join(tmp, "job.md");
+    const envPath = path.join(tmp, "github.env");
+    const metadataPath = path.join(tmp, "action-session.json");
+    fs.writeFileSync(
+      jobPath,
+      `---
+repo: openclaw/openclaw
+cluster_id: repair-pr-openclaw-openclaw-1
+target_branch: main
+job_intent: pr_repair
+---
+Source issue: https://github.com/openclaw/openclaw/issues/1
+`,
+    );
+    fs.writeFileSync(envPath, "");
+
+    const previousEnv = {
+      CLAWSWEEPER_CRABFLEET_SERVICE_TOKEN: process.env.CLAWSWEEPER_CRABFLEET_SERVICE_TOKEN,
+      CLAWSWEEPER_CRABFLEET_URL: process.env.CLAWSWEEPER_CRABFLEET_URL,
+      CLAWSWEEPER_CRABFLEET_OWNER: process.env.CLAWSWEEPER_CRABFLEET_OWNER,
+      CLAWSWEEPER_CRABFLEET_WORK_STATE_URL: process.env.CLAWSWEEPER_CRABFLEET_WORK_STATE_URL,
+      CLAWSWEEPER_CRABFLEET_AGENT_TOKEN: process.env.CLAWSWEEPER_CRABFLEET_AGENT_TOKEN,
+      CLAWSWEEPER_ACTION_SESSION_METADATA: process.env.CLAWSWEEPER_ACTION_SESSION_METADATA,
+      GITHUB_ENV: process.env.GITHUB_ENV,
+    };
+    t.after(() => {
+      AbortSignal.timeout = previousTimeout;
+      restoreEnv(
+        "CLAWSWEEPER_CRABFLEET_SERVICE_TOKEN",
+        previousEnv.CLAWSWEEPER_CRABFLEET_SERVICE_TOKEN,
+      );
+      restoreEnv("CLAWSWEEPER_CRABFLEET_URL", previousEnv.CLAWSWEEPER_CRABFLEET_URL);
+      restoreEnv("CLAWSWEEPER_CRABFLEET_OWNER", previousEnv.CLAWSWEEPER_CRABFLEET_OWNER);
+      restoreEnv(
+        "CLAWSWEEPER_CRABFLEET_WORK_STATE_URL",
+        previousEnv.CLAWSWEEPER_CRABFLEET_WORK_STATE_URL,
+      );
+      restoreEnv(
+        "CLAWSWEEPER_CRABFLEET_AGENT_TOKEN",
+        previousEnv.CLAWSWEEPER_CRABFLEET_AGENT_TOKEN,
+      );
+      restoreEnv(
+        "CLAWSWEEPER_ACTION_SESSION_METADATA",
+        previousEnv.CLAWSWEEPER_ACTION_SESSION_METADATA,
+      );
+      restoreEnv("GITHUB_ENV", previousEnv.GITHUB_ENV);
+      fs.rmSync(tmp, { recursive: true, force: true });
+    });
+
+    const server = http.createServer((_request, _response) => {});
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    t.after(
+      () =>
+        new Promise<void>((resolve) => {
+          server.closeAllConnections();
+          server.close(() => resolve());
+        }),
+    );
+    const address = server.address();
+    assert.ok(address && typeof address !== "string");
+    const origin = `http://127.0.0.1:${address.port}`;
+
+    const seenTimeouts: number[] = [];
+    t.mock.method(AbortSignal, "timeout", (ms: number) => {
+      seenTimeouts.push(ms);
+      return previousTimeout(50);
+    });
+
+    process.env.CLAWSWEEPER_CRABFLEET_SERVICE_TOKEN = "service-token";
+    process.env.CLAWSWEEPER_CRABFLEET_URL = origin;
+    process.env.CLAWSWEEPER_CRABFLEET_OWNER = "@steipete";
+    process.env.CLAWSWEEPER_ACTION_SESSION_METADATA = metadataPath;
+    process.env.GITHUB_ENV = envPath;
+    process.env.CLAWSWEEPER_CRABFLEET_WORK_STATE_URL = `${origin}/work-state`;
+    process.env.CLAWSWEEPER_CRABFLEET_AGENT_TOKEN = "agent-token";
+
+    await assert.rejects(
+      () => registerActionSession(jobPath),
+      (error: unknown) => {
+        assert.ok(error instanceof Error);
+        assert.match(error.name, /AbortError|TimeoutError/);
+        return true;
+      },
+    );
+    await assert.rejects(
+      () =>
+        updateActionSession({
+          state: "running",
+          phase: "planning",
+          summary: "Planning",
+          completionReason: "",
+        }),
+      (error: unknown) => {
+        assert.ok(error instanceof Error);
+        assert.match(error.name, /AbortError|TimeoutError/);
+        return true;
+      },
+    );
+    assert.deepEqual(seenTimeouts, [
+      ACTION_SESSION_FETCH_TIMEOUT_MS,
+      ACTION_SESSION_FETCH_TIMEOUT_MS,
+    ]);
+  },
+);
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where GitHub Actions repair jobs could remain occupied by a stalled CrabFleet action-session request. Registration runs before planning/execution, and work-state updates publish later progress and completion; a server that accepted the request without responding could hold either step for a prolonged period.

## Why This Change Was Made

Both request owners now use the same native 15-second `AbortSignal.timeout` deadline. It cancels stalled requests and response-body reads through the CLI's existing error path, which exits with code 1. The implementation stays at the two fetch sites and adds no retry layer.

The missing application deadlines were already present when [the action-session client was introduced on June 13](https://github.com/openclaw/clawsweeper/commit/86d0ca37755b3b476a32f6b510a439ce1fa73eea). The raw-parent diff against `5abcd35eb422c1da671dc2719591c4311548b75b` adds both calls without a signal. The later [owner-configuration fix](https://github.com/openclaw/clawsweeper/commit/bfb82a96da0e034a55081e4779c011457142d451) changes owner handling. [PR 1346](https://github.com/openclaw/clawsweeper/pull/1346) does not change this file against its raw parent and did not introduce this problem.

## User Impact

A stalled CrabFleet request now releases the Action step after about 15 seconds. Successful registration and work-state updates retain their existing payloads, session metadata, and credentials handling. The deadline applies per request.

**Maintainer decision:** accept this deadline, including failure of an otherwise valid response that takes longer than 15 seconds. The controlled native Node 24 transport proof below is sufficient for this narrowly scoped request-owner change; it exercises cancellation and successful behavior through the actual compiled CLI.

## OpenClaw Bay Impact

Bay is unaffected. These calls belong to the GitHub Actions CrabFleet session client; Bay remains an observer of status and does not register or update these sessions.

## Documentation Impact

Updated the active [steerable repair architecture note](https://github.com/openclaw/clawsweeper/blob/34fa122e355fec8d7d7b2a7921e94dbca186ee67/docs/steerable-repair-automation.md) with the registration/work-state deadline. Its source of truth remains the two request owners in `src/repair/action-session.ts`; changing their deadline or session contract requires updating that note. Release-note context is retained in this PR description.

## Evidence

Both repair builds and all five focused action-session tests passed on Node 24.20.0. The pre-commit and committed-branch managed Codex reviews returned P0 `scoped-clean`. Full `pnpm check` and the required CI checks on final head `34fa122e355fec8d7d7b2a7921e94dbca186ee67` remain landing gates, together with a ClawSweeper review for the current head and body.

## Real Behavior Proof

**Claim and environment:** the actual compiled `dist/repair/action-session.js` cancels stalled HTTP transport at the native 15-second deadline while preserving successful registration and update behavior. Eight cases ran concurrently on macOS arm64, Node 24.20.0, using independent ephemeral IPv4 loopback HTTP servers. The successful run completed at `2026-09-02T21:28:03.764Z`.

**Source identity:** baseline `ff071968ca4e3fa62c364f9642e10a03c2fda025`; tested candidate tree `6138d8558fe70ca416508cdcf855477632cae5fb`. Final commit `34fa122e355fec8d7d7b2a7921e94dbca186ee67` was verified to resolve to that exact tested tree. The maintainer cleanup only removes the premature changelog entry; the runtime fix and regression coverage are preserved.

The audited driver launches the public `register <job.md>` and `update --state completed --phase proof --summary "Synthetic loopback proof" --completion-reason proof_complete` CLI commands with isolated environments and synthetic credentials. It checks every observed request's peer, Host, method, path, authorization, content type, and complete JSON payload. Native fetch and timeout behavior are neither intercepted nor accelerated.

The proof invocation, expressed relative to the repository root, was:

```sh
node .artifacts/autonomous-20260902/pr1359/native-proof.mjs \
  --candidate-source .worktrees/codex-crabfleet-timeout-1359-20260902 \
  --baseline-source .worktrees/codex-crabfleet-timeout-baseline-20260902 \
  --output .artifacts/autonomous-20260902/pr1359/native-local-2
```

| Case | Observed outcome | Elapsed ms |
| --- | --- | ---: |
| Baseline registration, silent headers | Still pending after 18 seconds; harness sent SIGTERM | 18083.82 |
| Baseline update, silent headers | Still pending after 18 seconds; harness sent SIGTERM | 18082.00 |
| Candidate registration, silent headers | Native timeout, exit 1 | 15071.13 |
| Candidate update, silent headers | Native timeout, exit 1 | 15069.99 |
| Candidate registration, HTTP 200 with unfinished JSON | Native abort, exit 1 | 15070.28 |
| Candidate update, HTTP 503 with unfinished error body | Native abort, exit 1 | 15070.63 |
| Candidate registration, valid session response | Exit 0; exact metadata/environment/output verified | 89.61 |
| Candidate update, HTTP 204 | Exit 0; registration metadata untouched | 83.89 |

**Observed integrity and cleanup:** all eight cases passed and each made exactly one expected request. All eight child processes, sockets, and listeners closed; fresh closed-port probes returned `ECONNREFUSED`. Complete manifests of 1,343 tracked source files and all 211 compiled files, along with the Git index, were identical before and after execution. An earlier attempt exposed a cleanup-event race in the proof driver; awaiting actual socket-close events fixed the driver, and the complete proof passed on rerun without application changes.

**Artifact identities:** the retained proof package is `.artifacts/autonomous-20260902/pr1359/`. These are SHA-256 digests of the recorded manifests or artifacts:

| Artifact | SHA-256 |
| --- | --- |
| Baseline tracked-source manifest | `50938b5d498ac6125032d4fa93ccb99da9b2d595514f671db2518849cd68b563` |
| Candidate tracked-source manifest | `943aed31dd96a139cca80eca589a6d56a99623ed678cf0b7e136ee4538ec384d` |
| Baseline complete 211-file build manifest | `e884b7726bf50785199a305a9ad021e853b1f50dbc3e7fbd522f95ff6a6fd170` |
| Candidate complete 211-file build manifest | `3f346e1de9a481691b08ec32837c73a38e8ca6826b546547faef06934a73d009` |
| Audited `native-proof.mjs` | `774d0f3a6cc25983d8bc71daa6bb3469e1ca47f1b9788ae67d04d7a2021bd0bd` |
| `native-local-2/summary.json` | `ea5ce168dbb656dcd18a4f0b15781b1d434b1337454d145f71951299d6f55985` |

**Limits:** this is controlled local transport proof. It does not establish live CrabFleet availability, real-account authentication, hosted runner behavior, or other operating systems. No production endpoint, GitHub mutation, or live credential was used. The driver is not an OS-level egress sandbox. The baseline observation is bounded to 18 seconds; native transport defaults may impose a later timeout.

## Disposition of the 21:43 UTC review

The [current-head review](https://github.com/openclaw/clawsweeper/pull/1359#issuecomment-5516348698) reports no code or security findings. Its container-proof request applies the Windows-specific provision beyond its stated scope: [AGENTS.md:85](https://github.com/openclaw/clawsweeper/blob/34fa122e355fec8d7d7b2a7921e94dbca186ee67/AGENTS.md#L85) qualifies Docker-backed Crabbox `local-container` with “On this Windows host.” [CONTRIBUTING.md:42](https://github.com/openclaw/clawsweeper/blob/34fa122e355fec8d7d7b2a7921e94dbca186ee67/CONTRIBUTING.md#L42) requires the narrowest meaningful real-behavior proof and the same review contract; it adds no universal container requirement.

The executed host was macOS arm64 with Node 24.20.0. The changed surface is the two compiled action-session request owners, exercised through real loopback HTTP with native timers: both baseline stalls, four header/body cancellations, and both successful commands. The completed eight-case proof, cleanup checks, and source/build manifests above satisfy that surface's runtime-proof claim and bind to the exact tree of this head. Docker provider/image/lease metadata does not describe this local execution, and Windows behavior is outside its stated scope. This resolves the container-proof checklist and optional rank-up requests by applicability, without invoking a proof-policy exception. The separate slow-valid-response risk is the deliberate 15-second owner decision already accepted under User Impact.

Original fix and regression coverage by @SebTardif.

Co-authored-by: Sebastien Tardif <sebtardif@ncf.ca>
