### PR TITLE
fix(review): unblock reviews containing the MCP Apps origin test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Admit the reviewed OpenClaw MCP Apps sandbox-origin test fixture using exact URI, source-line, path, and decoder bindings so config reviews can proceed through the existing scanner rules.
+
 - Retain only Cloudflare failure flags in queue transport logs so backend faults can be diagnosed without exposing exception details.
 
 - Hydrate review blobs from cached PR snapshots that store an absent previous filename as `null`, preventing repeat reviews from refusing otherwise available source.

--- a/README.md
+++ b/README.md
@@ -592,13 +592,14 @@ the [MCP endpoint-redaction fixture](https://github.com/openclaw/openclaw/blob/a
 the [Crabbox fleet audit sanitization fixture](https://github.com/openclaw/crabbox/blob/937523aced0f6c2d3b9242461eeab1a03bd893e8/worker/test/fleet.test.ts),
 the [Mac dashboard credentialed-subframe rejection fixture](https://github.com/openclaw/openclaw/blob/9ba01d6c7b1c308e7b41eac11ba6f43e0fd0393d/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift#L273),
 the [Mattermost slash-error sanitization fixtures](https://github.com/openclaw/openclaw/blob/9c0975c1c20ed635532c7aa0f510154224adee7f/extensions/mattermost/src/mattermost/slash-http.test.ts),
+the [MCP Apps sandbox-origin rejection fixture](https://github.com/openclaw/openclaw/blob/f3971bbd56e4aadea0f8b0c1434f6860f953cbbd/src/config/config-misc.test.ts),
 and the OpenClaw config [URL-redaction](https://github.com/openclaw/openclaw/blob/5fe22a7d88919f260e7999fc775733feff3cb1fa/src/config/redact-snapshot.test.ts)
 and [restoration fixtures](https://github.com/openclaw/openclaw/blob/5fe22a7d88919f260e7999fc775733feff3cb1fa/src/config/redact-snapshot.restore.test.ts)
 after a complete scan. Static host policy associates each
 exact detector-matched URI SHA-256 with only its approved source paths and exact
 scanner `Raw` digest, including when `Raw` omits a path retained by `RawV2`. The
 matched value must be a literal in a host-staged Git blob from mode `100644`.
-The three guarded-CDP/MCP entries, Crabbox fixture, Mac dashboard entry, and four Mattermost entries also bind complete
+The three guarded-CDP/MCP entries, Crabbox fixture, Mac dashboard entry, MCP Apps entry, and four Mattermost entries also bind complete
 reviewed source lines, including surrounding query text that TruffleHog's URI
 detector does not match. Changes to those lines or additional literal occurrences
 refuse classification. These witnesses do not expand native query detection.
@@ -610,8 +611,8 @@ original source. Repeated literals remain eligible unless an entry is bound to
 an approved complete-line digest; those entries require exactly one occurrence
 in the staged blob. Finding order and duplicate records do not change the exact
 value, path, and mode checks.
-Findings must use `PLAIN` or `HTML`, except the Mac dashboard entry permits only
-its observed `PLAIN` decoder and the two guarded-CDP fixtures also permit `BASE64`.
+Findings must use `PLAIN` or `HTML`, except the Mac dashboard and MCP Apps entries permit only
+their observed `PLAIN` decoder and the two guarded-CDP fixtures also permit `BASE64`.
 The pinned Base64 decoder preserves the rest of a chunk after
 decoding another token, so an unchanged literal can acquire that decoder label
 and win cross-decoder deduplication. Those entries still require the literal in

--- a/src/agent-input-scan-fixtures.ts
+++ b/src/agent-input-scan-fixtures.ts
@@ -111,6 +111,13 @@ const REVIEWED_FIXTURES: readonly ReviewedFixture[] = [
     sources: ["extensions/mattermost/src/mattermost/slash-http.test.ts"],
   },
   {
+    // OpenClaw MCP Apps sandbox-origin rejection fixture introduced by f3971bbd56e4.
+    fixtureSha256: "354e44c28981412829c4cd79588c7c5385d55221eb1f5d0014e96421d35e76a4",
+    lineSha256s: ["f7d672c72c5b3f9f67b09a5b0f15fdab1c565d36d534c62e3424c4cd1981bb06"],
+    decoders: ["PLAIN"],
+    sources: ["src/config/config-misc.test.ts"],
+  },
+  {
     // OpenClaw config endpoint redaction and restoration fixtures.
     fixtureSha256: "a2e43ebb989e154a5cfde0e9f67d0e7465adffdba2c8be60394f35e7797149a3",
     rawSha256: "6b167ea4a777545dcca0e4d425aafccd750a6c6fca8a5b2b370f16491f3a8a4d",

--- a/test/agent-input-scan.test.ts
+++ b/test/agent-input-scan.test.ts
@@ -551,6 +551,7 @@ const browserToolSource = "extensions/browser/src/browser-tool.test.ts";
 const browserCdpHelpersSource = "extensions/browser/src/browser/cdp.helpers.test.ts";
 const browserMcpSource = "extensions/browser/src/browser/chrome-mcp.test.ts";
 const macDashboardSource = "apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift";
+const mcpAppsSource = "src/config/config-misc.test.ts";
 const mattermostSource = "extensions/mattermost/src/mattermost/slash-http.test.ts";
 const ledgerFixtureSha256 = "a728de5dbbef23b8aa5ef2d99060835f4f2fb5a0fa2abb9fe249d08aa09bd09e";
 const nativeContractFailures = new Map([
@@ -700,10 +701,11 @@ for (const scenarioName of [
     "missing verification error",
     "wrong version",
     "missing completion",
-  ].map((scenario) => `mac dashboard ${scenario}`),
+  ].flatMap((scenario) => [`mac dashboard ${scenario}`, `mcp apps ${scenario}`]),
 ]) {
   const macDashboardFixture = scenarioName.startsWith("mac dashboard ");
-  const scenario = macDashboardFixture ? scenarioName.slice("mac dashboard ".length) : scenarioName;
+  const mcpAppsFixture = scenarioName.startsWith("mcp apps ");
+  const scenario = scenarioName.replace(/^(?:mac dashboard|mcp apps) /, "");
   test(`reviewed synthetic fixture admission: ${scenarioName}`, (t) => {
     const notices: unknown[][] = [];
     t.mock.method(console, "error", (...args: unknown[]) => notices.push(args));
@@ -724,15 +726,17 @@ for (const scenarioName of [
     const browserExactFixture = browserCdpFixture || browserMcpFixture;
     const encodedCdpFixture = browserCdpFixture && scenario.includes("encoded");
     // Preserve the literal witnesses captured from the native OpenClaw scan.
-    const literalLine = macDashboardFixture
-      ? 273
-      : browserCdpFixture
-        ? encodedCdpFixture
-          ? 406
-          : 293
-        : browserMcpFixture
-          ? 1339
-          : 42;
+    const literalLine = mcpAppsFixture
+      ? 763
+      : macDashboardFixture
+        ? 273
+        : browserCdpFixture
+          ? encodedCdpFixture
+            ? 406
+            : 293
+          : browserMcpFixture
+            ? 1339
+            : 42;
     const scannerLine = scenario.includes("shifted BASE64") ? literalLine - 4 : literalLine;
     const primaryDecoder = scenario.includes("BASE64")
       ? "BASE64"
@@ -792,6 +796,12 @@ for (const scenarioName of [
       url.username = "user";
       url.password = "pass";
       uri = url.href;
+    }
+    if (mcpAppsFixture) {
+      const url = new URL("https://mcp-apps.example.com");
+      url.username = "user";
+      url.password = "pass";
+      uri = url.href.slice(0, -1);
     }
     assert.ok(uri, "reviewed synthetic fixture is present");
     const authority = new URL(uri);
@@ -869,6 +879,7 @@ for (const scenarioName of [
                     ];
     if (macDashboardFixture)
       files = [scenario === "other file" ? "other.test.swift" : macDashboardSource];
+    if (mcpAppsFixture) files = [scenario === "other file" ? "other.test.ts" : mcpAppsSource];
     const value =
       scenario === "decoded only" || scenario.endsWith("encoded-only")
         ? primaryDecoder === "BASE64"
@@ -898,8 +909,11 @@ for (const scenarioName of [
         ? JSON.stringify(value)
         : `        let credentialedFrame = try #require(URL(string: "${value}"))`
       : undefined;
-    const reviewedFixtureLine =
-      reviewedMacDashboardLine ?? reviewedBrowserLine ?? reviewedMattermostLine;
+    const reviewedFixtureLine = mcpAppsFixture
+      ? scenario === "unapproved line"
+        ? JSON.stringify(value)
+        : `      ${JSON.stringify(value)},`
+      : (reviewedMacDashboardLine ?? reviewedBrowserLine ?? reviewedMattermostLine);
     const contents =
       "// context\n".repeat(literalLine - 2) +
       (reviewedFixtureLine ?? JSON.stringify(otherReviewedUri ?? value)) +


### PR DESCRIPTION
## What Problem This Solves

ClawSweeper stops before reviewing OpenClaw config changes because the native URI scanner encounters a longstanding negative sandbox-origin fixture. This blocked https://github.com/openclaw/openclaw/pull/136923 before a model review could run.

## Why This Change Was Made

Add one independently reviewed synthetic fixture to the existing host registry, bound to the exact URI/raw hash, complete source-line hash, `src/config/config-misc.test.ts`, and PLAIN decoding. The classifier and its rejection rules are unchanged. The original OpenClaw security regression test remains byte-for-byte intact.

Production delta: +7 registry lines. The existing admission matrix gains 20 cases covering the accepted fixture and altered values, wrong source/line, duplicate occurrences, executable source, wrong decoder/metadata, verified or mixed findings, and incomplete scans.

## User Impact

OpenClaw configuration PRs containing this existing negative test can reach review through the normal complete scanner pass. Changed values, source lines, source paths, or scanner metadata remain rejected.

## OpenClaw Bay Impact

Bay is unaffected: no queue, schema, status contract, navigation, or action changes.

## Documentation Impact

Updated the active README fixture-family and exact-binding reference; its source of truth remains the host registry owned by the input-scanning maintainers. Verified against base `f7c9afb15584b1837893877fdb3eca64f321b8bd` plus this entry. Future registry changes must keep that list and decoder/line-binding explanation aligned. The unreleased changelog records this behavior fix.

## Evidence

The positive regression failed before the entry. All 188 scanner/diagnostic tests pass, including 20 fixture-specific cases. Full `pnpm run check` passed: 4,652 tests passed, zero failed, nine skipped; builds, lint, static checks, and coverage gates passed. Documentation checks pass. Independent Codex review through P3 found no actionable issues.

Production delta is seven registry lines; no classifier or guard logic changed. The following native scan exercises the real admission boundary, including the complete source of the affected PR.

## Real Behavior Proof

Claim: the existing synthetic fixture can reach review while unmatched inputs remain blocked. Exercised the real `scanAgentInput` staging and classifier with native TruffleHog 3.97.1 on macOS arm64 / Node 26.8.1. Before the entry, the complete fixture input failed with `literal_not_reviewed`; after the entry, the same before/after blobs were admitted.

Also scanned the complete OpenClaw PR input from base `3100ba535f1d003d67a6a7536deacf8666367b38` to head `31394045bf48034d5266b43845ceaef0c483c513`. It admitted exactly the same synthetic fixture in the base blob at line 759 and head blob at line 763, one PLAIN occurrence in each. Safe native classification evidence:

```json
{"fixtureSha256":"354e44c28981412829c4cd79588c7c5385d55221eb1f5d0014e96421d35e76a4","source":"src/config/config-misc.test.ts","detector":"URI","findings":[{"blob":"a9d76ac8ee8beb360de4c6ec3a6a1c11a0db378f","literalLine":763,"decoder":"PLAIN","occurrences":1},{"blob":"fe9c0865ef3df7e24936a4caa249aae04a3e1f69","literalLine":759,"decoder":"PLAIN","occurrences":1}]}
```

Reproduction after building ClawSweeper, using an OpenClaw checkout containing both exact revisions:

```js
import { scanAgentInput } from "./dist/agent-input-scan.js";
scanAgentInput({
  cwd: process.env.OPENCLAW_REVIEW_CHECKOUT,
  prompt: "Review the community invitation policy change.",
  source: {
    kind: "committed",
    baseSha: "3100ba535f1d003d67a6a7536deacf8666367b38",
    headSha: "31394045bf48034d5266b43845ceaef0c483c513",
  },
  timeoutMs: 120000,
});
```

Before the registry entry this throws `AgentInputScanError` with `literal_not_reviewed`. With the entry it completes and emits the safe classification trace above. Original hosted refusal: https://github.com/openclaw/clawsweeper/actions/runs/33713389974.

Limits: this proves source admission, not hosted model review or publication. The workflow must load the landed host registry before retrying the blocked review. No Worker deployment or package release is needed. OpenClaw Bay is unaffected: no queue, schema, status contract, navigation, or action changes.
