### PR TITLE
fix(publish): prevent stale queue writes after transient failures

### DIFF
--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -471,14 +471,17 @@ counts but are not serialized by the public projector. Document effective
 production values from `dashboard/wrangler.toml`, not only fallback constants
 in `dashboard/exact-review-queue.ts`.
 
-Batch publication heartbeats and post-effect enqueue, router-receipt, and
-terminal-disposition POSTs retry network errors, timeouts, and HTTP 5xx responses
-(including `exact_review_queue_unavailable`) up to three attempts within 45
-seconds, with at most 20 seconds per attempt. Retries preserve the signed bytes,
-use jittered exponential backoff, and honor `Retry-After` up to 10 seconds;
-heartbeats additionally stop at the last confirmed lease expiry. Validation,
-authentication, and fence rejections are never retried, and receipt retries do
-not repeat the GitHub router dispatch.
+Batch publication heartbeats retry network errors, timeouts, and HTTP 5xx
+responses (including `exact_review_queue_unavailable`) up to three attempts
+within 45 seconds, with at most 20 seconds per attempt. Heartbeat retries
+preserve the signed bytes, use jittered exponential backoff, honor `Retry-After`
+up to 10 seconds, and stop at the last confirmed server lease expiry.
+Validation, authentication, and fence rejections are never retried.
+
+Post-effect enqueue, router-receipt, and terminal-disposition POSTs are
+deliberately one-shot until Worker replay ordering is repaired. An ambiguous
+failure ends the publication run so scheduled recovery can replay it without an
+in-process retry arriving after newer queue state.
 
 Lifecycle receipt replays are no-ops for the whole operation, including terminal
 transitions and acknowledgement drivers. Terminal-disposition requests from the

