### PR TITLE
fix(queue): back off stalled Bay recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,6 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
-- Back off stalled OpenClaw Bay lifecycle recovery for one minute while preserving one-second drains whenever durable progress is made.
-
 - Retain only Cloudflare failure flags in queue transport logs so backend faults can be diagnosed without exposing exception details.
 
 - Hydrate review blobs from cached PR snapshots that store an absent previous filename as `null`, preventing repeat reviews from refusing otherwise available source.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Back off stalled OpenClaw Bay lifecycle recovery for one minute while preserving one-second drains whenever durable progress is made.
+
 - Retain only Cloudflare failure flags in queue transport logs so backend faults can be diagnosed without exposing exception details.
 
 - Hydrate review blobs from cached PR snapshots that store an absent previous filename as `null`, preventing repeat reviews from refusing otherwise available source.

--- a/dashboard/exact-review-lifecycle-telemetry.ts
+++ b/dashboard/exact-review-lifecycle-telemetry.ts
@@ -1553,6 +1553,7 @@ export class ExactReviewLifecycleTelemetryStore {
   }
 
   reconcileBayLifecyclePending() {
+    let progressed = false;
     const rows = Array.from(
       this.storage.sql.exec(
         `SELECT canonical_target_key, fence_key, revision, projection_json
@@ -1574,20 +1575,20 @@ export class ExactReviewLifecycleTelemetryStore {
       // stale if its clear was interrupted after compacting the aggregate;
       // replaying that older serialized object after timing retention would
       // otherwise lose its durable marker and count the completion twice.
-      const projection = this.currentLifecycleProjectionSync(identity);
-      if (
-        !pendingProjection ||
-        !projection ||
-        pendingProjection.canonicalTargetKey !== identity[0] ||
-        pendingProjection.fenceKey !== identity[1] ||
-        pendingProjection.revision !== identity[2] ||
-        projection.canonicalTargetKey !== identity[0] ||
-        projection.fenceKey !== identity[1] ||
-        projection.revision !== identity[2]
-      ) {
-        return false;
-      }
       try {
+        const projection = this.currentLifecycleProjectionSync(identity);
+        if (
+          !pendingProjection ||
+          !projection ||
+          pendingProjection.canonicalTargetKey !== identity[0] ||
+          pendingProjection.fenceKey !== identity[1] ||
+          pendingProjection.revision !== identity[2] ||
+          projection.canonicalTargetKey !== identity[0] ||
+          projection.fenceKey !== identity[1] ||
+          projection.revision !== identity[2]
+        ) {
+          return { pending: true, progressed };
+        }
         this.storage.transactionSync(() => {
           this.materializeBayLifecycleSync(projection);
           if (projection.bayTelemetryPending)
@@ -1595,10 +1596,11 @@ export class ExactReviewLifecycleTelemetryStore {
           this.clearBayLifecyclePendingSync(identity);
         });
       } catch {
-        return false;
+        return { pending: true, progressed };
       }
+      progressed = true;
     }
-    return !pendingMore;
+    return { pending: pendingMore, progressed };
   }
 
   private currentLifecycleProjectionSync(

--- a/dashboard/exact-review-lifecycle.ts
+++ b/dashboard/exact-review-lifecycle.ts
@@ -1264,6 +1264,7 @@ export class ExactReviewLifecycleProjectionStore {
     materialize: (projection: ExactReviewLifecycleProjection) => boolean,
   ) {
     this.ensureSchemaSync();
+    let progressed = false;
     const rows = Array.from(
       this.storage.sql.exec(
         `SELECT projection_json FROM ${EXACT_REVIEW_LIFECYCLE_PROJECTION_TABLE}
@@ -1275,14 +1276,21 @@ export class ExactReviewLifecycleProjectionStore {
     );
     const more = rows.length > EXACT_REVIEW_LIFECYCLE_BAY_TELEMETRY_RECOVERY_BATCH_LIMIT;
     for (const row of rows.slice(0, EXACT_REVIEW_LIFECYCLE_BAY_TELEMETRY_RECOVERY_BATCH_LIMIT)) {
-      const projection = projectionFromRow(String(row.projection_json || ""));
-      // Materialization has its own Durable Object transaction. Keep this
-      // source transaction separate: a retry after its source-marker clear is
-      // interrupted is idempotent by lifecycle event id.
-      if (!projection || !projection.bayTelemetryPending || !materialize(projection)) return false;
-      this.markBayTelemetryMaterialized(projection);
+      try {
+        const projection = projectionFromRow(String(row.projection_json || ""));
+        // Materialization has its own Durable Object transaction. Keep this
+        // source transaction separate: a retry after its source-marker clear is
+        // interrupted is idempotent by lifecycle event id.
+        if (!projection.bayTelemetryPending || !materialize(projection)) {
+          return { pending: true, progressed };
+        }
+        this.markBayTelemetryMaterialized(projection);
+      } catch {
+        return { pending: true, progressed };
+      }
+      progressed = true;
     }
-    return !more;
+    return { pending: more, progressed };
   }
 
   markBayTelemetryPending(input: ProjectionIdentity) {

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -815,6 +815,9 @@ export class ExactReviewQueue {
   private readonly random: () => number;
   private readonly baselines = new WeakMap<ExactReviewQueueState, ExactReviewQueueBaseline>();
   private reviewCoverageCache: { at: number; summary: ReviewCoverageSummary } | null = null;
+  // Back off a wedged Bay row without adding durable queue state. Any durable
+  // progress clears this single-slot deadline so the one-second drain resumes.
+  private bayTelemetryNoProgressDeadline: number | null = null;
   private recentDurablePublicationEventsCache = new Map<
     string,
     { expiresAt: number; value: NonNullable<ReturnType<typeof recentDurablePublicationEvents>> }
@@ -4056,7 +4059,7 @@ export class ExactReviewQueue {
     const startedAt = Date.now();
     const hostedTargetMetadataToken = exactReviewHostedTargetMetadataTokenSource(this.env);
     await this.storage.deleteAlarm();
-    this.reconcileBayTelemetryInternalSync();
+    this.reconcileBayTelemetryInternalSync(startedAt);
     await this.processBranchAuthorityReservations(startedAt, hostedTargetMetadataToken);
     await this.processSourceAuthorityReservations(startedAt, hostedTargetMetadataToken);
     await this.processCommandIntakes(startedAt, hostedTargetMetadataToken);
@@ -7706,17 +7709,22 @@ export class ExactReviewQueue {
     );
   }
 
-  private reconcileBayTelemetryInternalSync() {
+  private reconcileBayTelemetryInternalSync(now = Date.now()) {
+    if (this.bayTelemetryNoProgressDeadline && now < this.bayTelemetryNoProgressDeadline)
+      return false;
+    let progressed = false;
     try {
-      if (
-        !this.lifecycleProjectionStore.reconcileBayTelemetryPending((projection) =>
-          this.lifecycleTelemetryStore.syncBayLifecycle(projection),
-        )
-      ) {
-        return false;
-      }
-      return this.lifecycleTelemetryStore.reconcileBayLifecyclePending();
+      const source = this.lifecycleProjectionStore.reconcileBayTelemetryPending((projection) =>
+        this.lifecycleTelemetryStore.syncBayLifecycle(projection),
+      );
+      progressed = source.progressed;
+      const outbox = this.lifecycleTelemetryStore.reconcileBayLifecyclePending();
+      const pending = source.pending || outbox.pending;
+      this.bayTelemetryNoProgressDeadline =
+        pending && !(progressed || outbox.progressed) ? now + 60_000 : null;
+      return !pending;
     } catch {
+      this.bayTelemetryNoProgressDeadline = progressed ? null : now + 60_000;
       return false;
     }
   }
@@ -11696,7 +11704,11 @@ export class ExactReviewQueue {
     const sourceAuthorityNext = await this.nextSourceAuthorityVerificationAt();
     const commandIntakeNext = this.commandIntakeStore.nextAttemptAt();
     const credentialCircuitNext = exactReviewGithubCircuitNextWakeAt(state, now);
-    const bayTelemetryRecoveryNext = this.bayTelemetryRecoveryPendingSync() ? now + 1_000 : null;
+    const bayTelemetryRecoveryPending = this.bayTelemetryRecoveryPendingSync();
+    if (!bayTelemetryRecoveryPending) this.bayTelemetryNoProgressDeadline = null;
+    const bayTelemetryRecoveryNext = bayTelemetryRecoveryPending
+      ? Math.max(now + 1_000, this.bayTelemetryNoProgressDeadline ?? 0)
+      : null;
     const next = [
       queueNext,
       batchOwnership.nextLeaseExpiresAt,

--- a/test/dashboard-worker-bay-records-routes.test.ts
+++ b/test/dashboard-worker-bay-records-routes.test.ts
@@ -40,6 +40,7 @@ import {
   leasedExactReviewPublicationItem,
 } from "./dashboard-worker-harness.ts";
 import { publicHealthHistoryContract } from "../dashboard/worker.ts";
+import { EXACT_REVIEW_LIFECYCLE_PROJECTION_TABLE } from "../dashboard/exact-review-lifecycle.ts";
 import {
   EXACT_REVIEW_LIFECYCLE_BAY_EVENT_TABLE,
   EXACT_REVIEW_LIFECYCLE_BAY_META_TABLE,
@@ -1796,9 +1797,9 @@ test("Bay lifecycle migration leaves a pending terminal source available for rec
       ?.bayTelemetryEventId,
     undefined,
   );
-  assert.equal(
+  assert.deepEqual(
     lifecycle.reconcileBayTelemetryPending((projection) => telemetry.syncBayLifecycle(projection)),
-    true,
+    { pending: false, progressed: true },
   );
   assert.equal(telemetry.baySnapshot(now + 1_000).terminal?.terminal_count, 1);
 });
@@ -2041,7 +2042,10 @@ test("Bay lifecycle tide compaction is retry-safe after terminal deletion fails"
       observedAt: now + 500,
     });
     assert.equal(telemetry.syncBayLifecycle(current), false);
-    assert.equal(telemetry.reconcileBayLifecyclePending(), true);
+    assert.deepEqual(telemetry.reconcileBayLifecyclePending(), {
+      pending: false,
+      progressed: true,
+    });
 
     const snapshot = telemetry.baySnapshot(now + 1_000);
     assert.equal(snapshot.terminal?.tide_generation, 1);
@@ -2156,7 +2160,10 @@ test("Bay lifecycle replays a stale telemetry outbox from its marked source", ()
     );
 
     now += 31 * 24 * 60 * 60 * 1_000;
-    assert.equal(telemetry.reconcileBayLifecyclePending(), true);
+    assert.deepEqual(telemetry.reconcileBayLifecyclePending(), {
+      pending: false,
+      progressed: true,
+    });
     const snapshot = telemetry.baySnapshot(now);
     assert.equal(snapshot.terminal?.terminal_count, 1);
     assert.equal(snapshot.terminal?.tide_generation, 0);
@@ -2241,7 +2248,15 @@ test("Bay lifecycle terminal facts queue a durable retry when metrics cannot mat
   // The queue alarm repairs the retained outbox fact; the public metrics read
   // stays observer-only while recovery is pending.
   assert.equal(telemetry.hasBayLifecyclePending(), true);
-  assert.equal(telemetry.reconcileBayLifecyclePending(), true);
+  storage.sql.failNext(new RegExp(`INSERT INTO ${EXACT_REVIEW_LIFECYCLE_BAY_EVENT_TABLE}`));
+  assert.deepEqual(telemetry.reconcileBayLifecyclePending(), {
+    pending: true,
+    progressed: false,
+  });
+  assert.deepEqual(telemetry.reconcileBayLifecyclePending(), {
+    pending: false,
+    progressed: true,
+  });
   assert.equal(telemetry.baySnapshot(now).terminal?.terminal_count, 1);
 });
 
@@ -2284,9 +2299,9 @@ test("Bay lifecycle terminal facts recover after telemetry outbox persistence fa
       ?.bayTelemetryPending,
     true,
   );
-  assert.equal(
+  assert.deepEqual(
     lifecycle.reconcileBayTelemetryPending((projection) => telemetry.syncBayLifecycle(projection)),
-    true,
+    { pending: false, progressed: true },
   );
   assert.equal(
     lifecycle.read(identity.canonicalTargetKey, identity.fenceKey, identity.revision)
@@ -2332,7 +2347,10 @@ test("Bay lifecycle retains its outbox until the source marker commits", () => {
   );
   assert.equal(telemetry.hasBayLifecyclePending(), true);
   assert.equal(telemetry.baySnapshot(now).collection.state, "unknown");
-  assert.equal(telemetry.reconcileBayLifecyclePending(), true);
+  assert.deepEqual(telemetry.reconcileBayLifecyclePending(), {
+    pending: false,
+    progressed: true,
+  });
   assert.equal(
     lifecycle.read(identity.canonicalTargetKey, identity.fenceKey, identity.revision)
       ?.bayTelemetryPending,
@@ -2370,18 +2388,129 @@ test("Bay lifecycle recovery drains source markers in bounded batches", () => {
       observedAt: now,
     });
   }
-  assert.equal(
+  assert.deepEqual(
     lifecycle.reconcileBayTelemetryPending((projection) => telemetry.syncBayLifecycle(projection)),
-    false,
+    { pending: true, progressed: true },
   );
-  assert.equal(
+  assert.deepEqual(
     lifecycle.reconcileBayTelemetryPending((projection) => telemetry.syncBayLifecycle(projection)),
-    true,
+    { pending: false, progressed: true },
   );
   const recovered = telemetry.baySnapshot(now);
   assert.equal(recovered.collection.state, "complete");
   assert.equal(recovered.terminal?.tide_generation, 12);
   assert.equal(recovered.terminal?.terminal_count, 17);
+});
+
+test("Bay lifecycle recovery reports no progress for malformed and unmaterialized sources", () => {
+  const storage = new MemoryDurableStorage();
+  const lifecycle = new ExactReviewLifecycleProjectionStore(storage);
+  const telemetry = new ExactReviewLifecycleTelemetryStore(storage);
+  const now = Date.now();
+  const identity = {
+    canonicalTargetKey: "openclaw/openclaw#9557",
+    fenceKey: "openclaw/openclaw#9557@exact:1",
+    revision: 1,
+  };
+  lifecycle.recordAdmission({
+    ...identity,
+    deliveryId: "no-progress-source",
+    sourceAction: "opened",
+    commandOriginated: false,
+    statusMarker: null,
+    statusCommentId: null,
+    triggeredAt: now,
+    observedAt: now,
+  });
+  lifecycle.markBayTelemetryPending(identity);
+  assert.deepEqual(
+    lifecycle.reconcileBayTelemetryPending(() => false),
+    {
+      pending: true,
+      progressed: false,
+    },
+  );
+
+  storage.sql.exec(
+    `UPDATE ${EXACT_REVIEW_LIFECYCLE_PROJECTION_TABLE}
+        SET projection_json = ?
+      WHERE canonical_target_key = ? AND fence_key = ? AND revision = ?`,
+    "{",
+    identity.canonicalTargetKey,
+    identity.fenceKey,
+    identity.revision,
+  );
+  assert.deepEqual(
+    lifecycle.reconcileBayTelemetryPending((projection) => telemetry.syncBayLifecycle(projection)),
+    { pending: true, progressed: false },
+  );
+  telemetry.ensureSchemaSync();
+  storage.sql.exec(
+    `INSERT INTO ${EXACT_REVIEW_LIFECYCLE_BAY_PENDING_TABLE}
+       (canonical_target_key, fence_key, revision, projection_json, queued_at)
+     VALUES (?, ?, ?, ?, ?)`,
+    identity.canonicalTargetKey,
+    identity.fenceKey,
+    identity.revision,
+    "{",
+    now,
+  );
+  assert.deepEqual(telemetry.reconcileBayLifecyclePending(), {
+    pending: true,
+    progressed: false,
+  });
+});
+
+test("Bay lifecycle recovery retains progress before a later outbox read fails", () => {
+  const storage = new MemoryDurableStorage();
+  const lifecycle = new ExactReviewLifecycleProjectionStore(storage);
+  const telemetry = new ExactReviewLifecycleTelemetryStore(storage);
+  const now = Date.now();
+  telemetry.ensureSchemaSync();
+  for (let index = 0; index < 2; index += 1) {
+    const identity = {
+      canonicalTargetKey: `openclaw/openclaw#${9_560 + index}`,
+      fenceKey: `openclaw/openclaw#${9_560 + index}@exact:1`,
+      revision: 1,
+    };
+    const projection = lifecycle.recordAdmission({
+      ...identity,
+      deliveryId: `partial-outbox:${index}`,
+      sourceAction: "opened",
+      commandOriginated: false,
+      statusMarker: null,
+      statusCommentId: null,
+      triggeredAt: now,
+      observedAt: now + index,
+    });
+    storage.sql.exec(
+      `INSERT INTO ${EXACT_REVIEW_LIFECYCLE_BAY_PENDING_TABLE}
+         (canonical_target_key, fence_key, revision, projection_json, queued_at)
+       VALUES (?, ?, ?, ?, ?)`,
+      identity.canonicalTargetKey,
+      identity.fenceKey,
+      identity.revision,
+      JSON.stringify(projection),
+      now + index,
+    );
+  }
+  const exec = storage.sql.exec.bind(storage.sql);
+  let sourceReads = 0;
+  storage.sql.exec = (query: string, ...bindings: unknown[]) => {
+    if (
+      /SELECT projection_json FROM exact_review_lifecycle_projection_v1\s+WHERE canonical_target_key/.test(
+        query,
+      ) &&
+      ++sourceReads === 2
+    ) {
+      throw new Error("injected later source read failure");
+    }
+    return exec(query, ...bindings);
+  };
+  assert.deepEqual(telemetry.reconcileBayLifecyclePending(), {
+    pending: true,
+    progressed: true,
+  });
 });
 
 test("Bay lifecycle metrics retain idle terminal progress and the bounded remainder card", () => {

--- a/test/exact-review-publication-batches.test.ts
+++ b/test/exact-review-publication-batches.test.ts
@@ -13,7 +13,10 @@ import {
   validateDirectPublicationPlan,
   type DirectPublicationPlan,
 } from "../dashboard/exact-review-direct-publication.ts";
-import { EXACT_REVIEW_LIFECYCLE_PROJECTION_TABLE } from "../dashboard/exact-review-lifecycle.ts";
+import {
+  EXACT_REVIEW_LIFECYCLE_PROJECTION_TABLE,
+  ExactReviewLifecycleProjectionStore,
+} from "../dashboard/exact-review-lifecycle.ts";
 import { ExactReviewQueue as RuntimeExactReviewQueue } from "../dashboard/exact-review-queue.ts";
 import worker from "../dashboard/worker.ts";
 
@@ -51,12 +54,16 @@ class TestStorage {
   private readonly database = new DatabaseSync(":memory:");
   private readonly values = new Map<string, unknown>();
   private failSqlPattern: RegExp | null = null;
+  private failSqlMatchesRemaining = 0;
   private alarmAt: number | null = null;
   readonly sql = {
     exec: (query: string, ...bindings: unknown[]) => {
       if (this.failSqlPattern?.test(query)) {
-        this.failSqlPattern = null;
-        throw new Error("injected telemetry state write failure");
+        this.failSqlMatchesRemaining -= 1;
+        if (this.failSqlMatchesRemaining === 0) {
+          this.failSqlPattern = null;
+          throw new Error("injected telemetry state write failure");
+        }
       }
       const statement = this.database.prepare(query);
       if (/^\s*(?:SELECT|WITH)\b/i.test(query) || /\bRETURNING\b/i.test(query)) {
@@ -69,6 +76,12 @@ class TestStorage {
 
   failNextSqlMatching(pattern: RegExp) {
     this.failSqlPattern = pattern;
+    this.failSqlMatchesRemaining = 1;
+  }
+
+  failSqlMatchingAfter(pattern: RegExp, successfulMatches: number) {
+    this.failSqlPattern = pattern;
+    this.failSqlMatchesRemaining = successfulMatches + 1;
   }
   readonly kv = {
     get: (key: string) => this.values.get(key),
@@ -3057,6 +3070,293 @@ test("oldest publication aging deadline drives the alarm and then its owner clai
           alarm_dispatched: dispatches.length === 1,
           terminal_preflight: checkedTargets,
           claimed_items: claim.batch.items.map((item: { item_key: string }) => item.item_key),
+        })}`,
+      );
+    }
+  } finally {
+    globalThis.fetch = originalFetch;
+    Date.now = originalNow;
+  }
+});
+
+test("Bay no-progress recovery backs off without duplicating an aged publication owner", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalNow = Date.now;
+  let now = 20_000_000;
+  Date.now = () => now;
+  const { privateKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  });
+  const dispatches: Array<{ inputs: Record<string, string> }> = [];
+  globalThis.fetch = async (input, init) => {
+    const url = new URL(String(input));
+    if (url.pathname === "/repos/openclaw/clawsweeper/installation") {
+      return new Response(JSON.stringify({ id: 999 }), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url.pathname === "/repos/aged/repo/installation") {
+      return new Response(JSON.stringify({ id: 1000 }), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url.pathname === "/app/installations/999/access_tokens") {
+      return new Response(JSON.stringify({ token: "dispatch-token" }), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url.pathname === "/app/installations/1000/access_tokens") {
+      return new Response(JSON.stringify({ token: "aged-token" }), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url.pathname === "/repos/aged/repo/issues/170") {
+      return new Response(JSON.stringify({ state: "open" }), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (
+      url.pathname ===
+      "/repos/openclaw/clawsweeper/actions/workflows/exact-review-batch-publish.yml/dispatches"
+    ) {
+      dispatches.push(JSON.parse(String(init?.body)));
+      return new Response(null, { status: 204 });
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  };
+  try {
+    const storage = new TestStorage();
+    const env = {
+      CLAWSWEEPER_APP_CLIENT_ID: "Iv23test",
+      CLAWSWEEPER_APP_PRIVATE_KEY: privateKey,
+      EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+      EXACT_REVIEW_PUBLICATION_BATCH_SIZE: "1",
+      EXACT_REVIEW_PUBLICATION_BATCH_WAIT_MS: "60000",
+      EXACT_REVIEW_PUBLICATION_BATCH_LEASE_MS: "600000",
+      EXACT_REVIEW_DISPATCH_DEBOUNCE_MS: "0",
+    };
+    let queue = new ExactReviewQueue({ storage }, env);
+    await queue.fetch(publicationRequest("bay-backoff-aged", 170, "1170", "aged/repo"));
+    const lifecycle = new ExactReviewLifecycleProjectionStore(storage);
+    const stalledIdentity = {
+      canonicalTargetKey: "openclaw/openclaw#9170",
+      fenceKey: "openclaw/openclaw#9170@exact:1",
+      revision: 1,
+    };
+    lifecycle.recordAdmission({
+      ...stalledIdentity,
+      deliveryId: "bay-backoff-stalled",
+      sourceAction: "opened",
+      commandOriginated: false,
+      statusMarker: null,
+      statusCommentId: null,
+      triggeredAt: now,
+      observedAt: now,
+    });
+    lifecycle.markBayTelemetryPending(stalledIdentity);
+    storage.run(
+      `UPDATE ${EXACT_REVIEW_LIFECYCLE_PROJECTION_TABLE}
+          SET projection_json = ?
+        WHERE canonical_target_key = ? AND fence_key = ? AND revision = ?`,
+      "{",
+      stalledIdentity.canonicalTargetKey,
+      stalledIdentity.fenceKey,
+      stalledIdentity.revision,
+    );
+
+    now += 60_000;
+    await queue.alarm();
+    assert.equal(dispatches.length, 1);
+    const stalledRetryAt = now + 60_000;
+    assert.equal(storage.scheduledAlarm(), stalledRetryAt);
+    now += 2_000;
+    await storage.setAlarm(now);
+    await queue.alarm();
+    assert.equal(dispatches.length, 1);
+    assert.equal(storage.scheduledAlarm(), stalledRetryAt);
+    const trafficIdentity = {
+      canonicalTargetKey: "openclaw/openclaw#9180",
+      fenceKey: "openclaw/openclaw#9180@exact:1",
+      revision: 1,
+    };
+    lifecycle.recordAdmission({
+      ...trafficIdentity,
+      deliveryId: "bay-backoff-traffic",
+      sourceAction: "opened",
+      commandOriginated: false,
+      statusMarker: null,
+      statusCommentId: null,
+      triggeredAt: now,
+      observedAt: now,
+    });
+    const traffic = await queue.fetch(
+      batchRequest("/lifecycle/terminal-disposition", {
+        canonical_target_key: trafficIdentity.canonicalTargetKey,
+        fence_key: trafficIdentity.fenceKey,
+        revision: trafficIdentity.revision,
+        kind: "failure",
+      }),
+    );
+    assert.equal(traffic.status, 200);
+    assert.equal(storage.scheduledAlarm(), stalledRetryAt);
+    const dispatch = dispatches[0]!;
+    now += 10_000;
+    const staleClaim = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/claim", {
+          claim_id: "claim-bay-backoff-stale",
+          lease_owner: "worker-stale",
+          max_items: 1,
+          dispatch_id: "publication-batch-dispatch:stale",
+          dispatched_at: new Date(now - 1_000).toISOString(),
+        }),
+      )
+    ).json();
+    assert.equal(staleClaim.claimed, false);
+    assert.equal(staleClaim.preflight_required, true);
+
+    const claim = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/claim", {
+          claim_id: "claim-bay-backoff",
+          lease_owner: "worker-1",
+          max_items: 1,
+          dispatch_id: dispatch.inputs.dispatch_id,
+          dispatched_at: dispatch.inputs.dispatched_at,
+        }),
+      )
+    ).json();
+    assert.equal(claim.claimed, true, JSON.stringify(claim));
+    assert.equal(claim.batch.items.length, 1);
+    const members = claim.batch.items.map((item) => ({
+      item_key: item.item_key,
+      revision: item.revision,
+      claim_generation: item.claim_generation,
+    }));
+    const heartbeat = await queue.fetch(
+      batchRequest("/publication-batches/heartbeat", {
+        batch_id: claim.batch.batch_id,
+        lease_owner: "worker-1",
+        items: members,
+      }),
+    );
+    assert.equal(heartbeat.status, 200, JSON.stringify(await heartbeat.clone().json()));
+
+    const competingClaim = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/claim", {
+          claim_id: "claim-bay-backoff-competing",
+          lease_owner: "worker-2",
+          max_items: 1,
+        }),
+      )
+    ).json();
+    assert.equal(competingClaim.claimed, false);
+    assert.equal(competingClaim.batch, null);
+
+    now = stalledRetryAt;
+    await queue.alarm();
+    const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+    assert.equal(dispatches.length, 1);
+    assert.equal(stats.lanes.publication.batches.active_items, 1);
+    assert.equal(storage.scheduledAlarm(), now + 60_000);
+
+    const progressingStorage = new TestStorage();
+    const progressingQueue = new ExactReviewQueue({ storage: progressingStorage }, {});
+    await progressingQueue.fetch(new Request("https://queue/stats"));
+    const progressingLifecycle = new ExactReviewLifecycleProjectionStore(progressingStorage);
+    for (let index = 0; index < 257; index += 1) {
+      const identity = {
+        canonicalTargetKey: `openclaw/openclaw#${9_500 + index}`,
+        fenceKey: `openclaw/openclaw#${9_500 + index}@exact:1`,
+        revision: 1,
+      };
+      progressingLifecycle.recordAdmission({
+        ...identity,
+        deliveryId: `bay-backoff-progress:${index}`,
+        sourceAction: "opened",
+        commandOriginated: false,
+        statusMarker: null,
+        statusCommentId: null,
+        triggeredAt: now,
+        observedAt: now,
+      });
+      progressingLifecycle.markBayTelemetryPending(identity);
+    }
+    progressingStorage.failSqlMatchingAfter(/INSERT INTO exact_review_lifecycle_projection_v1/, 1);
+    await progressingQueue.alarm();
+    assert.equal(progressingStorage.scheduledAlarm(), now + 1_000);
+
+    const clearedStorage = new TestStorage();
+    const clearedQueue = new ExactReviewQueue({ storage: clearedStorage }, {});
+    await clearedQueue.fetch(new Request("https://queue/stats"));
+    const clearedLifecycle = new ExactReviewLifecycleProjectionStore(clearedStorage);
+    const clearedIdentity = {
+      canonicalTargetKey: "openclaw/openclaw#9800",
+      fenceKey: "openclaw/openclaw#9800@exact:1",
+      revision: 1,
+    };
+    clearedLifecycle.recordAdmission({
+      ...clearedIdentity,
+      deliveryId: "bay-backoff-cleared",
+      sourceAction: "opened",
+      commandOriginated: false,
+      statusMarker: null,
+      statusCommentId: null,
+      triggeredAt: now,
+      observedAt: now,
+    });
+    clearedLifecycle.markBayTelemetryPending(clearedIdentity);
+    clearedStorage.run(
+      `UPDATE ${EXACT_REVIEW_LIFECYCLE_PROJECTION_TABLE}
+          SET projection_json = ?
+        WHERE canonical_target_key = ? AND fence_key = ? AND revision = ?`,
+      "{",
+      clearedIdentity.canonicalTargetKey,
+      clearedIdentity.fenceKey,
+      clearedIdentity.revision,
+    );
+    await clearedQueue.alarm();
+    assert.equal(clearedStorage.scheduledAlarm(), now + 60_000);
+    clearedStorage.run(
+      `DELETE FROM ${EXACT_REVIEW_LIFECYCLE_PROJECTION_TABLE}
+        WHERE canonical_target_key = ? AND fence_key = ? AND revision = ?`,
+      clearedIdentity.canonicalTargetKey,
+      clearedIdentity.fenceKey,
+      clearedIdentity.revision,
+    );
+    await clearedQueue.fetch(new Request("https://queue/stats"));
+    const laterIdentity = {
+      canonicalTargetKey: "openclaw/openclaw#9801",
+      fenceKey: "openclaw/openclaw#9801@exact:1",
+      revision: 1,
+    };
+    clearedLifecycle.recordAdmission({
+      ...laterIdentity,
+      deliveryId: "bay-backoff-later",
+      sourceAction: "opened",
+      commandOriginated: false,
+      statusMarker: null,
+      statusCommentId: null,
+      triggeredAt: now,
+      observedAt: now,
+    });
+    clearedLifecycle.markBayTelemetryPending(laterIdentity);
+    await clearedQueue.fetch(new Request("https://queue/stats"));
+    assert.equal(clearedStorage.scheduledAlarm(), now + 1_000);
+
+    if (process.env.CLAWSWEEPER_EVIDENCE_TRANSCRIPT === "1") {
+      console.log(
+        `BAY_RECOVERY_BACKOFF_PROOF=${JSON.stringify({
+          no_progress_alarm_delay_ms: 60_000,
+          dispatch_count: dispatches.length,
+          stale_claimed: staleClaim.claimed,
+          heartbeat_status: heartbeat.status,
+          active_items: stats.lanes.publication.batches.active_items,
+          progress_alarm_delay_ms: 1_000,
+          cleared_deadline_alarm_delay_ms: 1_000,
         })}`,
       );
     }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled so maintainers can help update the branch.

</details>

## What Problem This Solves

Resolves a problem where stalled OpenClaw Bay lifecycle recovery can repeatedly wake the queue once per second without repairing a row. Publication work can continue, but the unsuccessful recovery repeatedly consumes alarm work.

## Why This Change Was Made

Distinguish pending recovery from durable progress and apply a single queue-owned, in-memory 60-second deadline when pending recovery makes no progress. Successful recovery retains the existing one-second bounded drain; no durable schema, configuration, retry framework, or publication-ownership change is introduced.

## User Impact

Within a running Durable Object, stalled Bay recovery waits one minute between attempts while healthy recovery continues draining quickly. Earlier publication, authority, command, credential-circuit, or lease deadlines still wake the queue independently.

**Maintainer decision:** accept the bounded recovery delay and the deliberately process-local deadline. Recreating the Durable Object resets that in-memory deadline; this change does not promise persistence of the delay across recreation or repair permanently malformed rows. Affected Bay metrics remain unavailable while their required recovery is pending. Adding persistent retry state is unnecessary for this scoped fix.

## OpenClaw Bay Impact

The internal lifecycle recovery cadence changes. Public Bay schemas, aggregate definitions, UI, observer-only routes, and action restrictions remain unchanged. The supplied handler proof covers stalled recovery alongside publication dispatch and ownership, healthy bounded progress, and clearing a stale deadline before a later recovery episode. This is separate from the public lifecycle read/cache work in https://github.com/openclaw/clawsweeper/pull/1362.

## Documentation Impact

Reviewed the active canonical [OpenClaw Bay documentation](https://github.com/openclaw/clawsweeper/blob/99f3867ac8c3b4f487951f3b5b0cd17a4d0a2bd1/docs/openclaw-bay-demo.md) and [scheduler documentation](https://github.com/openclaw/clawsweeper/blob/99f3867ac8c3b4f487951f3b5b0cd17a4d0a2bd1/docs/scheduler.md). Their public observer boundary, fail-closed projection, ownership, and queue-operation contracts remain accurate; this adds no operator input or action and changes no documented public shape. The internal recovery cadence and its restart limit are recorded here. The premature changelog entry was removed because changelog work belongs to release preparation.

## Evidence

Vincent Koc supplied the implementation and executed the following checks at `99f3867ac8c3b4f487951f3b5b0cd17a4d0a2bd1`:

- The two affected Bay/queue suites: 186 passed, 0 failed.
- Dashboard TypeScript compilation, correctness/error-preservation lint, queue-boundary checks, targeted formatting, and diff checks passed.
- [CI run 33686128577](https://github.com/openclaw/clawsweeper/actions/runs/33686128577) passed `pnpm check`, sparse repair smoke, and Windows launcher checks.

The [published ClawSweeper review of the original contributor head](https://github.com/openclaw/clawsweeper/pull/1363#issuecomment-5516835561) accepted the supplied runtime proof and reported no actionable code finding at `99f3867ac8c3b4f487951f3b5b0cd17a4d0a2bd1`. Its one-minute/recreation risk is explicitly accepted above. That review and the linked CI run cover the original head only; they are not current-head approval.

Current maintainer head `26336642aa57f16b537951185feed63142707c65`, tree `80b8bc05cdc81ec7707810ae8ad64b13966ba48d`, removes only two `CHANGELOG.md` lines from contributor head `99f3867ac8c3b4f487951f3b5b0cd17a4d0a2bd1` (tree `e8b7bed35137b464f2c8da1ab432eca364c3cb13`). Git object comparison across all 1,343 tracked files verifies that every other blob and mode—including production, tests, workflow, dependencies, and runtime inputs—is identical. The runtime proof was not independently rerun for this changelog-only correction. Managed precommit and committed-branch P0 reviews of the full change against its original base returned no findings at that bounded threshold. These are local managed reviews, distinct from the required current-head GitHub CI and ClawSweeper review.

**Current-head gates:** new GitHub CI and a ClawSweeper review for `26336642aa57f16b537951185feed63142707c65` and this updated body are required after push and remain pending. The byte-identical runtime proof supports the change but does not replace these fresh gates.

## Real Behavior Proof

**Claim:** pending Bay recovery without durable progress backs off for 60 seconds without interrupting an aged publication owner; successful recovery progress and a later episode after a cleared deadline retain a one-second wake.

**Exercised surface and provenance:** contributor-run execution of the real `ExactReviewQueue` alarm and HTTP route handlers with SQLite-backed lifecycle, telemetry, queue, and publication-batch stores. The tested contributor head is `99f3867ac8c3b4f487951f3b5b0cd17a4d0a2bd1`; the current head `26336642aa57f16b537951185feed63142707c65` has the unchanged runtime tree binding stated above. This maintainer pass inspected the source and retained trace; it does not claim an independent replay.

**Scenario:** an aged publication and malformed Bay source coexist. The alarm dispatches one publication batch, rejects a stale claim, accepts one fenced owner, extends its heartbeat, prevents a competing owner, and backs off Bay recovery. Separate 257-row and cleared-deadline fixtures exercise durable progress before a later failure and the next recovery episode.

**Command and environment, as reported by the contributor:**

```sh
CLAWSWEEPER_EVIDENCE_TRANSCRIPT=1 node --test --test-name-pattern='Bay no-progress recovery backs off' test/exact-review-publication-batches.test.ts
```

Node v26.7.0, Darwin arm64. The test uses a controlled clock, native SQLite-backed storage, and synthetic GitHub responses. The attempted AWS lease creation failed before provisioning or repository execution, so the recorded execution was local; no AWS proof is claimed.

**Observed contributor trace:**

```json
{"no_progress_alarm_delay_ms":60000,"dispatch_count":1,"stale_claimed":false,"heartbeat_status":200,"active_items":1,"progress_alarm_delay_ms":1000,"cleared_deadline_alarm_delay_ms":1000}
```

The test passed. Its assertions check the scheduled alarm, exactly one dispatch, stale and competing claims, heartbeat response, active item count, healthy progress, and clearing the stale deadline before emitting the trace. The [proof implementation](https://github.com/openclaw/clawsweeper/blob/99f3867ac8c3b4f487951f3b5b0cd17a4d0a2bd1/test/exact-review-publication-batches.test.ts#L3082) and supporting store tests remain byte-identical in current head `26336642aa57f16b537951185feed63142707c65`.

**Limits:** this is controlled native handler and persistence execution, not a deployed Cloudflare alarm-timing measurement or fleet-wide cost benchmark. The clock and external API transport are synthetic. Durable Object recreation resets the deadline, and a permanently malformed row remains pending; these limits are accepted above. No live deployment or independent maintainer runtime rerun is claimed.
