### PR TITLE
ci(state): schedule record snapshots every 6 hours

### DIFF
--- a/.github/workflows/worker-records-ops.yml
+++ b/.github/workflows/worker-records-ops.yml
@@ -1,6 +1,8 @@
 name: Snapshot canonical Worker records
 
 on:
+  schedule:
+    - cron: "9 */6 * * *"
   workflow_dispatch:
     inputs:
       target_repo:
@@ -9,7 +11,7 @@ on:
         type: string
 
 concurrency:
-  group: worker-records-snapshot-${{ inputs.target_repo }}
+  group: worker-records-snapshot
   cancel-in-progress: false
 
 permissions:
@@ -36,7 +38,7 @@ jobs:
       - name: Resolve target record slug
         id: target
         env:
-          TARGET_REPO: ${{ inputs.target_repo }}
+          TARGET_REPO: ${{ github.event_name == 'schedule' && 'openclaw/openclaw' || inputs.target_repo }}
         run: |
           if ! [[ "$TARGET_REPO" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
             echo "target_repo must be owner/name" >&2

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -471,6 +471,12 @@ counts but are not serialized by the public projector. Document effective
 production values from `dashboard/wrangler.toml`, not only fallback constants
 in `dashboard/exact-review-queue.ts`.
 
+Canonical record snapshots for `openclaw/openclaw` are produced every six hours
+by `worker-records-ops.yml`, at minute 9 UTC. Manual dispatch remains available
+for a selected repository; scheduled and manual snapshots share a concurrency
+group so snapshot runs do not overlap. Full record hydration replays changes
+since the latest snapshot.
+
 Batch publication heartbeats retry network errors, timeouts, and HTTP 5xx
 responses (including `exact_review_queue_unavailable`) up to three attempts
 within 45 seconds, with at most 20 seconds per attempt. Heartbeat retries

--- a/test/canonical-state-readers.test.ts
+++ b/test/canonical-state-readers.test.ts
@@ -53,3 +53,33 @@ test("canonical record operations retain snapshot only", () => {
     assert.throws(() => readFileSync(retiredWorkflow, "utf8"));
   }
 });
+
+test("canonical record snapshots run every six hours without cancelling an active snapshot", () => {
+  const workflow = parse(readFileSync(".github/workflows/worker-records-ops.yml", "utf8"));
+  assert.deepEqual(workflow.on.schedule, [{ cron: "9 */6 * * *" }]);
+  assert.ok(workflow.on.workflow_dispatch.inputs.target_repo);
+  assert.deepEqual(workflow.concurrency, {
+    group: "worker-records-snapshot",
+    "cancel-in-progress": false,
+  });
+});
+
+test("scheduled canonical record snapshots use the manual apply path for OpenClaw", () => {
+  const workflow = parse(readFileSync(".github/workflows/worker-records-ops.yml", "utf8"));
+  const job = workflow.jobs.snapshot;
+  assert.equal(job.if, undefined);
+  const target = job.steps.find((step: { id?: string }) => step.id === "target");
+  assert.equal(
+    target.env.TARGET_REPO,
+    "${{ github.event_name == 'schedule' && 'openclaw/openclaw' || inputs.target_repo }}",
+  );
+  const trigger = job.steps.find(
+    (step: { name?: string }) => step.name === "Trigger canonical records snapshot",
+  );
+  assert.equal(trigger.if, undefined);
+  assert.equal(trigger.env.TARGET_SLUG, "${{ steps.target.outputs.slug }}");
+  assert.match(trigger.run, /await signedPost\(/);
+  assert.match(trigger.run, /path: "\/internal\/state\/records\/snapshots\/trigger"/);
+  assert.match(trigger.run, /body: \{ repoSlug: process.env.TARGET_SLUG \}/);
+  assert.doesNotMatch(trigger.run, /dry.run|inputs\./i);
+});


### PR DESCRIPTION
## What Problem This Solves

Partially addresses https://github.com/openclaw/clawsweeper/issues/1372. Batch publication runs [33713603453](https://github.com/openclaw/clawsweeper/actions/runs/33713603453) and [33714125567](https://github.com/openclaw/clawsweeper/actions/runs/33714125567) replayed approximately 111,000 changed records from snapshot revision 49,199. Snapshots currently require manual dispatch, so full hydration repeatedly pays for a large delta.

## Why

Refresh the snapshot base every six hours using the existing snapshot implementation. This reduces the opportunity for the export delta to accumulate; production cost and latency have not been measured by this change.

The requested focused batch hydration is **stopped under the work order's backfill-prior-record condition**. A controlled reproduction seeded a backfill-only `closed/101.md` in the actual SQLite store. Full hydration retained it; the existing focused GET returned `record_not_found`. Feeding those trees to the publisher's pre-effect check changed the outcome from `remote-closed` with zero effect callbacks to `open` with one callback. The callback was a local counter, with no GitHub request. Enabling focused hydration would therefore change stale-event semantics until backfill visibility is addressed. Batch claim, batch workflow, hydrator, and Durable Object code remain unchanged.

The dependency is explicit: `scripts/worker-records.ts` full hydration materializes export records; `dashboard/exact-review-direct-publication.ts` export reconstruction supports the backfill table; the GET route in `dashboard/exact-review-queue.ts` calls only `readCanonical`; and `src/repair/publish-event-result.ts` calls `captureEventBaseSnapshot` before `applyEventSnapshotIfCurrent` in `src/repair/event-record-store.ts`.

## What Changed

- Schedule `worker-records-ops.yml` at `9 */6 * * *`, avoiding the existing cron minutes. Scheduled runs target `openclaw/openclaw`.
- Preserve manual repository selection and the existing signed snapshot-trigger POST. There is no dry-run/apply switch; both triggers perform snapshot creation.
- Serialize all snapshot runs with `worker-records-snapshot` and `cancel-in-progress: false`.
- Add workflow-definition coverage and document the snapshot cadence. No changelog change.

## pr-behavior-proof

Claim: the scheduled and manual paths execute the same snapshot-producing command with their intended repository slugs. Surface: actual YAML shell steps, signed HTTP client, Worker routes, SQLite-backed queue store, and snapshot tar/gzip implementation. Environment: local macOS, Node v26.8.1, loopback HTTP, memory-backed R2 adapter; provider `local-host`, no lease or container image. Crabbox is unavailable on this host. No live workflow was dispatched.

Source head: `2802129356da343d90a3498d02015718bdac6417`. Command: `node .artifacts/records-snapshot-proof.ts`. The harness executes the target-resolution and trigger shell steps extracted from the workflow, then verifies the stored gzip/tar bytes. Scheduled OpenClaw snapshot: HTTP 201, revision 2, 2 files, 235 bytes. Manual ClawHub snapshot: HTTP 201, revision 3, 1 file, 142 bytes. Both archives contained the synthetic fixture. The same harness records the backfill stale-check divergence described above. Artifacts: `.artifacts/records-snapshot-proof.ts`, `.artifacts/records-snapshot-proof.json`, and `.artifacts/records-snapshot-proof.log` in the task worktree. GitHub scheduler timing and concurrency enforcement are checked structurally, not exercised live; this is not Cloudflare CPU or production-backfill inventory proof.

Both new workflow tests failed on the original workflow and passed after the change:

- `canonical record snapshots run every six hours without cancelling an active snapshot`
- `scheduled canonical record snapshots use the manual apply path for OpenClaw`

Validation: `pnpm run format`; `pnpm run build:all`; `pnpm run lint`; `pnpm run check:docs`; `pnpm run check:limits`; `git diff --check`; `pnpm run build:repair && node scripts/run-node-tests.mjs repair`; `node --test test/repair/focused-state-hydration.test.ts test/repair/exact-review-batch-cli.test.ts test/repair/exact-review-batch-workflow.test.ts`; `node --test test/canonical-state-readers.test.ts`; `pnpm run check`. All explicitly requested gates passed: repair suite 1,373 passed / 7 skipped, selected three-file suite 56 passed, snapshot workflow tests 5 passed. The additional repository-wide `pnpm run check` passed: 4,693 passed / 9 skipped / 0 failures, with coverage thresholds satisfied. [Exact-head CI](https://github.com/openclaw/clawsweeper/actions/runs/33813015217) passed for `2802129356da343d90a3498d02015718bdac6417`; no CI fix or retry was needed. Independent pre-commit review: clean through P2.

**OpenClaw Bay is unaffected.** This changes private snapshot production only. Public projections, lifecycle/status contracts, and observer-only navigation are unchanged, so no Bay change or new Bay proof is needed.