--- a/src/repair/exact-review-batch-queue-client.ts
+++ b/src/repair/exact-review-batch-queue-client.ts
@@ -245,7 +245,7 @@ export class ExactReviewBatchQueueClient implements ExactReviewBatchQueue {
   async postEffect(route: ExactReviewBatchPostEffectRoute, payload: string) {
     if (!Object.hasOwn(POST_EFFECT_ROUTES, route))
       throw new Error("Invalid batch post-effect route");
-    return this.postUrl(POST_EFFECT_ROUTES[route], payload, Date.now() + RETRY_DEADLINE_MS);
+    return this.postUrl(POST_EFFECT_ROUTES[route], payload);
   }
 
   async reconcilePublications(input: { apply: boolean; maxItems: number }) {

--- a/test/repair/exact-review-batch-cli.test.ts
+++ b/test/repair/exact-review-batch-cli.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
 import {
   appendFileSync,
   existsSync,
@@ -1174,10 +1175,10 @@ for (const [route, endpoint] of [
   ["router-receipt", "/internal/exact-review/lifecycle/router-receipt"],
   ["terminal-disposition", "/internal/exact-review/lifecycle/terminal-disposition"],
 ]) {
-  for (const [scenario, statuses, exitCode] of [
-    ["recovers after one 500", [500, 200], 0],
-    ["exhausts three 500 attempts", [500, 500, 500], 1],
-    ["fails immediately on 409", [409], 1],
+  for (const [scenario, statuses, exitCode, expectedAttempts] of [
+    ["fails after the first 500 in a recovery sequence", [500, 200], 1, 1],
+    ["fails after the first 500 in a repeated failure sequence", [500, 500, 500], 1, 1],
+    ["fails immediately on 409", [409], 1, 1],
   ]) {
     test(`batch post-effect ${route} ${scenario}`, () => {
       const root = mkdtempSync(join(tmpdir(), "clawsweeper-post-effect-"));
@@ -1231,15 +1232,26 @@ globalThis.fetch = async (url, init) => {
               .split("\n")
               .map((line) => JSON.parse(line))
           : [];
-        assert.equal(posts.length, statuses.length, result.stderr);
+        assert.equal(posts.length, expectedAttempts, result.stderr);
         assert.equal(result.status, exitCode, result.stderr);
+        assert.equal(result.stdout, "");
         assert.ok(posts.every((post) => post.url === `https://queue.example.test${endpoint}`));
         assert.ok(posts.every((post) => post.body === payload));
         assert.ok(
           posts.every((post) => JSON.stringify(post.headers) === JSON.stringify(posts[0].headers)),
         );
+        assert.ok(
+          posts.every(
+            (post) =>
+              post.headers["x-clawsweeper-exact-review-signature"] ===
+              `sha256=${createHmac("sha256", "proof-secret").update(payload).digest("hex")}`,
+          ),
+        );
         assert.doesNotMatch(result.stderr, /proof-secret|stable-fixture|sha256=/);
-        if (exitCode === 0) assert.deepEqual(JSON.parse(result.stdout), { ok: true, queued: true });
+        if (statuses[0] === 500) {
+          assert.match(result.stderr, /HTTP 500/);
+          assert.doesNotMatch(result.stderr, /Batch queue retry/);
+        }
       } finally {
         rmSync(root, { recursive: true, force: true });
       }

--- a/test/repair/exact-review-batch-queue-client.test.ts
+++ b/test/repair/exact-review-batch-queue-client.test.ts
@@ -38,96 +38,20 @@ function unavailable(headers = {}) {
   return new Response("exact_review_queue_unavailable", { status: 500, headers });
 }
 
-test("post-effect retries 500 then 200 with identical payload and signature bytes", async (t) => {
-  const { client, calls, logs } = fixture(t, (attempt) =>
-    attempt === 1 ? unavailable() : Response.json({ ok: true }),
-  );
-  const result = client.postEffect("router-receipt", payload);
-  await flush();
+test("post-effect HTTP 500 is attempted once", async (t) => {
+  const { client, calls, logs } = fixture(t, () => unavailable());
+  await assert.rejects(client.postEffect("router-receipt", payload), /HTTP 500/);
   assert.equal(calls.length, 1);
-  t.mock.timers.tick(1_000);
-  assert.deepEqual(await result, { ok: true });
-  assert.equal(calls.length, 2);
-  assert.equal(calls[0].body, payload);
-  assert.equal(calls[1].body, payload);
-  assert.deepEqual(calls[0].headers, calls[1].headers);
-  assert.equal(
-    calls[0].headers["x-clawsweeper-exact-review-signature"],
-    `sha256=${createHmac("sha256", "synthetic-test-secret").update(payload).digest("hex")}`,
-  );
-  assert.deepEqual(logs, [
-    "Batch queue retry endpoint=/internal/exact-review/lifecycle/router-receipt reason=HTTP_500 attempt=2/3",
-  ]);
+  assert.deepEqual(logs, []);
 });
 
-for (const error of [
-  new TypeError("private network detail"),
-  new DOMException("private detail", "TimeoutError"),
-]) {
-  test(`post-effect retries ${error.name} then 200 without logging error text`, async (t) => {
-    const { client, calls, logs } = fixture(t, (attempt) => {
-      if (attempt === 1) throw error;
-      return Response.json({ ok: true });
-    });
-    const result = client.postEffect("enqueue", payload);
-    await flush();
-    t.mock.timers.tick(1_000);
-    assert.deepEqual(await result, { ok: true });
-    assert.equal(calls.length, 2);
-    assert.equal(calls[0].body, calls[1].body);
-    assert.deepEqual(calls[0].headers, calls[1].headers);
-    assert.equal(logs.length, 1);
-    assert.doesNotMatch(logs[0], /private|stable-receipt|synthetic-test-secret|sha256=/);
+test("post-effect network failure is attempted once", async (t) => {
+  const { client, calls, logs } = fixture(t, () => {
+    throw new TypeError("private network detail");
   });
-}
-
-test("post-effect repeated 500 exhausts at the 45 second deadline", async (t) => {
-  const { client, calls } = fixture(
-    t,
-    () =>
-      new Promise((resolve) => {
-        setTimeout(() => resolve(unavailable({ "retry-after": "10" })), 17_500);
-      }),
-  );
-  const result = assert.rejects(client.postEffect("enqueue", payload), /HTTP 500/);
-  await flush();
-  t.mock.timers.tick(17_500);
-  await flush();
-  t.mock.timers.tick(10_000);
-  await flush();
-  t.mock.timers.tick(17_500);
-  await result;
-  assert.equal(calls.length, 2);
-  assert.equal(Date.now(), now + 45_000);
-});
-
-test("post-effect limits each attempt to 20 seconds and all attempts to 45 seconds", async (t) => {
-  const { client, calls } = fixture(
-    t,
-    (_attempt, init) =>
-      new Promise((_resolve, reject) => {
-        init.signal.addEventListener("abort", () => reject(init.signal.reason), { once: true });
-      }),
-  );
-  const result = assert.rejects(
-    client.postEffect("terminal-disposition", payload),
-    /timeout|deadline/i,
-  );
-  await flush();
-  t.mock.timers.tick(20_000);
-  await flush();
-  assert.equal(calls[0].signal.aborted, true);
-  t.mock.timers.tick(1_000);
-  await flush();
-  t.mock.timers.tick(20_000);
-  await flush();
-  t.mock.timers.tick(2_000);
-  await flush();
-  t.mock.timers.tick(2_000);
-  await result;
-  assert.equal(calls.length, 3);
-  assert.ok(calls.every((call) => call.signal.aborted));
-  assert.equal(Date.now(), now + 45_000);
+  await assert.rejects(client.postEffect("enqueue", payload), /network_error/);
+  assert.equal(calls.length, 1);
+  assert.deepEqual(logs, []);
 });
 
 for (const status of [400, 401, 403, 404, 409, 422, 429]) {
@@ -147,14 +71,8 @@ for (const status of [409, 500]) {
     const result = assert.rejects(client.postEffect("enqueue", payload), {
       message: `Batch queue /internal/exact-review/enqueue failed (HTTP ${status}): exact_review_queue_unavailable`,
     });
-    await flush();
-    if (status === 500) {
-      t.mock.timers.tick(1_000);
-      await flush();
-      t.mock.timers.tick(2_000);
-    }
     await result;
-    assert.equal(calls.length, status === 500 ? 3 : 1);
+    assert.equal(calls.length, 1);
   });
 }
 
@@ -197,27 +115,6 @@ test("post-effect stops reading error bodies at 512 bytes and cancels the stream
   assert.equal(cancelled, true);
 });
 
-for (const [header, delay] of [
-  ["5", 5_000],
-  [new Date(now + 6_000).toUTCString(), 6_000],
-  ["999999", 10_000],
-  ["invalid", 750],
-]) {
-  test(`post-effect Retry-After ${header} is honored and bounded`, async (t) => {
-    const { client, calls } = fixture(t, (attempt) =>
-      attempt === 1 ? unavailable({ "retry-after": header }) : Response.json({ ok: true }),
-    );
-    const result = client.postEffect("enqueue", payload);
-    await flush();
-    t.mock.timers.tick(delay - 1);
-    await flush();
-    assert.equal(calls.length, 1);
-    t.mock.timers.tick(1);
-    assert.deepEqual(await result, { ok: true });
-    assert.equal(calls[1].at - calls[0].at, delay);
-  });
-}
-
 test("heartbeat retries 500 with unchanged signed bytes and returns the renewed expiry", async (t) => {
   const batch = {
     batch_id: heartbeat.batchId,
@@ -235,6 +132,10 @@ test("heartbeat retries 500 with unchanged signed bytes and returns the renewed 
   assert.equal(calls.length, 2);
   assert.equal(calls[0].body, calls[1].body);
   assert.deepEqual(calls[0].headers, calls[1].headers);
+  assert.equal(
+    calls[0].headers["x-clawsweeper-exact-review-signature"],
+    `sha256=${createHmac("sha256", "synthetic-test-secret").update(calls[0].body).digest("hex")}`,
+  );
   assert.equal(JSON.parse(calls[0].body).leaseExpiresAt, undefined);
 });
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a publication safety issue where an ambiguous transient failure after a
review commit could be retried in-process after newer queue state, allowing a
stale post-effect request to arrive out of order.

## Why This Change Was Made

Post-effect enqueue, router-receipt, and terminal-disposition requests now make
one bounded request. Heartbeats retain their existing three-attempt, 45-second
retry window because they renew the currently owned lease rather than replaying
a post-commit state transition.

This is immediate containment. Worker replay ordering remains the durable
follow-up; this PR does not change Worker, workflow, schema, queue policy,
capacity, cadence, or live operations.

## User Impact

An ambiguous post-effect failure now fails the current publication run and
leaves unfinished work for scheduled recovery instead of risking a stale
in-process retry. This can delay later batch members, but preserves newer queue
state.

There is no end-user UI or Telegram-visible change.

## OpenClaw Bay Impact

Bay is unaffected. This PR changes only the batch client's retry admission and
does not modify Worker lifecycle projection, Bay synchronization, dashboard
source, or any public/private dashboard data contract. Failed post-effects still
leave the member unfinished so the existing release path returns it to scheduled
recovery.

## Documentation Impact

`docs/live-dashboard.md` is an active operator runbook. It now distinguishes
bounded heartbeat retries from deliberately one-shot post-effects.

- Role owner: ClawSweeper maintainers
- Runtime source of truth: `src/repair/exact-review-batch-queue-client.ts`
- Verified revision: `288389c13afc1e2d8079cbf7a2a0362f9a82037c`
- Update triggers: heartbeat/post-effect retry policy or Worker replay-ordering changes

## Evidence

Exact head: `288389c13afc1e2d8079cbf7a2a0362f9a82037c`

- Signed semantic commit: verified locally with a good ED25519 signature.
- Focused/expanded tests: 67 passed, 0 failed across the queue client, CLI, and
  unchanged batch workflow tests.
- Build: all three TypeScript projects passed (`tsconfig.json`,
  `tsconfig.repair.json`, and `tsconfig.dashboard.json`).
- Static gates: active-surface, dashboard queue boundary, dashboard strict,
  documentation, limits, repository formatting, repair/test lint, and
  `git diff --check` passed.
- Production delta: `+1/-1`; four files total.
- Precommit and committed-range Codex reviews found no actionable defect.

### Infrastructure disclosure

- AWS Crabbox could not create a lease: coordinator HTTP 500, error code 1101.
  Crabbox recorded a durable cancellation.
- The local-container backend was unavailable because the Docker socket was not
  running.
- A disposable local full-check fallback passed install, build, static checks,
  formatting, and lint. Its full coverage suite failed only in unrelated
  terminal-proof infrastructure: repeated tmux pane-cleanup timeouts and one
  synthetic profile test observing the host home directory. This PR does not
  claim a green full `pnpm run check`.

## Real Behavior Proof

**Claim:** post-effect HTTP 500 and network failures issue exactly one request,
while heartbeat HTTP 500 still retries with byte-identical signed payloads.

**Exercised surface:** the built production
`ExactReviewBatchQueueClient` over a loopback HTTP server.

**Scenario:** the loopback server returned HTTP 500 for a router receipt and
HTTP 500 then 200 for a heartbeat; a separate production-client request threw a
network error.

**Command/environment:** Node 26.7.0, built `dist` client, loopback HTTP transport,
synthetic credentials and identifiers only.

**Observed result:**

```json
{
  "headSha": "288389c13afc1e2d8079cbf7a2a0362f9a82037c",
  "postEffectHttp500Attempts": 1,
  "postEffectNetworkAttempts": 1,
  "heartbeatAttempts": 2,
  "heartbeatSignedBytesIdentical": true
}
```

**Artifact/trace:** `.artifacts/post-effect-containment-proof.json` in the local
proof workspace; the redacted result is reproduced above.

**Limits:** this proves the production client transport boundary, not a
Cloudflare edge, live queue, or end-to-end Worker release/recovery cycle. The
offline ClawSweeper review requested a Worker injected-fault recovery trace.
That rank-up move is not performed here because this containment scope
explicitly excludes Worker/dashboard changes and live queue mutation. The Bay
non-impact disposition is recorded above.
