### PR TITLE
fix(repair): time out hung issue-status ingest fetches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,6 @@ checkpoint, and status-only commits are intentionally omitted.
 - Retain numeric queue failure source locations inside the Durable Object before remote transport discards the original stack, without logging private error text.
 - Bound shared repair GitHub CLI calls with native process deadlines and honor per-call timeout settings. Thanks @SebTardif.
 - Bound standalone webhook GitHub requests to 15 seconds, including response bodies, so stalled calls return a retryable response. Thanks @SebTardif.
-- Bound automatic issue-to-PR status ingest fetches to 15 seconds so a stalled dashboard endpoint cannot hang the status reporter. Thanks @SebTardif.
 - Kept leading report metadata authoritative through ordinary and fenced body quotes across review, repair intake, workflow selection, and decision packets; shared structural parsing rejects competing records and duplicate packet keys while preserving legacy promotion guards. Thanks @dwin-gharibi for the original report and proposed fix in [#1137](https://github.com/openclaw/clawsweeper/pull/1137).
 
 - Completed obsolete exact-review publications when apply verifies a strictly newer durable review for the same revision, preserving retry behavior for unproven results. Thanks @vincentkoc. (#1249)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ checkpoint, and status-only commits are intentionally omitted.
 - Retain numeric queue failure source locations inside the Durable Object before remote transport discards the original stack, without logging private error text.
 - Bound shared repair GitHub CLI calls with native process deadlines and honor per-call timeout settings. Thanks @SebTardif.
 - Bound standalone webhook GitHub requests to 15 seconds, including response bodies, so stalled calls return a retryable response. Thanks @SebTardif.
+- Bound automatic issue-to-PR status ingest fetches to 15 seconds so a stalled dashboard endpoint cannot hang the status reporter. Thanks @SebTardif.
 - Kept leading report metadata authoritative through ordinary and fenced body quotes across review, repair intake, workflow selection, and decision packets; shared structural parsing rejects competing records and duplicate packet keys while preserving legacy promotion guards. Thanks @dwin-gharibi for the original report and proposed fix in [#1137](https://github.com/openclaw/clawsweeper/pull/1137).
 
 - Completed obsolete exact-review publications when apply verifies a strictly newer durable review for the same revision, preserving retry behavior for unproven results. Thanks @vincentkoc. (#1249)

--- a/src/repair/issue-implementation-status.ts
+++ b/src/repair/issue-implementation-status.ts
@@ -12,6 +12,7 @@ import { parseArgs, parseJob, repoRoot } from "./lib.js";
 
 const PROGRESS_START = "<!-- clawsweeper-issue-implementation-progress:start -->";
 const PROGRESS_END = "<!-- clawsweeper-issue-implementation-progress:end -->";
+export const ISSUE_STATUS_INGEST_TIMEOUT_MS = 15_000;
 
 type StatusOptions = {
   repo: string;
@@ -195,7 +196,7 @@ export function renderIssueImplementationStatusComment(
   return `${existing}\n\n${progress}`;
 }
 
-async function postDashboardStatus(options: StatusOptions) {
+export async function postDashboardStatus(options: StatusOptions) {
   const token = String(process.env.CLAWSWEEPER_STATUS_INGEST_TOKEN ?? "").trim();
   if (!token) return "skipped";
   const url =
@@ -208,6 +209,7 @@ async function postDashboardStatus(options: StatusOptions) {
       Authorization: `Bearer ${token}`,
       "Content-Type": "application/json",
     },
+    signal: AbortSignal.timeout(ISSUE_STATUS_INGEST_TIMEOUT_MS),
     body: JSON.stringify({
       event_type: eventTypeForState(state),
       mode: "automatic-issue-to-pr",

--- a/test/repair/issue-implementation-status.test.ts
+++ b/test/repair/issue-implementation-status.test.ts
@@ -1,9 +1,12 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
+import http from "node:http";
 import test from "node:test";
 
 import {
+  ISSUE_STATUS_INGEST_TIMEOUT_MS,
   issueImplementationStatusMarker,
+  postDashboardStatus,
   renderIssueImplementationStatusComment,
 } from "../../dist/repair/issue-implementation-status.js";
 
@@ -77,3 +80,112 @@ test("issue build workflow reports an opened PR without calling pending CI block
     /detail="The automatic implementation worker stopped before all post-flight gates passed:/,
   );
 });
+
+test("issue implementation status ingest skips when no token is configured", async () => {
+  const previousToken = process.env.CLAWSWEEPER_STATUS_INGEST_TOKEN;
+  const previousUrl = process.env.CLAWSWEEPER_STATUS_INGEST_URL;
+  delete process.env.CLAWSWEEPER_STATUS_INGEST_TOKEN;
+  delete process.env.CLAWSWEEPER_STATUS_INGEST_URL;
+  try {
+    assert.equal(await postDashboardStatus(options), "skipped");
+  } finally {
+    restoreEnv("CLAWSWEEPER_STATUS_INGEST_TOKEN", previousToken);
+    restoreEnv("CLAWSWEEPER_STATUS_INGEST_URL", previousUrl);
+  }
+});
+
+test(
+  "issue implementation status ingest aborts a hung dashboard fetch",
+  { timeout: 3_000 },
+  async (t) => {
+    const previousTimeout = AbortSignal.timeout;
+    const previousToken = process.env.CLAWSWEEPER_STATUS_INGEST_TOKEN;
+    const previousUrl = process.env.CLAWSWEEPER_STATUS_INGEST_URL;
+    t.after(() => {
+      AbortSignal.timeout = previousTimeout;
+      restoreEnv("CLAWSWEEPER_STATUS_INGEST_TOKEN", previousToken);
+      restoreEnv("CLAWSWEEPER_STATUS_INGEST_URL", previousUrl);
+    });
+
+    const server = http.createServer((_request, _response) => {});
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    t.after(
+      () =>
+        new Promise<void>((resolve) => {
+          server.closeAllConnections();
+          server.close(() => resolve());
+        }),
+    );
+    const address = server.address();
+    assert.ok(address && typeof address !== "string");
+    const origin = `http://127.0.0.1:${address.port}`;
+
+    const seenTimeouts: number[] = [];
+    t.mock.method(AbortSignal, "timeout", (ms: number) => {
+      seenTimeouts.push(ms);
+      return previousTimeout(50);
+    });
+
+    process.env.CLAWSWEEPER_STATUS_INGEST_TOKEN = "status-secret";
+    process.env.CLAWSWEEPER_STATUS_INGEST_URL = `${origin}/api/events`;
+
+    await assert.rejects(
+      () => postDashboardStatus(options),
+      (error: unknown) => {
+        assert.ok(error instanceof Error);
+        assert.match(error.name, /AbortError|TimeoutError/);
+        return true;
+      },
+    );
+    assert.deepEqual(seenTimeouts, [ISSUE_STATUS_INGEST_TIMEOUT_MS]);
+    assert.ok(ISSUE_STATUS_INGEST_TIMEOUT_MS >= 15_000);
+    assert.ok(ISSUE_STATUS_INGEST_TIMEOUT_MS <= 30_000);
+  },
+);
+
+test("issue implementation status ingest still publishes a successful event", async (t) => {
+  const previousToken = process.env.CLAWSWEEPER_STATUS_INGEST_TOKEN;
+  const previousUrl = process.env.CLAWSWEEPER_STATUS_INGEST_URL;
+  t.after(() => {
+    restoreEnv("CLAWSWEEPER_STATUS_INGEST_TOKEN", previousToken);
+    restoreEnv("CLAWSWEEPER_STATUS_INGEST_URL", previousUrl);
+  });
+
+  const requests: Array<{ method?: string; url?: string; authorization?: string }> = [];
+  const server = http.createServer((request, response) => {
+    requests.push({
+      method: request.method,
+      url: request.url,
+      authorization: request.headers.authorization,
+    });
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end("{}");
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  t.after(
+    () =>
+      new Promise<void>((resolve) => {
+        server.closeAllConnections();
+        server.close(() => resolve());
+      }),
+  );
+  const address = server.address();
+  assert.ok(address && typeof address !== "string");
+
+  process.env.CLAWSWEEPER_STATUS_INGEST_TOKEN = "status-secret";
+  process.env.CLAWSWEEPER_STATUS_INGEST_URL = `http://127.0.0.1:${address.port}/api/events`;
+
+  assert.equal(await postDashboardStatus(options), "sent");
+  assert.deepEqual(requests, [
+    {
+      method: "POST",
+      url: "/api/events",
+      authorization: "Bearer status-secret",
+    },
+  ]);
+});
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes automatic issue-to-PR status reporting hanging when the dashboard ingest endpoint accepts a connection but never returns HTTP headers. The GitHub progress comment has already been written, but the secondary request has no application deadline and leaves the status command waiting.

## Why This Change Was Made

The existing ingest fetch now uses `AbortSignal.timeout(15_000)`. Native cancellation bounds the request without another HTTP wrapper or retry loop. The existing caller catches the timeout, reports `dashboard_status=failed`, and finishes successfully with the GitHub progress comment preserved. Successful ingest still reports `sent`; an absent ingest token still reports `skipped`.

## User Impact

A stalled dashboard no longer pins the repair status command. Maintainers retain the GitHub progress comment while dashboard telemetry may be unavailable. This is a per-request deadline, not a deadline for the complete repair worker.

Maintainer disposition: accept that telemetry taking longer than 15 seconds is reported as failed. This preserves the established non-blocking dashboard-failure behavior. Thanks to @SebTardif (Sebastien Tardif) for the fix and production-helper proof.

## OpenClaw Bay Impact

No Bay code or data-contract change: the event payload and ingest schema are unchanged, and Bay continues to display persisted events. A timed-out request does not claim that its event persisted. The proof below does not establish deployed Bay behavior.

## Documentation Impact

Reviewed active `docs/live-dashboard.md` and `docs/repair/automatic-issue-prs.md`; their bearer-ingest and public progress-comment contracts remain accurate. The deadline and failure semantics are recorded here for release-note generation. The premature changelog addition was removed; changelogs remain release-owned.

## Evidence

- Original tested head: `aa1c86068bb3a33af74ec907cb5ea9bad6fb3e83`.
- Final cleanup head: `9e4e640f8d51284e21086603d610a1b4fde1188e`; tree: `eee2f904d8f5bb05a556bd692be1aa8670644118`. Only the changelog line differs from the tested head; production, tests, dependencies, and build configuration are byte-identical. Current-head CI and review remain the landing gates.
- [Exact-head CI](https://github.com/openclaw/clawsweeper/actions/runs/33683297449) passed `pnpm check`, sparse repair build, and Windows launcher checks; CodeQL also passed.
- [Hosted review](https://github.com/openclaw/clawsweeper/pull/1361#issuecomment-5516471893) found no actionable defect and accepted the controlled production-helper proof.
- Managed P0 review of the complete cleanup candidate against its pinned base found no accepted/actionable findings.
- Regression tests cover a hanging HTTP server with a shortened native timeout, successful POST, and missing-token skip.

## Real Behavior Proof

**Contributor-provided execution:** macOS Darwin 25.6.0 arm64, Node 26.7.0. `node /tmp/proof-f009-issue-status-timeout.mjs` imported compiled `postDashboardStatus` and pointed the ingest URL at a silent loopback HTTP server. This cleanup did not rerun it. The contributor reported:

```console
core timeout ms: 15000
unbounded fetch after 250ms: still-pending-after-250ms
timed fetch name= TimeoutError message= The operation was aborted due to timeout
timed fetch elapsed_ms= 15003
```

The compiled production helper requested the full 15,000ms deadline and rejected with `TimeoutError` after 15,003ms. This directly exercises the changed fetch owner. Source inspection establishes that its caller catches the error after writing the GitHub comment and emits `dashboard_status=failed`.

Limits: the trace is a supplied terminal record, not a retained downloadable script or an independently repeated run. It does not prove a live ingest outage, service-side receipt/persistence, or the complete GitHub-writing workflow. The 250ms control establishes pending behavior during that interval, not an unlimited observation.
