### PR TITLE
fix(queue): keep legacy lifecycle projections replay-safe

### DIFF
--- a/dashboard/exact-review-lifecycle.ts
+++ b/dashboard/exact-review-lifecycle.ts
@@ -223,7 +223,7 @@ export type ExactReviewLifecycleProjection = {
    */
   terminalDispositions: Array<{ kind: LifecycleTerminalDisposition; observedAt: number }>;
   /** Applied terminal POST identities, retained with the revision's receipt history. */
-  terminalOperationIds: Array<{ operationId: string; kind: LifecycleTerminalDisposition }>;
+  terminalOperationIds: Array<{ operationId: string; kind: LifecycleTerminalDisposition | null }>;
   /** Current terminal outcome used to derive lifecycle and acknowledgement state. */
   terminalDisposition: { kind: LifecycleTerminalDisposition; observedAt: number } | null;
   /**
@@ -586,7 +586,7 @@ export class ExactReviewLifecycleProjectionStore {
           (entry) => entry.operationId === input.operationId,
         );
         if (operation) {
-          if (operation.kind !== input.kind) {
+          if (operation.kind !== null && operation.kind !== input.kind) {
             throw new Error("conflicting lifecycle terminal operation");
           }
           return true;
@@ -1845,7 +1845,7 @@ function validDurableLifecycleBayProjection(value: ExactReviewLifecycleProjectio
       (disposition) =>
         terminalKinds.has(disposition.kind) && finiteTimestamp(disposition.observedAt),
     ) ||
-    !validTerminalOperations(value.terminalOperationIds, terminalKinds) ||
+    !normalizeTerminalOperations(value.terminalOperationIds, terminalKinds) ||
     !value.acknowledgement.attempts.every(
       (attempt) =>
         /^ack:[1-9]\d*$/.test(attempt.attemptId) &&
@@ -1941,14 +1941,14 @@ function projectionFromRow(value: string): ExactReviewLifecycleProjection {
   parsed.routerReceipts ??= parsed.routerReceipt ? [parsed.routerReceipt] : [];
   parsed.terminalDispositions ??= parsed.terminalDisposition ? [parsed.terminalDisposition] : [];
   parsed.terminalOperationIds ??= [];
-  if (!validTerminalOperations(parsed.terminalOperationIds)) {
-    throw new Error("invalid lifecycle projection row");
-  }
+  const terminalOperationIds = normalizeTerminalOperations(parsed.terminalOperationIds);
+  if (!terminalOperationIds) throw new Error("invalid lifecycle projection row");
+  parsed.terminalOperationIds = terminalOperationIds;
   parsed.bayTelemetryPending ??= false;
   return parsed;
 }
 
-function validTerminalOperations(
+function normalizeTerminalOperations(
   operations: unknown,
   terminalKinds = new Set<LifecycleTerminalDisposition>([
     "review_completed_routed",
@@ -1962,23 +1962,32 @@ function validTerminalOperations(
     "failure",
   ]),
 ) {
-  if (!Array.isArray(operations)) return false;
+  if (!Array.isArray(operations)) return null;
   const operationIds = new Set<string>();
-  return operations.every((operation) => {
-    const candidate = operation as { operationId?: unknown; kind?: unknown } | null;
+  const normalized: ExactReviewLifecycleProjection["terminalOperationIds"] = [];
+  for (const operation of operations) {
+    const candidate =
+      typeof operation === "string"
+        ? { operationId: operation, kind: null }
+        : (operation as { operationId?: unknown; kind?: unknown } | null);
     if (
       !candidate ||
       typeof candidate !== "object" ||
       typeof candidate.operationId !== "string" ||
       !validText(candidate.operationId, 1, 300) ||
-      !terminalKinds.has(candidate.kind as LifecycleTerminalDisposition) ||
+      (candidate.kind !== null &&
+        !terminalKinds.has(candidate.kind as LifecycleTerminalDisposition)) ||
       operationIds.has(candidate.operationId)
     ) {
-      return false;
+      return null;
     }
     operationIds.add(candidate.operationId);
-    return true;
-  });
+    normalized.push({
+      operationId: candidate.operationId,
+      kind: candidate.kind as LifecycleTerminalDisposition | null,
+    });
+  }
+  return normalized;
 }
 
 function sameClaim(left: LifecycleClaimFact, right: LifecycleClaimFact) {

--- a/test/dashboard-worker-publication-lifecycle.test.ts
+++ b/test/dashboard-worker-publication-lifecycle.test.ts
@@ -460,7 +460,14 @@ for (const route of ["router-receipt", "terminal-disposition"] as const) {
   }
 }
 
-for (const scenario of ["conflict", "lifetime", "old-row", "invalid"] as const) {
+for (const scenario of [
+  "conflict",
+  "lifetime",
+  "old-row",
+  "legacy-string",
+  "legacy-null",
+  "invalid",
+] as const) {
   test(`lifecycle terminal operation store ${scenario}`, () => {
     const storage = new MemoryDurableStorage();
     const store = new ExactReviewLifecycleProjectionStore(storage);
@@ -514,13 +521,35 @@ for (const scenario of ["conflict", "lifetime", "old-row", "invalid"] as const) 
         identity.revision,
       )!;
       assert.deepEqual(projection.terminalOperationIds, []);
+    } else if (scenario === "legacy-string" || scenario === "legacy-null") {
+      storage.sql.exec(
+        "UPDATE exact_review_lifecycle_projection_v1 SET projection_json = ?",
+        JSON.stringify({
+          ...projection,
+          terminalOperationIds:
+            scenario === "legacy-string"
+              ? [operation(0).operationId]
+              : [{ operationId: operation(0).operationId, kind: null }],
+        }),
+      );
+      const upgradedStore = new ExactReviewLifecycleProjectionStore(storage);
+      projection = upgradedStore.read(
+        identity.canonicalTargetKey,
+        identity.fenceKey,
+        identity.revision,
+      )!;
+      assert.deepEqual(projection.terminalOperationIds, [
+        { operationId: operation(0).operationId, kind: null },
+      ]);
+      assert.deepEqual(
+        upgradedStore.recordTerminalDisposition({ ...operation(0), kind: "requeue" }),
+        projection,
+      );
     } else if (scenario === "invalid") {
       for (const terminalOperationIds of [
-        [operation(0).operationId],
-        [
-          { operationId: operation(0).operationId, kind: "policy_noop" },
-          { operationId: operation(0).operationId, kind: "policy_noop" },
-        ],
+        [""],
+        [{ operationId: operation(0).operationId, kind: "unknown" }],
+        [operation(0).operationId, { operationId: operation(0).operationId, kind: null }],
       ]) {
         storage.sql.exec(
           "UPDATE exact_review_lifecycle_projection_v1 SET projection_json = ?",


### PR DESCRIPTION
Related: #1375

## What Problem This Solves

Fixes an upgrade issue where a lifecycle projection written before #1375 could be rejected when its terminal-operation ledger still used a string operation ID or a null-kind operation entry.

## Why This Change Was Made

Read-time normalization converts legacy string IDs to `{ operationId, kind: null }`. A legacy null-kind ID remains an idempotent duplicate for any replayed terminal kind, matching the earlier deployed behavior; concrete different-kind reuse still returns 409. New writes continue to store concrete kinds, the ledger remains unbounded for the projection lifetime, and malformed or duplicate IDs remain invalid.

This is the narrow compatibility follow-up required because #1375 merged before its replacing exact-head ClawSweeper review tuple completed. It does not revert #1375 and does not change queue, workflow, schema, configuration, capacity, cadence, or live operations.

## User Impact

Maintainers can upgrade without legacy terminal-operation rows becoming unreadable or replaying a previously applied terminal mutation. Current-format rows retain strict conflicting-kind protection.

## OpenClaw Bay Impact

Bay lifecycle behavior is unchanged. A real local Wrangler Worker with its SQLite Durable Object accepted the existing router and terminal flows: delayed router replay preserved `requeue`, duplicate replay left the durable timestamp unchanged, and concrete conflicting-kind reuse returned 409.

## Documentation Impact

No documentation change. This restores read compatibility for deployed durable rows without changing the documented queue or lifecycle contract.

## Evidence

- Signed head: `98a2e67789544319e149db762d16cb6eb0ed2f14`
- Production delta: `+23/-14` (net `+9`)
- Test delta: `+35/-6` (net `+29`)
- `node --test test/dashboard-worker-publication-lifecycle.test.ts`: 81 passed
- TypeScript builds: `tsconfig.json`, `tsconfig.repair.json`, and `tsconfig.dashboard.json` passed
- Static checks: active surface, dashboard queue boundary, dashboard strict, docs, and limits passed
- Targeted `oxfmt --check`, `oxlint`, and `git diff --check` passed
- Focused upgrade coverage proves legacy string IDs and null-kind objects normalize and replay without mutation, concrete different-kind reuse conflicts, and malformed or duplicate ledgers remain rejected.

The repository's broad Bay proof started the real Wrangler runtime but its public-visibility fixture returned `503 target_visibility_unverified`; that fixture failure is unrelated to this read-compatibility change and is not counted as passing proof.

## Real Behavior Proof

- **Claim:** the compatibility read path does not regress the repaired router/terminal replay boundary.
- **Surface:** signed lifecycle HTTP routes through the compiled dashboard Worker and real SQLite Durable Object.
- **Scenario:** enqueue a disposable public target, record a requeue, deliver and replay a delayed router receipt, then record/replay a terminal operation and reuse its concrete ID with a different kind.
- **Environment:** local Wrangler `4.107.0`, loopback mock GitHub API, disposable local persistence, no production credentials or endpoints.
- **Observed result:** router replay preserved requeue and left `updated_at` unchanged; terminal replay left `updated_at` unchanged; conflicting concrete kind returned HTTP 409.
- **Trace:**

```json
{"ok":true,"transport":"HTTP loopback","runtime":"Wrangler Worker with SQLite Durable Object","router":{"delayed_receipt_preserved_requeue":true,"duplicate_left_updated_at_unchanged":true},"terminal":{"duplicate_left_updated_at_unchanged":true,"conflicting_kind_status":409}}
```

- **Limits:** legacy persisted shapes are injected and verified in the focused Durable Object storage tests; the public HTTP API does not expose raw projection-row mutation. No production queue action, dispatch, retry, cancellation, or deployment was performed.
