### PR TITLE
fix(queue): queued publications starve behind stale batch probes and superseded rows

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1717,6 +1717,19 @@ jobs:
           done
           exit 1
 
+      - name: Expire queued exact review lease
+        if: ${{ always() && !cancelled() && steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.queue-exact-review-publication.outcome == 'success' && steps.direct-exact-review-publication.outputs.accepted != 'true' && steps.reserve-exact-review-lease.outputs.status == 'posted' }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
+          TARGET_REPO: ${{ steps.target.outputs.target_repo }}
+          ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
+          COMMENT_ID: ${{ steps.reserve-exact-review-lease.outputs.comment_id }}
+        run: |
+          set -euo pipefail
+          node dist/clawsweeper.js expire-review-lease \
+            --repo "$TARGET_REPO" --item-number "$ITEM_NUMBER" --comment-id "$COMMENT_ID"
+
       - name: Release unsuccessful workflow-owned review lease
         if: ${{ always() && steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.live-item.outputs.proceed == 'true' && steps.reserve-exact-review-lease.outputs.status != 'held' && steps.prepare-direct-exact-review-publication.outputs.failure_kind != 'github_rate_limit' && steps.prepare-direct-exact-review-publication.outputs.failure_kind != 'github_transient' && steps.direct-exact-review-publication.outputs.accepted != 'true' && steps.queue-exact-review-publication.outcome != 'success' }}
         env:

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -4063,12 +4063,16 @@ export class ExactReviewQueue {
     await this.processBranchAuthorityReservations(startedAt, hostedTargetMetadataToken);
     await this.processSourceAuthorityReservations(startedAt, hostedTargetMetadataToken);
     await this.processCommandIntakes(startedAt, hostedTargetMetadataToken);
+    const pruneBatchItemKeys = new Set<string>(
+      this.batchStore.activeLeaseSnapshot(startedAt).itemKeys,
+    );
     let snapshot = this.storage.transactionSync(() => {
       this.pruneDeliveryReceiptsSync(startedAt);
       this.commandIntakeStore.pruneTerminalReceipts(startedAt);
       this.directPublicationStore.pruneTerminalSync(startedAt);
       const current = this.readStateSync();
       this.syncLegacyCompatibilitySync(current);
+      this.pruneStalePublicationsSync(current, pruneBatchItemKeys);
       return current;
     });
     let snapshotBatchOwnership = this.batchStore.activeLeaseSnapshot(startedAt);
@@ -5879,6 +5883,79 @@ export class ExactReviewQueue {
     return json({ ok: true, superseded, skipped: candidates.length - superseded });
   }
 
+  private stalePublicationCandidatesSync(
+    state: ExactReviewQueueState,
+    activeBatchItemKeys: ReadonlySet<string>,
+  ) {
+    const newestByTarget = new Map<string, number>();
+    const versioned = Object.values(state.items).flatMap((item) => {
+      if (item.terminalFinalization || !exactReviewQueueIsPublication(item)) return [];
+      const revision = exactReviewPublicationRevision(item.decision);
+      if (!revision) return [];
+      newestByTarget.set(
+        revision.targetKey,
+        Math.max(
+          newestByTarget.get(revision.targetKey) ?? 0,
+          revision.sourceRevision,
+          this.publicationHeadRevisionSync(revision.targetKey),
+        ),
+      );
+      return [{ item, revision, lineage: exactReviewPublicationLineage(item.decision) }];
+    });
+    const stale = versioned
+      .filter(
+        ({ item, revision }) =>
+          revision.sourceRevision < (newestByTarget.get(revision.targetKey) ?? 0) &&
+          (item.state === "pending" || item.state === "parked") &&
+          !activeBatchItemKeys.has(item.key),
+      )
+      .sort(
+        (left, right) =>
+          left.item.createdAt - right.item.createdAt || left.item.key.localeCompare(right.item.key),
+      );
+    return { versioned, newestByTarget, stale };
+  }
+
+  private pruneStalePublicationsSync(
+    state: ExactReviewQueueState,
+    activeBatchItemKeys: ReadonlySet<string>,
+  ) {
+    const { stale, newestByTarget } = this.stalePublicationCandidatesSync(
+      state,
+      activeBatchItemKeys,
+    );
+    let changed = 0;
+    for (const { item, revision } of stale
+      .filter(({ item }) => !exactReviewQueueHasCommandContext(item))
+      .slice(0, exactReviewStalePublicationPruneLimit(this.env))) {
+      const current = state.items[item.key];
+      const currentRevision = current ? exactReviewPublicationRevision(current.decision) : null;
+      if (
+        !current ||
+        current.terminalFinalization ||
+        exactReviewQueueHasCommandContext(current) ||
+        current.revision !== item.revision ||
+        !currentRevision ||
+        currentRevision.sourceRevision !== revision.sourceRevision ||
+        (current.state !== "pending" && current.state !== "parked") ||
+        activeBatchItemKeys.has(current.key) ||
+        currentRevision.sourceRevision >=
+          (newestByTarget.get(currentRevision.targetKey) ?? currentRevision.sourceRevision)
+      ) {
+        continue;
+      }
+      delete state.items[current.key];
+      changed += 1;
+    }
+    if (changed) {
+      this.writeStateSync(state);
+      this.incrementQueueMetricsSync({
+        publicationCompleted: changed,
+        publicationSuperseded: changed,
+      });
+    }
+  }
+
   private async reconcilePublicationCandidates(
     value: unknown,
     hostedTargetMetadataToken: HostedTargetMetadataToken,
@@ -5926,23 +6003,10 @@ export class ExactReviewQueue {
           exactReviewLegacyTerminalPublicationCandidate(item, legacyAuthorityByTarget),
       )
       .sort((left, right) => left.createdAt - right.createdAt || left.key.localeCompare(right.key));
-    const newestByTarget = new Map<string, number>();
-    const versioned = Object.values(state.items).flatMap((item) => {
-      if (item.terminalFinalization) return [];
-      const revision = exactReviewPublicationRevision(item.decision);
-      if (!revision) return [];
-      newestByTarget.set(
-        revision.targetKey,
-        Math.max(newestByTarget.get(revision.targetKey) ?? 0, revision.sourceRevision),
-      );
-      return [{ item, revision, lineage: exactReviewPublicationLineage(item.decision) }];
-    });
-    for (const [targetKey, sourceRevision] of newestByTarget) {
-      newestByTarget.set(
-        targetKey,
-        Math.max(sourceRevision, this.publicationHeadRevisionSync(targetKey)),
-      );
-    }
+    const { versioned, newestByTarget, stale } = this.stalePublicationCandidatesSync(
+      state,
+      activeBatchItemKeys,
+    );
     const legacyStateBatchAuthorityByTarget = exactReviewLegacyStateBatchPublicationAuthorityIndex(
       state,
       activeBatchItemKeys,
@@ -5967,17 +6031,8 @@ export class ExactReviewQueue {
       retainedKey?: string;
     };
     const candidatesByKey = new Map<string, ReconcileCandidate>();
-    for (const entry of versioned) {
-      if (
-        entry.revision.sourceRevision < (newestByTarget.get(entry.revision.targetKey) ?? 0) &&
-        (entry.item.state === "pending" || entry.item.state === "parked") &&
-        !activeBatchItemKeys.has(entry.item.key)
-      ) {
-        candidatesByKey.set(entry.item.key, {
-          ...entry,
-          reason: "stale_revision",
-        });
-      }
+    for (const entry of stale) {
+      candidatesByKey.set(entry.item.key, { ...entry, reason: "stale_revision" });
     }
 
     const lineageGroups = new Map<string, typeof versioned>();
@@ -6296,6 +6351,7 @@ export class ExactReviewQueue {
     publicationCapacity: number,
     requestedSize: number,
     leaseSize: number,
+    probedPairs: ReadonlySet<string> | null = null,
   ) {
     // The outer comparison charges one publisher slot for the whole batch. The
     // shared helper counts candidate rows, so widen only its scan window by
@@ -6306,6 +6362,15 @@ export class ExactReviewQueue {
       ...this.supersededPublicationItemKeysSync(state),
     ]);
     for (const item of Object.values(state.items)) {
+      // Apply the departure fence before admission consumes its bounded scan.
+      if (
+        probedPairs &&
+        item.state === "pending" &&
+        exactReviewQueueIsPublication(item) &&
+        !probedPairs.has(JSON.stringify([item.key, item.revision]))
+      ) {
+        excludedItemKeys.add(item.key);
+      }
       // Direct receipts and terminal acknowledgement drivers must remain on
       // the normal publisher. Exclude them before admission so they cannot
       // consume a bounded batch scan slot and starve an ordinary publication.
@@ -6336,7 +6401,14 @@ export class ExactReviewQueue {
             // immutable lifecycle plan must return through the fenced legacy
             // publisher, which is the only path that replays that plan.
             .filter(exactReviewQueueIsBatchablePublication)
-            .filter((item) => !item.terminalFinalization);
+            .filter((item) => !item.terminalFinalization)
+            // A dispatched workflow may claim only members that passed its
+            // departure's terminal preflight. Filter before the lease-size cut so
+            // an unprobed fresh arrival cannot push a probed member out of the
+            // batch; the arrival waits for the next departure instead.
+            .filter(
+              (item) => !probedPairs || probedPairs.has(JSON.stringify([item.key, item.revision])),
+            );
     const selection = exactReviewPublicationBatchSelection(
       readyCandidates,
       freshItemKeys,
@@ -6504,7 +6576,14 @@ export class ExactReviewQueue {
         effective_max_items: leaseSize,
       });
     }
-    let candidates = this.publicationBatchClaimCandidates(state, now, requestedSize, leaseSize);
+    let probedPairs = exactReviewPublicationBatchReservedProbe(state, now, dispatch?.id);
+    let candidates = this.publicationBatchClaimCandidates(
+      state,
+      now,
+      requestedSize,
+      leaseSize,
+      probedPairs,
+    );
     const admissions = new Map(
       await Promise.all(
         [...new Set(candidates.map((item) => item.decision.targetRepo))].map(
@@ -6515,7 +6594,14 @@ export class ExactReviewQueue {
     );
     now = Date.now();
     state = this.readStateSync();
-    candidates = this.publicationBatchClaimCandidates(state, now, requestedSize, leaseSize);
+    probedPairs = exactReviewPublicationBatchReservedProbe(state, now, dispatch?.id);
+    candidates = this.publicationBatchClaimCandidates(
+      state,
+      now,
+      requestedSize,
+      leaseSize,
+      probedPairs,
+    );
     if (candidates.some((item) => !admissions.has(item.decision.targetRepo))) {
       return unclaimedPublicationBatch(requestedSize, leaseSize, { preflight_required: true });
     }
@@ -6577,7 +6663,9 @@ export class ExactReviewQueue {
       !terminalProbeRequired ||
       legacyDispatchReservation ||
       (dispatchReservationActive &&
-        state.dispatcher.publicationBatchTerminalProbe === candidateProbe &&
+        (probedPairs
+          ? candidates.length > 0
+          : state.dispatcher.publicationBatchTerminalProbe === candidateProbe) &&
         dispatchMatchesReservation);
     if (!probeMatches) {
       // Only the workflow holding this exact departure may retire its stale
@@ -7519,6 +7607,7 @@ export class ExactReviewQueue {
     now: number,
     requestedSize: number,
     leaseSize: number,
+    probedPairs: ReadonlySet<string> | null = null,
   ) {
     const control = this.refreshPublicationControlSync(state, now);
     return this.publicationBatchCandidates(
@@ -7535,6 +7624,7 @@ export class ExactReviewQueue {
       ),
       requestedSize,
       leaseSize,
+      probedPairs,
     );
   }
 
@@ -7543,9 +7633,30 @@ export class ExactReviewQueue {
     hostedTargetMetadataToken: HostedTargetMetadataToken,
     eligibilityPrepared = false,
   ): Promise<HostedTargetAdmission> {
+    const normalizedRepo = targetRepo.trim().toLowerCase();
+    const cacheKey = `hosted-target-admission:${normalizedRepo}`;
+    const revocationKey = `hosted-target-admission-revoked:${normalizedRepo}`;
+    const maxStaleMs = exactReviewHostedTargetAdmissionMaxStaleMs(this.env);
+    const revocationRetentionMs = Math.max(maxStaleMs, 30 * 60_000);
+    // Revocations carry a unique token, not only a timestamp: two observations
+    // inside one millisecond, or a revocation recorded after an expired
+    // tombstone was deleted, must still fence an in-flight probe.
+    const revocation = objectValue(this.storage.kv.get(revocationKey));
+    if (typeof revocation.at === "number" && Date.now() - revocation.at >= revocationRetentionMs) {
+      this.storage.kv.delete(revocationKey);
+    }
+    const revocationToken = () => {
+      const token = objectValue(this.storage.kv.get(revocationKey)).token;
+      return typeof token === "string" ? token : null;
+    };
+    const revoke = () => {
+      this.storage.kv.delete(cacheKey);
+      this.storage.kv.put(revocationKey, { at: Date.now(), token: crypto.randomUUID() });
+    };
     if (!eligibilityPrepared) {
       const eligibility = await this.hostedTargetEligibility(targetRepo);
       if (eligibility.outcome !== "eligible") {
+        if (eligibility.outcome === "terminal") revoke();
         return eligibility.outcome === "terminal"
           ? { outcome: "terminal" }
           : {
@@ -7554,22 +7665,66 @@ export class ExactReviewQueue {
             };
       }
     }
+    const cached = objectValue(this.storage.kv.get(cacheKey));
+    const age = Date.now() - Number(cached.observedAt);
+    const cachedPublic =
+      maxStaleMs > 0 &&
+      cached.outcome === "public" &&
+      typeof cached.observedAt === "number" &&
+      age >= 0 &&
+      age < maxStaleMs;
+    if (!cachedPublic) this.storage.kv.delete(cacheKey);
+    if (cachedPublic && age < exactReviewHostedTargetAdmissionFreshMs(this.env)) {
+      return { outcome: "public" };
+    }
     const injected = this.env.hostedPublicTargetProbe;
+    const probeStartedAt = Date.now();
+    const probeRevocationToken = revocationToken();
+    let admission: HostedTargetAdmission;
     if (typeof injected === "function") {
-      return normalizeHostedTargetAdmission(await injected(targetRepo));
+      admission = normalizeHostedTargetAdmission(await injected(targetRepo));
+    } else {
+      try {
+        admission = await probeHostedPublicTarget(
+          targetRepo,
+          await hostedTargetMetadataToken(),
+          (input, init) => fetch(input, init),
+          { apiUrl: (path) => githubApiUrl(this.env, path) },
+        );
+      } catch (error) {
+        admission = hostedTargetRetryableAdmission(error);
+      }
     }
-    try {
-      return await probeHostedPublicTarget(
-        targetRepo,
-        await hostedTargetMetadataToken(),
-        (input, init) => fetch(input, init),
-        {
-          apiUrl: (path) => githubApiUrl(this.env, path),
-        },
-      );
-    } catch (error) {
-      return hostedTargetRetryableAdmission(error);
+    if (admission.outcome === "public") {
+      // A tombstone that merely expired during the probe is not a new
+      // observation; any token the probe did not start with is.
+      const currentRevocationToken = revocationToken();
+      if (currentRevocationToken !== null && currentRevocationToken !== probeRevocationToken) {
+        return { outcome: "terminal" };
+      }
+      // A probe outliving revocation retention cannot safely repopulate admission.
+      if (Date.now() - probeStartedAt >= revocationRetentionMs) return { outcome: "retryable" };
+      if (maxStaleMs > 0) {
+        this.storage.kv.put(cacheKey, { outcome: "public", observedAt: Date.now() });
+      }
+    } else if (admission.outcome === "terminal") {
+      revoke();
+    } else if (admission.outcome === "retryable") {
+      // Re-read after the probe: a concurrent terminal observation revokes fallback.
+      const current = objectValue(this.storage.kv.get(cacheKey));
+      const currentAge = Date.now() - Number(current.observedAt);
+      if (
+        maxStaleMs > 0 &&
+        current.outcome === "public" &&
+        typeof current.observedAt === "number" &&
+        currentAge >= 0 &&
+        currentAge < maxStaleMs
+      ) {
+        return { outcome: "public" };
+      }
+      this.storage.kv.delete(cacheKey);
     }
+    return admission;
   }
 
   private async hostedTargetEligibility(targetRepo: string): Promise<HostedTargetEligibility> {
@@ -13993,6 +14148,55 @@ function exactReviewPublicationBatchCandidateProbe(
   candidates: ReadonlyArray<Pick<ExactReviewQueueItem, "key" | "revision">>,
 ) {
   return JSON.stringify(candidates.map((candidate) => [candidate.key, candidate.revision]));
+}
+
+function exactReviewPublicationBatchReservedProbe(
+  state: ExactReviewQueueState,
+  now: number,
+  dispatchId: string | undefined,
+): Set<string> | null {
+  const dispatcher = state.dispatcher;
+  if (
+    !dispatchId ||
+    dispatcher?.publicationBatchDispatchedAt === undefined ||
+    dispatchId !== dispatcher.publicationBatchDispatchId ||
+    Number(dispatcher.publicationBatchDispatchPendingUntil || 0) <= now
+  )
+    return null;
+  try {
+    const pairs: unknown = JSON.parse(dispatcher.publicationBatchTerminalProbe ?? "");
+    if (
+      !Array.isArray(pairs) ||
+      !pairs.every(
+        (pair) =>
+          Array.isArray(pair) &&
+          pair.length === 2 &&
+          typeof pair[0] === "string" &&
+          pair[0].length > 0 &&
+          Number.isSafeInteger(pair[1]) &&
+          pair[1] > 0,
+      )
+    )
+      return null;
+    return new Set(pairs.map((pair) => JSON.stringify(pair)));
+  } catch {
+    return null;
+  }
+}
+
+function exactReviewHostedTargetAdmissionFreshMs(env) {
+  return Math.max(0, numberFrom(env.EXACT_REVIEW_HOSTED_TARGET_ADMISSION_FRESH_MS, 60_000));
+}
+
+function exactReviewHostedTargetAdmissionMaxStaleMs(env) {
+  return Math.max(
+    0,
+    numberFrom(env.EXACT_REVIEW_HOSTED_TARGET_ADMISSION_MAX_STALE_MS, 30 * 60_000),
+  );
+}
+
+function exactReviewStalePublicationPruneLimit(env) {
+  return Math.max(0, Math.floor(numberFrom(env.EXACT_REVIEW_STALE_PUBLICATION_PRUNE_LIMIT, 100)));
 }
 
 function exactReviewPublicationBatchLeaseMs(env) {

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -1022,6 +1022,7 @@ export class ExactReviewQueue {
           targetRepo,
           hostedTargetMetadataToken,
           this.hasPreparedHostedTargetEligibility(request, targetRepo),
+          true,
         );
         if (admission.outcome !== "public") {
           return hostedTargetProbeResponse(admission);
@@ -1070,6 +1071,7 @@ export class ExactReviewQueue {
         decision.targetRepo,
         hostedTargetMetadataToken,
         this.hasPreparedHostedTargetEligibility(request, decision.targetRepo),
+        true,
       );
       if (admission.outcome !== "public") {
         return hostedTargetProbeResponse(admission);
@@ -1141,6 +1143,7 @@ export class ExactReviewQueue {
         decision.targetRepo,
         hostedTargetMetadataToken,
         this.hasPreparedHostedTargetEligibility(request, decision.targetRepo),
+        true,
       );
       if (admission.outcome !== "public") {
         return hostedTargetProbeResponse(admission);
@@ -1319,6 +1322,7 @@ export class ExactReviewQueue {
         decision.targetRepo,
         hostedTargetMetadataToken,
         this.hasPreparedHostedTargetEligibility(request, decision.targetRepo),
+        true,
       );
       if (admission.outcome !== "public") return hostedTargetProbeResponse(admission);
 
@@ -7632,6 +7636,11 @@ export class ExactReviewQueue {
     targetRepo: string,
     hostedTargetMetadataToken: HostedTargetMetadataToken,
     eligibilityPrepared = false,
+    // Only intake routes may consume a cached public observation. Review
+    // claims, dispatch, batch claims, and acknowledgement paths hand out
+    // credential-bearing work, so they always require a current live public
+    // probe (fail closed).
+    intake = false,
   ): Promise<HostedTargetAdmission> {
     const normalizedRepo = targetRepo.trim().toLowerCase();
     const cacheKey = `hosted-target-admission:${normalizedRepo}`;
@@ -7674,7 +7683,7 @@ export class ExactReviewQueue {
       age >= 0 &&
       age < maxStaleMs;
     if (!cachedPublic) this.storage.kv.delete(cacheKey);
-    if (cachedPublic && age < exactReviewHostedTargetAdmissionFreshMs(this.env)) {
+    if (intake && cachedPublic && age < exactReviewHostedTargetAdmissionFreshMs(this.env)) {
       return { outcome: "public" };
     }
     const injected = this.env.hostedPublicTargetProbe;
@@ -7713,16 +7722,16 @@ export class ExactReviewQueue {
       // Re-read after the probe: a concurrent terminal observation revokes fallback.
       const current = objectValue(this.storage.kv.get(cacheKey));
       const currentAge = Date.now() - Number(current.observedAt);
-      if (
+      const currentValid =
         maxStaleMs > 0 &&
         current.outcome === "public" &&
         typeof current.observedAt === "number" &&
         currentAge >= 0 &&
-        currentAge < maxStaleMs
-      ) {
-        return { outcome: "public" };
-      }
-      this.storage.kv.delete(cacheKey);
+        currentAge < maxStaleMs;
+      if (intake && currentValid) return { outcome: "public" };
+      // A transient failure on a live-only path is not evidence against the
+      // target; keep a still-valid observation for intake and drop only stale.
+      if (!currentValid) this.storage.kv.delete(cacheKey);
     }
     return admission;
   }

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -5899,9 +5899,9 @@ export class ExactReviewQueue {
       newestByTarget.set(
         revision.targetKey,
         Math.max(
-          newestByTarget.get(revision.targetKey) ?? 0,
+          newestByTarget.get(revision.targetKey) ??
+            this.publicationHeadRevisionSync(revision.targetKey),
           revision.sourceRevision,
-          this.publicationHeadRevisionSync(revision.targetKey),
         ),
       );
       return [{ item, revision, lineage: exactReviewPublicationLineage(item.decision) }];
@@ -5928,10 +5928,14 @@ export class ExactReviewQueue {
       state,
       activeBatchItemKeys,
     );
+    const limit = Math.max(
+      0,
+      Math.floor(numberFrom(this.env.EXACT_REVIEW_STALE_PUBLICATION_PRUNE_LIMIT, 100)),
+    );
     let changed = 0;
     for (const { item, revision } of stale
       .filter(({ item }) => !exactReviewQueueHasCommandContext(item))
-      .slice(0, exactReviewStalePublicationPruneLimit(this.env))) {
+      .slice(0, limit)) {
       const current = state.items[item.key];
       const currentRevision = current ? exactReviewPublicationRevision(current.decision) : null;
       if (
@@ -6405,14 +6409,7 @@ export class ExactReviewQueue {
             // immutable lifecycle plan must return through the fenced legacy
             // publisher, which is the only path that replays that plan.
             .filter(exactReviewQueueIsBatchablePublication)
-            .filter((item) => !item.terminalFinalization)
-            // A dispatched workflow may claim only members that passed its
-            // departure's terminal preflight. Filter before the lease-size cut so
-            // an unprobed fresh arrival cannot push a probed member out of the
-            // batch; the arrival waits for the next departure instead.
-            .filter(
-              (item) => !probedPairs || probedPairs.has(JSON.stringify([item.key, item.revision])),
-            );
+            .filter((item) => !item.terminalFinalization);
     const selection = exactReviewPublicationBatchSelection(
       readyCandidates,
       freshItemKeys,
@@ -7636,20 +7633,18 @@ export class ExactReviewQueue {
     targetRepo: string,
     hostedTargetMetadataToken: HostedTargetMetadataToken,
     eligibilityPrepared = false,
-    // Only intake routes may consume a cached public observation. Review
-    // claims, dispatch, batch claims, and acknowledgement paths hand out
-    // credential-bearing work, so they always require a current live public
-    // probe (fail closed).
+    // Credential-bearing paths must probe live; only intake can consume the cache.
     intake = false,
   ): Promise<HostedTargetAdmission> {
     const normalizedRepo = targetRepo.trim().toLowerCase();
     const cacheKey = `hosted-target-admission:${normalizedRepo}`;
     const revocationKey = `hosted-target-admission-revoked:${normalizedRepo}`;
-    const maxStaleMs = exactReviewHostedTargetAdmissionMaxStaleMs(this.env);
+    const maxStaleMs = Math.max(
+      0,
+      numberFrom(this.env.EXACT_REVIEW_HOSTED_TARGET_ADMISSION_MAX_STALE_MS, 30 * 60_000),
+    );
     const revocationRetentionMs = Math.max(maxStaleMs, 30 * 60_000);
-    // Revocations carry a unique token, not only a timestamp: two observations
-    // inside one millisecond, or a revocation recorded after an expired
-    // tombstone was deleted, must still fence an in-flight probe.
+    // Unique tokens fence probes across same-millisecond revocations and tombstone expiry.
     const revocation = objectValue(this.storage.kv.get(revocationKey));
     if (typeof revocation.at === "number" && Date.now() - revocation.at >= revocationRetentionMs) {
       this.storage.kv.delete(revocationKey);
@@ -7674,16 +7669,22 @@ export class ExactReviewQueue {
             };
       }
     }
-    const cached = objectValue(this.storage.kv.get(cacheKey));
-    const age = Date.now() - Number(cached.observedAt);
-    const cachedPublic =
-      maxStaleMs > 0 &&
-      cached.outcome === "public" &&
-      typeof cached.observedAt === "number" &&
-      age >= 0 &&
-      age < maxStaleMs;
-    if (!cachedPublic) this.storage.kv.delete(cacheKey);
-    if (intake && cachedPublic && age < exactReviewHostedTargetAdmissionFreshMs(this.env)) {
+    const cachedPublicAge = () => {
+      const cached = objectValue(this.storage.kv.get(cacheKey));
+      const age = Date.now() - Number(cached.observedAt);
+      if (
+        cached.outcome === "public" &&
+        typeof cached.observedAt === "number" &&
+        age >= 0 &&
+        age < maxStaleMs
+      ) {
+        return age;
+      }
+      this.storage.kv.delete(cacheKey);
+      return null;
+    };
+    const age = cachedPublicAge();
+    if (intake && age !== null && age < exactReviewHostedTargetAdmissionFreshMs(this.env)) {
       return { outcome: "public" };
     }
     const injected = this.env.hostedPublicTargetProbe;
@@ -7711,7 +7712,7 @@ export class ExactReviewQueue {
       if (currentRevocationToken !== null && currentRevocationToken !== probeRevocationToken) {
         return { outcome: "terminal" };
       }
-      // A probe outliving revocation retention cannot safely repopulate admission.
+      // A longer probe could miss both a revocation and its later expiry.
       if (Date.now() - probeStartedAt >= revocationRetentionMs) return { outcome: "retryable" };
       if (maxStaleMs > 0) {
         this.storage.kv.put(cacheKey, { outcome: "public", observedAt: Date.now() });
@@ -7720,18 +7721,7 @@ export class ExactReviewQueue {
       revoke();
     } else if (admission.outcome === "retryable") {
       // Re-read after the probe: a concurrent terminal observation revokes fallback.
-      const current = objectValue(this.storage.kv.get(cacheKey));
-      const currentAge = Date.now() - Number(current.observedAt);
-      const currentValid =
-        maxStaleMs > 0 &&
-        current.outcome === "public" &&
-        typeof current.observedAt === "number" &&
-        currentAge >= 0 &&
-        currentAge < maxStaleMs;
-      if (intake && currentValid) return { outcome: "public" };
-      // A transient failure on a live-only path is not evidence against the
-      // target; keep a still-valid observation for intake and drop only stale.
-      if (!currentValid) this.storage.kv.delete(cacheKey);
+      if (cachedPublicAge() !== null && intake) return { outcome: "public" };
     }
     return admission;
   }
@@ -14174,20 +14164,16 @@ function exactReviewPublicationBatchReservedProbe(
     return null;
   try {
     const pairs: unknown = JSON.parse(dispatcher.publicationBatchTerminalProbe ?? "");
-    if (
-      !Array.isArray(pairs) ||
-      !pairs.every(
-        (pair) =>
-          Array.isArray(pair) &&
-          pair.length === 2 &&
-          typeof pair[0] === "string" &&
-          pair[0].length > 0 &&
-          Number.isSafeInteger(pair[1]) &&
-          pair[1] > 0,
-      )
-    )
-      return null;
-    return new Set(pairs.map((pair) => JSON.stringify(pair)));
+    if (!Array.isArray(pairs)) return null;
+    const probed = new Set<string>();
+    for (const pair of pairs) {
+      if (!Array.isArray(pair) || pair.length !== 2) return null;
+      const [key, revision] = pair;
+      if (typeof key !== "string" || !key || !Number.isSafeInteger(revision) || revision <= 0)
+        return null;
+      probed.add(JSON.stringify(pair));
+    }
+    return probed;
   } catch {
     return null;
   }
@@ -14195,17 +14181,6 @@ function exactReviewPublicationBatchReservedProbe(
 
 function exactReviewHostedTargetAdmissionFreshMs(env) {
   return Math.max(0, numberFrom(env.EXACT_REVIEW_HOSTED_TARGET_ADMISSION_FRESH_MS, 60_000));
-}
-
-function exactReviewHostedTargetAdmissionMaxStaleMs(env) {
-  return Math.max(
-    0,
-    numberFrom(env.EXACT_REVIEW_HOSTED_TARGET_ADMISSION_MAX_STALE_MS, 30 * 60_000),
-  );
-}
-
-function exactReviewStalePublicationPruneLimit(env) {
-  return Math.max(0, Math.floor(numberFrom(env.EXACT_REVIEW_STALE_PUBLICATION_PRUNE_LIMIT, 100)));
 }
 
 function exactReviewPublicationBatchLeaseMs(env) {

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -358,13 +358,9 @@ and hot intake `14`. Existing repair lanes keep their
 
 ## Runtime Overrides
 
-- `EXACT_REVIEW_HOSTED_TARGET_ADMISSION_FRESH_MS` sets the public-admission
-  cache's no-probe window (60,000 ms by default).
-- `EXACT_REVIEW_HOSTED_TARGET_ADMISSION_MAX_STALE_MS` bounds reuse of cached
-  public admission after retryable probes (1,800,000 ms by default). Zero
-  disables both cache tiers; terminal probes always clear the cache.
-- `EXACT_REVIEW_STALE_PUBLICATION_PRUNE_LIMIT` bounds automatic stale-revision
-  publication cleanup per alarm (100 by default; zero disables the pass).
+- `EXACT_REVIEW_HOSTED_TARGET_ADMISSION_FRESH_MS`: intake's no-probe public-admission cache window (default 60,000 ms).
+- `EXACT_REVIEW_HOSTED_TARGET_ADMISSION_MAX_STALE_MS`: intake fallback after retryable probes (default 1,800,000 ms; zero disables caching; terminal probes revoke).
+- `EXACT_REVIEW_STALE_PUBLICATION_PRUNE_LIMIT`: stale-revision cleanup per alarm (default 100; zero disables).
 - `EXACT_REVIEW_PUBLICATION_RECOVERY_SUCCESSES` overrides how many consecutive
   clean publications raise the adaptive publication ceiling by one step; the
   default is 10 (clamped 1-1000). The former hardcoded 50 pinned the lane at

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -358,6 +358,13 @@ and hot intake `14`. Existing repair lanes keep their
 
 ## Runtime Overrides
 
+- `EXACT_REVIEW_HOSTED_TARGET_ADMISSION_FRESH_MS` sets the public-admission
+  cache's no-probe window (60,000 ms by default).
+- `EXACT_REVIEW_HOSTED_TARGET_ADMISSION_MAX_STALE_MS` bounds reuse of cached
+  public admission after retryable probes (1,800,000 ms by default). Zero
+  disables both cache tiers; terminal probes always clear the cache.
+- `EXACT_REVIEW_STALE_PUBLICATION_PRUNE_LIMIT` bounds automatic stale-revision
+  publication cleanup per alarm (100 by default; zero disables the pass).
 - `EXACT_REVIEW_PUBLICATION_RECOVERY_SUCCESSES` overrides how many consecutive
   clean publications raise the adaptive publication ceiling by one step; the
   default is 10 (clamped 1-1000). The former hardcoded 50 pinned the lane at

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -465,31 +465,21 @@ still-valid subset of the key/revision pairs checked before departure. Fresh
 arrivals wait for the next departure; changed or removed members are skipped.
 An empty subset retires that reservation and requests another preflight.
 
-Eligible hosted targets retain successful public-admission observations in
-the queue's durable KV. Only the signed intake routes (`/enqueue`,
-`/command-intake`, `/branch-authority`, `/source-authority`) may consume that
-cache; review claims, dispatch, batch claims, and acknowledgement paths always
-require a current live public probe before handing out credential-bearing
-work, so a target that turns private is refused there immediately (a batch
-fetch relies on the probe its claim performed). On intake,
-`EXACT_REVIEW_HOSTED_TARGET_ADMISSION_FRESH_MS` (60,000 ms by default) admits
-without another probe, and after that window a retryable probe may reuse public
-admission until `EXACT_REVIEW_HOSTED_TARGET_ADMISSION_MAX_STALE_MS`
-(1,800,000 ms by default). Terminal probes clear the entry; max-stale zero
-disables both cache tiers. Expired entries are removed when read.
-Terminal visibility or eligibility observations persist a revocation tombstone
-with a unique token that fences older in-flight public probes even across
-tombstone expiry; tombstones expire lazily after at least 30 minutes, and probes
-outliving that retention must retry.
+Only signed intake (`/enqueue`, `/command-intake`, `/branch-authority`,
+`/source-authority`) may reuse durable KV public-admission observations;
+credential-bearing paths require live probes. `EXACT_REVIEW_HOSTED_TARGET_ADMISSION_FRESH_MS`
+(60,000 ms) permits intake without probing; retryable probes allow fallback until
+`EXACT_REVIEW_HOSTED_TARGET_ADMISSION_MAX_STALE_MS` (1,800,000 ms; zero disables caching).
+Terminal visibility or eligibility revokes admission with a unique token fencing
+older probes, including across tombstone expiry. Tombstones expire lazily after
+at least 30 minutes; probes outliving retention must retry.
 
-Each alarm removes up to `EXACT_REVIEW_STALE_PUBLICATION_PRUNE_LIMIT` superseded
-publication revisions (100 by default), oldest first, without GitHub reads.
-Only pending or parked rows without active batch ownership or terminal
-finalization qualify; rows with command context remain for acknowledgement or
-explicit operator reconciliation. Duplicate-lineage and legacy terminal cleanup remain
-operator reconciliation work. A successfully queued publication also expires
-its workflow-owned review-start lease so another exact-head review can proceed;
-the later publisher still deletes the placeholder after terminal publication.
+Alarms prune up to `EXACT_REVIEW_STALE_PUBLICATION_PRUNE_LIMIT` stale revisions
+(default 100), oldest first, without GitHub reads. Only pending/parked rows without
+active batch ownership, terminal finalization or command context qualify;
+duplicate-lineage and legacy terminal cleanup remains operator-owned.
+Successful queue handoff expires the workflow's review-start lease to permit
+another exact-head review; terminal publication still deletes the placeholder.
 
 The binding-only publication state retains additional diagnostics:
 

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -460,6 +460,31 @@ counts but are not serialized by the public projector. Document effective
 production values from `dashboard/wrangler.toml`, not only fallback constants
 in `dashboard/exact-review-queue.ts`.
 
+Batch claims carrying the current dispatch reservation consume only the
+still-valid subset of the key/revision pairs checked before departure. Fresh
+arrivals wait for the next departure; changed or removed members are skipped.
+An empty subset retires that reservation and requests another preflight.
+
+Eligible hosted targets retain successful public-admission observations in
+the queue's durable KV. `EXACT_REVIEW_HOSTED_TARGET_ADMISSION_FRESH_MS` defaults
+to 60,000 ms without another probe. After that window, a retryable probe may
+reuse public admission until `EXACT_REVIEW_HOSTED_TARGET_ADMISSION_MAX_STALE_MS`
+(1,800,000 ms by default). Terminal probes clear the entry; max-stale zero
+disables both cache tiers. Expired entries are removed when read.
+Terminal visibility or eligibility observations persist a revocation tombstone
+with a unique token that fences older in-flight public probes even across
+tombstone expiry; tombstones expire lazily after at least 30 minutes, and probes
+outliving that retention must retry.
+
+Each alarm removes up to `EXACT_REVIEW_STALE_PUBLICATION_PRUNE_LIMIT` superseded
+publication revisions (100 by default), oldest first, without GitHub reads.
+Only pending or parked rows without active batch ownership or terminal
+finalization qualify; rows with command context remain for acknowledgement or
+explicit operator reconciliation. Duplicate-lineage and legacy terminal cleanup remain
+operator reconciliation work. A successfully queued publication also expires
+its workflow-owned review-start lease so another exact-head review can proceed;
+the later publisher still deletes the placeholder after terminal publication.
+
 The binding-only publication state retains additional diagnostics:
 
 - `credential_circuits` records the pool class, optional target owner,

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -466,9 +466,15 @@ arrivals wait for the next departure; changed or removed members are skipped.
 An empty subset retires that reservation and requests another preflight.
 
 Eligible hosted targets retain successful public-admission observations in
-the queue's durable KV. `EXACT_REVIEW_HOSTED_TARGET_ADMISSION_FRESH_MS` defaults
-to 60,000 ms without another probe. After that window, a retryable probe may
-reuse public admission until `EXACT_REVIEW_HOSTED_TARGET_ADMISSION_MAX_STALE_MS`
+the queue's durable KV. Only the signed intake routes (`/enqueue`,
+`/command-intake`, `/branch-authority`, `/source-authority`) may consume that
+cache; review claims, dispatch, batch claims, and acknowledgement paths always
+require a current live public probe before handing out credential-bearing
+work, so a target that turns private is refused there immediately (a batch
+fetch relies on the probe its claim performed). On intake,
+`EXACT_REVIEW_HOSTED_TARGET_ADMISSION_FRESH_MS` (60,000 ms by default) admits
+without another probe, and after that window a retryable probe may reuse public
+admission until `EXACT_REVIEW_HOSTED_TARGET_ADMISSION_MAX_STALE_MS`
 (1,800,000 ms by default). Terminal probes clear the entry; max-stale zero
 disables both cache tiers. Expired entries are removed when read.
 Terminal visibility or eligibility observations persist a revocation tombstone

--- a/src/clawsweeper-command-operations.ts
+++ b/src/clawsweeper-command-operations.ts
@@ -14,6 +14,7 @@ import {
 import { createApplyActionLedger } from "./clawsweeper-apply-ledger.js";
 import { boolArg, numberArg, stringArg, type Args } from "./clawsweeper-args.js";
 import { createFailedReviewRetryWorkflow } from "./clawsweeper-failed-review-retry.js";
+import { expireReviewStartStatusLease } from "./clawsweeper-review-comment-state.js";
 import type {
   ExactReviewQueueAuthority,
   ExpectedIssueSourceRevisionOptions,
@@ -286,6 +287,35 @@ export function createCommandOperations(dependencies: CreateCommandOperationsDep
     workflowRunEvidence,
     workPlanPathForReport,
   } = dependencies;
+
+  function expireReviewLeaseCommand(args: Args): void {
+    repoFromArgs(args.repo === undefined ? args : { ...args, target_repo: args.repo });
+    const itemNumber = numberArg(args.item_number, 0);
+    const commentId = numberArg(args.comment_id, 0);
+    if (
+      !Number.isSafeInteger(itemNumber) ||
+      itemNumber <= 0 ||
+      !Number.isSafeInteger(commentId) ||
+      commentId <= 0
+    ) {
+      throw new UserFacingCommandError("--item-number and --comment-id must be positive integers.");
+    }
+    const path = `repos/${targetRepo()}/issues/comments/${commentId}`;
+    const comment = ghJson<{ body?: string; user?: { login?: string } }>(["api", path]);
+    const body = comment.body ?? "";
+    const identity = /<!--\s*clawsweeper-review(?:-lease)?\s+item=(\d+)\s*-->\s*$/i.exec(body);
+    if (
+      Number(identity?.[1]) !== itemNumber ||
+      !["clawsweeper", "clawsweeper[bot]", "openclaw-clawsweeper[bot]"].includes(
+        comment.user?.login ?? "",
+      )
+    )
+      return;
+    const expired = expireReviewStartStatusLease(body, new Date().toISOString());
+    if (expired !== body) {
+      ghWithRetry(["api", path, "--method", "PATCH", "-f", `body=${expired}`]);
+    }
+  }
 
   function reserveReviewLeaseCommand(args: Args): void {
     repoFromArgs(args);
@@ -956,6 +986,7 @@ export function createCommandOperations(dependencies: CreateCommandOperationsDep
     recordApplyActionLedgerItemResults,
     recordApplyMutationBoundary,
     reserveReviewLeaseCommand,
+    expireReviewLeaseCommand,
     retryFailedReviewsCommand,
     reviewCommentPublicationEventDisposition,
     reviewRetryActionDisposition,

--- a/src/clawsweeper-command-operations.ts
+++ b/src/clawsweeper-command-operations.ts
@@ -292,26 +292,19 @@ export function createCommandOperations(dependencies: CreateCommandOperationsDep
     repoFromArgs(args.repo === undefined ? args : { ...args, target_repo: args.repo });
     const itemNumber = numberArg(args.item_number, 0);
     const commentId = numberArg(args.comment_id, 0);
-    if (
-      !Number.isSafeInteger(itemNumber) ||
-      itemNumber <= 0 ||
-      !Number.isSafeInteger(commentId) ||
-      commentId <= 0
-    ) {
+    if (![itemNumber, commentId].every((value) => Number.isSafeInteger(value) && value > 0)) {
       throw new UserFacingCommandError("--item-number and --comment-id must be positive integers.");
     }
     const path = `repos/${targetRepo()}/issues/comments/${commentId}`;
     const comment = ghJson<{ body?: string; user?: { login?: string } }>(["api", path]);
     const body = comment.body ?? "";
-    const identity = /<!--\s*clawsweeper-review(?:-lease)?\s+item=(\d+)\s*-->\s*$/i.exec(body);
     if (
-      Number(identity?.[1]) !== itemNumber ||
       !["clawsweeper", "clawsweeper[bot]", "openclaw-clawsweeper[bot]"].includes(
         comment.user?.login ?? "",
       )
     )
       return;
-    const expired = expireReviewStartStatusLease(body, new Date().toISOString());
+    const expired = expireReviewStartStatusLease(body, new Date().toISOString(), itemNumber);
     if (expired !== body) {
       ghWithRetry(["api", path, "--method", "PATCH", "-f", `body=${expired}`]);
     }

--- a/src/clawsweeper-review-comment-state.ts
+++ b/src/clawsweeper-review-comment-state.ts
@@ -32,7 +32,11 @@ export function normalizeNoopReviewMarkerMetadata(body: string): string {
 }
 import type { createReviewCommentIdentity } from "./clawsweeper-review-comment-identity.js";
 
-export function expireReviewStartStatusLease(body: string, expiresAt: string): string {
+export function expireReviewStartStatusLease(
+  body: string,
+  expiresAt: string,
+  itemNumber?: number,
+): string {
   const trailing = trailingHtmlComments(body);
   const identity = /^<!--\s*clawsweeper-review(?:-lease)?\s+item=([1-9]\d*)\s*-->$/i.exec(
     trailing.at(-1) ?? "",
@@ -40,6 +44,7 @@ export function expireReviewStartStatusLease(body: string, expiresAt: string): s
   const marker = trailing.at(-2) ?? "";
   if (
     !identity ||
+    (itemNumber !== undefined && Number(identity[1]) !== itemNumber) ||
     !/^<!--\s*clawsweeper-review-status:started\b[^>]*-->$/i.test(marker) ||
     /\sitem=(\d+)(?=\s|-->)/.exec(marker)?.[1] !== identity[1]
   )

--- a/src/clawsweeper-review-comment-state.ts
+++ b/src/clawsweeper-review-comment-state.ts
@@ -32,6 +32,26 @@ export function normalizeNoopReviewMarkerMetadata(body: string): string {
 }
 import type { createReviewCommentIdentity } from "./clawsweeper-review-comment-identity.js";
 
+export function expireReviewStartStatusLease(body: string, expiresAt: string): string {
+  const trailing = trailingHtmlComments(body);
+  const identity = /^<!--\s*clawsweeper-review(?:-lease)?\s+item=([1-9]\d*)\s*-->$/i.exec(
+    trailing.at(-1) ?? "",
+  );
+  const marker = trailing.at(-2) ?? "";
+  if (
+    !identity ||
+    !/^<!--\s*clawsweeper-review-status:started\b[^>]*-->$/i.test(marker) ||
+    /\sitem=(\d+)(?=\s|-->)/.exec(marker)?.[1] !== identity[1]
+  )
+    return body;
+  const rewritten = marker.replace(
+    /(\slease_expires_at=)[^\s>]+/,
+    (_match, prefix: string) => `${prefix}${expiresAt}`,
+  );
+  const offset = body.lastIndexOf(marker);
+  return body.slice(0, offset) + rewritten + body.slice(offset + marker.length);
+}
+
 export function createReviewCommentState(
   dependencies: ReviewCommentWorkflowDependencies & ReturnType<typeof createReviewCommentIdentity>,
 ) {

--- a/src/clawsweeper-runtime.ts
+++ b/src/clawsweeper-runtime.ts
@@ -1270,6 +1270,7 @@ const {
   failedReviewRetryStatePath,
   readFailedReviewRetryState,
   reserveReviewLeaseCommand,
+  expireReviewLeaseCommand,
   retryFailedReviewsCommand,
 } = commandOperations;
 
@@ -1581,6 +1582,7 @@ function liveProofCommentCommand(args: Args): void {
 const COMMAND_HANDLERS: Readonly<Record<string, CommandHandler<Args>>> = {
   plan: planCommand,
   "reserve-review-lease": reserveReviewLeaseCommand,
+  "expire-review-lease": expireReviewLeaseCommand,
   review: reviewCommand,
   "retry-failed-reviews": retryFailedReviewsCommand,
   "apply-artifacts": applyArtifactsCommand,

--- a/test/command.test.ts
+++ b/test/command.test.ts
@@ -32,20 +32,21 @@ import { writeFakeScanner } from "./agent-input-scan-helpers.ts";
 
 const CLI = fileURLToPath(new URL("../dist/clawsweeper.js", import.meta.url));
 
-test("expire-review-lease patches the queued placeholder and preserves unrelated comments", () => {
+test("expire-review-lease patches the queued placeholder and preserves unrelated comments", (t) => {
+  const repo = "openclaw/openclaw";
   const root = mkdtempSync(join(tmpdir(), "cmd-expire-lease-"));
   const ghPath = join(root, "gh.js");
   const commentPath = join(root, "comment.json");
   const patchPath = join(root, "patch.json");
   const expiresAt = "2099-09-02T21:41:00.000Z";
   const body = `Review started.\n<!-- clawsweeper-review-status:started item=357 sha=${"a".repeat(40)} started_at=2026-09-02T21:00:00.000Z lease_expires_at=${expiresAt} owner=worker-1 v=1 -->\n<!-- clawsweeper-review-lease item=357 -->\n`;
-  try {
-    writeFileSync(
-      ghPath,
-      `
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  writeFileSync(
+    ghPath,
+    `
 const fs = require("node:fs");
 const args = process.argv.slice(2);
-if (args[0] !== "api" || args[1] !== "repos/openclaw/openclaw/issues/comments/9991") process.exit(1);
+if (args[0] !== "api" || args[1] !== "repos/${repo}/issues/comments/9991") process.exit(1);
 if (args.includes("PATCH")) {
   const field = args.find((arg) => arg.startsWith("body="));
   if (!field) process.exit(2);
@@ -53,45 +54,32 @@ if (args.includes("PATCH")) {
 }
 process.stdout.write(fs.readFileSync(${JSON.stringify(commentPath)}, "utf8"));
 `,
+  );
+  for (const fixture of [
+    body,
+    "Published review without a lease.\n",
+    body.replace(/item=357/g, "item=358"),
+  ]) {
+    writeFileSync(
+      commentPath,
+      JSON.stringify({ id: 9991, body: fixture, user: { login: "clawsweeper[bot]" } }),
     );
-    for (const fixture of [
-      body,
-      "Published review without a lease.\n",
-      body.replace(/item=357/g, "item=358"),
-    ]) {
-      writeFileSync(
-        commentPath,
-        JSON.stringify({ id: 9991, body: fixture, user: { login: "clawsweeper[bot]" } }),
-      );
-      rmSync(patchPath, { force: true });
-      const before = Date.now();
-      const result = spawnSync(
-        process.execPath,
-        [
-          CLI,
-          "expire-review-lease",
-          "--repo",
-          "openclaw/openclaw",
-          "--item-number",
-          "357",
-          "--comment-id",
-          "9991",
-        ],
-        {
-          encoding: "utf8",
-          env: { ...process.env, ...mockGhBinEnv(ghPath, root) },
-        },
-      );
-      assert.equal(result.status, 0, result.stderr);
-      if (fixture === body) {
-        const patched = JSON.parse(readFileSync(patchPath, "utf8")).body;
-        const expiry = /lease_expires_at=([^\s>]+)/.exec(patched)![1];
-        assert.ok(Date.parse(expiry) >= before && Date.parse(expiry) <= Date.now());
-        assert.equal(patched, body.replace(expiresAt, expiry));
-      } else assert.equal(existsSync(patchPath), false);
-    }
-  } finally {
-    rmSync(root, { recursive: true, force: true });
+    rmSync(patchPath, { force: true });
+    const before = Date.now();
+    execFileSync(
+      process.execPath,
+      [CLI, "expire-review-lease", "--repo", repo, "--item-number", "357", "--comment-id", "9991"],
+      {
+        encoding: "utf8",
+        env: { ...process.env, ...mockGhBinEnv(ghPath, root) },
+      },
+    );
+    if (fixture === body) {
+      const patched = JSON.parse(readFileSync(patchPath, "utf8")).body;
+      const expiry = /lease_expires_at=([^\s>]+)/.exec(patched)![1];
+      assert.ok(Date.parse(expiry) >= before && Date.parse(expiry) <= Date.now());
+      assert.equal(patched, body.replace(expiresAt, expiry));
+    } else assert.equal(existsSync(patchPath), false);
   }
 });
 

--- a/test/command.test.ts
+++ b/test/command.test.ts
@@ -32,6 +32,69 @@ import { writeFakeScanner } from "./agent-input-scan-helpers.ts";
 
 const CLI = fileURLToPath(new URL("../dist/clawsweeper.js", import.meta.url));
 
+test("expire-review-lease patches the queued placeholder and preserves unrelated comments", () => {
+  const root = mkdtempSync(join(tmpdir(), "cmd-expire-lease-"));
+  const ghPath = join(root, "gh.js");
+  const commentPath = join(root, "comment.json");
+  const patchPath = join(root, "patch.json");
+  const expiresAt = "2099-09-02T21:41:00.000Z";
+  const body = `Review started.\n<!-- clawsweeper-review-status:started item=357 sha=${"a".repeat(40)} started_at=2026-09-02T21:00:00.000Z lease_expires_at=${expiresAt} owner=worker-1 v=1 -->\n<!-- clawsweeper-review-lease item=357 -->\n`;
+  try {
+    writeFileSync(
+      ghPath,
+      `
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+if (args[0] !== "api" || args[1] !== "repos/openclaw/openclaw/issues/comments/9991") process.exit(1);
+if (args.includes("PATCH")) {
+  const field = args.find((arg) => arg.startsWith("body="));
+  if (!field) process.exit(2);
+  fs.writeFileSync(${JSON.stringify(patchPath)}, JSON.stringify({ body: field.slice(5) }));
+}
+process.stdout.write(fs.readFileSync(${JSON.stringify(commentPath)}, "utf8"));
+`,
+    );
+    for (const fixture of [
+      body,
+      "Published review without a lease.\n",
+      body.replace(/item=357/g, "item=358"),
+    ]) {
+      writeFileSync(
+        commentPath,
+        JSON.stringify({ id: 9991, body: fixture, user: { login: "clawsweeper[bot]" } }),
+      );
+      rmSync(patchPath, { force: true });
+      const before = Date.now();
+      const result = spawnSync(
+        process.execPath,
+        [
+          CLI,
+          "expire-review-lease",
+          "--repo",
+          "openclaw/openclaw",
+          "--item-number",
+          "357",
+          "--comment-id",
+          "9991",
+        ],
+        {
+          encoding: "utf8",
+          env: { ...process.env, ...mockGhBinEnv(ghPath, root) },
+        },
+      );
+      assert.equal(result.status, 0, result.stderr);
+      if (fixture === body) {
+        const patched = JSON.parse(readFileSync(patchPath, "utf8")).body;
+        const expiry = /lease_expires_at=([^\s>]+)/.exec(patched)![1];
+        assert.ok(Date.parse(expiry) >= before && Date.parse(expiry) <= Date.now());
+        assert.equal(patched, body.replace(expiresAt, expiry));
+      } else assert.equal(existsSync(patchPath), false);
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("runText explains missing working directories", () => {
   const root = mkdtempSync(join(tmpdir(), "cmd-"));
   const missing = join(root, "missing");

--- a/test/dashboard-worker-harness.ts
+++ b/test/dashboard-worker-harness.ts
@@ -92,6 +92,15 @@ function withHostedTargetAdmissionDefaults<Env extends Record<string, unknown>>(
       value: async () => "public",
     });
   }
+  // Visibility fencing tests exercise each live probe; cache policy has its own queue tests.
+  if (!Object.hasOwn(prepared, "EXACT_REVIEW_HOSTED_TARGET_ADMISSION_MAX_STALE_MS")) {
+    Object.defineProperty(prepared, "EXACT_REVIEW_HOSTED_TARGET_ADMISSION_MAX_STALE_MS", {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value: "0",
+    });
+  }
   return prepared;
 }
 

--- a/test/dashboard-worker-queue-runtime.test.ts
+++ b/test/dashboard-worker-queue-runtime.test.ts
@@ -2720,7 +2720,7 @@ test("exact-review batch claims keep a newer departure fence when an older workf
   }
 });
 
-test("matching stale batch departures release their own fence and redispatch current work", async () => {
+test("matching empty batch departures release their own fence and redispatch current work", async () => {
   const originalNow = Date.now;
   let now = Date.parse("2026-07-25T14:00:00.000Z");
   Date.now = () => now;
@@ -2765,6 +2765,18 @@ test("matching stale batch departures release their own fence and redispatch cur
     };
     const firstDispatch = reserved.dispatcher;
     assert.ok(firstDispatch.publicationBatchTerminalProbe);
+    const superseded = await harness.queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/publications/supersede", {
+        method: "POST",
+        body: JSON.stringify({
+          items: [9251, 9252].map((number) => ({
+            item_key: `openclaw/gogcli#${number}@publish:${number * 10}:1`,
+            revision: 1,
+          })),
+        }),
+      }),
+    );
+    assert.equal((await superseded.json()).superseded, 2);
 
     assert.equal(
       (
@@ -2802,7 +2814,7 @@ test("matching stale batch departures release their own fence and redispatch cur
     assert.equal(released.dispatcher.publicationBatchDispatchPendingUntil, undefined);
     assert.equal(released.dispatcher.publicationBatchTerminalProbe, undefined);
 
-    now += 60_000;
+    now += 300_000;
     await harness.queue.alarm();
     assert.equal(harness.batchDispatches, 2);
     const refreshed = (await harness.storage.get("exact-review-queue")) as typeof reserved;

--- a/test/exact-review-publication-batches.test.ts
+++ b/test/exact-review-publication-batches.test.ts
@@ -1053,30 +1053,90 @@ function batchRequest(path: string, body: unknown) {
   });
 }
 
+function admissionQueue(t: import("node:test").TestContext, overrides = {}) {
+  const storage = new TestStorage();
+  const harness = {
+    now: 7_000_000,
+    outcome: "public" as string | Promise<string>,
+    eligible: true,
+    probes: [] as string[],
+    networkCalls: 0,
+    probeStarted: () => {},
+    storage,
+    queue: null! as ExactReviewQueue,
+    async enqueue(number: number, revision = 1, repo = "openclaw/openclaw") {
+      const delivery = `delivery-${number}-${revision}`;
+      return harness.queue.fetch(
+        publicationRequest(delivery, number, String(7000 + number), repo, revision),
+      );
+    },
+    async post(path: string, body = {}) {
+      return (await harness.queue.fetch(batchRequest(path, body))).json();
+    },
+    async claim(body = {}) {
+      return harness.post("/publication-batches/claim", {
+        claim_id: "claim-1",
+        lease_owner: "worker-1",
+        max_items: 4,
+        ...body,
+      });
+    },
+    async publicationStats() {
+      return (await (await harness.queue.fetch(new Request("https://queue/stats"))).json()).lanes
+        .publication;
+    },
+    restart() {
+      harness.queue = new ExactReviewQueue({ storage }, env);
+    },
+  };
+  const env = {
+    EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+    hostedTargetPredicate: () => harness.eligible,
+    hostedPublicTargetProbe: async (repo: string) => {
+      harness.probes.push(repo);
+      harness.probeStarted();
+      return harness.outcome;
+    },
+    ...overrides,
+  };
+  t.mock.method(Date, "now", () => harness.now);
+  t.mock.method(globalThis, "fetch", async () => {
+    harness.networkCalls += 1;
+    throw new Error("unexpected network");
+  });
+  harness.restart();
+  return harness;
+}
+
 for (const churn of [
   "fresh arrival",
   "revision bump",
   "all probed items gone",
   "older retries become ready beyond the scan window",
 ]) {
-  test(`batch claim after ${churn} consumes only still-valid probed items`, async () => {
-    const originalNow = Date.now;
-    const originalFetch = globalThis.fetch;
-    let now = 7_000_000;
-    Date.now = () => now;
+  test(`batch claim after ${churn} consumes only still-valid probed items`, async (t) => {
     const { privateKey } = generateKeyPairSync("rsa", {
       modulusLength: 2048,
       privateKeyEncoding: { type: "pkcs8", format: "pem" },
       publicKeyEncoding: { type: "spki", format: "pem" },
     });
+    const h = admissionQueue(t, {
+      CLAWSWEEPER_APP_CLIENT_ID: "Iv23test",
+      CLAWSWEEPER_APP_PRIVATE_KEY: privateKey,
+      EXACT_REVIEW_PUBLICATION_BATCH_SIZE: "4",
+      EXACT_REVIEW_PUBLICATION_BATCH_MAX_CONCURRENT: "2",
+      EXACT_REVIEW_PUBLICATION_FRESH_LANE_ENABLED: "1",
+      EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_ITEMS: "1",
+      EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_AGE_MS: "60000",
+      EXACT_REVIEW_PUBLICATION_BATCH_DISPATCH_COOLDOWN_MS: "5000",
+      EXACT_REVIEW_HOSTED_TARGET_ADMISSION_MAX_STALE_MS: "0",
+    });
     const dispatches: Array<{ inputs: Record<string, string> }> = [];
-    const admissionRepos: string[] = [];
-    globalThis.fetch = async (input, init) => {
+    t.mock.method(globalThis, "fetch", async (input, init) => {
       const path = new URL(String(input)).pathname;
       if (path.endsWith("/installation")) return Response.json({ id: 999 });
-      if (path === "/app/installations/999/access_tokens") {
+      if (path === "/app/installations/999/access_tokens")
         return Response.json({ token: "test-token" });
-      }
       if (/\/issues\/\d+$/.test(path)) return Response.json({ state: "open" });
       if (path.endsWith("/exact-review-batch-publish.yml/dispatches")) {
         dispatches.push(JSON.parse(String(init?.body)));
@@ -1084,569 +1144,230 @@ for (const churn of [
       }
       if (path.endsWith("/sweep.yml")) return Response.json({ state: "active" });
       throw new Error(`unexpected fetch ${path}`);
-    };
-    try {
-      const storage = new TestStorage();
-      const queue = new ExactReviewQueue(
-        { storage },
-        {
-          CLAWSWEEPER_APP_CLIENT_ID: "Iv23test",
-          CLAWSWEEPER_APP_PRIVATE_KEY: privateKey,
-          EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
-          EXACT_REVIEW_PUBLICATION_BATCH_SIZE: "4",
-          EXACT_REVIEW_PUBLICATION_BATCH_MAX_CONCURRENT: "2",
-          EXACT_REVIEW_PUBLICATION_FRESH_LANE_ENABLED: "1",
-          EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_ITEMS: "1",
-          EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_AGE_MS: "60000",
-          EXACT_REVIEW_PUBLICATION_BATCH_DISPATCH_COOLDOWN_MS: "5000",
-          EXACT_REVIEW_HOSTED_TARGET_ADMISSION_MAX_STALE_MS: "0",
-          hostedPublicTargetProbe: async (repo: string) => {
-            admissionRepos.push(repo);
-            return "public";
-          },
-        },
-      );
-      if (churn === "older retries become ready beyond the scan window") {
-        for (let number = 1; number <= 6; number += 1) {
-          await queue.fetch(publicationRequest(`retry-${number}`, number, String(7000 + number)));
-          now += 1;
-        }
-        const rows = Array.from(
-          storage.sql.exec("SELECT item_key, item_json FROM exact_review_queue_items"),
-        ) as Array<{ item_key: string; item_json: string }>;
-        for (const row of rows) {
-          const item = JSON.parse(row.item_json);
-          item.nextAttemptAt = now + 80_000;
-          storage.run(
-            "UPDATE exact_review_queue_items SET item_json = ? WHERE item_key = ?",
-            JSON.stringify(item),
-            row.item_key,
-          );
-        }
+    });
+    if (churn === "older retries become ready beyond the scan window") {
+      for (let number = 1; number <= 6; number += 1) {
+        await h.enqueue(number);
+        h.now += 1;
       }
-      for (let number = 10; number <= 13; number += 1) {
-        await queue.fetch(publicationRequest(`probe-${number}`, number, String(7000 + number)));
-        now += 1;
-      }
-      now += 60_001;
-      await queue.alarm();
-      assert.equal(dispatches.length, 1);
-      if (churn === "all probed items gone") {
-        await queue.fetch(
-          batchRequest("/publications/supersede", {
-            items: [10, 11, 12, 13].map((number) => ({
-              item_key: `openclaw/openclaw#${number}@publish:${7000 + number}:1`,
-              revision: 1,
-            })),
-          }),
-        );
-      } else if (churn === "revision bump") {
-        await queue.fetch(publicationRequest("probe-bump", 13, "7013"));
-      }
-      await queue.fetch(publicationRequest("probe-fresh", 90, "7090", "openclaw/other"));
-      now += 30_000;
-      admissionRepos.length = 0;
-      const claim = await (
-        await queue.fetch(
-          batchRequest("/publication-batches/claim", {
-            claim_id: "claim-probed-subset",
-            lease_owner: "worker-1",
-            max_items: 4,
-            dispatch_id: dispatches[0].inputs.dispatch_id,
-            dispatched_at: dispatches[0].inputs.dispatched_at,
-          }),
-        )
-      ).json();
-      if (churn === "all probed items gone") {
-        assert.equal(claim.claimed, false);
-        assert.equal(claim.preflight_required, true);
-        assert.deepEqual(admissionRepos, []);
-      } else {
-        assert.equal(
-          claim.claimed,
-          true,
-          "claim after a fresh arrival no longer returns unclaimed",
-        );
-        assert.deepEqual(admissionRepos, ["openclaw/openclaw"]);
-        assert.deepEqual(
-          claim.batch.items.map((item: { item_key: string }) => item.item_key),
-          (churn === "revision bump" ? [10, 11, 12] : [10, 11, 12, 13]).map(
-            (number) => `openclaw/openclaw#${number}@publish:${7000 + number}:1`,
-          ),
+      for (const row of h.storage.sql.exec(
+        "SELECT item_key, item_json FROM exact_review_queue_items",
+      )) {
+        const item = JSON.parse(String(row.item_json));
+        item.nextAttemptAt = h.now + 80_000;
+        h.storage.run(
+          "UPDATE exact_review_queue_items SET item_json = ? WHERE item_key = ?",
+          JSON.stringify(item),
+          row.item_key,
         );
       }
-      const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
-      assert.equal(stats.lanes.publication.batches.dispatch_pending_until, null);
-      now += 60_001;
-      await queue.alarm();
-      assert.equal(dispatches.length, 2);
-    } finally {
-      Date.now = originalNow;
-      globalThis.fetch = originalFetch;
     }
+    for (const number of [10, 11, 12, 13]) {
+      await h.enqueue(number);
+      h.now += 1;
+    }
+    h.now += 60_001;
+    await h.queue.alarm();
+    assert.equal(dispatches.length, 1);
+    if (churn === "all probed items gone") {
+      await h.post("/publications/supersede", {
+        items: [10, 11, 12, 13].map((number) => ({
+          item_key: `openclaw/openclaw#${number}@publish:${7000 + number}:1`,
+          revision: 1,
+        })),
+      });
+    } else if (churn === "revision bump") {
+      await h.queue.fetch(publicationRequest("probe-bump", 13, "7013"));
+    }
+    await h.enqueue(90, 1, "openclaw/other");
+    h.now += 30_000;
+    h.probes.length = 0;
+    const claim = await h.claim(dispatches[0].inputs);
+    const empty = churn === "all probed items gone";
+    assert.deepEqual(h.probes, empty ? [] : ["openclaw/openclaw"]);
+    if (empty) assert.deepEqual([claim.claimed, claim.preflight_required], [false, true]);
+    else
+      assert.deepEqual(
+        claim.batch.items.map((item: { item_key: string }) => item.item_key),
+        (churn === "revision bump" ? [10, 11, 12] : [10, 11, 12, 13]).map(
+          (number) => `openclaw/openclaw#${number}@publish:${7000 + number}:1`,
+        ),
+      );
+    assert.equal((await h.publicationStats()).batches.dispatch_pending_until, null);
+    h.now += 60_001;
+    await h.queue.alarm();
+    assert.equal(dispatches.length, 2);
   });
 }
 
-for (const maxStaleMs of [1_800_000, 0]) {
-  test(`hosted admission rejects an older public probe after terminal revocation (cache ${maxStaleMs})`, async () => {
-    const originalNow = Date.now;
-    let now = 9_000_000;
-    Date.now = () => now;
+const revocationCases = [
+  ...[1_800_000, 0].map((maxStaleMs) => ({
+    name: `hosted admission rejects an older public probe after terminal revocation (cache ${maxStaleMs})`,
+    maxStaleMs,
+  })),
+  ...["same-millisecond revocations", "revocation tombstone expiry"].map((race) => ({
+    name: `hosted admission fences an older public probe across ${race}`,
+    seed: "terminal",
+    before: race === "revocation tombstone expiry" ? 29 * 60_000 : 0,
+    during: race === "revocation tombstone expiry" ? 2 * 60_000 : 0,
+  })),
+  ...["public", "retryable"].map((result) => ({
+    name: `terminal eligibility revokes cached admission and an overlapping ${result} probe`,
+    seed: "public",
+    before: 60_001,
+    eligibility: true,
+    result,
+  })),
+];
+for (const entry of revocationCases) {
+  const scenario = {
+    maxStaleMs: 1_800_000,
+    seed: "",
+    before: 0,
+    during: 1,
+    eligibility: false,
+    result: "public",
+    ...entry,
+  };
+  test(scenario.name, async (t) => {
+    const h = admissionQueue(t, {
+      EXACT_REVIEW_HOSTED_TARGET_ADMISSION_MAX_STALE_MS: String(scenario.maxStaleMs),
+    });
+    if (scenario.seed) {
+      h.outcome = scenario.seed;
+      assert.equal((await h.enqueue(811)).status, scenario.seed === "public" ? 202 : 422);
+    }
+    h.now += scenario.before;
     const started = Promise.withResolvers<void>();
-    const olderProbe = Promise.withResolvers<string>();
-    let probes = 0;
-    try {
-      const storage = new TestStorage();
-      const queue = new ExactReviewQueue(
-        { storage },
-        {
-          EXACT_REVIEW_HOSTED_TARGET_ADMISSION_MAX_STALE_MS: String(maxStaleMs),
-          hostedPublicTargetProbe: async () => {
-            probes += 1;
-            if (probes === 1) {
-              started.resolve();
-              return olderProbe.promise;
-            }
-            return probes === 2 ? "terminal" : "retryable";
-          },
-        },
-      );
-      const older = queue.fetch(publicationRequest("older-public", 811, "8811"));
-      await started.promise;
-      now += 1;
-      assert.equal(
-        (await queue.fetch(publicationRequest("newer-terminal", 812, "8812"))).status,
-        422,
-      );
-      now += 1;
-      olderProbe.resolve("public");
-      assert.equal(
-        (await older).status,
-        422,
-        "newer terminal observation fences the older public result",
-      );
-      assert.equal(storage.kv.get("hosted-target-admission:openclaw/openclaw"), undefined);
-      assert.equal(
-        (await queue.fetch(publicationRequest("later-retryable", 813, "8813"))).status,
-        503,
-      );
-      assert.equal(probes, 3);
-    } finally {
-      olderProbe.resolve("retryable");
-      Date.now = originalNow;
-    }
+    const probe = Promise.withResolvers<string>();
+    t.after(() => probe.resolve("retryable"));
+    h.probeStarted = started.resolve;
+    h.outcome = probe.promise;
+    const older = h.enqueue(812);
+    await started.promise;
+    h.now += scenario.during;
+    h.outcome = "terminal";
+    h.eligible = !scenario.eligibility;
+    assert.equal((await h.enqueue(813)).status, 422);
+    probe.resolve(scenario.result);
+    assert.equal((await older).status, scenario.result === "public" ? 422 : 503);
+    assert.equal(h.storage.kv.get("hosted-target-admission:openclaw/openclaw"), undefined);
+    h.eligible = true;
+    h.outcome = "retryable";
+    assert.equal((await h.enqueue(814)).status, 503);
+    assert.equal(
+      h.probes.length,
+      3 + Number(Boolean(scenario.seed)) - Number(scenario.eligibility),
+    );
   });
 }
 
-test("hosted admission fences an older public probe across same-millisecond revocations", async () => {
-  const originalNow = Date.now;
-  // Frozen clock: an earlier revocation, the probe start, and a second
-  // terminal observation all share one timestamp.
-  Date.now = () => 9_500_000;
-  const started = Promise.withResolvers<void>();
-  const olderProbe = Promise.withResolvers<string>();
-  let probes = 0;
-  try {
-    const storage = new TestStorage();
-    const queue = new ExactReviewQueue(
-      { storage },
-      {
-        hostedPublicTargetProbe: async () => {
-          probes += 1;
-          if (probes === 1) return "terminal";
-          if (probes === 2) {
-            started.resolve();
-            return olderProbe.promise;
-          }
-          return probes === 3 ? "terminal" : "retryable";
-        },
-      },
+for (const [scenario, age, probes, expectedStatus] of [
+  ["fresh", 1, 1, 202],
+  ["stale fallback", 60_001, 2, 202],
+  ["terminal clears", 60_001, 3, 503],
+  ["too old", 1_800_001, 2, 503],
+  ["disabled", 1, 2, 503],
+] as const) {
+  test(`hosted admission cache: ${scenario}`, async (t) => {
+    const h = admissionQueue(t, {
+      EXACT_REVIEW_HOSTED_TARGET_ADMISSION_MAX_STALE_MS: scenario === "disabled" ? "0" : "1800000",
+    });
+    assert.equal((await h.enqueue(801)).status, 202);
+    const cacheKey = "hosted-target-admission:openclaw/openclaw";
+    assert.deepEqual(
+      h.storage.kv.get(cacheKey),
+      scenario === "disabled" ? undefined : { outcome: "public", observedAt: h.now },
     );
-    assert.equal(
-      (await queue.fetch(publicationRequest("first-terminal", 821, "8821"))).status,
-      422,
-    );
-    const older = queue.fetch(publicationRequest("older-public", 822, "8822"));
-    await started.promise;
-    assert.equal(
-      (await queue.fetch(publicationRequest("second-terminal", 823, "8823"))).status,
-      422,
-    );
-    olderProbe.resolve("public");
-    assert.equal((await older).status, 422, "same-millisecond revocation still fences the probe");
-    assert.equal(storage.kv.get("hosted-target-admission:openclaw/openclaw"), undefined);
-    assert.equal(
-      (await queue.fetch(publicationRequest("later-retryable", 824, "8824"))).status,
-      503,
-    );
-    assert.equal(probes, 4);
-  } finally {
-    olderProbe.resolve("retryable");
-    Date.now = originalNow;
-  }
-});
-
-test("hosted admission fences an older public probe across revocation tombstone expiry", async () => {
-  const originalNow = Date.now;
-  let now = 9_600_000;
-  Date.now = () => now;
-  const started = Promise.withResolvers<void>();
-  const olderProbe = Promise.withResolvers<string>();
-  let probes = 0;
-  try {
-    const storage = new TestStorage();
-    const queue = new ExactReviewQueue(
-      { storage },
-      {
-        hostedPublicTargetProbe: async () => {
-          probes += 1;
-          if (probes === 1) return "terminal";
-          if (probes === 2) {
-            started.resolve();
-            return olderProbe.promise;
-          }
-          return probes === 3 ? "terminal" : "retryable";
-        },
-      },
-    );
-    assert.equal(
-      (await queue.fetch(publicationRequest("first-terminal", 831, "8831"))).status,
-      422,
-    );
-    // The probe starts while the first tombstone is still retained, then the
-    // tombstone expires and a new terminal observation replaces it.
-    now += 29 * 60_000;
-    const older = queue.fetch(publicationRequest("older-public", 832, "8832"));
-    await started.promise;
-    now += 2 * 60_000;
-    assert.equal(
-      (await queue.fetch(publicationRequest("second-terminal", 833, "8833"))).status,
-      422,
-    );
-    olderProbe.resolve("public");
-    assert.equal((await older).status, 422, "a revocation after tombstone expiry still fences");
-    assert.equal(storage.kv.get("hosted-target-admission:openclaw/openclaw"), undefined);
-    assert.equal(
-      (await queue.fetch(publicationRequest("later-retryable", 834, "8834"))).status,
-      503,
-    );
-    assert.equal(probes, 4);
-  } finally {
-    olderProbe.resolve("retryable");
-    Date.now = originalNow;
-  }
-});
-
-for (const outcome of ["public", "retryable"]) {
-  test(`terminal eligibility revokes cached admission and an overlapping ${outcome} probe`, async () => {
-    const originalNow = Date.now;
-    let now = 9_000_000;
-    Date.now = () => now;
-    let eligible = true;
-    let probes = 0;
-    const started = Promise.withResolvers<void>();
-    const pendingProbe = Promise.withResolvers<string>();
-    try {
-      const storage = new TestStorage();
-      const queue = new ExactReviewQueue(
-        { storage },
-        {
-          hostedTargetPredicate: () => eligible,
-          hostedPublicTargetProbe: async () => {
-            probes += 1;
-            if (probes === 1) return "public";
-            if (probes === 2) {
-              started.resolve();
-              return pendingProbe.promise;
-            }
-            return "retryable";
-          },
-        },
-      );
-      assert.equal(
-        (await queue.fetch(publicationRequest("eligible-seed", 821, "8821"))).status,
-        202,
-      );
-      now += 60_001;
-      const pending = queue.fetch(publicationRequest("eligible-inflight", 822, "8822"));
-      await started.promise;
-      now += 1;
-      eligible = false;
-      assert.equal((await queue.fetch(publicationRequest("ineligible", 823, "8823"))).status, 422);
-      pendingProbe.resolve(outcome);
-      assert.equal((await pending).status, outcome === "public" ? 422 : 503);
-      assert.equal(storage.kv.get("hosted-target-admission:openclaw/openclaw"), undefined);
-      eligible = true;
-      assert.equal(
-        (await queue.fetch(publicationRequest("eligible-retry", 824, "8824"))).status,
-        503,
-      );
-      assert.equal(probes, 3, "terminal eligibility never invokes the visibility probe");
-    } finally {
-      pendingProbe.resolve("retryable");
-      Date.now = originalNow;
+    h.restart();
+    h.outcome = "retryable";
+    h.now += age;
+    if (scenario === "terminal clears") {
+      h.outcome = "terminal";
+      assert.equal((await h.enqueue(802)).status, 422);
+      h.outcome = "retryable";
     }
-  });
-}
-
-for (const scenario of ["fresh", "stale fallback", "terminal clears", "too old", "disabled"]) {
-  test(`hosted admission cache: ${scenario}`, async () => {
-    const originalNow = Date.now;
-    let now = 9_000_000;
-    Date.now = () => now;
-    let outcome = "public";
-    let probes = 0;
-    try {
-      const storage = new TestStorage();
-      const env = {
-        EXACT_REVIEW_HOSTED_TARGET_ADMISSION_MAX_STALE_MS:
-          scenario === "disabled" ? "0" : "1800000",
-        hostedPublicTargetProbe: async () => {
-          probes += 1;
-          return outcome;
-        },
-      };
-      let queue = new ExactReviewQueue({ storage }, env);
-      assert.equal((await queue.fetch(publicationRequest("cache-1", 801, "8801"))).status, 202);
-      assert.equal(probes, 1);
-      const cacheKey = "hosted-target-admission:openclaw/openclaw";
-      if (scenario === "terminal clears" || scenario === "too old") {
-        assert.deepEqual(storage.kv.get(cacheKey), { outcome: "public", observedAt: now });
-      }
-      // Recreate the object to prove the cache survives a Worker restart.
-      queue = new ExactReviewQueue({ storage }, env);
-      outcome = scenario === "fresh" ? "public" : "retryable";
-      now +=
-        scenario === "fresh" || scenario === "disabled"
-          ? 1
-          : scenario === "too old"
-            ? 1_800_001
-            : 60_001;
-      if (scenario === "terminal clears") {
-        outcome = "terminal";
-        const terminal = await queue.fetch(publicationRequest("cache-terminal", 802, "8802"));
-        assert.equal(terminal.status, 422);
-        assert.equal(storage.kv.get(cacheKey), undefined);
-        outcome = "retryable";
-      }
-      const response = await queue.fetch(publicationRequest("cache-2", 803, "8803"));
-      const admitted = scenario === "fresh" || scenario === "stale fallback";
-      assert.equal(response.status, admitted ? 202 : 503);
-      assert.equal(probes, scenario === "fresh" ? 1 : scenario === "terminal clears" ? 3 : 2);
-      if (scenario === "too old") assert.equal(storage.kv.get(cacheKey), undefined);
-    } finally {
-      Date.now = originalNow;
-    }
+    assert.equal((await h.enqueue(803)).status, expectedStatus);
+    assert.equal(h.probes.length, probes);
+    if (expectedStatus === 503) assert.equal(h.storage.kv.get(cacheKey), undefined);
   });
 }
 
 for (const transition of ["terminal", "retryable"]) {
-  test(`batch claim ignores cached public admission when the live probe is ${transition}`, async () => {
-    const originalNow = Date.now;
-    let now = 9_700_000;
-    Date.now = () => now;
-    let outcome = "public";
-    let probes = 0;
-    try {
-      const storage = new TestStorage();
-      const queue = new ExactReviewQueue(
-        { storage },
-        {
-          EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
-          EXACT_REVIEW_HOSTED_TARGET_ADMISSION_MAX_STALE_MS: "1800000",
-          hostedPublicTargetProbe: async () => {
-            probes += 1;
-            return outcome;
-          },
-        },
-      );
-      assert.equal((await queue.fetch(publicationRequest("cached-841", 841, "8841"))).status, 202);
-      assert.equal(probes, 1);
-      // Still inside the 60 s fresh window: intake would not probe again, but
-      // the target turned private (or cannot be rechecked) in the meantime.
-      now += 1_000;
-      outcome = transition;
-      const claim = await (
-        await queue.fetch(
-          batchRequest("/publication-batches/claim", {
-            claim_id: "claim-cached-admission",
-            lease_owner: "worker-1",
-            max_items: 4,
-          }),
-        )
-      ).json();
-      assert.equal(claim.claimed, false, "credential-bearing claim must not trust the cache");
-      assert.equal(
-        claim.reason,
+  test(`batch claim ignores cached public admission when the live probe is ${transition}`, async (t) => {
+    const h = admissionQueue(t, { EXACT_REVIEW_HOSTED_TARGET_ADMISSION_MAX_STALE_MS: "1800000" });
+    assert.equal((await h.enqueue(841)).status, 202);
+    h.now += 1_000;
+    h.outcome = transition;
+    const claim = await h.claim();
+    assert.deepEqual(
+      [claim.claimed, claim.reason],
+      [
+        false,
         transition === "terminal" ? "private_target_unsupported" : "target_visibility_unverified",
-      );
-      assert.equal(probes, 2, "the claim performed its own live probe");
-      const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
-      assert.equal(stats.lanes.publication.pending, transition === "terminal" ? 0 : 1);
-      if (transition === "terminal") {
-        assert.equal(storage.kv.get("hosted-target-admission:openclaw/openclaw"), undefined);
-        assert.equal(
-          (await queue.fetch(publicationRequest("after-private", 842, "8842"))).status,
-          422,
-          "intake is revoked too once the live probe observed a private target",
-        );
-      } else {
-        // A transient claim-side failure must not erase intake's resilience.
-        assert.equal(
-          (await queue.fetch(publicationRequest("after-transient", 843, "8843"))).status,
-          202,
-          "intake still admits from the valid cached observation",
-        );
-        assert.equal(probes, 2, "intake inside the fresh window did not probe again");
-      }
-    } finally {
-      Date.now = originalNow;
-    }
+      ],
+    );
+    assert.equal(h.probes.length, 2);
+    assert.equal((await h.publicationStats()).pending, transition === "terminal" ? 0 : 1);
+    if (transition === "terminal")
+      assert.equal(h.storage.kv.get("hosted-target-admission:openclaw/openclaw"), undefined);
+    assert.equal((await h.enqueue(842)).status, transition === "terminal" ? 422 : 202);
+    assert.equal(
+      h.probes.length,
+      transition === "terminal" ? 3 : 2,
+      "transient claim failure preserves intake's fresh cache",
+    );
   });
 }
 
-test("alarm preserves command acknowledgements after batch expiry while pruning ordinary stale publications", async () => {
-  const originalNow = Date.now;
-  const originalFetch = globalThis.fetch;
-  let now = 6_400_000;
-  Date.now = () => now;
-  globalThis.fetch = async () => {
-    throw new Error("unexpected network");
-  };
-  try {
-    const storage = new TestStorage();
-    const queue = new ExactReviewQueue(
-      { storage },
-      {
-        EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+for (const [limit, command] of [
+  [100, false],
+  [1, false],
+  [1, true],
+] as const) {
+  test(
+    command
+      ? "alarm preserves command acknowledgements after batch expiry while pruning ordinary stale publications"
+      : `alarm prunes stale publication revisions after batch expiry with limit ${limit}`,
+    async (t) => {
+      const h = admissionQueue(t, {
         EXACT_REVIEW_PUBLICATION_BATCH_LEASE_MS: "60000",
-        EXACT_REVIEW_STALE_PUBLICATION_PRUNE_LIMIT: "1",
-      },
-    );
-    for (const number of [831, 832]) {
-      const request = publicationRequest(`command-prune-old-${number}`, number, String(number));
-      const body = await request.json();
-      if (number === 831) body.decision.publication.producerDecision.statusCommentId = 12345;
-      assert.equal((await queue.fetch(batchRequest("/enqueue", body))).status, 202);
-      now += 1;
-    }
-    const claim = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "command-prune",
-          lease_owner: "worker-1",
-          max_items: 2,
-        }),
-      )
-    ).json();
-    assert.equal(claim.claimed, true);
-    assert.equal(claim.batch.items.length, 2);
-    for (const number of [831, 832]) {
-      await queue.fetch(
-        publicationRequest(
-          `command-prune-new-${number}`,
-          number,
-          String(number + 1000),
-          "openclaw/openclaw",
-          2,
-        ),
-      );
-    }
-    now += 60_001;
-    await queue.alarm();
-    const remaining = await (await queue.fetch(batchRequest("/publications/reconcile", {}))).json();
-    assert.equal(remaining.stale_revision_eligible, 1);
-    assert.equal(remaining.sample[0].item_key, "openclaw/openclaw#831@publish:831:1");
-    const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
-    assert.equal(stats.lanes.publication.pending, 3);
-    assert.equal(stats.lanes.publication.completed_total, 1);
-    // Explicit operator reconciliation retains its existing command-row authority.
-    const reconciled = await (
-      await queue.fetch(batchRequest("/publications/reconcile", { apply: true }))
-    ).json();
-    assert.equal(reconciled.stale_revision_changed, 1);
-  } finally {
-    Date.now = originalNow;
-    globalThis.fetch = originalFetch;
-  }
-});
-
-for (const limit of [100, 1]) {
-  test(`alarm prunes stale publication revisions after batch expiry with limit ${limit}`, async () => {
-    const originalNow = Date.now;
-    const originalFetch = globalThis.fetch;
-    let now = 6_400_000;
-    Date.now = () => now;
-    let networkCalls = 0;
-    globalThis.fetch = async () => {
-      networkCalls += 1;
-      throw new Error("unexpected network");
-    };
-    try {
-      const queue = new ExactReviewQueue(
-        { storage: new TestStorage() },
-        {
-          EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
-          EXACT_REVIEW_PUBLICATION_BATCH_LEASE_MS: "60000",
-          EXACT_REVIEW_STALE_PUBLICATION_PRUNE_LIMIT: String(limit),
-        },
-      );
+        EXACT_REVIEW_STALE_PUBLICATION_PRUNE_LIMIT: String(limit),
+      });
       for (const number of [801, 802]) {
-        await queue.fetch(
-          publicationRequest(`prune-old-${number}`, number, String(number), "openclaw/openclaw", 1),
-        );
-        now += 1;
+        const body = await publicationRequest(`prune-old-${number}`, number, String(number)).json();
+        if (command && number === 801)
+          body.decision.publication.producerDecision.statusCommentId = 12345;
+        assert.equal((await h.queue.fetch(batchRequest("/enqueue", body))).status, 202);
+        h.now += 1;
       }
-      assert.equal(
-        (
-          await (
-            await queue.fetch(
-              batchRequest("/publication-batches/claim", {
-                claim_id: "claim-prune",
-                lease_owner: "worker-1",
-                max_items: 2,
-              }),
-            )
-          ).json()
-        ).claimed,
-        true,
-      );
-      for (const number of [801, 802]) {
-        await queue.fetch(
-          publicationRequest(
-            `prune-new-${number}`,
-            number,
-            String(number + 1000),
-            "openclaw/openclaw",
-            2,
-          ),
-        );
-      }
-      await queue.alarm();
-      const before = await (await queue.fetch(new Request("https://queue/stats"))).json();
-      assert.equal(before.lanes.publication.pending, 4);
-      now += 60_001;
-      await queue.alarm();
-      const after = await (await queue.fetch(new Request("https://queue/stats"))).json();
-      assert.equal(after.lanes.publication.pending, limit === 1 ? 3 : 2);
-      assert.equal(after.lanes.publication.completed_total, limit === 1 ? 1 : 2);
-      const remaining = await (
-        await queue.fetch(batchRequest("/publications/reconcile", {}))
-      ).json();
+      assert.equal((await h.claim()).batch.items.length, 2);
+      for (const number of [801, 802]) await h.enqueue(number, 2);
+      await h.queue.alarm();
+      assert.equal((await h.publicationStats()).pending, 4);
+      h.now += 60_001;
+      await h.queue.alarm();
+      const after = await h.publicationStats();
+      assert.deepEqual([after.pending, after.completed_total], limit === 1 ? [3, 1] : [2, 2]);
+      const remaining = await h.post("/publications/reconcile");
       assert.equal(remaining.stale_revision_eligible, limit === 1 ? 1 : 0);
       if (limit === 1) {
-        assert.equal(remaining.sample[0].item_key, "openclaw/openclaw#802@publish:802:1");
-        await queue.alarm();
+        assert.equal(
+          remaining.sample[0].item_key,
+          `openclaw/openclaw#${command ? 801 : 802}@publish:${command ? 801 : 802}:1`,
+        );
+        if (command)
+          assert.equal(
+            (await h.post("/publications/reconcile", { apply: true })).stale_revision_changed,
+            1,
+          );
+        else await h.queue.alarm();
       }
-      const final = await (await queue.fetch(new Request("https://queue/stats"))).json();
-      assert.equal(final.lanes.publication.pending, 2);
-      assert.equal(final.lanes.publication.completed_total, 2);
-      assert.equal(networkCalls, 0);
-    } finally {
-      Date.now = originalNow;
-      globalThis.fetch = originalFetch;
-    }
-  });
+      const final = await h.publicationStats();
+      assert.deepEqual([final.pending, final.completed_total], [2, 2]);
+      assert.equal(h.networkCalls, 0);
+    },
+  );
 }
 
 test("batch claims retain lifecycle identity until canonical routing is durable", async () => {

--- a/test/exact-review-publication-batches.test.ts
+++ b/test/exact-review-publication-batches.test.ts
@@ -1440,6 +1440,71 @@ for (const scenario of ["fresh", "stale fallback", "terminal clears", "too old",
   });
 }
 
+for (const transition of ["terminal", "retryable"]) {
+  test(`batch claim ignores cached public admission when the live probe is ${transition}`, async () => {
+    const originalNow = Date.now;
+    let now = 9_700_000;
+    Date.now = () => now;
+    let outcome = "public";
+    let probes = 0;
+    try {
+      const storage = new TestStorage();
+      const queue = new ExactReviewQueue(
+        { storage },
+        {
+          EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+          EXACT_REVIEW_HOSTED_TARGET_ADMISSION_MAX_STALE_MS: "1800000",
+          hostedPublicTargetProbe: async () => {
+            probes += 1;
+            return outcome;
+          },
+        },
+      );
+      assert.equal((await queue.fetch(publicationRequest("cached-841", 841, "8841"))).status, 202);
+      assert.equal(probes, 1);
+      // Still inside the 60 s fresh window: intake would not probe again, but
+      // the target turned private (or cannot be rechecked) in the meantime.
+      now += 1_000;
+      outcome = transition;
+      const claim = await (
+        await queue.fetch(
+          batchRequest("/publication-batches/claim", {
+            claim_id: "claim-cached-admission",
+            lease_owner: "worker-1",
+            max_items: 4,
+          }),
+        )
+      ).json();
+      assert.equal(claim.claimed, false, "credential-bearing claim must not trust the cache");
+      assert.equal(
+        claim.reason,
+        transition === "terminal" ? "private_target_unsupported" : "target_visibility_unverified",
+      );
+      assert.equal(probes, 2, "the claim performed its own live probe");
+      const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+      assert.equal(stats.lanes.publication.pending, transition === "terminal" ? 0 : 1);
+      if (transition === "terminal") {
+        assert.equal(storage.kv.get("hosted-target-admission:openclaw/openclaw"), undefined);
+        assert.equal(
+          (await queue.fetch(publicationRequest("after-private", 842, "8842"))).status,
+          422,
+          "intake is revoked too once the live probe observed a private target",
+        );
+      } else {
+        // A transient claim-side failure must not erase intake's resilience.
+        assert.equal(
+          (await queue.fetch(publicationRequest("after-transient", 843, "8843"))).status,
+          202,
+          "intake still admits from the valid cached observation",
+        );
+        assert.equal(probes, 2, "intake inside the fresh window did not probe again");
+      }
+    } finally {
+      Date.now = originalNow;
+    }
+  });
+}
+
 test("alarm preserves command acknowledgements after batch expiry while pruning ordinary stale publications", async () => {
   const originalNow = Date.now;
   const originalFetch = globalThis.fetch;

--- a/test/exact-review-publication-batches.test.ts
+++ b/test/exact-review-publication-batches.test.ts
@@ -1053,6 +1053,537 @@ function batchRequest(path: string, body: unknown) {
   });
 }
 
+for (const churn of [
+  "fresh arrival",
+  "revision bump",
+  "all probed items gone",
+  "older retries become ready beyond the scan window",
+]) {
+  test(`batch claim after ${churn} consumes only still-valid probed items`, async () => {
+    const originalNow = Date.now;
+    const originalFetch = globalThis.fetch;
+    let now = 7_000_000;
+    Date.now = () => now;
+    const { privateKey } = generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+      privateKeyEncoding: { type: "pkcs8", format: "pem" },
+      publicKeyEncoding: { type: "spki", format: "pem" },
+    });
+    const dispatches: Array<{ inputs: Record<string, string> }> = [];
+    const admissionRepos: string[] = [];
+    globalThis.fetch = async (input, init) => {
+      const path = new URL(String(input)).pathname;
+      if (path.endsWith("/installation")) return Response.json({ id: 999 });
+      if (path === "/app/installations/999/access_tokens") {
+        return Response.json({ token: "test-token" });
+      }
+      if (/\/issues\/\d+$/.test(path)) return Response.json({ state: "open" });
+      if (path.endsWith("/exact-review-batch-publish.yml/dispatches")) {
+        dispatches.push(JSON.parse(String(init?.body)));
+        return new Response(null, { status: 204 });
+      }
+      if (path.endsWith("/sweep.yml")) return Response.json({ state: "active" });
+      throw new Error(`unexpected fetch ${path}`);
+    };
+    try {
+      const storage = new TestStorage();
+      const queue = new ExactReviewQueue(
+        { storage },
+        {
+          CLAWSWEEPER_APP_CLIENT_ID: "Iv23test",
+          CLAWSWEEPER_APP_PRIVATE_KEY: privateKey,
+          EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+          EXACT_REVIEW_PUBLICATION_BATCH_SIZE: "4",
+          EXACT_REVIEW_PUBLICATION_BATCH_MAX_CONCURRENT: "2",
+          EXACT_REVIEW_PUBLICATION_FRESH_LANE_ENABLED: "1",
+          EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_ITEMS: "1",
+          EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_AGE_MS: "60000",
+          EXACT_REVIEW_PUBLICATION_BATCH_DISPATCH_COOLDOWN_MS: "5000",
+          EXACT_REVIEW_HOSTED_TARGET_ADMISSION_MAX_STALE_MS: "0",
+          hostedPublicTargetProbe: async (repo: string) => {
+            admissionRepos.push(repo);
+            return "public";
+          },
+        },
+      );
+      if (churn === "older retries become ready beyond the scan window") {
+        for (let number = 1; number <= 6; number += 1) {
+          await queue.fetch(publicationRequest(`retry-${number}`, number, String(7000 + number)));
+          now += 1;
+        }
+        const rows = Array.from(
+          storage.sql.exec("SELECT item_key, item_json FROM exact_review_queue_items"),
+        ) as Array<{ item_key: string; item_json: string }>;
+        for (const row of rows) {
+          const item = JSON.parse(row.item_json);
+          item.nextAttemptAt = now + 80_000;
+          storage.run(
+            "UPDATE exact_review_queue_items SET item_json = ? WHERE item_key = ?",
+            JSON.stringify(item),
+            row.item_key,
+          );
+        }
+      }
+      for (let number = 10; number <= 13; number += 1) {
+        await queue.fetch(publicationRequest(`probe-${number}`, number, String(7000 + number)));
+        now += 1;
+      }
+      now += 60_001;
+      await queue.alarm();
+      assert.equal(dispatches.length, 1);
+      if (churn === "all probed items gone") {
+        await queue.fetch(
+          batchRequest("/publications/supersede", {
+            items: [10, 11, 12, 13].map((number) => ({
+              item_key: `openclaw/openclaw#${number}@publish:${7000 + number}:1`,
+              revision: 1,
+            })),
+          }),
+        );
+      } else if (churn === "revision bump") {
+        await queue.fetch(publicationRequest("probe-bump", 13, "7013"));
+      }
+      await queue.fetch(publicationRequest("probe-fresh", 90, "7090", "openclaw/other"));
+      now += 30_000;
+      admissionRepos.length = 0;
+      const claim = await (
+        await queue.fetch(
+          batchRequest("/publication-batches/claim", {
+            claim_id: "claim-probed-subset",
+            lease_owner: "worker-1",
+            max_items: 4,
+            dispatch_id: dispatches[0].inputs.dispatch_id,
+            dispatched_at: dispatches[0].inputs.dispatched_at,
+          }),
+        )
+      ).json();
+      if (churn === "all probed items gone") {
+        assert.equal(claim.claimed, false);
+        assert.equal(claim.preflight_required, true);
+        assert.deepEqual(admissionRepos, []);
+      } else {
+        assert.equal(
+          claim.claimed,
+          true,
+          "claim after a fresh arrival no longer returns unclaimed",
+        );
+        assert.deepEqual(admissionRepos, ["openclaw/openclaw"]);
+        assert.deepEqual(
+          claim.batch.items.map((item: { item_key: string }) => item.item_key),
+          (churn === "revision bump" ? [10, 11, 12] : [10, 11, 12, 13]).map(
+            (number) => `openclaw/openclaw#${number}@publish:${7000 + number}:1`,
+          ),
+        );
+      }
+      const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+      assert.equal(stats.lanes.publication.batches.dispatch_pending_until, null);
+      now += 60_001;
+      await queue.alarm();
+      assert.equal(dispatches.length, 2);
+    } finally {
+      Date.now = originalNow;
+      globalThis.fetch = originalFetch;
+    }
+  });
+}
+
+for (const maxStaleMs of [1_800_000, 0]) {
+  test(`hosted admission rejects an older public probe after terminal revocation (cache ${maxStaleMs})`, async () => {
+    const originalNow = Date.now;
+    let now = 9_000_000;
+    Date.now = () => now;
+    const started = Promise.withResolvers<void>();
+    const olderProbe = Promise.withResolvers<string>();
+    let probes = 0;
+    try {
+      const storage = new TestStorage();
+      const queue = new ExactReviewQueue(
+        { storage },
+        {
+          EXACT_REVIEW_HOSTED_TARGET_ADMISSION_MAX_STALE_MS: String(maxStaleMs),
+          hostedPublicTargetProbe: async () => {
+            probes += 1;
+            if (probes === 1) {
+              started.resolve();
+              return olderProbe.promise;
+            }
+            return probes === 2 ? "terminal" : "retryable";
+          },
+        },
+      );
+      const older = queue.fetch(publicationRequest("older-public", 811, "8811"));
+      await started.promise;
+      now += 1;
+      assert.equal(
+        (await queue.fetch(publicationRequest("newer-terminal", 812, "8812"))).status,
+        422,
+      );
+      now += 1;
+      olderProbe.resolve("public");
+      assert.equal(
+        (await older).status,
+        422,
+        "newer terminal observation fences the older public result",
+      );
+      assert.equal(storage.kv.get("hosted-target-admission:openclaw/openclaw"), undefined);
+      assert.equal(
+        (await queue.fetch(publicationRequest("later-retryable", 813, "8813"))).status,
+        503,
+      );
+      assert.equal(probes, 3);
+    } finally {
+      olderProbe.resolve("retryable");
+      Date.now = originalNow;
+    }
+  });
+}
+
+test("hosted admission fences an older public probe across same-millisecond revocations", async () => {
+  const originalNow = Date.now;
+  // Frozen clock: an earlier revocation, the probe start, and a second
+  // terminal observation all share one timestamp.
+  Date.now = () => 9_500_000;
+  const started = Promise.withResolvers<void>();
+  const olderProbe = Promise.withResolvers<string>();
+  let probes = 0;
+  try {
+    const storage = new TestStorage();
+    const queue = new ExactReviewQueue(
+      { storage },
+      {
+        hostedPublicTargetProbe: async () => {
+          probes += 1;
+          if (probes === 1) return "terminal";
+          if (probes === 2) {
+            started.resolve();
+            return olderProbe.promise;
+          }
+          return probes === 3 ? "terminal" : "retryable";
+        },
+      },
+    );
+    assert.equal(
+      (await queue.fetch(publicationRequest("first-terminal", 821, "8821"))).status,
+      422,
+    );
+    const older = queue.fetch(publicationRequest("older-public", 822, "8822"));
+    await started.promise;
+    assert.equal(
+      (await queue.fetch(publicationRequest("second-terminal", 823, "8823"))).status,
+      422,
+    );
+    olderProbe.resolve("public");
+    assert.equal((await older).status, 422, "same-millisecond revocation still fences the probe");
+    assert.equal(storage.kv.get("hosted-target-admission:openclaw/openclaw"), undefined);
+    assert.equal(
+      (await queue.fetch(publicationRequest("later-retryable", 824, "8824"))).status,
+      503,
+    );
+    assert.equal(probes, 4);
+  } finally {
+    olderProbe.resolve("retryable");
+    Date.now = originalNow;
+  }
+});
+
+test("hosted admission fences an older public probe across revocation tombstone expiry", async () => {
+  const originalNow = Date.now;
+  let now = 9_600_000;
+  Date.now = () => now;
+  const started = Promise.withResolvers<void>();
+  const olderProbe = Promise.withResolvers<string>();
+  let probes = 0;
+  try {
+    const storage = new TestStorage();
+    const queue = new ExactReviewQueue(
+      { storage },
+      {
+        hostedPublicTargetProbe: async () => {
+          probes += 1;
+          if (probes === 1) return "terminal";
+          if (probes === 2) {
+            started.resolve();
+            return olderProbe.promise;
+          }
+          return probes === 3 ? "terminal" : "retryable";
+        },
+      },
+    );
+    assert.equal(
+      (await queue.fetch(publicationRequest("first-terminal", 831, "8831"))).status,
+      422,
+    );
+    // The probe starts while the first tombstone is still retained, then the
+    // tombstone expires and a new terminal observation replaces it.
+    now += 29 * 60_000;
+    const older = queue.fetch(publicationRequest("older-public", 832, "8832"));
+    await started.promise;
+    now += 2 * 60_000;
+    assert.equal(
+      (await queue.fetch(publicationRequest("second-terminal", 833, "8833"))).status,
+      422,
+    );
+    olderProbe.resolve("public");
+    assert.equal((await older).status, 422, "a revocation after tombstone expiry still fences");
+    assert.equal(storage.kv.get("hosted-target-admission:openclaw/openclaw"), undefined);
+    assert.equal(
+      (await queue.fetch(publicationRequest("later-retryable", 834, "8834"))).status,
+      503,
+    );
+    assert.equal(probes, 4);
+  } finally {
+    olderProbe.resolve("retryable");
+    Date.now = originalNow;
+  }
+});
+
+for (const outcome of ["public", "retryable"]) {
+  test(`terminal eligibility revokes cached admission and an overlapping ${outcome} probe`, async () => {
+    const originalNow = Date.now;
+    let now = 9_000_000;
+    Date.now = () => now;
+    let eligible = true;
+    let probes = 0;
+    const started = Promise.withResolvers<void>();
+    const pendingProbe = Promise.withResolvers<string>();
+    try {
+      const storage = new TestStorage();
+      const queue = new ExactReviewQueue(
+        { storage },
+        {
+          hostedTargetPredicate: () => eligible,
+          hostedPublicTargetProbe: async () => {
+            probes += 1;
+            if (probes === 1) return "public";
+            if (probes === 2) {
+              started.resolve();
+              return pendingProbe.promise;
+            }
+            return "retryable";
+          },
+        },
+      );
+      assert.equal(
+        (await queue.fetch(publicationRequest("eligible-seed", 821, "8821"))).status,
+        202,
+      );
+      now += 60_001;
+      const pending = queue.fetch(publicationRequest("eligible-inflight", 822, "8822"));
+      await started.promise;
+      now += 1;
+      eligible = false;
+      assert.equal((await queue.fetch(publicationRequest("ineligible", 823, "8823"))).status, 422);
+      pendingProbe.resolve(outcome);
+      assert.equal((await pending).status, outcome === "public" ? 422 : 503);
+      assert.equal(storage.kv.get("hosted-target-admission:openclaw/openclaw"), undefined);
+      eligible = true;
+      assert.equal(
+        (await queue.fetch(publicationRequest("eligible-retry", 824, "8824"))).status,
+        503,
+      );
+      assert.equal(probes, 3, "terminal eligibility never invokes the visibility probe");
+    } finally {
+      pendingProbe.resolve("retryable");
+      Date.now = originalNow;
+    }
+  });
+}
+
+for (const scenario of ["fresh", "stale fallback", "terminal clears", "too old", "disabled"]) {
+  test(`hosted admission cache: ${scenario}`, async () => {
+    const originalNow = Date.now;
+    let now = 9_000_000;
+    Date.now = () => now;
+    let outcome = "public";
+    let probes = 0;
+    try {
+      const storage = new TestStorage();
+      const env = {
+        EXACT_REVIEW_HOSTED_TARGET_ADMISSION_MAX_STALE_MS:
+          scenario === "disabled" ? "0" : "1800000",
+        hostedPublicTargetProbe: async () => {
+          probes += 1;
+          return outcome;
+        },
+      };
+      let queue = new ExactReviewQueue({ storage }, env);
+      assert.equal((await queue.fetch(publicationRequest("cache-1", 801, "8801"))).status, 202);
+      assert.equal(probes, 1);
+      const cacheKey = "hosted-target-admission:openclaw/openclaw";
+      if (scenario === "terminal clears" || scenario === "too old") {
+        assert.deepEqual(storage.kv.get(cacheKey), { outcome: "public", observedAt: now });
+      }
+      // Recreate the object to prove the cache survives a Worker restart.
+      queue = new ExactReviewQueue({ storage }, env);
+      outcome = scenario === "fresh" ? "public" : "retryable";
+      now +=
+        scenario === "fresh" || scenario === "disabled"
+          ? 1
+          : scenario === "too old"
+            ? 1_800_001
+            : 60_001;
+      if (scenario === "terminal clears") {
+        outcome = "terminal";
+        const terminal = await queue.fetch(publicationRequest("cache-terminal", 802, "8802"));
+        assert.equal(terminal.status, 422);
+        assert.equal(storage.kv.get(cacheKey), undefined);
+        outcome = "retryable";
+      }
+      const response = await queue.fetch(publicationRequest("cache-2", 803, "8803"));
+      const admitted = scenario === "fresh" || scenario === "stale fallback";
+      assert.equal(response.status, admitted ? 202 : 503);
+      assert.equal(probes, scenario === "fresh" ? 1 : scenario === "terminal clears" ? 3 : 2);
+      if (scenario === "too old") assert.equal(storage.kv.get(cacheKey), undefined);
+    } finally {
+      Date.now = originalNow;
+    }
+  });
+}
+
+test("alarm preserves command acknowledgements after batch expiry while pruning ordinary stale publications", async () => {
+  const originalNow = Date.now;
+  const originalFetch = globalThis.fetch;
+  let now = 6_400_000;
+  Date.now = () => now;
+  globalThis.fetch = async () => {
+    throw new Error("unexpected network");
+  };
+  try {
+    const storage = new TestStorage();
+    const queue = new ExactReviewQueue(
+      { storage },
+      {
+        EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+        EXACT_REVIEW_PUBLICATION_BATCH_LEASE_MS: "60000",
+        EXACT_REVIEW_STALE_PUBLICATION_PRUNE_LIMIT: "1",
+      },
+    );
+    for (const number of [831, 832]) {
+      const request = publicationRequest(`command-prune-old-${number}`, number, String(number));
+      const body = await request.json();
+      if (number === 831) body.decision.publication.producerDecision.statusCommentId = 12345;
+      assert.equal((await queue.fetch(batchRequest("/enqueue", body))).status, 202);
+      now += 1;
+    }
+    const claim = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/claim", {
+          claim_id: "command-prune",
+          lease_owner: "worker-1",
+          max_items: 2,
+        }),
+      )
+    ).json();
+    assert.equal(claim.claimed, true);
+    assert.equal(claim.batch.items.length, 2);
+    for (const number of [831, 832]) {
+      await queue.fetch(
+        publicationRequest(
+          `command-prune-new-${number}`,
+          number,
+          String(number + 1000),
+          "openclaw/openclaw",
+          2,
+        ),
+      );
+    }
+    now += 60_001;
+    await queue.alarm();
+    const remaining = await (await queue.fetch(batchRequest("/publications/reconcile", {}))).json();
+    assert.equal(remaining.stale_revision_eligible, 1);
+    assert.equal(remaining.sample[0].item_key, "openclaw/openclaw#831@publish:831:1");
+    const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+    assert.equal(stats.lanes.publication.pending, 3);
+    assert.equal(stats.lanes.publication.completed_total, 1);
+    // Explicit operator reconciliation retains its existing command-row authority.
+    const reconciled = await (
+      await queue.fetch(batchRequest("/publications/reconcile", { apply: true }))
+    ).json();
+    assert.equal(reconciled.stale_revision_changed, 1);
+  } finally {
+    Date.now = originalNow;
+    globalThis.fetch = originalFetch;
+  }
+});
+
+for (const limit of [100, 1]) {
+  test(`alarm prunes stale publication revisions after batch expiry with limit ${limit}`, async () => {
+    const originalNow = Date.now;
+    const originalFetch = globalThis.fetch;
+    let now = 6_400_000;
+    Date.now = () => now;
+    let networkCalls = 0;
+    globalThis.fetch = async () => {
+      networkCalls += 1;
+      throw new Error("unexpected network");
+    };
+    try {
+      const queue = new ExactReviewQueue(
+        { storage: new TestStorage() },
+        {
+          EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+          EXACT_REVIEW_PUBLICATION_BATCH_LEASE_MS: "60000",
+          EXACT_REVIEW_STALE_PUBLICATION_PRUNE_LIMIT: String(limit),
+        },
+      );
+      for (const number of [801, 802]) {
+        await queue.fetch(
+          publicationRequest(`prune-old-${number}`, number, String(number), "openclaw/openclaw", 1),
+        );
+        now += 1;
+      }
+      assert.equal(
+        (
+          await (
+            await queue.fetch(
+              batchRequest("/publication-batches/claim", {
+                claim_id: "claim-prune",
+                lease_owner: "worker-1",
+                max_items: 2,
+              }),
+            )
+          ).json()
+        ).claimed,
+        true,
+      );
+      for (const number of [801, 802]) {
+        await queue.fetch(
+          publicationRequest(
+            `prune-new-${number}`,
+            number,
+            String(number + 1000),
+            "openclaw/openclaw",
+            2,
+          ),
+        );
+      }
+      await queue.alarm();
+      const before = await (await queue.fetch(new Request("https://queue/stats"))).json();
+      assert.equal(before.lanes.publication.pending, 4);
+      now += 60_001;
+      await queue.alarm();
+      const after = await (await queue.fetch(new Request("https://queue/stats"))).json();
+      assert.equal(after.lanes.publication.pending, limit === 1 ? 3 : 2);
+      assert.equal(after.lanes.publication.completed_total, limit === 1 ? 1 : 2);
+      const remaining = await (
+        await queue.fetch(batchRequest("/publications/reconcile", {}))
+      ).json();
+      assert.equal(remaining.stale_revision_eligible, limit === 1 ? 1 : 0);
+      if (limit === 1) {
+        assert.equal(remaining.sample[0].item_key, "openclaw/openclaw#802@publish:802:1");
+        await queue.alarm();
+      }
+      const final = await (await queue.fetch(new Request("https://queue/stats"))).json();
+      assert.equal(final.lanes.publication.pending, 2);
+      assert.equal(final.lanes.publication.completed_total, 2);
+      assert.equal(networkCalls, 0);
+    } finally {
+      Date.now = originalNow;
+      globalThis.fetch = originalFetch;
+    }
+  });
+}
+
 test("batch claims retain lifecycle identity until canonical routing is durable", async () => {
   const storage = new TestStorage();
   const queue = new ExactReviewQueue(

--- a/test/review-comment-publication.test.ts
+++ b/test/review-comment-publication.test.ts
@@ -12,10 +12,53 @@ import {
 } from "../dist/clawsweeper-review-comment-publication.js";
 import { createReviewCommentAutomation } from "../dist/clawsweeper-review-comment-automation.js";
 import { createReviewCommentState } from "../dist/clawsweeper-review-comment-state.js";
+import * as commentState from "../dist/clawsweeper-review-comment-state.js";
+import { freshExactHeadReviewStartLease } from "../dist/repair/comment-router-core.js";
 
 const itemNumber = 120232;
 const headSha = "522ac4a03828a827c5c266194459d995b9982ff9";
 const reviewMarker = `<!-- clawsweeper-review item=${itemNumber} -->`;
+
+test("expireReviewStartStatusLease changes only the canonical expiry and releases the exact-head lease", () => {
+  const startedAt = "2026-09-02T21:00:00.000Z";
+  const expiresAt = "2026-09-02T21:41:00.000Z";
+  const queuedAt = "2026-09-02T21:23:00.000Z";
+  const marker = `<!-- clawsweeper-review-status:started item=${itemNumber} sha=${headSha} started_at=${startedAt} lease_expires_at=${expiresAt} owner=worker-1 v=1 -->`;
+  const body = `Review started.  \r\n\r\n${marker}\r\n<!-- clawsweeper-review-lease item=${itemNumber} -->\r\n`;
+  assert.equal(typeof commentState.expireReviewStartStatusLease, "function");
+  const rewritten = commentState.expireReviewStartStatusLease(body, queuedAt);
+  assert.equal(
+    rewritten,
+    body.replace(`lease_expires_at=${expiresAt}`, `lease_expires_at=${queuedAt}`),
+  );
+  const options = {
+    itemNumber,
+    headSha,
+    trustedAuthors: new Set(["clawsweeper[bot]"]),
+    nowMs: Date.parse(queuedAt) + 1,
+    comments: [{ body, user: { login: "clawsweeper[bot]" } }],
+  };
+  assert.ok(freshExactHeadReviewStartLease(options));
+  assert.equal(
+    freshExactHeadReviewStartLease({
+      ...options,
+      comments: [{ body: rewritten, user: { login: "clawsweeper[bot]" } }],
+    }),
+    null,
+  );
+});
+
+test("expireReviewStartStatusLease leaves noncanonical markers and unrelated text byte-identical", () => {
+  assert.equal(typeof commentState.expireReviewStartStatusLease, "function");
+  for (const body of [
+    "No marker.  \r\n",
+    "<!-- clawsweeper-review-status:started item=1 lease_expires_at=later -->\nVisible text",
+    "```\n<!-- clawsweeper-review-status:started item=1 lease_expires_at=later -->\n```",
+    "<!-- clawsweeper-review-status:started item=1 lease_expires_at=later -->\n<!-- clawsweeper-review-lease item=2 -->",
+  ]) {
+    assert.equal(commentState.expireReviewStartStatusLease(body, "2026-09-02T21:23:00.000Z"), body);
+  }
+});
 
 function sha256(value: string): string {
   return createHash("sha256").update(value).digest("hex");

--- a/test/review-comment-publication.test.ts
+++ b/test/review-comment-publication.test.ts
@@ -11,8 +11,10 @@ import {
   DurableReviewPublicationBlockedError,
 } from "../dist/clawsweeper-review-comment-publication.js";
 import { createReviewCommentAutomation } from "../dist/clawsweeper-review-comment-automation.js";
-import { createReviewCommentState } from "../dist/clawsweeper-review-comment-state.js";
-import * as commentState from "../dist/clawsweeper-review-comment-state.js";
+import {
+  createReviewCommentState,
+  expireReviewStartStatusLease,
+} from "../dist/clawsweeper-review-comment-state.js";
 import { freshExactHeadReviewStartLease } from "../dist/repair/comment-router-core.js";
 
 const itemNumber = 120232;
@@ -25,12 +27,8 @@ test("expireReviewStartStatusLease changes only the canonical expiry and release
   const queuedAt = "2026-09-02T21:23:00.000Z";
   const marker = `<!-- clawsweeper-review-status:started item=${itemNumber} sha=${headSha} started_at=${startedAt} lease_expires_at=${expiresAt} owner=worker-1 v=1 -->`;
   const body = `Review started.  \r\n\r\n${marker}\r\n<!-- clawsweeper-review-lease item=${itemNumber} -->\r\n`;
-  assert.equal(typeof commentState.expireReviewStartStatusLease, "function");
-  const rewritten = commentState.expireReviewStartStatusLease(body, queuedAt);
-  assert.equal(
-    rewritten,
-    body.replace(`lease_expires_at=${expiresAt}`, `lease_expires_at=${queuedAt}`),
-  );
+  const rewritten = expireReviewStartStatusLease(body, queuedAt);
+  assert.equal(rewritten, body.replace(expiresAt, queuedAt));
   const options = {
     itemNumber,
     headSha,
@@ -39,24 +37,18 @@ test("expireReviewStartStatusLease changes only the canonical expiry and release
     comments: [{ body, user: { login: "clawsweeper[bot]" } }],
   };
   assert.ok(freshExactHeadReviewStartLease(options));
-  assert.equal(
-    freshExactHeadReviewStartLease({
-      ...options,
-      comments: [{ body: rewritten, user: { login: "clawsweeper[bot]" } }],
-    }),
-    null,
-  );
+  options.comments[0].body = rewritten;
+  assert.equal(freshExactHeadReviewStartLease(options), null);
 });
 
 test("expireReviewStartStatusLease leaves noncanonical markers and unrelated text byte-identical", () => {
-  assert.equal(typeof commentState.expireReviewStartStatusLease, "function");
   for (const body of [
     "No marker.  \r\n",
     "<!-- clawsweeper-review-status:started item=1 lease_expires_at=later -->\nVisible text",
     "```\n<!-- clawsweeper-review-status:started item=1 lease_expires_at=later -->\n```",
     "<!-- clawsweeper-review-status:started item=1 lease_expires_at=later -->\n<!-- clawsweeper-review-lease item=2 -->",
   ]) {
-    assert.equal(commentState.expireReviewStartStatusLease(body, "2026-09-02T21:23:00.000Z"), body);
+    assert.equal(expireReviewStartStatusLease(body, "2026-09-02T21:23:00.000Z"), body);
   }
 });
 

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -26,6 +26,42 @@ import {
 } from "./helpers.ts";
 import { scheduledReviewSemanticSourceRevision } from "../scripts/classify-scheduled-review-noop.ts";
 
+test("queued publication expires only its posted review lease after successful handoff", () => {
+  const steps = YAML.parse(readText(".github/workflows/sweep.yml")).jobs["event-review-apply"]
+    .steps;
+  const index = steps.findIndex((entry) => entry.id === "queue-exact-review-publication");
+  const expiry = steps[index + 1];
+  assert.equal(expiry.name, "Expire queued exact review lease");
+  assert.equal(expiry["continue-on-error"], true);
+  assert.equal(expiry.env.GH_TOKEN, "${{ steps.target-write-token.outputs.token }}");
+  assert.equal(expiry.env.COMMENT_ID, "${{ steps.reserve-exact-review-lease.outputs.comment_id }}");
+  assert.match(expiry.run, /node dist\/clawsweeper.js expire-review-lease/);
+  assert.match(expiry.run, /--comment-id "\$COMMENT_ID"/);
+  assert.match(expiry.if, /always\(\)/);
+  assert.match(expiry.if, /!cancelled\(\)/);
+  for (const queued of ["success", "failure"]) {
+    for (const accepted of ["true", "false"]) {
+      for (const reservation of ["posted", "held", "superseded"]) {
+        const expression = expiry.if
+          .replace(/^\$\{\{\s*|\s*\}\}$/g, "")
+          .replace("always()", "true")
+          .replace("cancelled()", "false")
+          .replace("steps.claim-exact-review-queue.outputs.claimed", "'true'")
+          .replace("steps.queue-exact-review-publication.outcome", JSON.stringify(queued))
+          .replace(
+            "steps.direct-exact-review-publication.outputs.accepted",
+            JSON.stringify(accepted),
+          )
+          .replace("steps.reserve-exact-review-lease.outputs.status", JSON.stringify(reservation));
+        assert.equal(
+          Function(`return (${expression});`)(),
+          queued === "success" && accepted !== "true" && reservation === "posted",
+        );
+      }
+    }
+  }
+});
+
 test("exact review failure annotation follows logical generation and preserves the failure gate", () => {
   const workflow = YAML.parse(readText(".github/workflows/sweep.yml"));
   const failure = workflow.jobs["event-review-apply"].steps.find(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a freshly reviewed pull request whose direct publication hit a GitHub rate limit was queued for durable publication but never published, while the review-lease placeholder kept blocking a maintainer `@clawsweeper re-review` for the full 41-minute lease.

Observed on 2026-09-02 (UTC):

- Review run https://github.com/openclaw/clawsweeper/actions/runs/33683907592 (https://github.com/openclaw/openclaw/pull/136621 rev 1) produced a review at 21:23. Direct publication failed with `GitHubRateLimitError` (credential scope `repository_actions`), the workflow fell back to `POST /internal/exact-review/enqueue`, attempt 1 returned HTTP 503 `target_visibility_unverified`, attempt 2 succeeded. The review was never published before the PR merged at 22:01.
- The maintainer re-review (https://github.com/openclaw/clawsweeper/actions/runs/33686680652) was refused with "Another exact-head review is already active".
- `GET /api/exact-review-queue` at 22:36 showed `lanes.publication`: pending 382, ready 381, dispatching 0, leased 0, active 0, capacity 40, available_slots 40, `oldest_pending_at` 2026-08-13T09:14:19Z, `next_attempt_at` 2026-08-13T09:24:59Z. At 22:52: pending 371, ready 371, active 0, same oldest/next-attempt values.

## Why This Change Was Made

Three independent defects in the exact-review queue Durable Object (`dashboard/exact-review-queue.ts`) combined into starvation:

1. **Batch claims demanded an exact selection match.** The alarm probes the eight selected members, dispatches `exact-review-batch-publish.yml`, and stores the probe. When the workflow claimed ~30-60 s later it required the current eight-item selection to be byte-identical to the probe. Under load the selection changes almost every time (a fresh-lane arrival, a fresh item ageing past the 15-minute window, a revision bump, a superseded row), so the workflow retired the reservation, claimed nothing, and exited after ~30 s; the alarm re-dispatched 5 s later and the cycle repeated. Evidence: between 21:20 and 21:43 roughly ten batch runs were dispatched and each exited in 26-45 s without claiming (for example https://github.com/openclaw/clawsweeper/actions/runs/33686404002, https://github.com/openclaw/clawsweeper/actions/runs/33686365000, https://github.com/openclaw/clawsweeper/actions/runs/33686326722, https://github.com/openclaw/clawsweeper/actions/runs/33686280755, https://github.com/openclaw/clawsweeper/actions/runs/33686215783, https://github.com/openclaw/clawsweeper/actions/runs/33686143313), which is exactly the fresh-lane window of the review enqueued at 21:23. Producer https://github.com/openclaw/clawsweeper/actions/runs/33668772748 (review at 18:41) was only published at 22:03/22:22.
2. **Superseded publication rows never drained.** A queue-maintenance dry run (https://github.com/openclaw/clawsweeper/actions/runs/33692922776, `execute=false`) reported `scanned=352`, `staleRevisionEligible=243`, `legacyStateBatchTerminalCandidates=44`. Those 243 rows have a source revision older than the target's publication head; they are excluded from batching but still count as pending/ready and pin `next_attempt_at` to Aug 13. Only the manual maintenance workflow with `execute=true` removed them, and it last ran successfully on 2026-08-08.
3. **Every enqueue re-probed target visibility live.** `hostedTargetAdmission` called `GET /repos/{repo}` on each `/enqueue`, claim, and alarm pass; under rate-limit pressure the probe is retryable and `/enqueue` answered 503, exactly when the review workflow needed the queue as fallback.

Secondary: when direct publication fails with a rate limit and the item is queued, sweep.yml deliberately keeps the review-start lease comment (the later publisher deletes it), so a re-review is refused until the 41-minute lease expires.

## What Changed

- **Batch claims consume the probed subset.** A claim carrying the current dispatch reservation now claims the still-valid intersection of the probed `[key, revision]` pairs and the current candidates (filtered before the admission scan and the lease-size cut). Unprobed fresh arrivals wait for the next departure; an empty intersection keeps today's retire-and-repreflight behavior. Malformed or legacy probes fall back to the strict comparison.
- **Public hosted-target admission is cached in the queue's durable KV, for intake only.** The four signed intake routes (`/enqueue`, `/command-intake`, `/branch-authority`, `/source-authority`) get a 60 s fresh tier without a probe and may reuse a public observation for up to 30 min when the live probe is retryable. Review claims, dispatch, batch claims, and acknowledgement paths always perform a live probe and fail closed, so a target that turns private is refused before any credential-bearing work is handed out. A terminal probe or terminal eligibility clears the entry and records a tokenized revocation so an out-of-order older probe cannot re-admit; `EXACT_REVIEW_HOSTED_TARGET_ADMISSION_MAX_STALE_MS=0` disables the cache.
- **Alarm housekeeping prunes superseded publication rows** (`stale_revision` class only, bounded by `EXACT_REVIEW_STALE_PUBLICATION_PRUNE_LIMIT`, default 100, oldest first, no GitHub reads, command-bearing rows excluded). Duplicate-lineage and legacy terminal classes stay on the operator workflow.
- **Queued publication expires the review-start lease.** New `expire-review-lease` CLI command rewrites only `lease_expires_at` in the placeholder marker; sweep.yml calls it right after a successful queue handoff so a maintainer re-review is no longer blocked. The publisher still deletes the placeholder on terminal publication.
- Docs: `docs/live-dashboard.md`, `docs/limits.md`.

No Durable Object binding, migration, SQLite table, or public `/api/exact-review-queue` field changed. OpenClaw Bay needs no change: it observes the same aggregate fields, which now reflect corrected pending/completed values.

## pr-behavior-proof

- Claim: dispatched batch workflows claim their probed members despite selection churn; superseded rows are pruned automatically; enqueue survives a retryable visibility probe; the review lease expires on queue handoff.
- Exercised surface: `ExactReviewQueue` alarm/claim/enqueue routes and `sweep.yml` step contract, through the existing in-memory SQLite Durable Object harness and workflow-definition tests.
- Regression tests (all fail before the fix, pass after): see the test list below.
- Command: `node --test <touched test files>` plus `pnpm run build:all`, `pnpm run lint`, `pnpm run format:check`, `pnpm run check:docs`, `pnpm run check:limits`, `pnpm run check:active-surface`, `pnpm run check:dashboard-queue-boundary`, `pnpm run check:dashboard-strict`, `git diff --check`.
- Limits: unit-level proof only; no deploy was performed. The full `pnpm run check` suite reports pre-existing, environment-caused failures in this worktree (agent-input-scan `unsafe_path` refusals because the worktree lives under a hidden directory); the same files pass from the main checkout path. Live before/after queue numbers must be captured after deployment.

### Regression tests added

- `test/exact-review-publication-batches.test.ts`: `batch claim after {fresh arrival | revision bump | all probed items gone | older retries become ready beyond the scan window} consumes only still-valid probed items`; `hosted admission cache: {fresh | stale fallback | terminal clears | too old | disabled}`; `hosted admission rejects an older public probe after terminal revocation (cache 1800000 | 0)`; `hosted admission fences an older public probe across same-millisecond revocations`; `terminal eligibility revokes cached admission and an overlapping {public | retryable} probe`; `alarm prunes stale publication revisions after batch expiry with limit {100 | 1}`; `alarm preserves command acknowledgements after batch expiry while pruning ordinary stale publications`.
- `test/exact-review-publication-batches.test.ts` (fail-closed follow-up): `batch claim ignores cached public admission when the live probe is {terminal | retryable}`.
- `test/dashboard-worker-queue-runtime.test.ts`: `matching empty batch departures release their own fence and redispatch current work` (updated to remove every probed member explicitly).
- `test/review-comment-publication.test.ts`: `expireReviewStartStatusLease changes only the canonical expiry and releases the exact-head lease`; `expireReviewStartStatusLease leaves noncanonical markers and unrelated text byte-identical`.
- `test/command.test.ts`: `expire-review-lease patches the queued placeholder and preserves unrelated comments`.
- `test/sweep-workflow.test.ts`: `queued publication expires only its posted review lease after successful handoff`.

Before the fix the claim tests returned `claimed:false`, the cache tests answered 503 on `/enqueue`, and the prune tests left the stale rows pending.

### Queue API before (2026-09-02T22:52Z, pre-deploy)

| lane.publication field | value |
| --- | --- |
| pending / ready | 371 / 371 |
| dispatching / leased / active | 0 / 0 / 0 |
| capacity / available_slots | 40 / 40 |
| oldest_pending_at | 2026-08-13T09:14:19Z |
| next_attempt_at | 2026-08-13T09:24:59Z |

After-deploy numbers will be added once the Worker is deployed through `dashboard.yml`.

### Review finding disposition

- ClawSweeper P1 "Fail closed when target visibility cannot be rechecked" (reviewed head b638315): accepted and fixed in the follow-up commit. The cache is now consumed only by the intake routes; every review claim, dispatch, batch claim, and acknowledgement path performs a live public probe and fails closed, with the private-transition regression test above.
- Real-behavior proof: the changed owner is the production Durable Object, which can only be exercised after deployment. Unit-level proof is the in-memory SQLite Durable Object harness plus workflow-definition tests; the after-fix production-path queue trace will be attached after the Worker deploys (proof: evidence-in-progress, approved by the repository owner in the landing request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
