### PR TITLE
fix(review): stop blocking in-memory caches on migration proof

### DIFF
--- a/docs/pr-review-comments.md
+++ b/docs/pr-review-comments.md
@@ -215,9 +215,12 @@ storage formats, SQL DDL, and structured storage keys (including frontmatter)
 remain evidence. Renames retain evidence from either production path. Missing,
 empty, or truncated patches on explicit production persistence paths or hook
 descriptors, and truncated file lists, still produce conservative unknown
-warnings. Generic `state`, `session`, `history`, and `worker` path names and typed runtime
-parameters alone do not establish persistence, including when their patches are
-truncated. Explicit serialization, browser storage (local/session storage and
+warnings. Generic `state`, `session`, `history`, `worker`, and `cache` path names,
+cache keys, versions, namespaces, TTLs, and typed runtime fields alone do not
+establish persistence, including when their patches are missing or truncated.
+Cache-shaped objects need an explicit cache schema, storage path, or same-hunk
+persistence boundary; component-local maps, promises, and abort signals do not
+supply one. Explicit serialization, browser storage (local/session storage and
 IndexedDB), durable storage, and schema/migration evidence remain eligible in
 UI code too. Unchanged storage context in the same diff hunk can establish the
 boundary for changed stored fields; an in-memory map or display-only comment

--- a/docs/proof/persistent-cache-evidence/replay.mjs
+++ b/docs/proof/persistent-cache-evidence/replay.mjs
@@ -1,0 +1,311 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { parseArgs } from "node:util";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+// Historical proof: run from any directory after building the selected module root.
+// --expect baseline asserts the known false positives; it does not swallow failures.
+const { values } = parseArgs({
+  options: {
+    module: { type: "string" },
+    output: { type: "string" },
+    expect: { type: "string" },
+  },
+});
+assert(
+  ["baseline", "candidate"].includes(values.expect) && values.module && values.output,
+  "Usage: node replay.mjs --module COMPILED_ROOT --expect baseline|candidate --output RESULT.json",
+);
+const worktree = fileURLToPath(new URL("../../../", import.meta.url));
+const moduleRoot = resolve(values.module);
+const load = (name) => import(pathToFileURL(join(moduleRoot, "dist", name + ".js")));
+const { renderReviewCommentFromReport, parseDecision, reviewAutomationMarkersFromReport } =
+  await load("clawsweeper");
+const { createReportDocumentRendering } = await load("clawsweeper-report-document");
+const { createRepositoryLinks } = await load("clawsweeper-links");
+const { createReportContextRendering } = await load("clawsweeper-report-context");
+const { createDashboardPresentation } = await load("clawsweeper-dashboard");
+const { normalizeRepo, repositoryProfileFor } = await load("repository-profiles");
+const { item, closeDecision } = await import(pathToFileURL(join(worktree, "test/helpers.ts")));
+const { hydratePrimaryBody } = await import(
+  pathToFileURL(join(worktree, "test/primary-body-fixture.ts"))
+);
+const hash = (value) => createHash("sha256").update(value).digest("hex");
+const fixtureBytes = readFileSync(
+  join(worktree, "test/fixtures/persistence-classifier-136772.json"),
+);
+const fixture = JSON.parse(fixtureBytes);
+const head = fixture.headSha;
+const captured = fixture.pullFiles;
+const normalized = hydratePrimaryBody("", "pull_request", { pullFiles: captured }).context
+  .pullFiles;
+const file = (filename, patch) => ({ filename, ...(patch === undefined ? {} : { patch }) });
+const cases = [
+  { name: "captured-runtime-raw", files: captured, stored: false, baselineFalsePositive: true },
+  {
+    name: "captured-runtime-normalized",
+    files: normalized,
+    stored: false,
+    baselineFalsePositive: true,
+  },
+  {
+    name: "cache-path-runtime-shape",
+    files: [
+      file(
+        "src/cache/requests.ts",
+        "@@ -1,2 +1,3 @@\n type CacheEntry = {\n+ signal: AbortSignal;\n };",
+      ),
+    ],
+    stored: false,
+    baselineFalsePositive: true,
+  },
+  {
+    name: "sqlite-column-with-memory-map",
+    files: [
+      file(
+        "src/runtime/cache.ts",
+        "@@ -1,4 +1,5 @@\n const cache = new Map();\n CREATE TABLE requests (\n+ revision INTEGER,\n );",
+      ),
+    ],
+    stored: true,
+    sqlite: true,
+  },
+  {
+    name: "explicit-cache-schema",
+    files: [file("src/cache/schema.ts", "@@ -1 +1 @@\n-version: number;\n+version: string;")],
+    stored: true,
+  },
+  {
+    name: "same-hunk-browser-storage",
+    files: [
+      file(
+        "ui/src/components/preview.ts",
+        "@@ -1,3 +1,4 @@\n localStorage.setItem(key, JSON.stringify({\n+ revision: 2,\n }));",
+      ),
+    ],
+    stored: true,
+  },
+  {
+    name: "same-hunk-indexed-db",
+    files: [
+      file(
+        "ui/src/components/preview.ts",
+        '@@ -1,3 +1,4 @@\n const store: IDBObjectStore = transaction.objectStore("previews");\n store.put({\n+ revision: 2,\n });',
+      ),
+    ],
+    stored: true,
+  },
+  {
+    name: "same-hunk-durable-storage",
+    files: [
+      file(
+        "src/cache/requests.ts",
+        "@@ -1,3 +1,4 @@\n await state.storage.put(key, {\n+ revision: 2,\n });",
+      ),
+    ],
+    stored: true,
+  },
+  {
+    name: "file-backed-cache",
+    files: [
+      file(
+        "src/cache/requests.ts",
+        "@@ -1 +1 @@\n+writeFile(cachePath, JSON.stringify({ revision: 2 }));",
+      ),
+    ],
+    stored: true,
+  },
+  {
+    name: "migration",
+    files: [file("src/migrations/cache.ts", "@@ -1 +1 @@\n+backfill(existingRows);")],
+    stored: true,
+  },
+  { name: "missing-explicit-cache-schema", files: [file("src/cache/schema.ts")], stored: true },
+  {
+    name: "missing-sqlite-cache-owner",
+    files: [file("src/cache/sqlite-store.ts")],
+    stored: true,
+    sqlite: true,
+  },
+  {
+    name: "config-compatibility",
+    files: [file("src/config/types.ts", "@@ -1 +1 @@\n+cacheLifetime: number;")],
+    stored: false,
+    config: true,
+  },
+  {
+    name: "protocol-schema-incomplete",
+    files: [file("src/gateway/protocol/schema/session.ts")],
+    stored: true,
+  },
+  {
+    name: "protocol-risk-independent",
+    files: [
+      file(
+        "packages/gateway-protocol/src/request.ts",
+        "@@ -1 +1 @@\n-requestId: string;\n+requestId: number;",
+      ),
+    ],
+    stored: false,
+    risk: true,
+  },
+];
+const document = createReportDocumentRendering({
+  ...createRepositoryLinks({
+    reportRepo: "openclaw/clawsweeper-state",
+    normalizeRepo,
+    targetRepo: () => "openclaw/openclaw",
+    targetProfile: () => repositoryProfileFor("openclaw/openclaw"),
+  }),
+  ...createReportContextRendering({}),
+  ...createDashboardPresentation({}),
+  prSurfaceFilesFromContext: () => [],
+  compactPullFilePaths: (entry) => [entry.filename],
+  confidenceText: String,
+  fixedInText: () => "unknown",
+  formatTimestamp: String,
+  labelJustificationsMarkdown: () => "- none",
+  publicLikelyOwnerRole: String,
+  pullHeadShaFromContext: () => head,
+  reviewStructuralPullStateFromContext: () => null,
+  sentence: String,
+  sha256: hash,
+});
+const failures = [];
+const results = cases.map((scenario) => {
+  const decision = parseDecision(
+    closeDecision({
+      decision: "keep_open",
+      closeReason: "none",
+      confidence: "high",
+      summary: "Synthetic offline review replay; not a live review receipt.",
+      changeSummary: "Classifier-to-report compatibility boundary replay.",
+      evidence: [
+        {
+          repo: "openclaw/openclaw",
+          label: "Offline fixture",
+          detail: "Captured source patch replay.",
+          file: null,
+          line: null,
+          command: null,
+          sha: null,
+        },
+      ],
+      likelyOwners: [
+        {
+          person: "synthetic-owner",
+          role: "review fixture",
+          reason: "Offline synthetic identity.",
+          commits: [],
+          files: [],
+          confidence: "low",
+        },
+      ],
+      risks: scenario.risk
+        ? [
+            "[P1] Changing the protocol request identifier breaks existing clients; retain wire compatibility before merge.",
+          ]
+        : [],
+      bestSolution: "The owner-boundary change is correct.",
+      reproductionAssessment: "Yes. The captured patch is the input.",
+      solutionAssessment: "Yes. No correctness defect was found.",
+      overallCorrectness: "patch is correct",
+      nextStep: { kind: "none", text: "" },
+      workReason: "",
+      realBehaviorProof: {
+        status: "not_applicable",
+        summary: "Synthetic MEMBER review context.",
+        evidenceKind: "not_applicable",
+        needsContributorAction: false,
+      },
+      prRating: {
+        proofTier: "NA",
+        patchTier: "B",
+        overallTier: "B",
+        summary: "Synthetic clean review.",
+        nextSteps: [],
+      },
+      securityReview: { status: "cleared", summary: "None.", concerns: [] },
+    }),
+  );
+  decision.localCheckoutAccess = "verified";
+  const report = document.markdownFor({
+    item: item({
+      number: 999999,
+      kind: "pull_request",
+      title: "Synthetic offline cache classification replay",
+      url: "https://github.com/openclaw/openclaw/pull/999999",
+      authorAssociation: "MEMBER",
+      labels: ["clawsweeper:automerge"],
+    }),
+    decision,
+    context: { issue: {}, comments: [], timeline: [], pullFiles: scenario.files },
+    git: { mainSha: "a".repeat(40), latestRelease: null, releaseStateComplete: true },
+    action: { actionTaken: "kept_open" },
+    reviewMode: "propose",
+    snapshotHash: "synthetic",
+    contentDigest: "synthetic",
+    reviewPolicy: "synthetic",
+    runtime: { model: "Codex", reasoningEffort: "high" },
+    reviewLeaseOwner: "synthetic-offline-replay",
+    reviewLeaseCommentId: 1,
+  });
+  const comment = renderReviewCommentFromReport(report, "none");
+  const markers = reviewAutomationMarkersFromReport(report);
+  const observed = {
+    name: scenario.name,
+    dataModel: /^data_model_change: true$/m.test(report),
+    surfaces: JSON.parse(report.match(/^data_model_surfaces: (.*)$/m)[1]),
+    sqlite: /^sqlite_schema_change: true$/m.test(report),
+    config: /^config_surface_change: true$/m.test(report),
+    migrationCheckbox: /- \[ \] \*\*Add data-model compatibility proof\*\*/.test(comment),
+    configCheckbox: /- \[ \] \*\*Review config compatibility\*\*/.test(comment),
+    needsHuman: markers.includes("clawsweeper-verdict:needs-human"),
+    passes: markers.includes("clawsweeper-verdict:pass"),
+    blocked: comment.includes("clawsweeper-review-state:blocked"),
+    ready: comment.includes("clawsweeper-review-state:ready"),
+  };
+  const expectedStored =
+    scenario.stored || (values.expect === "baseline" && Boolean(scenario.baselineFalsePositive));
+  const expectedBlocked = Boolean(expectedStored || scenario.config || scenario.risk);
+  const expected = {
+    dataModel: expectedStored,
+    migrationCheckbox: expectedStored,
+    config: Boolean(scenario.config),
+    configCheckbox: Boolean(scenario.config),
+    sqlite: Boolean(scenario.sqlite),
+    needsHuman: expectedBlocked,
+    passes: !expectedBlocked,
+    blocked: expectedBlocked,
+    ready: !expectedBlocked,
+  };
+  for (const [key, value] of Object.entries(expected)) {
+    if (observed[key] !== value)
+      failures.push(`${scenario.name}: ${key} expected ${value}, got ${observed[key]}`);
+  }
+  return observed;
+});
+const receipt = {
+  expectation: values.expect,
+  provider: "local-process",
+  image: null,
+  lease: null,
+  node: process.version,
+  platform: process.platform,
+  arch: process.arch,
+  fixture: {
+    path: "test/fixtures/persistence-classifier-136772.json",
+    head,
+    sha256: hash(fixtureBytes),
+  },
+  classifierSha256: hash(readFileSync(join(moduleRoot, "dist/clawsweeper-change-detection.js"))),
+  results,
+  failures,
+  limits:
+    "Offline compiled classifier -> canonical report producer -> comment/readiness/markers. Captured runtime patch only; 12 synthetic compatibility controls. Production normalization uses the unchanged test hydration fixture. Review and lease metadata are synthetic. No model inference, migration execution, GitHub publication, or live service mutation.",
+};
+writeFileSync(values.output, JSON.stringify(receipt, null, 2) + "\n");
+console.log(JSON.stringify({ expectation: values.expect, scenarios: results.length, failures }));
+process.exitCode = failures.length ? 1 : 0;

--- a/docs/proof/persistent-cache-evidence/results.json
+++ b/docs/proof/persistent-cache-evidence/results.json
@@ -1,0 +1,76 @@
+{
+  "claim": "Runtime cache names no longer create migration checkboxes; twelve storage/config/protocol controls retain their gate booleans.",
+  "baselineRevision": "f8f7cb84a7a869d099d3d3551fa0c76fb37c49b7",
+  "candidateSourceSha256": "7a12b239e3864f3914e90e0ceec20ee002ef9ac083549bb3d42d6d0ba827bd39",
+  "replaySha256": "6e9258866a3e1a7a51c7af901c1c0999ed4a5f0f20ccc6c045b2f41dda147751",
+  "runs": [
+    {
+      "expectation": "baseline",
+      "provider": "local-process",
+      "image": null,
+      "lease": null,
+      "node": "v24.20.0",
+      "platform": "darwin",
+      "arch": "arm64",
+      "fixture": {
+        "path": "test/fixtures/persistence-classifier-136772.json",
+        "head": "5b8573144dfe8f1d423e55d818baeafb81efc9c4",
+        "sha256": "6e7a050b1de321690ef7c61ab2e7094dda69bf9ca6426987ba30934e445a225c"
+      },
+      "classifierSha256": "dfbadb678924440521bc3d0fb91571b2235f957ab13b6006350c697a333d2700",
+      "results": [
+        {"name": "captured-runtime-raw", "dataModel": true, "surfaces": ["persistent cache schema: ui/src/components/github-link-hovercard.runtime.ts"], "sqlite": false, "config": false, "migrationCheckbox": true, "configCheckbox": false, "needsHuman": true, "passes": false, "blocked": true, "ready": false},
+        {"name": "captured-runtime-normalized", "dataModel": true, "surfaces": ["persistent cache schema: ui/src/components/github-link-hovercard.runtime.ts"], "sqlite": false, "config": false, "migrationCheckbox": true, "configCheckbox": false, "needsHuman": true, "passes": false, "blocked": true, "ready": false},
+        {"name": "cache-path-runtime-shape", "dataModel": true, "surfaces": ["persistent cache schema: src/cache/requests.ts"], "sqlite": false, "config": false, "migrationCheckbox": true, "configCheckbox": false, "needsHuman": true, "passes": false, "blocked": true, "ready": false},
+        {"name": "sqlite-column-with-memory-map", "dataModel": true, "surfaces": ["database schema: src/runtime/cache.ts"], "sqlite": true, "config": false, "migrationCheckbox": true, "configCheckbox": false, "needsHuman": true, "passes": false, "blocked": true, "ready": false},
+        {"name": "explicit-cache-schema", "dataModel": true, "surfaces": ["persistent cache schema: src/cache/schema.ts"], "sqlite": false, "config": false, "migrationCheckbox": true, "configCheckbox": false, "needsHuman": true, "passes": false, "blocked": true, "ready": false},
+        {"name": "same-hunk-browser-storage", "dataModel": true, "surfaces": ["serialized state: ui/src/components/preview.ts"], "sqlite": false, "config": false, "migrationCheckbox": true, "configCheckbox": false, "needsHuman": true, "passes": false, "blocked": true, "ready": false},
+        {"name": "same-hunk-indexed-db", "dataModel": true, "surfaces": ["serialized state: ui/src/components/preview.ts"], "sqlite": false, "config": false, "migrationCheckbox": true, "configCheckbox": false, "needsHuman": true, "passes": false, "blocked": true, "ready": false},
+        {"name": "same-hunk-durable-storage", "dataModel": true, "surfaces": ["durable storage schema: src/cache/requests.ts", "persistent cache schema: src/cache/requests.ts"], "sqlite": false, "config": false, "migrationCheckbox": true, "configCheckbox": false, "needsHuman": true, "passes": false, "blocked": true, "ready": false},
+        {"name": "file-backed-cache", "dataModel": true, "surfaces": ["persistent cache schema: src/cache/requests.ts", "serialized state: src/cache/requests.ts"], "sqlite": false, "config": false, "migrationCheckbox": true, "configCheckbox": false, "needsHuman": true, "passes": false, "blocked": true, "ready": false},
+        {"name": "migration", "dataModel": true, "surfaces": ["migration/backfill/repair: src/migrations/cache.ts"], "sqlite": false, "config": false, "migrationCheckbox": true, "configCheckbox": false, "needsHuman": true, "passes": false, "blocked": true, "ready": false},
+        {"name": "missing-explicit-cache-schema", "dataModel": true, "surfaces": ["unknown-data-model-change: src/cache/schema.ts"], "sqlite": false, "config": false, "migrationCheckbox": true, "configCheckbox": false, "needsHuman": true, "passes": false, "blocked": true, "ready": false},
+        {"name": "missing-sqlite-cache-owner", "dataModel": true, "surfaces": ["unknown-data-model-change: src/cache/sqlite-store.ts"], "sqlite": true, "config": false, "migrationCheckbox": true, "configCheckbox": false, "needsHuman": true, "passes": false, "blocked": true, "ready": false},
+        {"name": "config-compatibility", "dataModel": false, "surfaces": [], "sqlite": false, "config": true, "migrationCheckbox": false, "configCheckbox": true, "needsHuman": true, "passes": false, "blocked": true, "ready": false},
+        {"name": "protocol-schema-incomplete", "dataModel": true, "surfaces": ["unknown-data-model-change: src/gateway/protocol/schema/session.ts"], "sqlite": false, "config": false, "migrationCheckbox": true, "configCheckbox": false, "needsHuman": true, "passes": false, "blocked": true, "ready": false},
+        {"name": "protocol-risk-independent", "dataModel": false, "surfaces": [], "sqlite": false, "config": false, "migrationCheckbox": false, "configCheckbox": false, "needsHuman": true, "passes": false, "blocked": true, "ready": false}
+      ],
+      "failures": [],
+      "limits": "Offline compiled classifier -> canonical report producer -> comment/readiness/markers. Captured runtime patch only; 12 synthetic compatibility controls. Production normalization uses the unchanged test hydration fixture. Review and lease metadata are synthetic. No model inference, migration execution, GitHub publication, or live service mutation."
+    },
+    {
+      "expectation": "candidate",
+      "provider": "local-process",
+      "image": null,
+      "lease": null,
+      "node": "v24.20.0",
+      "platform": "darwin",
+      "arch": "arm64",
+      "fixture": {
+        "path": "test/fixtures/persistence-classifier-136772.json",
+        "head": "5b8573144dfe8f1d423e55d818baeafb81efc9c4",
+        "sha256": "6e7a050b1de321690ef7c61ab2e7094dda69bf9ca6426987ba30934e445a225c"
+      },
+      "classifierSha256": "0a11ae359efd19ed2f106b7e3ae5448612679b1ff901eade26e9a0be9657e845",
+      "results": [
+        {"name": "captured-runtime-raw", "dataModel": false, "surfaces": [], "sqlite": false, "config": false, "migrationCheckbox": false, "configCheckbox": false, "needsHuman": false, "passes": true, "blocked": false, "ready": true},
+        {"name": "captured-runtime-normalized", "dataModel": false, "surfaces": [], "sqlite": false, "config": false, "migrationCheckbox": false, "configCheckbox": false, "needsHuman": false, "passes": true, "blocked": false, "ready": true},
+        {"name": "cache-path-runtime-shape", "dataModel": false, "surfaces": [], "sqlite": false, "config": false, "migrationCheckbox": false, "configCheckbox": false, "needsHuman": false, "passes": true, "blocked": false, "ready": true},
+        {"name": "sqlite-column-with-memory-map", "dataModel": true, "surfaces": ["database schema: src/runtime/cache.ts"], "sqlite": true, "config": false, "migrationCheckbox": true, "configCheckbox": false, "needsHuman": true, "passes": false, "blocked": true, "ready": false},
+        {"name": "explicit-cache-schema", "dataModel": true, "surfaces": ["persistent cache schema: src/cache/schema.ts"], "sqlite": false, "config": false, "migrationCheckbox": true, "configCheckbox": false, "needsHuman": true, "passes": false, "blocked": true, "ready": false},
+        {"name": "same-hunk-browser-storage", "dataModel": true, "surfaces": ["serialized state: ui/src/components/preview.ts"], "sqlite": false, "config": false, "migrationCheckbox": true, "configCheckbox": false, "needsHuman": true, "passes": false, "blocked": true, "ready": false},
+        {"name": "same-hunk-indexed-db", "dataModel": true, "surfaces": ["serialized state: ui/src/components/preview.ts"], "sqlite": false, "config": false, "migrationCheckbox": true, "configCheckbox": false, "needsHuman": true, "passes": false, "blocked": true, "ready": false},
+        {"name": "same-hunk-durable-storage", "dataModel": true, "surfaces": ["durable storage schema: src/cache/requests.ts"], "sqlite": false, "config": false, "migrationCheckbox": true, "configCheckbox": false, "needsHuman": true, "passes": false, "blocked": true, "ready": false},
+        {"name": "file-backed-cache", "dataModel": true, "surfaces": ["serialized state: src/cache/requests.ts"], "sqlite": false, "config": false, "migrationCheckbox": true, "configCheckbox": false, "needsHuman": true, "passes": false, "blocked": true, "ready": false},
+        {"name": "migration", "dataModel": true, "surfaces": ["migration/backfill/repair: src/migrations/cache.ts"], "sqlite": false, "config": false, "migrationCheckbox": true, "configCheckbox": false, "needsHuman": true, "passes": false, "blocked": true, "ready": false},
+        {"name": "missing-explicit-cache-schema", "dataModel": true, "surfaces": ["unknown-data-model-change: src/cache/schema.ts"], "sqlite": false, "config": false, "migrationCheckbox": true, "configCheckbox": false, "needsHuman": true, "passes": false, "blocked": true, "ready": false},
+        {"name": "missing-sqlite-cache-owner", "dataModel": true, "surfaces": ["unknown-data-model-change: src/cache/sqlite-store.ts"], "sqlite": true, "config": false, "migrationCheckbox": true, "configCheckbox": false, "needsHuman": true, "passes": false, "blocked": true, "ready": false},
+        {"name": "config-compatibility", "dataModel": false, "surfaces": [], "sqlite": false, "config": true, "migrationCheckbox": false, "configCheckbox": true, "needsHuman": true, "passes": false, "blocked": true, "ready": false},
+        {"name": "protocol-schema-incomplete", "dataModel": true, "surfaces": ["unknown-data-model-change: src/gateway/protocol/schema/session.ts"], "sqlite": false, "config": false, "migrationCheckbox": true, "configCheckbox": false, "needsHuman": true, "passes": false, "blocked": true, "ready": false},
+        {"name": "protocol-risk-independent", "dataModel": false, "surfaces": [], "sqlite": false, "config": false, "migrationCheckbox": false, "configCheckbox": false, "needsHuman": true, "passes": false, "blocked": true, "ready": false}
+      ],
+      "failures": [],
+      "limits": "Offline compiled classifier -> canonical report producer -> comment/readiness/markers. Captured runtime patch only; 12 synthetic compatibility controls. Production normalization uses the unchanged test hydration fixture. Review and lease metadata are synthetic. No model inference, migration execution, GitHub publication, or live service mutation."
+    }
+  ]
+}

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -733,6 +733,10 @@ DDL or migrations, database schema installers/helpers, persistent cache schemas,
 Durable Object or hosted storage schemas, serialized JSON state written to disk
 or a database, vector or embedding row identity/query-compatibility metadata,
 and doctor, repair, migration, or backfill code that rewrites persisted state.
+Cache names, keys, versions, namespaces, TTLs, and cache helper filenames alone
+do not establish persistence. Identify an explicit storage or schema boundary;
+component-local maps, promises, and abort signals are runtime state. Their
+presence does not exempt real browser or durable storage changes in the same PR.
 Do not treat pure query-only changes or non-semantic docs wording as data-model
 breakage by default. Markdown beside source is not automatically runtime code:
 distinguish prose from changed machine-consumed frontmatter, configuration, or

--- a/src/clawsweeper-change-detection.ts
+++ b/src/clawsweeper-change-detection.ts
@@ -469,13 +469,7 @@ function dataModelSurfacesFromPatch(
   if (dataModelTextHasSerialization(text)) {
     add("serialized state");
   }
-  if (
-    /\b(?:cache(?:Key|Version|Schema|Namespace)?|cache[_-]?(?:key|version|schema|namespace)|ttl)\b/i.test(
-      text,
-    )
-  ) {
-    add("persistent cache schema");
-  }
+  if (dataModelTextHasCacheSchema(text)) add("persistent cache schema");
   // Generic metadata and IDs need the storage path or hunk evidence above;
   // those names alone also occur in diagnostics and in-memory values.
   if (
@@ -494,6 +488,10 @@ function dataModelTextHasSerialization(text: string): boolean {
   );
 }
 
+function dataModelTextHasCacheSchema(text: string): boolean {
+  return /\bcache[_-]?schema\b|\bcache\s+(?:data\s+)?(?:format|schema|layout)\b/i.test(text);
+}
+
 function dataModelStorageContext(patch: string): string[] {
   // Retain nearby storage evidence when only the stored fields change. Hunk
   // headers and comments cannot establish a persistence boundary on their own.
@@ -505,6 +503,7 @@ function dataModelStorageContext(patch: string): string[] {
     .join("\n");
   const surfaces: string[] = [];
   if (dataModelTextHasSerialization(text)) surfaces.push("serialized state");
+  if (dataModelTextHasCacheSchema(text)) surfaces.push("persistent cache schema");
   if (/\b(?:DurableObject|state\.storage|storage\.(?:get|put|delete|list))\b/i.test(text)) {
     surfaces.push("durable storage schema");
   }
@@ -547,7 +546,7 @@ function dataModelPathHint(path: string): string {
   if (/(^|\/)(?:durable-?objects?|storage)(?:\/|[-_.])|durable-?object|state-storage/i.test(path)) {
     return "durable storage schema";
   }
-  if (/(^|\/)(?:cache|caches)(?:\/|[-_.])|cache[-_.]schema/i.test(path)) {
+  if (/(?:^|\/)caches?\/schema(?:\/|[-_.])|cache[-_.]schema/i.test(path)) {
     return "persistent cache schema";
   }
   if (/(^|\/)persistence(?:\/|[-_.])|(?:serialized|persisted?)[-_.]?(?:state|json)/i.test(path)) {
@@ -564,7 +563,8 @@ function dataModelPathHint(path: string): string {
     return "migration/backfill/repair";
   }
   if (
-    /\.sql$|(^|\/)(?:migrations?|schema|database|db|sql)(?:\/|[-_.])|(?:schema|migration|ddl|prisma)\.(?:ts|js|sql|prisma)$/i.test(
+    isLikelySqliteSchemaPath(path) ||
+    /(^|\/)(?:migrations?|schema|database|db|sql)(?:\/|[-_.])|(?:schema|migration|ddl|prisma)\.(?:ts|js|sql|prisma)$/i.test(
       path,
     )
   ) {

--- a/test/fixtures/persistence-classifier-136772.json
+++ b/test/fixtures/persistence-classifier-136772.json
@@ -1,0 +1,10 @@
+{
+  "pullRequest": "https://github.com/openclaw/openclaw/pull/136772",
+  "headSha": "5b8573144dfe8f1d423e55d818baeafb81efc9c4",
+  "pullFiles": [
+    {
+      "filename": "ui/src/components/github-link-hovercard.runtime.ts",
+      "patch": "diff --git a/ui/src/components/github-link-hovercard.runtime.ts b/ui/src/components/github-link-hovercard.runtime.ts\nindex 21958537d00..12d5b6427d5 100644\n--- a/ui/src/components/github-link-hovercard.runtime.ts\n+++ b/ui/src/components/github-link-hovercard.runtime.ts\n@@ -31,6 +31,7 @@ type PreviewState = {\n type CacheEntry = {\n   expiresAt: number;\n   promise: Promise<GitHubPreview>;\n+  signal: AbortSignal;\n };\n \n let nextHovercardId = 0;\n@@ -598,14 +599,12 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {\n     const key = `${target.kind}:${target.owner.toLowerCase()}/${target.repo.toLowerCase()}#${target.number}`;\n     const now = Date.now();\n     const cached = this.cache.get(key);\n-    if (cached && cached.expiresAt > now) {\n-      this.cache.delete(key);\n+    this.cache.delete(key);\n+    // Dismissal invalidates only that request, even before its rejection settles.\n+    if (cached && !cached.signal.aborted && cached.expiresAt > now) {\n       this.cache.set(key, cached);\n       return cached.promise;\n     }\n-    if (cached) {\n-      this.cache.delete(key);\n-    }\n \n     const load = async (): Promise<GitHubPreview> => {\n       if (!this.client) {\n@@ -626,6 +625,7 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {\n \n     const entry: CacheEntry = {\n       expiresAt: now + SUCCESS_CACHE_MS,\n+      signal,\n       promise: load().catch((error: unknown) => {\n         // Keep short-lived failures cached so repeatedly crossing a broken or\n         // private link does not burn GitHub's anonymous rate limit.\n"
+    }
+  ]
+}

--- a/test/pr-surface-policy.test.ts
+++ b/test/pr-surface-policy.test.ts
@@ -6,11 +6,15 @@ import test from "node:test";
 import {
   configSurfaceChangeFromPullFilesForTest,
   dataModelChangeFromPullFilesForTest,
+  parseDecision,
   renderReviewCommentFromReport,
   reviewAutomationMarkersFromReport,
   sqliteSchemaChangeFromPullFilesForTest,
 } from "../dist/clawsweeper.js";
-import { reviewReportFrontMatter as reportFrontMatter } from "./helpers.ts";
+import { createReportDocumentRendering } from "../dist/clawsweeper-report-document.js";
+import { createReportContextRendering } from "../dist/clawsweeper-report-context.js";
+import { createDashboardPresentation } from "../dist/clawsweeper-dashboard.js";
+import { closeDecision, item, reviewReportFrontMatter as reportFrontMatter } from "./helpers.ts";
 import { hydratePrimaryBody } from "./primary-body-fixture.ts";
 import { namedTestRoles, pinnedTestRolePaths } from "./openclaw-file-role-fixture.ts";
 
@@ -192,12 +196,81 @@ function persistenceReport(detection: { change: boolean; surfaces: string[] }, h
   })}\n\n## Summary\n\nReview completed.\n\n## Review Findings\n\nOverall correctness: patch is correct\n\nOverall confidence: 0.9\n\nFull review comments:\n\n- none\n`;
 }
 
+function renderPersistenceReport(
+  pullFiles: unknown[],
+  headSha: string,
+  pullFilesTruncated = false,
+) {
+  const document = createReportDocumentRendering({
+    ...createReportContextRendering({} as never),
+    ...createDashboardPresentation({} as never),
+    prSurfaceFilesFromContext: () => [],
+    compactPullFilePaths: (file) => [file.filename],
+    confidenceText: String,
+    fixedInText: () => "unknown",
+    formatTimestamp: String,
+    labelJustificationsMarkdown: () => "- none",
+    linkedSha: String,
+    markdownLink: (label, url) => `[${label}](${url})`,
+    publicLikelyOwnerRole: String,
+    pullHeadShaFromContext: () => headSha,
+    reviewStructuralPullStateFromContext: () => null,
+    sentence: String,
+    sha256: () => "synthetic-digest",
+  } as Parameters<typeof createReportDocumentRendering>[0]);
+  return document.markdownFor({
+    item: item({
+      kind: "pull_request",
+      url: "https://github.com/openclaw/openclaw/pull/123",
+      labels: ["clawsweeper:automerge"],
+    }),
+    decision: {
+      ...parseDecision(
+        closeDecision({
+          decision: "keep_open",
+          closeReason: "none",
+          summary: "Review completed.",
+          changeSummary: "Changes runtime fields.",
+          evidence: [],
+          overallCorrectness: "patch is correct",
+          workReason: "",
+          nextStep: { kind: "none", text: "" },
+          realBehaviorProof: {
+            status: "sufficient",
+            summary: "Synthetic runtime proof is sufficient; no upgrade proof is supplied.",
+            evidenceKind: "terminal",
+            needsContributorAction: false,
+          },
+        }),
+      ),
+      localCheckoutAccess: "verified",
+    },
+    context: {
+      issue: {},
+      comments: [],
+      timeline: [],
+      pullFiles,
+      counts: { comments: 0, timeline: 0, pullFilesTruncated },
+    },
+    git: { mainSha: "a".repeat(40), latestRelease: null, releaseStateComplete: true },
+    action: { actionTaken: "kept_open" },
+    reviewMode: "propose",
+    snapshotHash: "synthetic-snapshot",
+    contentDigest: "synthetic-content",
+    reviewPolicy: "synthetic-policy",
+    reviewLeaseOwner: "synthetic-lease",
+    reviewLeaseCommentId: 123,
+    runtime: { model: "Codex", reasoningEffort: "high" },
+  } as Parameters<typeof document.markdownFor>[0]);
+}
+
 for (const [name, fixturePath, normalizationTruncates] of [
   ["pane-local diagnostics", "./fixtures/persistence-classifier-132718.json", true],
   ["test-support workspace guard", "./fixtures/persistence-classifier-133209.json", true],
   ["Go chunk diagnostics", "./fixtures/persistence-classifier-134934.json", false],
   ["retained image runtime fields", "./fixtures/persistence-classifier-132839.json", true],
   ["worker input layout fields", "./fixtures/persistence-classifier-132839-workers.json", true],
+  ["hovercard promise cancellation", "./fixtures/persistence-classifier-136772.json", false],
 ] as const) {
   for (const normalized of [false, true]) {
     test(`${name} creates no stored-data warning or migration gate (${normalized ? "production-normalized" : "full"} patch)`, () => {
@@ -212,14 +285,17 @@ for (const [name, fixturePath, normalizationTruncates] of [
         );
       }
       const detection = dataModelChangeFromPullFilesForTest({ pullFiles });
-      const report = persistenceReport(detection, fixture.headSha ?? fixture.mergeCommit);
+      const report = renderPersistenceReport(pullFiles, fixture.headSha ?? fixture.mergeCommit);
+      const comment = renderReviewCommentFromReport(report, "none");
       // Check the contributor-visible consequence before the classification detail.
       assert.doesNotMatch(
-        renderReviewCommentFromReport(report, "none"),
+        comment,
         /Persistent data-model change detected|### Stored data model|Confirm migration/,
       );
       assert.match(reviewAutomationMarkersFromReport(report), /clawsweeper-verdict:pass/);
       assert.doesNotMatch(reviewAutomationMarkersFromReport(report), /needs-human|fix-required/);
+      assert.match(report, /^data_model_change: false$/m);
+      assert.match(comment, /clawsweeper-review-state:ready/);
       assert.deepEqual(detection, { change: false, surfaces: [] });
       assert.deepEqual(sqliteSchemaChangeFromPullFilesForTest({ pullFiles }), {
         change: false,
@@ -240,12 +316,23 @@ test("runtime state names and typed parameters alone do not establish stored dat
     "src/runtime/row-id.ts",
     "src/runtime/document-id.ts",
     "src/runtime/chunk-id.ts",
+    "ui/src/cache.ts",
+    "src/cache/helpers.ts",
+    "src/caches/request.ts",
+    "src/cache-key.ts",
+    "src/cache_version.ts",
+    "src/cache.helper.ts",
   ]) {
     for (const evidence of [patch, "", `${patch}\n\n[truncated 90 chars]`, undefined]) {
-      const detection = dataModelChangeFromPullFilesForTest({
-        pullFiles: [{ filename, previous_filename: "ui/src/session-view.ts", patch: evidence }],
-      });
+      const pullFiles = [
+        { filename, previous_filename: "ui/src/session-view.ts", patch: evidence },
+      ];
+      const detection = dataModelChangeFromPullFilesForTest({ pullFiles });
       assert.deepEqual(detection, { change: false, surfaces: [] }, filename);
+      assert.match(
+        renderReviewCommentFromReport(renderPersistenceReport(pullFiles, "a".repeat(40)), "none"),
+        /clawsweeper-review-state:ready/,
+      );
     }
   }
 });
@@ -269,13 +356,29 @@ for (const [name, patch] of [
   });
 }
 
-test("generic metadata and diagnostic identifiers do not warn or gate without storage evidence", () => {
-  for (const name of ["metadata", "documentId", "chunkID", "collection", "dimension", "rowId"]) {
+test("generic metadata, cache keys, versions, and TTL do not warn or gate without storage evidence", () => {
+  for (const name of [
+    "metadata",
+    "documentId",
+    "chunkID",
+    "collection",
+    "dimension",
+    "rowId",
+    "cache",
+    "cacheKey",
+    "cacheVersion",
+    "cacheNamespace",
+    "cache_key",
+    "cache_version",
+    "cache_namespace",
+    "ttl",
+  ]) {
     for (const patch of [
       `@@\n+  ${name}: value,`,
       `@@\n+log.Printf("rejected %s", ${name})`,
       `@@\n+const ${name} = input;`,
       `@@\n localStorage.getItem("preferences");\n@@\n+  ${name}: value,`,
+      `@@\n const cacheSchema = { revision: 1 };\n@@\n+  ${name}: value,`,
     ]) {
       const pullFiles = [{ filename: "scripts/translation/diagnostics.go", patch }];
       const detection = dataModelChangeFromPullFilesForTest({ pullFiles });
@@ -393,8 +496,45 @@ test("storage evidence still warns and gates browser, runtime, and schema change
       surface: "database schema",
     },
     {
-      filename: "src/cache/store.ts",
+      filename: "src/cache/schema.ts",
       patch: "@@\n-  ttl: 86400,\n+  ttl: 3600,",
+      surface: "persistent cache schema",
+    },
+    {
+      filename: "src/cache/helpers.ts",
+      patch: '@@\n writeFile("cache.json", JSON.stringify({\n+  expiresAt: now,\n }));',
+      surface: "serialized state",
+    },
+    {
+      filename: "ui/src/cache.ts",
+      patch: "@@\n const cacheSchema = {\n+  revision: 2,\n };",
+      surface: "persistent cache schema",
+    },
+    {
+      filename: "src/runtime/preview.ts",
+      patch: "@@\n+  cache_schema: 2,",
+      surface: "persistent cache schema",
+    },
+    {
+      filename: "ui/src/cache.ts",
+      patch:
+        '@@\n const cache = new Map();\n cache.set(key, {\n+  signal: controller.signal,\n });\n@@\n localStorage.setItem("cache", JSON.stringify({\n+  expiresAt: now,\n }));',
+      surface: "serialized state",
+    },
+    {
+      filename: "ui/src/cache.ts",
+      patch:
+        '@@\n const cache = new Map();\n const store: IDBObjectStore = transaction.objectStore("previews");\n store.put({\n+  expiresAt: now,\n });',
+      surface: "serialized state",
+    },
+    {
+      filename: "src/cache/helpers.ts",
+      patch: '@@\n await state.storage.put("cache", {\n+  expiresAt: now,\n });',
+      surface: "durable storage schema",
+    },
+    {
+      filename: "docs/storage.md",
+      patch: "@@\n+The cache schema now includes a revision field.",
       surface: "persistent cache schema",
     },
     {
@@ -431,8 +571,12 @@ test("storage evidence still warns and gates browser, runtime, and schema change
     if (file.patch.includes("TABLE")) {
       assert.equal(sqliteSchemaChangeFromPullFilesForTest({ pullFiles }).change, true);
     }
-    const report = persistenceReport(detection, "a".repeat(40));
-    assert.match(renderReviewCommentFromReport(report, "none"), /Confirm migration/);
+    const report = renderPersistenceReport(pullFiles, "a".repeat(40));
+    const comment = renderReviewCommentFromReport(report, "none");
+    assert.match(report, /^data_model_change: true$/m);
+    assert.match(comment, /- \[ \] \*\*Add data-model compatibility proof\*\*/);
+    assert.match(comment, /clawsweeper-review-state:blocked/);
+    if (file.patch.includes("TABLE")) assert.match(comment, /SQLite table change/);
     const markers = reviewAutomationMarkersFromReport(report);
     assert.match(markers, /clawsweeper-verdict:needs-human/);
     assert.doesNotMatch(markers, /clawsweeper-verdict:pass|clawsweeper-action:fix-required/);
@@ -453,6 +597,11 @@ test("strong persistence evidence remains unknown when production normalization 
     { filename: "src/embedding/records.ts" },
     { filename: "src/embeddings/records.ts" },
     { filename: "src/memory/records.ts" },
+    { filename: "src/cache/schema.ts" },
+    { filename: "src/cache-schema.ts" },
+    { filename: "ui/src/cache.ts", previous_filename: "src/cache/schema.ts" },
+    { filename: "src/cache/schema.ts", previous_filename: "ui/src/cache.ts" },
+    { filename: "ui/src/cache.ts", patch: "@@\n const cacheSchema = {\n" },
     { filename: "src/runtime/metadata.ts", previous_filename: "src/vector/records.ts" },
     { filename: "src/vector/records.ts", previous_filename: "src/runtime/metadata.ts" },
   ]) {
@@ -506,6 +655,19 @@ Full review comments:
   assert.match(markers, /clawsweeper-verdict:needs-human/);
   assert.doesNotMatch(markers, /clawsweeper-verdict:pass/);
   assert.doesNotMatch(markers, /clawsweeper-action:fix-required/);
+});
+
+test("cache config fields retain their config blocker without inventing a persistence blocker", () => {
+  const report = renderPersistenceReport(
+    [{ filename: "src/config/types.ts", patch: "@@\n+  cacheTtl?: number;" }],
+    "a".repeat(40),
+  );
+  assert.match(report, /^config_surface_change: true$/m);
+  assert.match(report, /^data_model_change: false$/m);
+  const comment = renderReviewCommentFromReport(report, "none");
+  assert.match(comment, /clawsweeper-verdict:needs-human/);
+  assert.match(comment, /clawsweeper-review-state:blocked/);
+  assert.doesNotMatch(comment, /Confirm migration/);
 });
 
 test("config surface reports preserve security-sensitive markers", () => {
@@ -810,7 +972,42 @@ test("Markdown persistence contracts and structured frontmatter remain detectabl
   }
 });
 
-for (const { name, file, surfaces, pullFilesTruncated } of [
+for (const { name, file, surfaces, pullFilesTruncated, sqliteSchemaChange } of [
+  ...[
+    { filename: "src/cache/sqlite-store.ts" },
+    { filename: "src/cache/sqlite.ts" },
+    { filename: "src/runtime/requests.ts", previous_filename: "src/cache/sqlite-schema-v2.ts" },
+    { filename: "src/cache/sqlite/store.ts", previous_filename: "src/runtime/requests.ts" },
+  ].flatMap((file) =>
+    [
+      ["missing", undefined],
+      ["empty", ""],
+      ["truncated", "@@\n+  refresh();\n\n[truncated 99 chars]"],
+    ].map(([patchKind, patch]) => ({
+      name: `incomplete SQLite cache ${file.previous_filename ? `${file.previous_filename} -> ` : ""}${file.filename} (${patchKind} patch)`,
+      file: { ...file, patch },
+      surfaces: [
+        `unknown-data-model-change: ${file.filename === "src/runtime/requests.ts" ? file.previous_filename : file.filename}`,
+      ],
+      sqliteSchemaChange: patchKind !== "empty",
+    })),
+  ),
+  {
+    name: "cache schema with a missing patch",
+    file: { filename: "src/cache/schema.ts" },
+    surfaces: ["unknown-data-model-change: src/cache/schema.ts"],
+  },
+  {
+    name: "cache schema moved to a helper with a missing patch",
+    file: { filename: "src/cache/helpers.ts", previous_filename: "src/cache/schema.ts" },
+    surfaces: ["unknown-data-model-change: src/cache/schema.ts"],
+  },
+  {
+    name: "cache helper with incomplete file list",
+    file: { filename: "src/cache/helpers.ts" },
+    pullFilesTruncated: true,
+    surfaces: ["unknown-truncated-pull-files"],
+  },
   {
     name: "plain form-validation schema fields",
     file: { filename: "ui/src/forms/schema.ts", patch: "@@\n+  fieldLabel: z.string()," },
@@ -977,11 +1174,17 @@ for (const { name, file, surfaces, pullFilesTruncated } of [
     });
 
     assert.deepEqual(detection, { change: surfaces.length > 0, surfaces });
-    const report = persistenceReport(detection, "a".repeat(40));
-    assert.equal(
-      /Confirm migration/.test(renderReviewCommentFromReport(report, "none")),
-      detection.change,
+    const report = renderPersistenceReport([file], "a".repeat(40), pullFilesTruncated);
+    const comment = renderReviewCommentFromReport(report, "none");
+    assert.equal(/Confirm migration/.test(comment), detection.change);
+    assert.match(
+      comment,
+      detection.change ? /clawsweeper-review-state:blocked/ : /clawsweeper-review-state:ready/,
     );
+    if (sqliteSchemaChange !== undefined) {
+      assert.equal(/^sqlite_schema_change: true$/m.test(report), sqliteSchemaChange);
+      assert.equal(comment.includes("SQLite table change"), sqliteSchemaChange);
+    }
     assert.match(
       reviewAutomationMarkersFromReport(report),
       detection.change ? /clawsweeper-verdict:needs-human/ : /clawsweeper-verdict:pass/,


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/136772#issuecomment-5518678948

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled through this same-repository branch.

</details>

## What Problem This Solves

Fixes an issue where contributors changing an in-memory cache would receive a migration-proof blocker in their ClawSweeper review. The captured hovercard cancellation fix adds an `AbortSignal` to a component-local cache entry and changes promise reuse; it does not change stored data. Its review nevertheless displayed “Add data-model compatibility proof” and blocked readiness.

## Why This Change Was Made

The classifier treated cache/key/version/namespace/TTL tokens and generic cache filenames as persistent-cache evidence. That classification became `data_model_change` in the canonical report, which correctly drove the warning, migration checkbox, and `needs-human` automation verdict. This fixes the evidence classification rather than bypassing report rendering or compatibility-proof checks.

Explicit cache schema/format/layout evidence and same-hunk storage boundaries still qualify. Reusing the existing SQLite path classifier preserves conservative handling of missing, empty, truncated, and renamed SQLite-cache patches. Browser storage is still eligible in UI code; in-memory values do not exempt real storage changes elsewhere in the patch. Config and protocol gates remain independent.

## User Impact

Runtime cache changes no longer need invented migration proof. Actual persisted schemas, serialization, database changes, and incomplete persistence evidence continue to require compatibility review. No parser, renderer, migration-proof exemption, production schema, dependency, or lockfile changes are included.

## OpenClaw Bay Impact

Bay is unaffected: this changes the evidence feeding existing review fields, with no observer API, field/schema, route, navigation, or control changes. No Bay implementation or proof update is needed.

## Documentation Impact

Reviewed `AGENTS.md`, `VISION.md`, `CONTRIBUTING.md`, the documentation lifecycle guidance, and the PR-review contract. Updated the active guidance in `docs/pr-review-comments.md` and `prompts/review-item.md` to require persistence evidence for cache-shaped code. ClawSweeper maintainers own that guidance; the classifier is its source of truth, and future classifier boundary changes are its update trigger. Verification covers this PR's classifier and rendered-review behavior. The replay and captured JSON are historical proof inputs/results, not product-state documentation or a new runbook.

## Review Follow-through: Proof Environment

The [current review's container-proof finding](https://github.com/openclaw/clawsweeper/pull/1369#issuecomment-5519396207) and identical rank-up request are **not applicable to this proof host**. The [cited policy at this exact head](https://github.com/openclaw/clawsweeper/blob/c72e9f25f5e4852f6f159e49ae98c69fe5a9bba3/AGENTS.md#L80-L92) says: “On this Windows host, proof for those surfaces uses Docker-backed Crabbox `local-container`.” The recorded execution was on macOS arm64, not Windows. That sentence does not establish a repository-wide container requirement for macOS proof.

The general real-behavior requirement remains satisfied by the executed compiled classifier → canonical report → public checklist/readiness/marker replay below, including its captured production patch, baseline failure, candidate result, hashes, commands, and twelve retained compatibility controls. The classifier reads only the supplied patch/context and uses deterministic TypeScript logic; this change adds no OS, package-install, network, or persistent-store behavior that requires a different environment. The null image/lease values accurately describe a local process and must not be replaced with invented container provenance. This is not an evidence-in-progress exception, a proof override, or a relaxation of any migration/config/protocol gate.

Exact-head [Linux CI](https://github.com/openclaw/clawsweeper/actions/runs/33707260572) and [CodeQL](https://github.com/openclaw/clawsweeper/actions/runs/33707260483) are also green. The implementation and checked-in proof bytes are unchanged; this section records the disposition of the environment-only finding. The original OpenClaw review remains untouched.

## Evidence

Final head `c72e9f25f5e4852f6f159e49ae98c69fe5a9bba3` is rebased on `139deec86562193879d62f66f3053f2b030d75e8`.

```bash
pnpm run build
node --test test/pr-surface-policy.test.ts test/review-prompt-policy.test.ts
PATH=/opt/homebrew/opt/bash/bin:/opt/homebrew/opt/node@24/bin:$PATH pnpm run check
```

The focused run passed **143/143** tests. The full check passed static checks, all builds, lint, changed-module coverage, and the complete **292-file suite: 4,576 passed, 9 platform skips, 0 failed/cancelled**, in approximately 10m 52s for the full test stage. Full coverage was 83.61% lines, 76.33% branches, and 88.65% functions; all thresholds passed. Validation used pinned pnpm 11.10.0 and Bash 5.3.15. An earlier full-check attempt selected macOS Bash 3.2 and failed the unchanged `mapfile` workflow fixture; this complete rerun selected the documented modern Bash and passed.

Fresh isolated Codex Autoreview passes at **P2 / high effort** were `scoped-clean` both before commit (`--mode uncommitted`) and on the rebased committed branch (`--mode branch --base origin/main`), with zero accepted/actionable findings. The reviews are supporting evidence; the executed runtime proof below establishes the behavior.

Test-authoring audit: the credible failure is a contributor-visible migration checkbox generated for the captured runtime-only patch. Coverage now exercises the canonical report producer before checking frontmatter, public comment, readiness, and automation markers. The original raw and normalized cases failed before the production edit. Twelve missing/empty/truncated/rename SQLite cases also caught an intermediate regression and now preserve the baseline contract. No test-only production export or seam was added.

Change size: production classifier +9/-9 (net zero); tests +219/-16 plus a 10-line captured fixture; guidance +10/-3; portable proof 311 lines of JavaScript and 76 lines of compact JSON. Most added lines establish observable regression and compatibility evidence.

## Real Behavior Proof

**Claim and surface:** a controlled offline execution of the compiled classifier → canonical `markdownFor` report producer → public comment/checklist/readiness/automation-marker path removes three cache false positives while retaining all twelve storage/config/protocol control gates.

**Scenario:** the exact runtime patch from reviewed OpenClaw head `5b8573144dfe8f1d423e55d818baeafb81efc9c4`, both raw and production-normalized, plus a generic cache-path runtime field. Positive controls cover SQLite with an in-memory map, explicit cache schema, browser storage, IndexedDB, durable storage, file serialization, migration, missing cache schema/SQLite evidence, config compatibility, incomplete protocol schema, and independent protocol risk.

| Observed surface | Baseline | Candidate |
| --- | --- | --- |
| Captured runtime patch, raw and normalized | Migration checkbox; blocked; needs-human | No migration checkbox; ready; pass |
| Generic cache-path runtime shape | Migration checkbox; blocked; needs-human | No migration checkbox; ready; pass |
| Ten persistence compatibility controls | Migration checkbox; blocked; needs-human | Same gate booleans |
| Config compatibility | Config checkbox; blocked; needs-human | Same; no invented migration checkbox |
| Independent protocol risk | Blocked; needs-human | Same; no invented migration checkbox |

**Artifacts:** [portable replay](https://github.com/openclaw/clawsweeper/blob/c72e9f25f5e4852f6f159e49ae98c69fe5a9bba3/docs/proof/persistent-cache-evidence/replay.mjs), [compact baseline/candidate trace](https://github.com/openclaw/clawsweeper/blob/c72e9f25f5e4852f6f159e49ae98c69fe5a9bba3/docs/proof/persistent-cache-evidence/results.json), and [captured source fixture](https://github.com/openclaw/clawsweeper/blob/c72e9f25f5e4852f6f159e49ae98c69fe5a9bba3/test/fixtures/persistence-classifier-136772.json). The trace records fixture, replay, candidate source, and both compiled-classifier SHA-256 hashes, plus per-scenario checkbox and marker observations. Some redundant “persistent cache” surface labels disappear from durable/file-backed controls; their required gates do not change.

**Environment and commands:** Node 24.20.0, macOS arm64, provider `local-process`; image and lease are not applicable. Baseline revision `f8f7cb84a7a869d099d3d3551fa0c76fb37c49b7`; candidate `c72e9f25f5e4852f6f159e49ae98c69fe5a9bba3`. From the candidate checkout with its dependencies and build present:

```bash
pnpm run build
node docs/proof/persistent-cache-evidence/replay.mjs \
  --module . --expect candidate --output /tmp/cache-candidate.json
```

To reproduce the baseline comparison in an isolated archive with the same installed dependencies:

```bash
baseline=$(mktemp -d)
git archive f8f7cb84a7a869d099d3d3551fa0c76fb37c49b7 | tar -x -C "$baseline"
ln -s "$PWD/node_modules" "$baseline/node_modules"
./node_modules/.bin/tsc -p "$baseline/tsconfig.json"
node docs/proof/persistent-cache-evidence/replay.mjs \
  --module "$baseline" --expect baseline --output /tmp/cache-baseline.json
```

Both modes assert all fifteen scenarios and return nonzero on unexpected observations. `--expect baseline` explicitly requires the known false positives; it does not ignore errors. The fixed expectation against the baseline returned exit 1 for exactly the three known false-positive cases (18 expected boolean mismatches); it serves as a negative control. An independent rebuild from the archived baseline commit reproduced the recorded classifier hash and all observed results. The rebased candidate replay also exactly matched its checked-in trace.

**Limits:** this proves the changed compiled classification/publication boundary using real production functions and captured source input. Review decisions and lease metadata are synthetic; normalization uses the unchanged production-hydration test fixture. It is not a live model review, a service deployment, or a data-migration execution. The portable fixture captures the runtime file, not the two accompanying OpenClaw test files; a separate local full-three-file replay agreed. No mutation of the original OpenClaw PR, review, or linked issue was performed.

