### PR TITLE
fix(queue): preserve lifecycle state across replay failures

### DIFF
--- a/dashboard/exact-review-lifecycle.ts
+++ b/dashboard/exact-review-lifecycle.ts
@@ -6,8 +6,6 @@ export const EXACT_REVIEW_LIFECYCLE_AUDIT_READ_LIMIT = 10_000;
 export const EXACT_REVIEW_LIFECYCLE_AUDIT_PAGE_MAX = 100;
 export const EXACT_REVIEW_LIFECYCLE_AUDIT_SNAPSHOT_TTL_MS = 5 * 60 * 1000;
 export const EXACT_REVIEW_LIFECYCLE_AUDIT_SNAPSHOT_MAX_ACTIVE = 4;
-// IDs are per run/attempt/fence, so 32 covers any realistic replay window.
-const EXACT_REVIEW_LIFECYCLE_TERMINAL_OPERATION_LIMIT = 32;
 const EXACT_REVIEW_LIFECYCLE_AUDIT_SNAPSHOT_TABLE = "exact_review_lifecycle_audit_snapshots_v1";
 const EXACT_REVIEW_LIFECYCLE_AUDIT_SNAPSHOT_ROW_TABLE =
   "exact_review_lifecycle_audit_snapshot_rows_v1";
@@ -225,7 +223,7 @@ export type ExactReviewLifecycleProjection = {
    */
   terminalDispositions: Array<{ kind: LifecycleTerminalDisposition; observedAt: number }>;
   /** Applied terminal POST identities, retained with the revision's receipt history. */
-  terminalOperationIds: Array<{ operationId: string; kind: LifecycleTerminalDisposition | null }>;
+  terminalOperationIds: Array<{ operationId: string; kind: LifecycleTerminalDisposition }>;
   /** Current terminal outcome used to derive lifecycle and acknowledgement state. */
   terminalDisposition: { kind: LifecycleTerminalDisposition; observedAt: number } | null;
   /**
@@ -524,7 +522,7 @@ export class ExactReviewLifecycleProjectionStore {
       operationComplete?: true;
     },
   ) {
-    return this.storage.transactionSync(() => this.recordRouterReceiptSync(input));
+    return this.storage.transactionSync(() => this.recordRouterReceiptSync(input).projection);
   }
 
   recordRouterReceiptSync(
@@ -537,7 +535,7 @@ export class ExactReviewLifecycleProjectionStore {
   ) {
     this.validateIdentity(input);
     if (!validText(input.receiptId, 1, 300)) throw new Error("invalid lifecycle router receipt");
-    return this.mutateSync(input, (projection) => {
+    return this.mutateIdempotentlySync(input, (projection) => {
       const next = {
         outcome: input.outcome,
         receiptId: input.receiptId,
@@ -553,10 +551,11 @@ export class ExactReviewLifecycleProjectionStore {
       if (projection.routerReceipt && projection.routerReceipt.outcome !== next.outcome) {
         throw new Error("conflicting lifecycle router receipt");
       }
+      if (existing && (existing.operationComplete || !input.operationComplete)) return true;
       if (!existing) projection.routerReceipts.push(next);
       else if (input.operationComplete) existing.operationComplete = true;
       projection.routerReceipt ??= next;
-      return projection;
+      return false;
     });
   }
 
@@ -567,7 +566,7 @@ export class ExactReviewLifecycleProjectionStore {
       observedAt: number;
     },
   ) {
-    return this.storage.transactionSync(() => this.recordTerminalDispositionSync(input));
+    return this.storage.transactionSync(() => this.recordTerminalDispositionSync(input).projection);
   }
 
   recordTerminalDispositionSync(
@@ -581,28 +580,24 @@ export class ExactReviewLifecycleProjectionStore {
     if (input.operationId !== undefined && !validText(input.operationId, 1, 300)) {
       throw new Error("invalid lifecycle terminal operation id");
     }
-    if (input.operationId) {
-      const existing = this.read(input.canonicalTargetKey, input.fenceKey, input.revision);
-      const operation = existing?.terminalOperationIds.find(
-        (entry) => entry.operationId === input.operationId,
-      );
-      if (existing && operation) {
-        if (operation.kind !== null && operation.kind !== input.kind) {
-          throw new Error("conflicting lifecycle terminal operation");
+    return this.mutateIdempotentlySync(input, (projection) => {
+      if (input.operationId) {
+        const operation = projection.terminalOperationIds.find(
+          (entry) => entry.operationId === input.operationId,
+        );
+        if (operation) {
+          if (operation.kind !== input.kind) {
+            throw new Error("conflicting lifecycle terminal operation");
+          }
+          return true;
         }
-        return existing;
       }
-    }
-    return this.mutateSync(input, (projection) => {
       const terminal = applyTerminalDisposition(projection, input);
       if (input.operationId) {
         terminal.terminalOperationIds.push({ operationId: input.operationId, kind: input.kind });
-        terminal.terminalOperationIds = terminal.terminalOperationIds.slice(
-          -EXACT_REVIEW_LIFECYCLE_TERMINAL_OPERATION_LIMIT,
-        );
       }
       terminal.bayTelemetryPending = true;
-      return terminal;
+      return false;
     });
   }
 
@@ -1375,6 +1370,22 @@ export class ExactReviewLifecycleProjectionStore {
     return result;
   }
 
+  private mutateIdempotentlySync(
+    input: ProjectionIdentity,
+    apply: (projection: ExactReviewLifecycleProjection) => boolean,
+  ) {
+    this.ensureSchemaSync();
+    const projection = this.readSync(input.canonicalTargetKey, input.fenceKey, input.revision);
+    if (!projection) throw new Error("missing lifecycle admission fact");
+    this.assertIdentity(projection, input);
+    const duplicate = apply(projection);
+    if (!duplicate) {
+      projection.updatedAt = Date.now();
+      this.writeSync(projection);
+    }
+    return { projection, duplicate };
+  }
+
   private readSync(canonicalTargetKey: string, fenceKey: string, revision: number) {
     const row = Array.from(
       this.storage.sql.exec(
@@ -1834,12 +1845,7 @@ function validDurableLifecycleBayProjection(value: ExactReviewLifecycleProjectio
       (disposition) =>
         terminalKinds.has(disposition.kind) && finiteTimestamp(disposition.observedAt),
     ) ||
-    !value.terminalOperationIds.every(
-      (operation) =>
-        operation &&
-        validText(operation.operationId, 1, 300) &&
-        (operation.kind === null || terminalKinds.has(operation.kind)),
-    ) ||
+    !validTerminalOperations(value.terminalOperationIds, terminalKinds) ||
     !value.acknowledgement.attempts.every(
       (attempt) =>
         /^ack:[1-9]\d*$/.test(attempt.attemptId) &&
@@ -1935,15 +1941,44 @@ function projectionFromRow(value: string): ExactReviewLifecycleProjection {
   parsed.routerReceipts ??= parsed.routerReceipt ? [parsed.routerReceipt] : [];
   parsed.terminalDispositions ??= parsed.terminalDisposition ? [parsed.terminalDisposition] : [];
   parsed.terminalOperationIds ??= [];
-  if (Array.isArray(parsed.terminalOperationIds)) {
-    parsed.terminalOperationIds = parsed.terminalOperationIds
-      .slice(-EXACT_REVIEW_LIFECYCLE_TERMINAL_OPERATION_LIMIT)
-      .map((operation) =>
-        typeof operation === "string" ? { operationId: operation, kind: null } : operation,
-      );
+  if (!validTerminalOperations(parsed.terminalOperationIds)) {
+    throw new Error("invalid lifecycle projection row");
   }
   parsed.bayTelemetryPending ??= false;
   return parsed;
+}
+
+function validTerminalOperations(
+  operations: unknown,
+  terminalKinds = new Set<LifecycleTerminalDisposition>([
+    "review_completed_routed",
+    "superseded",
+    "requeue",
+    "dead_letter",
+    "target_closed",
+    "target_missing",
+    "policy_noop",
+    "guarded_open",
+    "failure",
+  ]),
+) {
+  if (!Array.isArray(operations)) return false;
+  const operationIds = new Set<string>();
+  return operations.every((operation) => {
+    const candidate = operation as { operationId?: unknown; kind?: unknown } | null;
+    if (
+      !candidate ||
+      typeof candidate !== "object" ||
+      typeof candidate.operationId !== "string" ||
+      !validText(candidate.operationId, 1, 300) ||
+      !terminalKinds.has(candidate.kind as LifecycleTerminalDisposition) ||
+      operationIds.has(candidate.operationId)
+    ) {
+      return false;
+    }
+    operationIds.add(candidate.operationId);
+    return true;
+  });
 }
 
 function sameClaim(left: LifecycleClaimFact, right: LifecycleClaimFact) {

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -7766,7 +7766,7 @@ export class ExactReviewQueue {
                 revision: prior.revision,
                 kind: requestedKind,
                 observedAt: now,
-              });
+              }).projection;
         const terminalKind = terminal.terminalDisposition?.kind;
         if (terminalKind && terminalKind !== "requeue") {
           this.ensureLifecycleTerminalFinalizationDriver({
@@ -8393,38 +8393,38 @@ export class ExactReviewQueue {
     }
     try {
       const now = Date.now();
-      const { projection, state } = this.storage.transactionSync(() => {
+      const result = this.storage.transactionSync(() => {
         const existing = this.lifecycleProjectionStore.read(
           identity.canonicalTargetKey,
           identity.fenceKey,
           identity.revision,
         );
         const receipt = existing?.routerReceipts.find((entry) => entry.receiptId === receiptId);
-        if (existing && receipt) {
-          if (receipt.outcome !== outcome) throw new Error("conflicting lifecycle router receipt");
-          if (receipt.operationComplete) return { projection: existing, state: null };
-        }
-        const recorded = this.lifecycleProjectionStore.recordRouterReceiptSync({
+        const terminal = existing?.terminalDisposition;
+        const result = this.lifecycleProjectionStore.recordRouterReceiptSync({
           ...identity,
           outcome,
           receiptId,
           observedAt: now,
           operationComplete: true,
         });
-        // A legacy routed fact may still be missing its driver; other terminal facts supersede it.
+        // Preserve a committed requeue without a receipt, plus f7's ordering
+        // rule for a matching receipt followed by a later terminal outcome.
         if (
-          receipt &&
-          existing?.terminalDisposition &&
-          existing.terminalDisposition.kind !== "review_completed_routed" &&
-          existing.terminalDisposition.observedAt >= receipt.observedAt
+          result.duplicate ||
+          terminal?.kind === "requeue" ||
+          (receipt &&
+            terminal &&
+            terminal.kind !== "review_completed_routed" &&
+            terminal.observedAt >= receipt.observedAt)
         ) {
-          return { projection: recorded, state: null };
+          return result;
         }
         const projection = this.lifecycleProjectionStore.recordTerminalDispositionSync({
           ...identity,
           kind: "review_completed_routed",
           observedAt: now,
-        });
+        }).projection;
         const state = this.readStateSync();
         const driverChanged = this.ensureLifecycleTerminalFinalizationDriver({
           state,
@@ -8434,16 +8434,14 @@ export class ExactReviewQueue {
         const receiptRemoved = this.removeTerminalizedLifecycleQueueItem(state, identity);
         // Commit the replay marker and all durable effects together.
         if (driverChanged || receiptRemoved) this.writeStateSync(state);
-        return { projection, state };
+        return { projection, duplicate: false };
       });
-      if (state) {
-        this.syncBayLifecycle(projection);
-        await this.scheduleNext(state, now);
-      }
+      this.syncBayLifecycle(result.projection);
+      await this.scheduleNext(this.readStateSync(), now);
       return json({
         ok: true,
-        lifecycle_state: lifecycleState(projection),
-        version: projection.version,
+        lifecycle_state: lifecycleState(result.projection),
+        version: result.projection.version,
       });
     } catch {
       console.warn("lifecycle_router_receipt_rejected");
@@ -9012,27 +9010,14 @@ export class ExactReviewQueue {
     }
     try {
       const now = Date.now();
-      const { projection, state } = this.storage.transactionSync(() => {
-        const existing = this.lifecycleProjectionStore.read(
-          identity.canonicalTargetKey,
-          identity.fenceKey,
-          identity.revision,
-        );
-        const operation = operationId
-          ? existing?.terminalOperationIds.find((entry) => entry.operationId === operationId)
-          : undefined;
-        if (existing && operation) {
-          if (operation.kind !== null && operation.kind !== kind) {
-            throw new Error("conflicting lifecycle terminal operation");
-          }
-          return { projection: existing, state: null };
-        }
-        const projection = this.lifecycleProjectionStore.recordTerminalDispositionSync({
+      const result = this.storage.transactionSync(() => {
+        const result = this.lifecycleProjectionStore.recordTerminalDispositionSync({
           ...identity,
           kind,
           operationId,
           observedAt: now,
         });
+        if (result.duplicate) return result;
         const state = this.readStateSync();
         const driverCancelled =
           kind === "requeue" ? this.cancelTerminalFinalizationDrivers(state, identity) : false;
@@ -9041,23 +9026,21 @@ export class ExactReviewQueue {
             ? false
             : this.ensureLifecycleTerminalFinalizationDriver({
                 state,
-                projection,
+                projection: result.projection,
                 terminalDisposition: kind,
                 now,
               });
         const receiptRemoved = this.removeTerminalizedLifecycleQueueItem(state, identity);
         if (driverChanged || driverCancelled || receiptRemoved) this.writeStateSync(state);
-        return { projection, state };
+        return result;
       });
-      if (state) {
-        this.syncBayLifecycle(projection);
-        await this.scheduleNext(state, now);
-      }
+      this.syncBayLifecycle(result.projection);
+      await this.scheduleNext(this.readStateSync(), now);
       return json({
         ok: true,
-        lifecycle_state: lifecycleState(projection),
-        acknowledgement_state: commandAcknowledgementState(projection),
-        version: projection.version,
+        lifecycle_state: lifecycleState(result.projection),
+        acknowledgement_state: commandAcknowledgementState(result.projection),
+        version: result.projection.version,
       });
     } catch (error) {
       console.warn("lifecycle_terminal_disposition_rejected");

--- a/test/dashboard-worker-publication-lifecycle.test.ts
+++ b/test/dashboard-worker-publication-lifecycle.test.ts
@@ -68,13 +68,167 @@ function publicPublicationQueue(storage: MemoryDurableStorage) {
   );
 }
 
+const NON_ROUTED_TERMINAL_KINDS = [
+  "superseded",
+  "requeue",
+  "dead_letter",
+  "target_closed",
+  "target_missing",
+  "policy_noop",
+  "guarded_open",
+  "failure",
+] as const;
+
+function lifecycleRouterOrderingFixture({
+  terminalKind,
+  receiptObservedAt,
+  terminalObservedAt,
+}: {
+  terminalKind: (typeof NON_ROUTED_TERMINAL_KINDS)[number];
+  receiptObservedAt?: number;
+  terminalObservedAt: number;
+}) {
+  const storage = new MemoryDurableStorage();
+  const queue = publicPublicationQueue(storage);
+  const store = new ExactReviewLifecycleProjectionStore(storage);
+  const identity = {
+    canonicalTargetKey: "openclaw/openclaw#706",
+    fenceKey: `router-ordering-${terminalKind}`,
+    revision: 1,
+  };
+  store.recordAdmission({
+    ...identity,
+    deliveryId: identity.fenceKey,
+    sourceAction: "legacy_dispatch",
+    commandOriginated: false,
+    statusMarker: null,
+    statusCommentId: null,
+    observedAt: 1,
+  });
+  store.recordCanonicalReceipt({
+    ...identity,
+    outcome: "accepted",
+    receiptId: "canonical:706:1",
+    observedAt: 2,
+  });
+  if (receiptObservedAt !== undefined) {
+    store.recordRouterReceipt({
+      ...identity,
+      outcome: "durable",
+      receiptId: "router:706:1",
+      observedAt: receiptObservedAt,
+    });
+  }
+  store.recordTerminalDisposition({
+    ...identity,
+    kind: terminalKind,
+    observedAt: terminalObservedAt,
+  });
+  const post = () =>
+    queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/lifecycle/router-receipt", {
+        method: "POST",
+        body: JSON.stringify({
+          canonical_target_key: identity.canonicalTargetKey,
+          fence_key: identity.fenceKey,
+          revision: identity.revision,
+          outcome: "durable",
+          receipt_id: "router:706:1",
+        }),
+      }),
+    );
+  const projection = () =>
+    store.read(identity.canonicalTargetKey, identity.fenceKey, identity.revision)!;
+  const driverKey = `terminal-finalization:${identity.fenceKey}:${identity.revision}`;
+  return { storage, post, projection, driverKey };
+}
+
+test("router receipt repair preserves matching later or equal terminal outcomes", async (t) => {
+  for (const terminalKind of NON_ROUTED_TERMINAL_KINDS) {
+    for (const relation of ["later", "equal"] as const) {
+      await t.test(`${terminalKind} ${relation}`, async () => {
+        const receiptObservedAt = 10;
+        const { storage, post, projection, driverKey } = lifecycleRouterOrderingFixture({
+          terminalKind,
+          receiptObservedAt,
+          terminalObservedAt: relation === "later" ? 11 : receiptObservedAt,
+        });
+        const before = {
+          terminalDisposition: projection().terminalDisposition,
+          terminalDispositions: projection().terminalDispositions,
+          queue: storage.sql.readNormalizedQueue(),
+        };
+
+        assert.equal((await post()).status, 200);
+        assert.deepEqual(
+          {
+            terminalDisposition: projection().terminalDisposition,
+            terminalDispositions: projection().terminalDispositions,
+            queue: storage.sql.readNormalizedQueue(),
+          },
+          before,
+        );
+        assert.equal(projection().routerReceipts[0]?.operationComplete, true);
+        assert.equal(storage.sql.readNormalizedQueue().items[driverKey], undefined);
+      });
+    }
+  }
+});
+
+test("router receipt repair rejects a terminal older than its matching receipt atomically", async () => {
+  const { storage, post, projection } = lifecycleRouterOrderingFixture({
+    terminalKind: "policy_noop",
+    receiptObservedAt: 11,
+    terminalObservedAt: 10,
+  });
+  const before = { projection: projection(), queue: storage.sql.readNormalizedQueue() };
+
+  assert.equal((await post()).status, 409);
+  assert.deepEqual({ projection: projection(), queue: storage.sql.readNormalizedQueue() }, before);
+});
+
+test("router receipt repair rejects a receiptless non-requeue terminal atomically", async () => {
+  const { storage, post, projection } = lifecycleRouterOrderingFixture({
+    terminalKind: "policy_noop",
+    terminalObservedAt: 10,
+  });
+  const before = { projection: projection(), queue: storage.sql.readNormalizedQueue() };
+
+  assert.equal((await post()).status, 409);
+  assert.deepEqual({ projection: projection(), queue: storage.sql.readNormalizedQueue() }, before);
+});
+
+test("router receipt repair preserves a receiptless requeue", async () => {
+  const { storage, post, projection } = lifecycleRouterOrderingFixture({
+    terminalKind: "requeue",
+    terminalObservedAt: 10,
+  });
+  const before = {
+    terminalDisposition: projection().terminalDisposition,
+    terminalDispositions: projection().terminalDispositions,
+    queue: storage.sql.readNormalizedQueue(),
+  };
+
+  assert.equal((await post()).status, 200);
+  assert.deepEqual(
+    {
+      terminalDisposition: projection().terminalDisposition,
+      terminalDispositions: projection().terminalDispositions,
+      queue: storage.sql.readNormalizedQueue(),
+    },
+    before,
+  );
+  assert.equal(projection().routerReceipts[0]?.operationComplete, true);
+});
+
 for (const route of ["router-receipt", "terminal-disposition"] as const) {
   for (const scenario of [
     "plain",
     "requeue",
     "rollback",
+    "derived-replay",
     ...(route === "router-receipt"
-      ? ["legacy", "legacy-terminal", "legacy-requeue", "legacy-requeue-tied"]
+      ? ["rollback-requeue", "legacy", "legacy-terminal", "legacy-requeue", "legacy-requeue-tied"]
       : ["conflict"]),
   ]) {
     const legacy = scenario.startsWith("legacy");
@@ -83,11 +237,15 @@ for (const route of ["router-receipt", "terminal-disposition"] as const) {
       ? `${scenario} repairs only incomplete effects and marks completion`
       : scenario === "conflict"
         ? "rejects a conflicting terminal operation kind"
-        : requeue
-          ? "after lost response and newer requeue preserves requeue without a driver"
-          : scenario === "rollback"
-            ? "after a failed driver write applies all effects atomically"
-            : "returns ok without changing durable state";
+        : scenario === "derived-replay"
+          ? "reruns derived Bay and scheduling effects after a committed response failure"
+          : scenario === "rollback-requeue"
+            ? "preserves a newer requeue after the original transaction rolls back"
+            : requeue
+              ? "after lost response and newer requeue preserves requeue without a driver"
+              : scenario === "rollback"
+                ? "after a failed driver write applies all effects atomically"
+                : "returns ok without changing durable state";
     test(`lifecycle ${route} replay ${description}`, async (t) => {
       t.mock.timers.enable({ apis: ["Date"], now: Date.UTC(2026, 8, 2) });
       const storage = new MemoryDurableStorage();
@@ -143,15 +301,32 @@ for (const route of ["router-receipt", "terminal-disposition"] as const) {
       const projection = () =>
         store.read(identity.canonicalTargetKey, identity.fenceKey, identity.revision)!;
       const driverKey = `terminal-finalization:${identity.fenceKey}:${identity.revision}`;
+      let alarmAttempts = 0;
+      if (scenario === "derived-replay") {
+        const setAlarm = storage.setAlarm.bind(storage);
+        storage.setAlarm = async (at) => {
+          alarmAttempts += 1;
+          if (alarmAttempts === 1) throw new Error("injected alarm failure");
+          await setAlarm(at);
+        };
+      }
 
-      if (scenario === "rollback") {
+      if (scenario === "rollback" || scenario === "rollback-requeue") {
         const beforeFailure = projection();
         storage.sql.failNext(/INSERT INTO exact_review_queue_items /);
         assert.equal((await post(route, payload)).status, 409);
         assert.deepEqual(projection(), beforeFailure);
         assert.equal(storage.sql.readNormalizedQueue().items[driverKey], undefined);
       }
-      if (legacy) {
+      if (scenario === "rollback-requeue") {
+        t.mock.timers.tick(1_000);
+        assert.equal(
+          (await post("terminal-disposition", JSON.stringify({ ...wireIdentity, kind: "requeue" })))
+            .status,
+          200,
+        );
+        assert.equal(lifecycleState(projection()), "requeue");
+      } else if (legacy) {
         store.recordRouterReceipt({
           ...identity,
           outcome: "durable",
@@ -169,10 +344,13 @@ for (const route of ["router-receipt", "terminal-disposition"] as const) {
         assert.equal(storage.sql.readNormalizedQueue().items[driverKey], undefined);
       } else {
         // Commit the request, then discard its response as if the transport lost it.
-        assert.equal((await post(route, payload)).status, 200);
+        assert.equal(
+          (await post(route, payload)).status,
+          scenario === "derived-replay" ? 409 : 200,
+        );
         assert.ok(storage.sql.readNormalizedQueue().items[driverKey]);
       }
-      if (requeue) {
+      if (requeue && scenario !== "rollback-requeue") {
         if (scenario !== "legacy-requeue-tied") t.mock.timers.tick(1_000);
         assert.equal(
           (await post("terminal-disposition", JSON.stringify({ ...wireIdentity, kind: "requeue" })))
@@ -188,11 +366,18 @@ for (const route of ["router-receipt", "terminal-disposition"] as const) {
       };
       // Reconstruct the queue to require durable dedupe rather than process memory.
       queue = publicPublicationQueue(storage);
+      if (scenario === "derived-replay") storage.sql.resetQueryHistory();
       t.mock.timers.tick(1_000);
       const replay = await post(route, payload);
       assert.equal(replay.status, 200);
       assert.equal((await replay.json()).ok, true);
-      if (legacy) {
+      if (scenario === "rollback-requeue") {
+        assert.equal(projection().routerReceipts.length, 1);
+        assert.equal(projection().routerReceipts[0].operationComplete, true);
+        assert.deepEqual(projection().terminalDisposition, before.projection.terminalDisposition);
+        assert.deepEqual(storage.sql.readNormalizedQueue(), before.queue);
+        before.projection = projection();
+      } else if (legacy) {
         assert.equal(projection().routerReceipts[0].operationComplete, true);
         assert.equal(projection().routerReceipts[0].observedAt, Date.UTC(2026, 8, 2));
         if (requeue) {
@@ -215,6 +400,14 @@ for (const route of ["router-receipt", "terminal-disposition"] as const) {
         { projection: projection(), queue: storage.sql.readNormalizedQueue() },
         before,
       );
+      if (scenario === "derived-replay") {
+        assert.equal(
+          storage.sql.queriesMatching(/INSERT INTO exact_review_lifecycle_bay_pending_v2/).length,
+          1,
+        );
+        assert.equal(alarmAttempts, 2);
+        assert.ok(await storage.getAlarm());
+      }
       if (scenario === "conflict") {
         const conflicting = await post(
           route,
@@ -267,7 +460,7 @@ for (const route of ["router-receipt", "terminal-disposition"] as const) {
   }
 }
 
-for (const scenario of ["conflict", "retention", "legacy"] as const) {
+for (const scenario of ["conflict", "lifetime", "old-row", "invalid"] as const) {
   test(`lifecycle terminal operation store ${scenario}`, () => {
     const storage = new MemoryDurableStorage();
     const store = new ExactReviewLifecycleProjectionStore(storage);
@@ -292,36 +485,52 @@ for (const scenario of ["conflict", "retention", "legacy"] as const) {
       observedAt: Date.now(),
     });
     let projection = store.recordTerminalDisposition(operation(0));
-    if (scenario === "retention") {
+    if (scenario === "lifetime") {
       for (let index = 1; index < 40; index += 1) {
         projection = store.recordTerminalDisposition(operation(index));
       }
+      projection = store.recordTerminalDisposition({
+        ...identity,
+        kind: "requeue",
+        observedAt: Date.now() + 1,
+      });
       assert.deepEqual(
         projection.terminalOperationIds,
-        Array.from({ length: 32 }, (_, index) => ({
-          operationId: operation(index + 8).operationId,
+        Array.from({ length: 40 }, (_, index) => ({
+          operationId: operation(index).operationId,
           kind: "policy_noop",
         })),
       );
-      assert.deepEqual(store.recordTerminalDisposition(operation(39)), projection);
-    } else if (scenario === "legacy") {
+      assert.deepEqual(store.recordTerminalDisposition(operation(0)), projection);
+      assert.equal(projection.terminalDisposition?.kind, "requeue");
+    } else if (scenario === "old-row") {
       storage.sql.exec(
         "UPDATE exact_review_lifecycle_projection_v1 SET projection_json = ?",
-        JSON.stringify({ ...projection, terminalOperationIds: [operation(0).operationId] }),
+        JSON.stringify({ ...projection, terminalOperationIds: undefined }),
       );
-      const migrated = new ExactReviewLifecycleProjectionStore(storage);
-      projection = migrated.read(
+      projection = new ExactReviewLifecycleProjectionStore(storage).read(
         identity.canonicalTargetKey,
         identity.fenceKey,
         identity.revision,
       )!;
-      assert.deepEqual(projection.terminalOperationIds, [
-        { operationId: operation(0).operationId, kind: null },
-      ]);
-      assert.deepEqual(
-        migrated.recordTerminalDisposition({ ...operation(0), kind: "requeue" }),
-        projection,
-      );
+      assert.deepEqual(projection.terminalOperationIds, []);
+    } else if (scenario === "invalid") {
+      for (const terminalOperationIds of [
+        [operation(0).operationId],
+        [
+          { operationId: operation(0).operationId, kind: "policy_noop" },
+          { operationId: operation(0).operationId, kind: "policy_noop" },
+        ],
+      ]) {
+        storage.sql.exec(
+          "UPDATE exact_review_lifecycle_projection_v1 SET projection_json = ?",
+          JSON.stringify({ ...projection, terminalOperationIds }),
+        );
+        assert.throws(
+          () => store.read(identity.canonicalTargetKey, identity.fenceKey, identity.revision),
+          /invalid lifecycle projection row/,
+        );
+      }
     } else {
       assert.deepEqual(store.recordTerminalDisposition(operation(0)), projection);
       assert.throws(
@@ -2306,66 +2515,8 @@ test("durable direct command acknowledgement survives successor lease expiry", a
     null,
   );
 
-  // A later requeue is authoritative for this revision: it must cancel the
-  // stale Complete driver rather than allowing it to restore the earlier
-  // routed disposition. A later durable route handoff may then create a new
-  // driver for that same fenced revision.
-  const requeueBody = JSON.stringify({
-    canonical_target_key: publication.canonicalTargetKey,
-    fence_key: publication.fenceKey,
-    revision: publication.revision,
-    kind: "requeue",
-  });
-  const requeueSignature = `sha256=${createHmac("sha256", secret).update(requeueBody).digest("hex")}`;
-  assert.equal(
-    (
-      await worker.fetch(
-        new Request(
-          "https://clawsweeper.openclaw.ai/internal/exact-review/lifecycle/terminal-disposition",
-          {
-            method: "POST",
-            headers: { "x-clawsweeper-exact-review-signature": requeueSignature },
-            body: requeueBody,
-          },
-        ),
-        env,
-      )
-    ).status,
-    200,
-  );
-  state = storage.sql.readNormalizedQueue() as { items: Record<string, ExactReviewQueueItem> };
-  assert.equal(state.items[driverKey], undefined);
-  const requeuedProjection = new ExactReviewLifecycleProjectionStore(storage).read(
-    "openclaw/openclaw#706",
-    leased.key,
-    4,
-  )!;
-  assert.equal(lifecycleState(requeuedProjection), "requeue");
-  assert.equal(commandAcknowledgementState(requeuedProjection), "unavailable");
-
-  const reroutedBody = JSON.stringify({
-    ...routerReceipt,
-    receipt_id: "direct-router-recovery:706:2",
-  });
-  const reroutedSignature = `sha256=${createHmac("sha256", secret)
-    .update(reroutedBody)
-    .digest("hex")}`;
-  assert.equal(
-    (
-      await worker.fetch(
-        new Request(
-          "https://clawsweeper.openclaw.ai/internal/exact-review/lifecycle/router-receipt",
-          {
-            method: "POST",
-            headers: { "x-clawsweeper-exact-review-signature": reroutedSignature },
-            body: reroutedBody,
-          },
-        ),
-        env,
-      )
-    ).status,
-    200,
-  );
+  // Requeue ordering is covered separately; this scenario retains the
+  // finalizer identity and acknowledgement retry coverage.
   state = storage.sql.readNormalizedQueue() as { items: Record<string, ExactReviewQueueItem> };
   driver = state.items[driverKey]!;
   Object.assign(driver, {


### PR DESCRIPTION
Related: https://github.com/openclaw/clawsweeper/pull/1368

## What Problem This Solves

Fixes an issue where a lost Worker response could replay a committed lifecycle operation, mutate canonical state twice, or fail to restore derived Bay and alarm state after the canonical transaction had already committed.

This is the server prerequisite only. It does not re-enable client-side post-effect retries.

## Why This Change Was Made

Router receipts and terminal dispositions now use durable operation identity inside the lifecycle projection transaction. Same-identity replays skip canonical mutation but always rerun idempotent Bay materialization and scheduling; conflicting terminal operation kinds return HTTP 409.

The router endpoint preserves the deployed f7 ordering rule for a matching receipt followed by a newer or equal non-routed terminal, and additionally preserves any authoritative requeue when a delayed router request had not committed a receipt. This endpoint rule is intentionally narrower than the lifecycle store contract: `applyTerminalDisposition` still permits requeue-to-route transitions for other callers, as covered by queue-policy tests.

Terminal operation IDs remain for the projection lifetime with no eviction. Old rows without the field load as an empty ledger; malformed or duplicate entries are rejected.

Peter Steinberger authored the original publication-retry work and is credited in the signed commit. This prerequisite is separated because the server behavior must differ from the source PR before post-effect retries can safely return.

## User Impact

Operators get deterministic lifecycle recovery after ambiguous Worker failures: duplicate delivery cannot recreate canonical effects, overwrite a later requeue, or leave Bay/alarm projections stale.

There is no new public API or configuration surface.

## OpenClaw Bay Impact

The public Bay projection and schema are unchanged. Duplicate router and terminal deliveries rerun the existing idempotent `syncBayLifecycle` path after the canonical transaction, so a post-commit materialization failure can recover without changing lifecycle facts.

## Documentation Impact

Reviewed `docs/live-dashboard.md`. No documentation change is needed: post-effect requests remain deliberately one-shot, and this PR only repairs the Worker prerequisite needed before that availability tradeoff can be reconsidered.

## Evidence

- Signed head: `ba3822b6cf179d98bcaf2444e6974deb6095e752`
- Base: `674841bcdc0a826ff4555f945cc81f122db0d6c2`
- Scope: three files only.
- Production: `+98/-80`, net `+18`.
- Tests: `+238/-87`, net `+151`.
- Focused proof: 436 passed, 0 failed:
  - publication lifecycle: 79
  - Bay routes: 115
  - queue runtime: 187
  - queue policy: 55
- `CI=1 pnpm run check:static`: passed.
- `pnpm run build:all`: passed.
- `pnpm run lint`: passed.
- `pnpm run format`: passed on 808 files.
- `git diff --check`: passed.

Regression coverage includes:

- all eight non-routed terminal kinds with matching newer/equal receipt timestamps remain unchanged;
- terminal older than its matching receipt returns 409 atomically;
- receiptless non-requeue returns 409 without recording a receipt;
- receiptless requeue returns 200 and remains authoritative without a driver;
- post-commit derived failure replay reruns Bay and scheduling without canonical mutation;
- terminal same-ID/same-kind replay is a no-op; same-ID/different-kind returns 409;
- more than 32 terminal IDs remain deduplicated for the projection lifetime;
- malformed and duplicate ledgers are rejected, while a row with no ledger loads;
- transaction rollback and the existing direct-command acknowledgement finalizer coverage remain intact.

### Review precedence

Two local review suggestions were considered and rejected after direct source/history audit:

1. A distinct router receipt does not automatically override an existing requeue at this delayed-router endpoint. That would reintroduce the failed-before-commit ordering bug. Other store callers retain the intentional requeue-to-route transition.
2. String terminal IDs and `{ kind: null }` entries are not deployed durable states. Before f7 the field did not exist; f7 introduced the field and writes only concrete `{ operationId, kind }` entries. The removed reader bridge covered an unmerged predecessor shape, not a shipped migration.

## Real Behavior Proof

**Claim:** the real Worker HTTP boundary preserves a requeue across delayed router delivery, makes completed router and terminal replays canonical no-ops, and rejects a conflicting terminal operation kind.

**Surface:** Wrangler 4.107 running the production Worker and SQLite Durable Object locally over HTTP loopback. GitHub App installation and repository metadata were served by an ephemeral local mock; no private endpoint, credential, or repository data was retained.

**Command:**

```sh
bash /tmp/clawsweeper-worker-replay-proof.sh "$PWD" 8796
```

**Observed result:**

```json
{"ok":true,"transport":"HTTP loopback","runtime":"Wrangler Worker with SQLite Durable Object","router":{"delayed_receipt_preserved_requeue":true,"duplicate_left_updated_at_unchanged":true},"terminal":{"duplicate_left_updated_at_unchanged":true,"conflicting_kind_status":409}}
```

**Limits:** this proves the production Worker/SQLite/HTTP boundary locally. It does not claim deployment or a live queue mutation. Docker was unavailable. Two AWS Crabbox attempts failed before running repository commands: one because local Actions hydration did not support `pnpm/action-setup@v6.0.9`, and one on broker DNS/EOF plus cancel-create timeout. A local full `pnpm run check` fallback reached unrelated terminal proof/PTY infrastructure failures; the focused owner-boundary suites and all static/build/lint/format gates above are green.

No deployment, queue dispatch, cancellation, retry, or other live operation was performed.
