### PR TITLE
perf(queue): cut per-request CPU in the exact-review queue object

### DIFF
--- a/dashboard/exact-review-direct-publication.ts
+++ b/dashboard/exact-review-direct-publication.ts
@@ -997,6 +997,15 @@ export class ExactReviewDirectPublicationStore {
     return row ? this.recordExportEntrySync(row) : null;
   }
 
+  count(): number {
+    const row = Array.from(
+      this.storage.sql.exec(
+        `SELECT COUNT(*) AS count FROM ${EXACT_REVIEW_DIRECT_PUBLICATION_TABLE}`,
+      ),
+    )[0];
+    return Number(row?.count ?? 0);
+  }
+
   list(): DirectPublicationRow[] {
     return Array.from(
       this.storage.sql.exec(

--- a/dashboard/exact-review-lifecycle.ts
+++ b/dashboard/exact-review-lifecycle.ts
@@ -260,6 +260,13 @@ type LifecycleAdmissionInput = ProjectionIdentity & {
 
 export class ExactReviewLifecycleProjectionStore {
   private readonly storage: DurableStorage;
+  private readonly bayProjectionCache = new Map<
+    string,
+    {
+      json: string;
+      projection: ExactReviewLifecycleProjection;
+    }
+  >();
   private schemaReady = false;
   private auditSchemaReady = false;
 
@@ -956,7 +963,18 @@ export class ExactReviewLifecycleProjectionStore {
           )) {
             let projection: ExactReviewLifecycleProjection;
             try {
-              projection = projectionFromRow(String(row.projection_json || ""));
+              const source = String(row.projection_json || "");
+              const key = JSON.stringify([row.canonical_target_key, row.fence_key, row.revision]);
+              const cached = this.bayProjectionCache.get(key);
+              if (cached?.json === source) projection = cached.projection;
+              else {
+                projection = projectionFromRow(source);
+                this.bayProjectionCache.set(key, { json: source, projection });
+                // Retain only a bounded working set; SQL remains authoritative.
+                if (this.bayProjectionCache.size > 512) {
+                  this.bayProjectionCache.delete(this.bayProjectionCache.keys().next().value!);
+                }
+              }
             } catch {
               return unknown("malformed");
             }
@@ -1003,15 +1021,28 @@ export class ExactReviewLifecycleProjectionStore {
         }
         // Resolve only sampled targets; a newer revision can be arbitrarily
         // old and absent from every retained lane sample.
+        const sampledTargets = [
+          ...new Set(sample.map((card) => `${card.target.repository}#${card.target.number}`)),
+        ];
         const maxRevisionByTarget = new Map<string, number>();
+        if (sampledTargets.length) {
+          for (const row of this.storage.sql.exec(
+            `SELECT canonical_target_key, MAX(revision) AS max_revision
+             FROM ${EXACT_REVIEW_LIFECYCLE_PROJECTION_TABLE}
+             WHERE canonical_target_key IN (SELECT value FROM json_each(?))
+             GROUP BY canonical_target_key`,
+            JSON.stringify(sampledTargets),
+          )) {
+            const revision = Number(row.max_revision || 0);
+            maxRevisionByTarget.set(
+              String(row.canonical_target_key),
+              Number.isSafeInteger(revision) && revision >= 0 ? revision : 0,
+            );
+          }
+        }
         for (const card of sample) {
           const key = `${card.target.repository}#${card.target.number}`;
-          let maxRevision = maxRevisionByTarget.get(key);
-          if (maxRevision === undefined) {
-            maxRevision = this.maxRevision(key);
-            maxRevisionByTarget.set(key, maxRevision);
-          }
-          card.current_revision &&= card.revision === maxRevision;
+          card.current_revision &&= card.revision === (maxRevisionByTarget.get(key) ?? 0);
         }
         return {
           version: 1,

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -485,6 +485,7 @@ type LegacyExactReviewQueueState = ExactReviewQueueState & {
 type ExactReviewQueueBaseline = {
   items: Map<string, string>;
   dispatcherJson: string | null;
+  unreadItems?: Map<string, () => ExactReviewQueueItem>;
 };
 type ExactReviewDeadLetterInsert = {
   id: string;
@@ -834,6 +835,17 @@ export class ExactReviewQueue {
   private githubWebhookReadModelStore;
   private readonly random: () => number;
   private readonly baselines = new WeakMap<ExactReviewQueueState, ExactReviewQueueBaseline>();
+  private statsCache: {
+    key: string;
+    expiresAt: number;
+    body: Promise<string>;
+    changes: number | null;
+  } | null = null;
+
+  private invalidateStatsCache() {
+    this.statsCache = null;
+  }
+
   private reviewCoverageCache: { at: number; summary: ReviewCoverageSummary } | null = null;
   // Back off a wedged Bay row without adding durable queue state. Any durable
   // progress clears this single-slot deadline so the one-second drain resumes.
@@ -901,10 +913,15 @@ export class ExactReviewQueue {
     request: Request,
     hostedTargetMetadataToken = exactReviewHostedTargetMetadataTokenSource(this.env),
   ) {
+    const mutating = request.method !== "GET";
+    if (mutating) this.invalidateStatsCache();
     try {
       return await this.handleFetch(request, hostedTargetMetadataToken);
     } catch (error) {
       rethrowQueueFailure(error, "fetch", request);
+    } finally {
+      // Mutators can yield to a dashboard poll while awaiting external work.
+      if (mutating) this.invalidateStatsCache();
     }
   }
 
@@ -3856,241 +3873,306 @@ export class ExactReviewQueue {
     }
 
     if (request.method === "GET" && url.pathname === "/stats") {
-      const bayPriorityKeys = exactReviewQueueBayPriorityKeys(
-        url.searchParams.getAll("bay_priority_key"),
-      );
-      const bayActiveKeys = exactReviewQueueBayActiveKeys(
-        url.searchParams.getAll("bay_active_key"),
-      );
-      const bayActiveLegacyKeys = exactReviewQueueBayActiveKeys(
-        url.searchParams.getAll("bay_active_legacy_key"),
-      );
-      const now = Date.now();
-      const snapshot = this.storage.transactionSync(() => {
-        this.pruneDeliveryReceiptsSync(now);
-        this.pruneEditedSemanticInputsSync(now);
-        this.pruneQueueTelemetrySync(now);
-        this.pruneReviewRunTelemetrySync(now);
-        const current = this.readStateSync();
-        // Dashboard reads are also the operational heartbeat. Reclaim leases and
-        // restore the alarm here so a deploy or lost alarm cannot strand backlog.
-        const changed = reclaimExpiredExactReviewLeases(
-          current,
-          now,
-          exactReviewPublicationDispatchLeaseMs(this.env),
-          exactReviewHeartbeatGraceMs(this.env),
-          this.env,
-        );
-        if (changed) this.writeStateSync(current);
-        else this.syncLegacyCompatibilitySync(current);
-        return {
-          state: current,
-          metrics: this.queueMetricTotalsSync(),
-          reviewFlow: this.reviewFlowSummarySync(now),
-          reviewFailureHealth: this.reviewFailureHealthSafely(now),
-          publicationFlow: this.publicationFlowSummarySync(now),
-          deadLetters: this.deadLetterStatsSync(),
-          // Full review observability scans up to 10k durable records. Keep it on
-          // the diagnostic endpoint so the frequently-polled status path stays bounded.
-          stateWriter: this.stateWriterSummarySync(now),
-        };
-      });
-      const {
-        state,
-        metrics,
-        reviewFlow,
-        reviewFailureHealth,
-        publicationFlow,
-        deadLetters,
-        stateWriter,
-      } = snapshot;
-      // Coordinator methods own their SQLite transaction. Keep this adjacent to
-      // the queue snapshot without nesting transactionSync calls.
-      const stateWriterCoordinator = this.stateWriterCoordinator.stats(
-        now,
-        stateWriterCoordinatorQueuedStaleMs(this.env),
-      );
-      const publicationBatches = this.batchStore.stats(now);
-      const directPublications = this.directPublicationStore.list();
-      const sourceAuthorityReservations = await this.sourceAuthorityReservations();
-      const branchAuthorityReservations = await this.branchAuthorityReservations();
-      const authorityPendingByOwner = exactReviewAuthorityPendingByOwner([
-        ...sourceAuthorityReservations,
-        ...branchAuthorityReservations,
-      ]);
-      const batchByItemKey = new Map<string, ExactReviewBayBatchOwner>(
-        publicationBatches.activeItemBatches.map((batch) => [batch.itemKey, batch] as const),
-      );
-      const batchOwnedItemKeys = new Set<string>(batchByItemKey.keys());
-      const freshPublicationItemKeys = this.freshPublicationItemKeysSync(state, now);
-      const legacyExcludedItemKeys = new Set(batchOwnedItemKeys);
-      if (exactReviewPublicationBatchingEnabled(this.env)) {
-        for (const item of Object.values(state.items) as ExactReviewQueueItem[]) {
-          if (
-            item.state === "pending" &&
-            exactReviewQueueIsBatchablePublication(item) &&
-            !item.terminalFinalization
-          ) {
-            legacyExcludedItemKeys.add(item.key);
-          }
-        }
-      }
-      const publicationControl = this.refreshPublicationControlSync(state, now);
-      await this.scheduleNext(state, now);
-      const stats = exactReviewQueueStats(
-        state,
-        now,
-        exactReviewQueueCapacity(this.env),
-        exactReviewTargetCapacity(this.env),
-        exactReviewPublicationCapacityForState(
-          this.env,
-          state,
-          now,
-          publicationControl.capacityCeiling,
-          true,
-          publicationControl.demandCapacity,
-        ),
-        exactReviewDispatchLeaseMs(this.env),
-        exactReviewExecutionLeaseMs(this.env),
-        exactReviewPublicationDispatchLeaseMs(this.env),
-        exactReviewHeartbeatGraceMs(this.env),
-        legacyExcludedItemKeys,
-        publicationBatches.nextLeaseExpiresAt,
-      );
-      const publicationHealth = summarizeExactReviewPublicationHealth(
-        stats.lanes.publication,
-        publicationFlow,
-      );
-      const reservationClaimObservability = exactReviewReservationClaimObservability({
-        now,
-        dispatcher: state.dispatcher,
-        publication: stats.lanes.publication,
-        batches: this.batchStore.observability(now).batches,
-        directPublicationEnabled: exactReviewDirectPublicationEnabled(this.env),
-        legacyStateRepoBatchEnabled: exactReviewPublicationBatchingEnabled(this.env),
-        maxConcurrentBatches: exactReviewPublicationBatchMaxConcurrent(this.env),
-      });
-      const bayProjection = exactReviewQueueBayProjectionFromStats(
-        stats,
-        bayPriorityKeys,
-        batchByItemKey,
-        bayActiveKeys,
-        bayActiveLegacyKeys,
-      );
-      return json({
-        ...stats,
-        bay_projection: bayProjection,
-        review_failure_health: reviewFailureHealth,
-        lanes: {
-          review: {
-            ...stats.lanes.review,
-            enqueued_total: metrics.review.enqueued,
-            completed_total: metrics.review.completed,
-            superseded_total: metrics.review.superseded,
-            semantic_deduped_total: metrics.review.semanticDeduped,
-            shed_reasons_since_reset: {
-              backpressure: metrics.review.shedBackpressure,
-              scheduled_rate: metrics.review.shedScheduledRate,
-              unattributed: Math.max(0, exactReviewShedSinceReset(state) - metrics.review.shed),
-            },
-            authority_pending: {
-              total: sourceAuthorityReservations.length + branchAuthorityReservations.length,
-              branch_resolution: branchAuthorityReservations.length,
-              source_verification: sourceAuthorityReservations.length,
-            },
-            flow: reviewFlow,
-          },
-          publication: {
-            ...stats.lanes.publication,
-            pending: stats.lanes.publication.pending,
-            enqueued_total: metrics.publication.enqueued,
-            completed_total: metrics.publication.completed,
-            published_total: metrics.publication.published,
-            superseded_total: metrics.publication.superseded,
-            semantic_deduped_total: metrics.publication.semanticDeduped,
-            retried_total: metrics.publication.retried,
-            dead_lettered_total: metrics.publication.deadLettered,
-            refreshed_total: metrics.publication.refreshed,
-            flow: publicationFlow,
-            dead_letters: deadLetters,
-            health: publicationHealth,
-            capacity_control: exactReviewPublicationControlStatus(this.env, publicationControl),
-            credential_circuits: exactReviewGithubCredentialCircuitStatus(
-              state,
-              now,
-              authorityPendingByOwner,
-            ),
-            github_request_metrics: {
-              updated_at: state.dispatcher?.githubRequestMetrics?.updatedAt
-                ? new Date(state.dispatcher.githubRequestMetrics.updatedAt).toISOString()
-                : null,
-              counters: state.dispatcher?.githubRequestMetrics?.counters || {},
-            },
-            github_egress_metrics_v2: this.githubEgressTelemetryStore.publicSummary(now),
-            batches: {
-              enabled: exactReviewPublicationBatchingEnabled(this.env),
-              max_items: exactReviewPublicationBatchSize(this.env),
-              max_concurrent: exactReviewPublicationBatchMaxConcurrent(this.env),
-              max_wait_seconds: exactReviewPublicationBatchWaitMs(this.env) / 1_000,
-              fresh_lane: {
-                enabled: exactReviewPublicationFreshLaneMaxItems(this.env) > 0,
-                reserved_items: exactReviewPublicationFreshLaneMaxItems(this.env),
-                max_age_seconds: exactReviewPublicationFreshLaneMaxAgeMs(this.env) / 1_000,
-                ready_items: freshPublicationItemKeys.size,
-                historical_ready_items: Math.max(
-                  0,
-                  stats.lanes.publication.ready - freshPublicationItemKeys.size,
-                ),
-              },
-              last_dispatch_at: state.dispatcher?.publicationBatchDispatchedAt
-                ? new Date(state.dispatcher.publicationBatchDispatchedAt).toISOString()
-                : null,
-              last_dispatch_succeeded: state.dispatcher?.publicationBatchDispatchSucceeded ?? null,
-              dispatch_pending_until: state.dispatcher?.publicationBatchDispatchPendingUntil
-                ? new Date(state.dispatcher.publicationBatchDispatchPendingUntil).toISOString()
-                : null,
-              leased: publicationBatches.leased,
-              completed: publicationBatches.completed,
-              expired: publicationBatches.expired,
-              active_items: publicationBatches.activeItems,
-              oldest_active_at:
-                publicationBatches.oldestActiveAt === null
-                  ? null
-                  : new Date(publicationBatches.oldestActiveAt).toISOString(),
-              oldest_active_age_seconds:
-                publicationBatches.oldestActiveAt === null
-                  ? null
-                  : Math.max(0, Math.floor((now - publicationBatches.oldestActiveAt) / 1000)),
-              reclaimed_items_retained: publicationBatches.reclaimedItemsRetained,
-              cleanup: {
-                deleted_this_pass: publicationBatches.cleanup.deletedThisPass,
-                eligible_remaining: publicationBatches.cleanup.eligibleRemaining,
-                limit: publicationBatches.cleanup.limit,
-              },
-            },
-            direct: {
-              enabled: exactReviewDirectPublicationEnabled(this.env),
-              health: { status: "healthy", store: "durable_object_sqlite" },
-              pending: 0,
-              retryable: 0,
-              failed: 0,
-              retained_receipts: directPublications.length,
-              oldest_pending_at: null,
-            },
-          },
-        },
-        delivery_receipts: this.deliveryReceiptCountSync(),
-        scheduled_feed: this.scheduledReviewFeedStatusSync(now),
-        reservation_claim_observability: reservationClaimObservability,
-        state_writer: { ...stateWriter, coordinator: stateWriterCoordinator },
-        storage_schema_version: EXACT_REVIEW_QUEUE_STORAGE_SCHEMA_VERSION,
-        legacy_rollback_available:
-          !this.legacyMirrorDisabled &&
-          now < this.migratedAt + EXACT_REVIEW_QUEUE_LEGACY_ROLLBACK_MS,
-      });
+      return this.statsResponse(url);
     }
 
     return new Response("not found", { status: 404 });
+  }
+
+  private storageChangeCountSync(): number {
+    return Number(
+      Array.from(
+        this.storage.sql.exec("SELECT total_changes() AS changes") as Iterable<{ changes: number }>,
+      )[0]?.changes,
+    );
+  }
+
+  private async statsResponse(url: URL) {
+    const configured = Number(this.env.EXACT_REVIEW_STATS_CACHE_MS ?? 10_000);
+    const ttl = Number.isFinite(configured) && configured >= 0 ? configured : 10_000;
+    if (!ttl) return this.computeStatsResponse(url);
+    // These parameters change the private Bay sample, so never share their responses.
+    const key = JSON.stringify([
+      exactReviewQueueBayPriorityKeys(url.searchParams.getAll("bay_priority_key")),
+      exactReviewQueueBayActiveKeys(url.searchParams.getAll("bay_active_key")),
+      exactReviewQueueBayActiveKeys(url.searchParams.getAll("bay_active_legacy_key")),
+    ]);
+    const now = Date.now();
+    let cached = this.statsCache;
+    if (cached && cached.changes !== null) {
+      const alarm = await this.storage.getAlarm();
+      // Another poll may have renewed the entry while the alarm read yielded.
+      // Join that replacement, including its in-flight alarm repair.
+      cached = this.statsCache;
+      if (
+        cached &&
+        cached.changes !== null &&
+        (cached.changes !== this.storageChangeCountSync() ||
+          (alarm !== null && alarm <= now) ||
+          (alarm === null && this.scheduledAlarmDecision !== null))
+      )
+        cached = null;
+    }
+    if (!cached || cached.key !== key || cached.expiresAt <= now) {
+      const entry = {
+        key,
+        expiresAt: now + ttl,
+        body: Promise.resolve(""),
+        changes: null as number | null,
+      };
+      cached = entry;
+      this.statsCache = entry;
+      entry.body = this.computeStatsResponse(url).then(async (response) => {
+        const body = await response.text();
+        entry.changes = this.storageChangeCountSync();
+        return body;
+      });
+    }
+    try {
+      return cors(
+        new Response(await cached.body, {
+          headers: {
+            "content-type": "application/json; charset=utf-8",
+            "cache-control": "no-store",
+          },
+        }),
+      );
+    } catch (error) {
+      if (this.statsCache === cached) this.invalidateStatsCache();
+      throw error;
+    }
+  }
+
+  private async computeStatsResponse(url: URL) {
+    const bayPriorityKeys = exactReviewQueueBayPriorityKeys(
+      url.searchParams.getAll("bay_priority_key"),
+    );
+    const bayActiveKeys = exactReviewQueueBayActiveKeys(url.searchParams.getAll("bay_active_key"));
+    const bayActiveLegacyKeys = exactReviewQueueBayActiveKeys(
+      url.searchParams.getAll("bay_active_legacy_key"),
+    );
+    const now = Date.now();
+    const snapshot = this.storage.transactionSync(() => {
+      this.pruneDeliveryReceiptsSync(now);
+      this.pruneEditedSemanticInputsSync(now);
+      this.pruneQueueTelemetrySync(now);
+      this.pruneReviewRunTelemetrySync(now);
+      const current = this.readStateSync();
+      // Dashboard reads are also the operational heartbeat. Reclaim leases and
+      // restore the alarm here so a deploy or lost alarm cannot strand backlog.
+      const changed = reclaimExpiredExactReviewLeases(
+        current,
+        now,
+        exactReviewPublicationDispatchLeaseMs(this.env),
+        exactReviewHeartbeatGraceMs(this.env),
+        this.env,
+      );
+      if (changed) this.writeStateSync(current);
+      else this.syncLegacyCompatibilitySync(current);
+      return {
+        state: current,
+        metrics: this.queueMetricTotalsSync(),
+        reviewFlow: this.reviewFlowSummarySync(now),
+        reviewFailureHealth: this.reviewFailureHealthSafely(now),
+        publicationFlow: this.publicationFlowSummarySync(now),
+        deadLetters: this.deadLetterStatsSync(),
+        // Full review observability scans up to 10k durable records. Keep it on
+        // the diagnostic endpoint so the frequently-polled status path stays bounded.
+        stateWriter: this.stateWriterSummarySync(now),
+      };
+    });
+    const {
+      state,
+      metrics,
+      reviewFlow,
+      reviewFailureHealth,
+      publicationFlow,
+      deadLetters,
+      stateWriter,
+    } = snapshot;
+    // Coordinator methods own their SQLite transaction. Keep this adjacent to
+    // the queue snapshot without nesting transactionSync calls.
+    const stateWriterCoordinator = this.stateWriterCoordinator.stats(
+      now,
+      stateWriterCoordinatorQueuedStaleMs(this.env),
+    );
+    const publicationBatches = this.batchStore.stats(now);
+    const directPublicationCount = this.directPublicationStore.count();
+    const sourceAuthorityReservations = await this.sourceAuthorityReservations();
+    const branchAuthorityReservations = await this.branchAuthorityReservations();
+    const authorityPendingByOwner = exactReviewAuthorityPendingByOwner([
+      ...sourceAuthorityReservations,
+      ...branchAuthorityReservations,
+    ]);
+    const batchByItemKey = new Map<string, ExactReviewBayBatchOwner>(
+      publicationBatches.activeItemBatches.map((batch) => [batch.itemKey, batch] as const),
+    );
+    const batchOwnedItemKeys = new Set<string>(batchByItemKey.keys());
+    const freshPublicationItemKeys = this.freshPublicationItemKeysSync(state, now);
+    const legacyExcludedItemKeys = new Set(batchOwnedItemKeys);
+    if (exactReviewPublicationBatchingEnabled(this.env)) {
+      for (const item of Object.values(state.items) as ExactReviewQueueItem[]) {
+        if (
+          item.state === "pending" &&
+          exactReviewQueueIsBatchablePublication(item) &&
+          !item.terminalFinalization
+        ) {
+          legacyExcludedItemKeys.add(item.key);
+        }
+      }
+    }
+    const publicationControl = this.refreshPublicationControlSync(state, now);
+    await this.scheduleNext(state, now);
+    const stats = exactReviewQueueStats(
+      state,
+      now,
+      exactReviewQueueCapacity(this.env),
+      exactReviewTargetCapacity(this.env),
+      exactReviewPublicationCapacityForState(
+        this.env,
+        state,
+        now,
+        publicationControl.capacityCeiling,
+        true,
+        publicationControl.demandCapacity,
+      ),
+      exactReviewDispatchLeaseMs(this.env),
+      exactReviewExecutionLeaseMs(this.env),
+      exactReviewPublicationDispatchLeaseMs(this.env),
+      exactReviewHeartbeatGraceMs(this.env),
+      legacyExcludedItemKeys,
+      publicationBatches.nextLeaseExpiresAt,
+    );
+    const publicationHealth = summarizeExactReviewPublicationHealth(
+      stats.lanes.publication,
+      publicationFlow,
+    );
+    const reservationClaimObservability = exactReviewReservationClaimObservability({
+      now,
+      dispatcher: state.dispatcher,
+      publication: stats.lanes.publication,
+      batches: this.batchStore.observability(now).batches,
+      directPublicationEnabled: exactReviewDirectPublicationEnabled(this.env),
+      legacyStateRepoBatchEnabled: exactReviewPublicationBatchingEnabled(this.env),
+      maxConcurrentBatches: exactReviewPublicationBatchMaxConcurrent(this.env),
+    });
+    const bayProjection = exactReviewQueueBayProjectionFromStats(
+      stats,
+      bayPriorityKeys,
+      batchByItemKey,
+      bayActiveKeys,
+      bayActiveLegacyKeys,
+    );
+    return json({
+      ...stats,
+      bay_projection: bayProjection,
+      review_failure_health: reviewFailureHealth,
+      lanes: {
+        review: {
+          ...stats.lanes.review,
+          enqueued_total: metrics.review.enqueued,
+          completed_total: metrics.review.completed,
+          superseded_total: metrics.review.superseded,
+          semantic_deduped_total: metrics.review.semanticDeduped,
+          shed_reasons_since_reset: {
+            backpressure: metrics.review.shedBackpressure,
+            scheduled_rate: metrics.review.shedScheduledRate,
+            unattributed: Math.max(0, exactReviewShedSinceReset(state) - metrics.review.shed),
+          },
+          authority_pending: {
+            total: sourceAuthorityReservations.length + branchAuthorityReservations.length,
+            branch_resolution: branchAuthorityReservations.length,
+            source_verification: sourceAuthorityReservations.length,
+          },
+          flow: reviewFlow,
+        },
+        publication: {
+          ...stats.lanes.publication,
+          pending: stats.lanes.publication.pending,
+          enqueued_total: metrics.publication.enqueued,
+          completed_total: metrics.publication.completed,
+          published_total: metrics.publication.published,
+          superseded_total: metrics.publication.superseded,
+          semantic_deduped_total: metrics.publication.semanticDeduped,
+          retried_total: metrics.publication.retried,
+          dead_lettered_total: metrics.publication.deadLettered,
+          refreshed_total: metrics.publication.refreshed,
+          flow: publicationFlow,
+          dead_letters: deadLetters,
+          health: publicationHealth,
+          capacity_control: exactReviewPublicationControlStatus(this.env, publicationControl),
+          credential_circuits: exactReviewGithubCredentialCircuitStatus(
+            state,
+            now,
+            authorityPendingByOwner,
+          ),
+          github_request_metrics: {
+            updated_at: state.dispatcher?.githubRequestMetrics?.updatedAt
+              ? new Date(state.dispatcher.githubRequestMetrics.updatedAt).toISOString()
+              : null,
+            counters: state.dispatcher?.githubRequestMetrics?.counters || {},
+          },
+          github_egress_metrics_v2: this.githubEgressTelemetryStore.publicSummary(now),
+          batches: {
+            enabled: exactReviewPublicationBatchingEnabled(this.env),
+            max_items: exactReviewPublicationBatchSize(this.env),
+            max_concurrent: exactReviewPublicationBatchMaxConcurrent(this.env),
+            max_wait_seconds: exactReviewPublicationBatchWaitMs(this.env) / 1_000,
+            fresh_lane: {
+              enabled: exactReviewPublicationFreshLaneMaxItems(this.env) > 0,
+              reserved_items: exactReviewPublicationFreshLaneMaxItems(this.env),
+              max_age_seconds: exactReviewPublicationFreshLaneMaxAgeMs(this.env) / 1_000,
+              ready_items: freshPublicationItemKeys.size,
+              historical_ready_items: Math.max(
+                0,
+                stats.lanes.publication.ready - freshPublicationItemKeys.size,
+              ),
+            },
+            last_dispatch_at: state.dispatcher?.publicationBatchDispatchedAt
+              ? new Date(state.dispatcher.publicationBatchDispatchedAt).toISOString()
+              : null,
+            last_dispatch_succeeded: state.dispatcher?.publicationBatchDispatchSucceeded ?? null,
+            dispatch_pending_until: state.dispatcher?.publicationBatchDispatchPendingUntil
+              ? new Date(state.dispatcher.publicationBatchDispatchPendingUntil).toISOString()
+              : null,
+            leased: publicationBatches.leased,
+            completed: publicationBatches.completed,
+            expired: publicationBatches.expired,
+            active_items: publicationBatches.activeItems,
+            oldest_active_at:
+              publicationBatches.oldestActiveAt === null
+                ? null
+                : new Date(publicationBatches.oldestActiveAt).toISOString(),
+            oldest_active_age_seconds:
+              publicationBatches.oldestActiveAt === null
+                ? null
+                : Math.max(0, Math.floor((now - publicationBatches.oldestActiveAt) / 1000)),
+            reclaimed_items_retained: publicationBatches.reclaimedItemsRetained,
+            cleanup: {
+              deleted_this_pass: publicationBatches.cleanup.deletedThisPass,
+              eligible_remaining: publicationBatches.cleanup.eligibleRemaining,
+              limit: publicationBatches.cleanup.limit,
+            },
+          },
+          direct: {
+            enabled: exactReviewDirectPublicationEnabled(this.env),
+            health: { status: "healthy", store: "durable_object_sqlite" },
+            pending: 0,
+            retryable: 0,
+            failed: 0,
+            retained_receipts: directPublicationCount,
+            oldest_pending_at: null,
+          },
+        },
+      },
+      delivery_receipts: this.deliveryReceiptCountSync(),
+      scheduled_feed: this.scheduledReviewFeedStatusSync(now),
+      reservation_claim_observability: reservationClaimObservability,
+      state_writer: { ...stateWriter, coordinator: stateWriterCoordinator },
+      storage_schema_version: EXACT_REVIEW_QUEUE_STORAGE_SCHEMA_VERSION,
+      legacy_rollback_available:
+        !this.legacyMirrorDisabled && now < this.migratedAt + EXACT_REVIEW_QUEUE_LEGACY_ROLLBACK_MS,
+    });
   }
 
   private readLifecycleAuditInventory(input: unknown) {
@@ -4189,6 +4271,15 @@ export class ExactReviewQueue {
   }
 
   async alarm() {
+    this.invalidateStatsCache();
+    try {
+      await this.handleAlarm();
+    } finally {
+      this.invalidateStatsCache();
+    }
+  }
+
+  private async handleAlarm() {
     await this.ensureReady();
     this.cleanupLegacyCompatibilitySync();
     const startedAt = Date.now();
@@ -4268,6 +4359,7 @@ export class ExactReviewQueue {
       true,
       snapshotPublicationControl.demandCapacity,
     );
+    let snapshotHeads = this.publicationHeadsSync(snapshot);
     let snapshotAdmission = exactReviewQueueAdmittedItems(
       snapshot,
       startedAt,
@@ -4283,8 +4375,8 @@ export class ExactReviewQueue {
       startedAt,
       new Set(snapshotBatchOwnership.itemKeys),
       snapshotBatchOwnership.activeBatches,
-      this.freshPublicationItemKeysSync(snapshot, startedAt),
-      this.supersededPublicationItemKeysSync(snapshot),
+      this.freshPublicationItemKeysSync(snapshot, startedAt, snapshotHeads),
+      this.supersededPublicationItemKeysSync(snapshot, snapshotHeads),
     );
     let snapshotBatchCandidates = snapshotBatchDeparture?.due
       ? this.publicationBatchCandidates(
@@ -4325,6 +4417,7 @@ export class ExactReviewQueue {
       // change gets a new departure and therefore a new probe.
       const recheckedAt = Date.now();
       snapshot = this.readStateSync();
+      snapshotHeads = this.publicationHeadsSync(snapshot);
       snapshotBatchOwnership = this.batchStore.activeLeaseSnapshot(recheckedAt);
       snapshotPublicationControl = this.refreshPublicationControlSync(snapshot, recheckedAt);
       snapshotPublicationCapacity = exactReviewPublicationCapacityForState(
@@ -4351,8 +4444,8 @@ export class ExactReviewQueue {
         recheckedAt,
         new Set(snapshotBatchOwnership.itemKeys),
         snapshotBatchOwnership.activeBatches,
-        this.freshPublicationItemKeysSync(snapshot, recheckedAt),
-        this.supersededPublicationItemKeysSync(snapshot),
+        this.freshPublicationItemKeysSync(snapshot, recheckedAt, snapshotHeads),
+        this.supersededPublicationItemKeysSync(snapshot, snapshotHeads),
       );
       snapshotBatchCandidates = snapshotBatchDeparture?.due
         ? this.publicationBatchCandidates(
@@ -6235,6 +6328,7 @@ export class ExactReviewQueue {
   private stalePublicationCandidatesSync(
     state: ExactReviewQueueState,
     activeBatchItemKeys: ReadonlySet<string>,
+    heads = this.publicationHeadsSync(state),
   ) {
     const newestByTarget = new Map<string, number>();
     const versioned = Object.values(state.items).flatMap((item) => {
@@ -6244,8 +6338,7 @@ export class ExactReviewQueue {
       newestByTarget.set(
         revision.targetKey,
         Math.max(
-          newestByTarget.get(revision.targetKey) ??
-            this.publicationHeadRevisionSync(revision.targetKey),
+          newestByTarget.get(revision.targetKey) ?? heads.get(revision.targetKey) ?? 0,
           revision.sourceRevision,
         ),
       );
@@ -7329,6 +7422,7 @@ export class ExactReviewQueue {
       return json({ error: "invalid_failure_fingerprint" }, 400);
     }
     let acceptedCount = 0;
+    let completedState: ExactReviewQueueState | undefined;
     const requestedByFence = new Map(
       completions.map(
         (completion) =>
@@ -7370,6 +7464,7 @@ export class ExactReviewQueue {
         acceptedCount = accepted.length;
         if (!accepted.length) return;
         const state = this.readStateSync();
+        completedState = state;
         let published = 0;
         let superseded = 0;
         let completed = 0;
@@ -7675,7 +7770,11 @@ export class ExactReviewQueue {
       batch = this.batchStore.recordGithubThrottle(batchId, leaseOwner, now) ?? batch;
     }
     this.recordStateWriterOperationSafely(stateWriter, false, now);
-    if (acceptedCount || telemetryApplied) await this.scheduleNext(this.readStateSync(), now);
+    if (acceptedCount || telemetryApplied)
+      await this.scheduleNext(
+        !telemetrySubmitted && completedState ? completedState : this.readSchedulingStateSync(),
+        now,
+      );
     return json({
       ok: true,
       accepted: acceptedCount,
@@ -8393,6 +8492,7 @@ export class ExactReviewQueue {
     }
     try {
       const now = Date.now();
+      let state: ExactReviewQueueState | undefined;
       const result = this.storage.transactionSync(() => {
         const existing = this.lifecycleProjectionStore.read(
           identity.canonicalTargetKey,
@@ -8425,7 +8525,7 @@ export class ExactReviewQueue {
           kind: "review_completed_routed",
           observedAt: now,
         }).projection;
-        const state = this.readStateSync();
+        state = this.readStateSync();
         const driverChanged = this.ensureLifecycleTerminalFinalizationDriver({
           state,
           projection,
@@ -8437,7 +8537,7 @@ export class ExactReviewQueue {
         return { projection, duplicate: false };
       });
       this.syncBayLifecycle(result.projection);
-      await this.scheduleNext(this.readStateSync(), now);
+      await this.scheduleNext(state ?? this.readSchedulingStateSync(), now);
       return json({
         ok: true,
         lifecycle_state: lifecycleState(result.projection),
@@ -8696,7 +8796,7 @@ export class ExactReviewQueue {
         statusCommentId,
         observedAt: now,
       });
-      await this.scheduleNext(state, now);
+      await this.scheduleNext(this.readSchedulingStateSync(), now);
       return json({
         ok: true,
         allowed: result.allowed,
@@ -9114,14 +9214,38 @@ export class ExactReviewQueue {
     return Number(row?.source_revision || 0);
   }
 
-  private supersededPublicationItemKeysSync(state: ExactReviewQueueState) {
+  private publicationHeadsSync(state: ExactReviewQueueState): ReadonlyMap<string, number> {
+    const targets = [
+      ...new Set(
+        Object.values(state.items).flatMap((item) => {
+          const revision = exactReviewPublicationRevision(item.decision);
+          return revision ? [revision.targetKey] : [];
+        }),
+      ),
+    ];
+    if (!targets.length) return new Map();
+    return new Map(
+      Array.from(
+        this.storage.sql.exec(
+          `SELECT target_key, source_revision FROM ${EXACT_REVIEW_PUBLICATION_HEAD_TABLE}
+       WHERE target_key IN (SELECT value FROM json_each(?))`,
+          JSON.stringify(targets),
+        ) as Iterable<{ target_key: string; source_revision: number }>,
+        (row) => [row.target_key, Number(row.source_revision)],
+      ),
+    );
+  }
+
+  private supersededPublicationItemKeysSync(
+    state: ExactReviewQueueState,
+    heads = this.publicationHeadsSync(state),
+  ) {
     // Active batch ownership can preserve an older row after a newer head lands.
     // Departure and claim must exclude that same row when ownership expires.
     return new Set(
       Object.values(state.items).flatMap((item) => {
         const revision = exactReviewPublicationRevision(item.decision);
-        return revision &&
-          revision.sourceRevision < this.publicationHeadRevisionSync(revision.targetKey)
+        return revision && revision.sourceRevision < (heads.get(revision.targetKey) ?? 0)
           ? [item.key]
           : [];
       }),
@@ -9142,7 +9266,11 @@ export class ExactReviewQueue {
     );
   }
 
-  private freshPublicationItemKeysSync(state: ExactReviewQueueState, now: number) {
+  private freshPublicationItemKeysSync(
+    state: ExactReviewQueueState,
+    now: number,
+    heads = this.publicationHeadsSync(state),
+  ) {
     const reserve = exactReviewPublicationFreshLaneMaxItems(this.env);
     if (!reserve) return new Set<string>();
     const cutoff = now - exactReviewPublicationFreshLaneMaxAgeMs(this.env);
@@ -9158,8 +9286,7 @@ export class ExactReviewQueue {
           return [];
         }
         const revision = exactReviewPublicationRevision(item.decision);
-        return revision &&
-          revision.sourceRevision >= this.publicationHeadRevisionSync(revision.targetKey)
+        return revision && revision.sourceRevision >= (heads.get(revision.targetKey) ?? 0)
           ? [item.key]
           : [];
       }),
@@ -10007,6 +10134,35 @@ export class ExactReviewQueue {
     return { generation, receipts };
   }
 
+  private readonly schedulingStates = new WeakSet<ExactReviewQueueState>();
+
+  private readSchedulingStateSync(): ExactReviewQueueState {
+    const meta = this.readStorageMetaSync();
+    if (!meta || Number(meta.schema_version) !== EXACT_REVIEW_QUEUE_STORAGE_SCHEMA_VERSION) {
+      throw new Error("exact-review queue storage is not initialized");
+    }
+    const items: Record<string, ExactReviewQueueItem> = {};
+    for (const row of this.storage.sql.exec(
+      `SELECT item_key, json_remove(item_json,
+        '$.leaseDecision', '$.decision.additionalPrompt',
+        '$.decision.publication.producerDecision.additionalPrompt') AS census_json
+       FROM ${EXACT_REVIEW_QUEUE_ITEM_TABLE}`,
+    ) as Iterable<{ item_key: string; census_json: string }>) {
+      const item = JSON.parse(row.census_json) as ExactReviewQueueItem;
+      if (!item || typeof item !== "object" || item.key !== row.item_key) {
+        throw new Error(`invalid exact-review queue item for ${row.item_key}`);
+      }
+      items[row.item_key] = item;
+    }
+    const state: ExactReviewQueueState = {
+      items,
+      dispatcher: meta.dispatcher_json ? JSON.parse(meta.dispatcher_json) : undefined,
+      shedSinceReset: Math.max(0, Number(meta.shed_since_reset || 0)),
+    };
+    this.schedulingStates.add(state);
+    return state;
+  }
+
   private readStateSync(): ExactReviewQueueState {
     const meta = this.readStorageMetaSync();
     if (!meta || Number(meta.schema_version) !== EXACT_REVIEW_QUEUE_STORAGE_SCHEMA_VERSION) {
@@ -10015,19 +10171,39 @@ export class ExactReviewQueue {
 
     const items: Record<string, ExactReviewQueueItem> = {};
     const baselineItems = new Map<string, string>();
+    const unreadItems = new Map<string, () => ExactReviewQueueItem>();
     for (const row of this.storage.sql.exec(
       `SELECT item_key, item_json FROM ${EXACT_REVIEW_QUEUE_ITEM_TABLE}`,
     ) as Iterable<{ item_key: string; item_json: string }>) {
+      let loaded = false;
       let item: ExactReviewQueueItem;
-      try {
-        item = JSON.parse(row.item_json) as ExactReviewQueueItem;
-      } catch {
-        throw new Error(`invalid exact-review queue item JSON for ${row.item_key}`);
-      }
-      if (!item || typeof item !== "object" || item.key !== row.item_key) {
-        throw new Error(`invalid exact-review queue item for ${row.item_key}`);
-      }
-      items[row.item_key] = item;
+      const read = () => {
+        if (loaded) return item;
+        try {
+          item = JSON.parse(row.item_json) as ExactReviewQueueItem;
+        } catch {
+          throw new Error(`invalid exact-review queue item JSON for ${row.item_key}`);
+        }
+        if (!item || typeof item !== "object" || item.key !== row.item_key) {
+          throw new Error(`invalid exact-review queue item for ${row.item_key}`);
+        }
+        loaded = true;
+        unreadItems.delete(row.item_key);
+        return item;
+      };
+      // Keep property descriptors stable during census enumeration. Redefining
+      // getters inside Object.values makes large snapshots quadratic in V8.
+      Object.defineProperty(items, row.item_key, {
+        get: read,
+        set: (next: ExactReviewQueueItem) => {
+          item = next;
+          loaded = true;
+          unreadItems.delete(row.item_key);
+        },
+        enumerable: true,
+        configurable: true,
+      });
+      unreadItems.set(row.item_key, read);
       baselineItems.set(row.item_key, row.item_json);
     }
 
@@ -10046,6 +10222,7 @@ export class ExactReviewQueue {
     };
     this.baselines.set(state, {
       items: baselineItems,
+      unreadItems,
       dispatcherJson: meta.dispatcher_json,
     });
     return state;
@@ -11210,11 +11387,19 @@ export class ExactReviewQueue {
   }
 
   private writeStateSync(state: ExactReviewQueueState) {
+    if (this.schedulingStates.has(state)) throw new Error("cannot persist a queue census");
+    this.invalidateStatsCache();
     const baseline = this.baselines.get(state) || this.readStateBaselineSync();
     const nextItems = new Map<string, string>();
     let reviewEnqueued = 0;
     let publicationEnqueued = 0;
-    for (const [itemKey, item] of Object.entries(state.items)) {
+    for (const itemKey of Object.keys(state.items)) {
+      const unread = baseline.unreadItems?.get(itemKey);
+      if (unread && Object.getOwnPropertyDescriptor(state.items, itemKey)?.get === unread) {
+        nextItems.set(itemKey, baseline.items.get(itemKey)!);
+        continue;
+      }
+      const item = state.items[itemKey]!;
       const itemJson = JSON.stringify(item);
       nextItems.set(itemKey, itemJson);
       if (baseline.items.get(itemKey) === itemJson) continue;
@@ -11255,6 +11440,7 @@ export class ExactReviewQueue {
     this.syncLegacyCompatibilitySync(state);
     this.baselines.set(state, {
       items: nextItems,
+      unreadItems: baseline.unreadItems,
       dispatcherJson,
     });
   }
@@ -12236,14 +12422,15 @@ export class ExactReviewQueue {
         ? Number(state.dispatcher?.reviewAdmissionNextAt)
         : null,
     );
+    const heads = this.publicationHeadsSync(state);
     const batchDeparture = exactReviewPublicationBatchDeparture(
       this.env,
       state,
       now,
       new Set(batchOwnership.itemKeys),
       batchOwnership.activeBatches,
-      this.freshPublicationItemKeysSync(state, now),
-      this.supersededPublicationItemKeysSync(state),
+      this.freshPublicationItemKeysSync(state, now, heads),
+      this.supersededPublicationItemKeysSync(state, heads),
     );
     const sourceAuthorityNext = await this.nextSourceAuthorityVerificationAt();
     const commandIntakeNext = this.commandIntakeStore.nextAttemptAt();

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -446,6 +446,14 @@ so handoff recovery stays live. If the optional queue read fails or is malformed
 the public response uses an unavailable/unknown aggregate and a bounded
 `telemetry_unavailable` diagnostic; it never returns the underlying error text.
 
+The object memoizes its private stats response for 10 seconds by default
+(`EXACT_REVIEW_STATS_CACHE_MS`; set `0` to disable). Concurrent polls with the
+same Bay sample parameters share the computation and its original `generated_at`.
+Queue mutations and auxiliary SQLite writes invalidate the memo; a missing or
+overdue alarm also bypasses it so polling still repairs the queue heartbeat.
+This only bounds observation freshness: the public projection's fields and
+meaning, admission, publication fences, and Bay behavior are unchanged.
+
 For capacity displays, `/api/exact-review-queue` also exposes compatible
 `lanes.review` and `lanes.publication` objects. Each lane reports its own
 pending, ready, backoff, dispatching, leased, capacity, active, available-slot,

--- a/test/dashboard-worker-observability.test.ts
+++ b/test/dashboard-worker-observability.test.ts
@@ -280,8 +280,9 @@ test("durable lifecycle Bay is a pure, bounded public-reference reducer snapshot
     queryBindings.push(bindings);
     assert.match(query, /^\s*SELECT\b/i, "Bay route must be read-only");
     assert.match(query, /FROM exact_review_lifecycle_projection_v1/);
-    if (/SELECT MAX\(revision\)/.test(query)) {
-      assert.match(query, /WHERE canonical_target_key = \?/);
+    if (/MAX\(revision\) AS max_revision/.test(query)) {
+      assert.match(query, /WHERE canonical_target_key IN \(SELECT value FROM json_each\(\?\)\)/);
+      assert.ok(JSON.parse(String(bindings[0])).length <= 24);
     } else {
       assert.match(query, /WHERE LOWER\(SUBSTR\(canonical_target_key/);
     }
@@ -313,7 +314,7 @@ test("durable lifecycle Bay is a pure, bounded public-reference reducer snapshot
   assert.equal(response.headers.get("cache-control"), "no-store");
   assert.equal(initialized, 1, "constructor must provision only the Bay read schema");
   assert.equal(storage.sql.hasNormalizedQueue(), false);
-  assert.equal(queries.filter((query) => /SELECT MAX\(revision\)/.test(query)).length, 6);
+  assert.equal(queries.filter((query) => /MAX\(revision\) AS max_revision/.test(query)).length, 1);
   assert.deepEqual(queryBindings.slice(0, 4), [
     ["openclaw/clawsweeper"],
     ["openclaw/clawsweeper"],

--- a/test/exact-review-publication-batches.test.ts
+++ b/test/exact-review-publication-batches.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { createHash, createHmac, generateKeyPairSync } from "node:crypto";
-import { DatabaseSync } from "node:sqlite";
+import { TestStorage } from "./exact-review-test-storage.ts";
 import test from "node:test";
 
 import { ExactReviewPublicationBatchStore } from "../dashboard/exact-review-publication-batches.ts";
@@ -35,119 +35,6 @@ class ExactReviewQueue extends RuntimeExactReviewQueue {
       },
       random,
     );
-  }
-}
-
-class SqlCursor<T extends Record<string, unknown>> implements Iterable<T> {
-  private readonly rows: T[];
-
-  constructor(rows: T[]) {
-    this.rows = rows;
-  }
-
-  *[Symbol.iterator]() {
-    yield* this.rows;
-  }
-}
-
-class TestStorage {
-  private readonly database = new DatabaseSync(":memory:");
-  private readonly values = new Map<string, unknown>();
-  private failSqlPattern: RegExp | null = null;
-  private failSqlMatchesRemaining = 0;
-  private alarmAt: number | null = null;
-  readonly sql = {
-    exec: (query: string, ...bindings: unknown[]) => {
-      if (this.failSqlPattern?.test(query)) {
-        this.failSqlMatchesRemaining -= 1;
-        if (this.failSqlMatchesRemaining === 0) {
-          this.failSqlPattern = null;
-          throw new Error("injected telemetry state write failure");
-        }
-      }
-      const statement = this.database.prepare(query);
-      if (/^\s*(?:SELECT|WITH)\b/i.test(query) || /\bRETURNING\b/i.test(query)) {
-        return new SqlCursor(statement.all(...bindings) as Record<string, unknown>[]);
-      }
-      statement.run(...bindings);
-      return new SqlCursor<Record<string, unknown>>([]);
-    },
-  };
-
-  failNextSqlMatching(pattern: RegExp) {
-    this.failSqlPattern = pattern;
-    this.failSqlMatchesRemaining = 1;
-  }
-
-  failSqlMatchingAfter(pattern: RegExp, successfulMatches: number) {
-    this.failSqlPattern = pattern;
-    this.failSqlMatchesRemaining = successfulMatches + 1;
-  }
-  readonly kv = {
-    get: (key: string) => this.values.get(key),
-    put: (key: string, value: unknown) => this.values.set(key, structuredClone(value)),
-    delete: (key: string) => this.values.delete(key),
-  };
-
-  transactionSync<T>(callback: () => T) {
-    this.database.exec("BEGIN IMMEDIATE");
-    try {
-      const result = callback();
-      this.database.exec("COMMIT");
-      return result;
-    } catch (error) {
-      this.database.exec("ROLLBACK");
-      throw error;
-    }
-  }
-
-  scalar(query: string) {
-    return Number((this.database.prepare(query).get() as { value: number }).value);
-  }
-
-  exec(query: string) {
-    this.database.exec(query);
-  }
-
-  run(query: string, ...bindings: unknown[]) {
-    this.database.prepare(query).run(...bindings);
-  }
-
-  async get(key: string) {
-    return this.values.get(key);
-  }
-
-  async put(key: string, value: unknown) {
-    this.values.set(key, structuredClone(value));
-  }
-
-  async delete(key: string) {
-    this.values.delete(key);
-  }
-
-  async list(options?: { prefix?: string }) {
-    const prefix = options?.prefix || "";
-    return new Map(
-      [...this.values.entries()]
-        .filter(([key]) => key.startsWith(prefix))
-        .sort(([left], [right]) => left.localeCompare(right)),
-    );
-  }
-
-  async getAlarm() {
-    return this.alarmAt;
-  }
-
-  async setAlarm(at: number) {
-    this.alarmAt = at;
-  }
-
-  async deleteAlarm() {
-    this.alarmAt = null;
-  }
-
-  scheduledAlarm() {
-    return this.alarmAt;
   }
 }
 

--- a/test/exact-review-queue-cpu.test.ts
+++ b/test/exact-review-queue-cpu.test.ts
@@ -1,0 +1,561 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { ExactReviewQueue, type ExactReviewQueueItem } from "../dashboard/exact-review-queue.ts";
+import {
+  ExactReviewLifecycleProjectionStore,
+  EXACT_REVIEW_LIFECYCLE_PROJECTION_TABLE,
+} from "../dashboard/exact-review-lifecycle.ts";
+import { ExactReviewPublicationBatchStore } from "../dashboard/exact-review-publication-batches.ts";
+import { exactReviewQueueStats } from "../dashboard/exact-review-read-model.ts";
+import type { ExactReviewQueueState } from "../dashboard/exact-review-queue.ts";
+import { TestStorage } from "./exact-review-test-storage.ts";
+
+const NOW = Date.parse("2026-09-03T22:20:00Z");
+const post = (path: string, body: unknown) =>
+  new Request(`https://queue${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+// Same publication/lease shape as the publication-batch fixtures. Historical direct
+// rows include the old inline base64 operations still readable after the cutover.
+async function fixture(size = 300, overrides = {}) {
+  const storage = new TestStorage();
+  const env: Record<string, unknown> = {
+    EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+    hostedTargetPredicate: () => true,
+    hostedPublicTargetProbe: async () => "public",
+    ...overrides,
+  };
+  let queue = new ExactReviewQueue({ storage }, env);
+  await queue.fetch(new Request("https://queue/stats"));
+  const lifecycle = new ExactReviewLifecycleProjectionStore(storage);
+  const items: ExactReviewQueueItem[] = [];
+  for (let n = 1; n <= size + 50; n++) {
+    const producerDecision = {
+      targetRepo: "openclaw/openclaw",
+      targetBranch: "main",
+      itemNumber: n,
+      itemKind: "issue" as const,
+      sourceEvent: "issues",
+      sourceAction: "opened",
+      supersedesInProgress: false,
+      ...(n >= 41 && n <= 50 ? { statusCommentId: n } : {}),
+      ...(n % 5 === 0
+        ? { additionalPrompt: "Verify the reproduction and current implementation. ".repeat(80) }
+        : {}),
+    };
+    const publication = {
+      artifactName: `exact-review-${10000 + n}-1`,
+      producerRunId: String(10000 + n),
+      producerRunAttempt: 1,
+      sourceSha: "a".repeat(40),
+      itemKey: `openclaw/openclaw#${n}`,
+      protocolVersion: 2 as const,
+      leaseRevision: 1,
+      claimGeneration: 1,
+      liveProceeded: true,
+      liveTerminalNoop: false,
+      liveTerminalMissing: false,
+      liveGuardedOpen: false,
+      producerDecision,
+    };
+    const decision =
+      n <= size
+        ? { ...producerDecision, sourceAction: "exact_review_artifact_publish", publication }
+        : producerDecision;
+    const item: ExactReviewQueueItem = {
+      key: n <= size ? `${publication.itemKey}@publish:${10000 + n}:1` : publication.itemKey,
+      decision,
+      state: n <= size ? "pending" : "leased",
+      revision: 1,
+      attempts: 0,
+      createdAt: NOW - 60_000 - n,
+      updatedAt: NOW - 60_000,
+      nextAttemptAt: NOW + 60_000,
+      ...(n > size
+        ? {
+            leaseDecision: decision,
+            leaseId: `lease-${n}`,
+            leaseRevision: 1,
+            leaseExpiresAt: NOW + 3_600_000,
+            claimedRunId: String(10000 + n),
+            claimedRunAttempt: 1,
+            claimGeneration: 1,
+            claimProtocolVersion: 2 as const,
+          }
+        : {}),
+    };
+    items.push(item);
+    storage.run(
+      "INSERT INTO exact_review_queue_items (item_key,item_json) VALUES (?,?)",
+      item.key,
+      JSON.stringify(item),
+    );
+    storage.run(
+      "INSERT INTO exact_review_publication_heads (target_key,source_revision,updated_at) VALUES (?,?,?)",
+      publication.itemKey,
+      1,
+      NOW,
+    );
+    lifecycle.recordAdmission({
+      canonicalTargetKey: publication.itemKey,
+      fenceKey: item.key,
+      revision: 1,
+      deliveryId: `fixture-${n}`,
+      sourceAction: "opened",
+      commandOriginated: n >= 41 && n <= 50,
+      statusMarker: null,
+      statusCommentId: n >= 41 && n <= 50 ? n : null,
+      observedAt: NOW - 60_000,
+    });
+    if (n <= size) {
+      const operations = [
+        {
+          path: `records/openclaw-openclaw/items/${n}.md`,
+          deleted: false,
+          mode: "100644",
+          bytes: 48000,
+          contentBase64: Buffer.from("Synthetic retained review evidence.\n".repeat(1400)).toString(
+            "base64",
+          ),
+        },
+      ];
+      storage.run(
+        `INSERT INTO exact_review_direct_publication_plans
+        (item_key,canonical_target_key,fence_key,revision,identity_item_key,identity_revision,claim_generation,
+         operations_json,lifecycle_json,total_bytes,file_count,state,created_at,updated_at,next_attempt_at)
+        VALUES (?,?,?,1,?,1,1,?,'{}',48000,1,'published',?,?,?)`,
+        item.key,
+        publication.itemKey,
+        item.key,
+        publication.itemKey,
+        JSON.stringify(operations),
+        NOW - 60_000,
+        NOW,
+        NOW,
+      );
+    }
+  }
+  // Match a long-running object whose rollback bridge has already expired.
+  storage.run("UPDATE exact_review_queue_meta SET migrated_at = ?", NOW - 2 * 86_400_000);
+  storage.kv.delete("exact-review-queue");
+  queue = new ExactReviewQueue({ storage }, env);
+  await queue.fetch(new Request("https://queue/stats"));
+  return { queue, storage, items, lifecycle, env };
+}
+
+test(
+  "queue request CPU benchmark (opt in)",
+  { skip: process.env.EXACT_REVIEW_CPU_BENCH !== "1" },
+  async (t) => {
+    t.mock.method(Date, "now", () => NOW);
+    const h = await fixture(320);
+    const samples: Record<string, unknown>[] = [];
+    const batchStore = new ExactReviewPublicationBatchStore(h.storage);
+    const batches = Array.from(
+      { length: 10 },
+      (_, i) =>
+        batchStore.claim({
+          batchId: `cpu-batch-${i}`,
+          leaseOwner: "cpu-worker",
+          leaseExpiresAt: NOW + 3_600_000,
+          now: NOW,
+          maxItems: 8,
+          maxConcurrentBatches: 10,
+          candidates: h.items
+            .slice(100 + i * 8, 108 + i * 8)
+            .map((item) => ({ itemKey: item.key, revision: 1 })),
+        })!,
+    );
+    // Seed publication and command-finalizer leases outside the measured call.
+    for (let i = 0; i < 20; i++) {
+      const item = h.items[30 + i]!;
+      Object.assign(item, {
+        state: "leased",
+        leaseDecision: item.decision,
+        leaseId: `cpu-lease-${i}`,
+        leaseRevision: 1,
+        leaseExpiresAt: NOW + 3_600_000,
+        claimedRunId: String(20000 + i),
+        claimedRunAttempt: 1,
+        claimGeneration: 1,
+        claimProtocolVersion: 2,
+      });
+      if (i >= 10)
+        item.terminalFinalization = {
+          disposition: "policy_noop",
+          statusState: "Complete",
+          statusDetail: "No action required.",
+        };
+      h.storage.run(
+        "UPDATE exact_review_queue_items SET item_json = ? WHERE item_key = ?",
+        JSON.stringify(item),
+        item.key,
+      );
+    }
+    // Warm the normal poll before distinguishing cached and uncached requests.
+    await h.queue.fetch(new Request("https://queue/stats"));
+    async function measure(route: string, run: (i: number) => Promise<unknown>, count = 10) {
+      const times: number[] = [];
+      let queries = 0;
+      const exec = h.storage.sql.exec;
+      h.storage.sql.exec = (query, ...bindings) => {
+        queries++;
+        return exec(query, ...bindings);
+      };
+      for (let i = 0; i < count; i++) {
+        const start = process.cpuUsage();
+        await run(i);
+        const cpu = process.cpuUsage(start);
+        times.push((cpu.user + cpu.system) / 1000);
+        // Keep 300 pending publications throughout the benchmark; fixture repair
+        // is outside both CPU timing and sql.exec instrumentation.
+        const restore =
+          route === "complete"
+            ? [h.items[320 + i]!]
+            : route === "complete-publication"
+              ? [h.items[30 + i]!]
+              : route === "lifecycle/router-receipt"
+                ? [h.items[i]!]
+                : route === "publication-batches/complete"
+                  ? h.items.slice(100 + i * 8, 108 + i * 8)
+                  : [];
+        for (const item of restore)
+          h.storage.run(
+            "INSERT OR REPLACE INTO exact_review_queue_items (item_key,item_json) VALUES (?,?)",
+            item.key,
+            JSON.stringify(item),
+          );
+      }
+      h.storage.sql.exec = exec;
+      times.sort((a, b) => a - b);
+      samples.push({
+        route,
+        median_cpu_ms: times[Math.floor(times.length / 2)],
+        max_cpu_ms: times.at(-1),
+        sql_per_call: queries / count,
+      });
+    }
+    await measure("stats", async () => {
+      assert.equal((await h.queue.fetch(new Request("https://queue/stats"))).status, 200);
+    });
+    h.env.EXACT_REVIEW_STATS_CACHE_MS = "0";
+    await measure("stats-uncached", async () => {
+      assert.equal((await h.queue.fetch(new Request("https://queue/stats"))).status, 200);
+    });
+    delete h.env.EXACT_REVIEW_STATS_CACHE_MS;
+    await measure("lifecycle-bay", async () => {
+      const r = await h.queue.fetch(new Request("https://queue/lifecycle-bay"));
+      assert.equal((await r.json()).durable_lifecycle_bay.collection.state, "complete");
+    });
+    await measure("complete", async (i) => {
+      const item = h.items[320 + i]!;
+      const response = await h.queue.fetch(
+        post("/complete", {
+          item_key: item.key,
+          lease_id: item.leaseId,
+          lease_revision: 1,
+          claim_generation: 1,
+          run_id: item.claimedRunId,
+          run_attempt: 1,
+          outcome: "success",
+        }),
+      );
+      assert.equal(response.status, 200, await response.text());
+    });
+    await measure("complete-publication", async (i) => {
+      const item = h.items[30 + i]!;
+      const response = await h.queue.fetch(
+        post("/complete", {
+          item_key: item.key,
+          lease_id: item.leaseId,
+          lease_revision: 1,
+          claim_generation: 1,
+          run_id: item.claimedRunId,
+          run_attempt: 1,
+          outcome: "success",
+          completion_kind: "published",
+          reason_code: "publication_applied",
+        }),
+      );
+      assert.equal(response.status, 200, await response.text());
+    });
+    await measure("terminal-finalization/attempt", async (i) => {
+      const item = h.items[40 + i]!;
+      const response = await h.queue.fetch(
+        post("/terminal-finalization/attempt", {
+          item_key: item.key,
+          lease_id: item.leaseId,
+          lease_revision: 1,
+          claim_generation: 1,
+          run_id: item.claimedRunId,
+          run_attempt: 1,
+          status_comment_id: item.decision.itemNumber,
+        }),
+      );
+      assert.equal(response.status, 200, await response.text());
+    });
+    await measure("publication-batches/complete", async (i) => {
+      const batch = batches[i]!;
+      const response = await h.queue.fetch(
+        post("/publication-batches/complete", {
+          batch_id: batch.batchId,
+          lease_owner: batch.leaseOwner,
+          items: batch.items.map((item) => ({
+            item_key: item.itemKey,
+            revision: item.revision,
+            claim_generation: item.claimGeneration,
+            terminal_outcome: "published",
+          })),
+        }),
+      );
+      assert.equal(response.status, 200, await response.text());
+    });
+    await measure("lifecycle/router-receipt", async (i) => {
+      const item = h.items[i]!;
+      const response = await h.queue.fetch(
+        post("/lifecycle/router-receipt", {
+          canonical_target_key: `openclaw/openclaw#${i + 1}`,
+          fence_key: item.key,
+          revision: 1,
+          receipt_id: `router-${i}`,
+        }),
+      );
+      assert.equal(response.status, 200, await response.text());
+    });
+    await measure("alarm-housekeeping", async () => {
+      await h.queue.alarm();
+    });
+    console.log(
+      JSON.stringify({
+        fixture: { pending: 300, leased: 70, lifecycle: 370, direct: 320 },
+        samples,
+      }),
+    );
+  },
+);
+
+type QueueInternals = {
+  readStateSync(): ExactReviewQueueState;
+  readSchedulingStateSync(): ExactReviewQueueState;
+  writeStateSync(state: ExactReviewQueueState): void;
+  scheduleNext(state: ExactReviewQueueState, now: number): Promise<void>;
+};
+const internals = (queue: ExactReviewQueue) => queue as unknown as QueueInternals;
+
+test("stats memo shares concurrent polls, expires, and retains the snapshot timestamp", async (t) => {
+  let now = NOW;
+  t.mock.method(Date, "now", () => now);
+  const { queue, storage } = await fixture(3, { EXACT_REVIEW_STATS_CACHE_MS: "10000" });
+  const exec = t.mock.method(storage.sql, "exec");
+  const responses = await Promise.all(
+    Array.from({ length: 4 }, () => queue.fetch(new Request("https://queue/stats"))),
+  );
+  assert.equal(responses[0]!.headers.get("cache-control"), "no-store");
+  assert.equal(responses[0]!.headers.get("content-type"), "application/json; charset=utf-8");
+  const first = await responses[0]!.text();
+  for (const response of responses.slice(1)) assert.equal(await response.text(), first);
+  assert.equal(
+    exec.mock.calls.filter(({ arguments: [sql] }) => /SELECT item_key, item_json FROM/.test(sql))
+      .length,
+    0,
+  );
+  now += 9_999;
+  assert.equal(await (await queue.fetch(new Request("https://queue/stats"))).text(), first);
+  now++;
+  assert.notEqual(await (await queue.fetch(new Request("https://queue/stats"))).text(), first);
+  assert.equal(
+    exec.mock.calls.filter(({ arguments: [sql] }) => /SELECT item_key, item_json FROM/.test(sql))
+      .length,
+    1,
+  );
+});
+
+test("stats memo invalidates on queue and auxiliary state writes, and keys Bay parameters", async (t) => {
+  t.mock.method(Date, "now", () => NOW);
+  const { queue, storage, items } = await fixture(3);
+  const read = async (query = "") =>
+    (await queue.fetch(new Request(`https://queue/stats${query}`))).json();
+  const before = await read();
+  const state = internals(queue).readStateSync();
+  delete state.items[items[0]!.key];
+  storage.transactionSync(() => internals(queue).writeStateSync(state));
+  assert.equal((await read()).lanes.publication.pending, before.lanes.publication.pending - 1);
+  storage.run(
+    "DELETE FROM exact_review_direct_publication_plans WHERE item_key = ?",
+    items[1]!.key,
+  );
+  assert.equal((await read()).lanes.publication.direct.retained_receipts, 2);
+  const exec = t.mock.method(storage.sql, "exec");
+  await read("?bay_priority_key=openclaw/openclaw%233");
+  assert.equal(
+    exec.mock.calls.filter(({ arguments: [sql] }) => /SELECT item_key, item_json FROM/.test(sql))
+      .length,
+    1,
+  );
+});
+
+test("stats memo TTL zero disables reuse and failures do not poison the memo", async (t) => {
+  t.mock.method(Date, "now", () => NOW);
+  const { queue, storage, env } = await fixture(3, { EXACT_REVIEW_STATS_CACHE_MS: "0" });
+  const exec = t.mock.method(storage.sql, "exec");
+  for (let i = 0; i < 2; i++) await queue.fetch(new Request("https://queue/stats"));
+  assert.equal(
+    exec.mock.calls.filter(({ arguments: [sql] }) => /SELECT item_key, item_json FROM/.test(sql))
+      .length,
+    2,
+  );
+  env.EXACT_REVIEW_STATS_CACHE_MS = "10000";
+  storage.failNextSqlMatching(/SELECT item_key, item_json FROM/);
+  await assert.rejects(queue.fetch(new Request("https://queue/stats")));
+  assert.equal((await queue.fetch(new Request("https://queue/stats"))).status, 200);
+});
+
+test("lazy item writes retain unread bytes and persist replacement, deletion, and nested edits", async (t) => {
+  t.mock.method(Date, "now", () => NOW);
+  const { queue, storage, items } = await fixture(3);
+  const state = internals(queue).readStateSync();
+  const untouched = items[2]!.key;
+  const original = Array.from(
+    storage.sql.exec(
+      "SELECT item_json FROM exact_review_queue_items WHERE item_key = ?",
+      untouched,
+    ),
+  )[0]!.item_json;
+  state.items[items[0]!.key]!.decision.publication!.producerDecision.additionalPrompt =
+    "changed nested prompt";
+  delete state.items[items[1]!.key];
+  const getter = Object.getOwnPropertyDescriptor(state.items, untouched)!.get;
+  assert.ok(getter);
+  storage.transactionSync(() => internals(queue).writeStateSync(state));
+  assert.equal(Object.getOwnPropertyDescriptor(state.items, untouched)!.get, getter);
+  assert.equal(
+    Array.from(
+      storage.sql.exec(
+        "SELECT item_json FROM exact_review_queue_items WHERE item_key = ?",
+        untouched,
+      ),
+    )[0]!.item_json,
+    original,
+  );
+  const reread = internals(queue).readStateSync();
+  assert.equal(
+    reread.items[items[0]!.key]!.decision.publication!.producerDecision.additionalPrompt,
+    "changed nested prompt",
+  );
+  assert.equal(reread.items[items[1]!.key], undefined);
+  reread.items[untouched] = { ...items[2]!, revision: 9 };
+  storage.transactionSync(() => internals(queue).writeStateSync(reread));
+  assert.equal(internals(queue).readStateSync().items[untouched]!.revision, 9);
+});
+
+test("scheduling census is equivalent on mixed leases, commands, legacy publications, and finalizers", async (t) => {
+  t.mock.method(Date, "now", () => NOW);
+  const { queue, storage, items } = await fixture(12);
+  const state = internals(queue).readStateSync();
+  const phases = ["pending", "dispatching", "leased", "parked"] as const;
+  for (const [index, item] of Object.values(state.items).entries()) {
+    item.state = phases[index % phases.length]!;
+    item.decision.additionalPrompt = "large prompt ".repeat(300);
+    item.leaseDecision = structuredClone(item.decision);
+    if (item.decision.publication) {
+      item.decision.publication.producerDecision.additionalPrompt = "producer prompt ".repeat(300);
+      if (index % 3 === 0) item.decision.publication.protocolVersion = 1;
+      if (index % 3 === 1)
+        item.decision.publication.directLifecycle = {
+          plan: { kind: "router" },
+          receiptOutcome: "accepted",
+        };
+      if (index % 3 === 2) item.decision.publication.producerDecision.statusCommentId = 100 + index;
+    }
+    if (index % 7 === 0)
+      item.terminalFinalization = {
+        disposition: "policy_noop",
+        statusState: "Complete",
+        statusDetail: "No action required.",
+      };
+  }
+  storage.transactionSync(() => internals(queue).writeStateSync(state));
+  const full = internals(queue).readStateSync();
+  const census = internals(queue).readSchedulingStateSync();
+  assert.equal(census.items[items[0]!.key]!.leaseDecision, undefined);
+  assert.equal(census.items[items[0]!.key]!.decision.additionalPrompt, undefined);
+  assert.deepEqual(
+    exactReviewQueueStats(census, NOW, 128, 120, 32),
+    exactReviewQueueStats(full, NOW, 128, 120, 32),
+  );
+  await storage.deleteAlarm();
+  await internals(queue).scheduleNext(full, NOW);
+  const expected = storage.scheduledAlarm();
+  await storage.deleteAlarm();
+  await internals(queue).scheduleNext(census, NOW);
+  assert.equal(storage.scheduledAlarm(), expected);
+  assert.throws(
+    () => storage.transactionSync(() => internals(queue).writeStateSync(census)),
+    /cannot persist a queue census/,
+  );
+});
+
+test("cold concurrent stats polls share one computation after invalidation", async (t) => {
+  t.mock.method(Date, "now", () => NOW);
+  const { queue, storage } = await fixture(3);
+  const state = internals(queue).readStateSync();
+  storage.transactionSync(() => internals(queue).writeStateSync(state));
+  const exec = t.mock.method(storage.sql, "exec");
+  const bodies = await Promise.all(
+    Array.from({ length: 8 }, async () =>
+      (await queue.fetch(new Request("https://queue/stats"))).text(),
+    ),
+  );
+  assert.ok(bodies.every((body) => body === bodies[0]));
+  assert.equal(
+    exec.mock.calls.filter(({ arguments: [sql] }) => /SELECT item_key, item_json FROM/.test(sql))
+      .length,
+    1,
+  );
+});
+
+test("Bay projection cache observes revised and malformed durable rows", async (t) => {
+  t.mock.method(Date, "now", () => NOW);
+  const { queue, storage, lifecycle, items } = await fixture(3);
+  const read = async () =>
+    (await (await queue.fetch(new Request("https://queue/lifecycle-bay"))).json())
+      .durable_lifecycle_bay;
+  const before = await read();
+  lifecycle.recordTerminalDisposition({
+    canonicalTargetKey: "openclaw/openclaw#1",
+    fenceKey: items[0]!.key,
+    revision: 1,
+    kind: "superseded",
+    observedAt: NOW,
+  });
+  const after = await read();
+  assert.equal(after.lanes.superseded, before.lanes.superseded + 1);
+  storage.run(
+    `UPDATE ${EXACT_REVIEW_LIFECYCLE_PROJECTION_TABLE} SET projection_json = ? WHERE canonical_target_key = ?`,
+    "{",
+    "openclaw/openclaw#1",
+  );
+  assert.equal((await read()).collection.state, "unknown");
+});
+
+test("concurrent renewal of an expired stats memo performs one queue scan", async (t) => {
+  let now = NOW;
+  t.mock.method(Date, "now", () => now);
+  const { queue, storage } = await fixture(3);
+  const exec = t.mock.method(storage.sql, "exec");
+  now += 10_000;
+  const bodies = await Promise.all(
+    Array.from({ length: 8 }, async () =>
+      (await queue.fetch(new Request("https://queue/stats"))).text(),
+    ),
+  );
+  assert.ok(bodies.every((body) => body === bodies[0]));
+  assert.equal(
+    exec.mock.calls.filter(({ arguments: [sql] }) => /SELECT item_key, item_json FROM/.test(sql))
+      .length,
+    1,
+  );
+});

--- a/test/exact-review-test-storage.ts
+++ b/test/exact-review-test-storage.ts
@@ -1,0 +1,114 @@
+import { DatabaseSync } from "node:sqlite";
+
+class SqlCursor<T extends Record<string, unknown>> implements Iterable<T> {
+  private readonly rows: T[];
+
+  constructor(rows: T[]) {
+    this.rows = rows;
+  }
+
+  *[Symbol.iterator]() {
+    yield* this.rows;
+  }
+}
+
+export class TestStorage {
+  private readonly database = new DatabaseSync(":memory:");
+  private readonly values = new Map<string, unknown>();
+  private failSqlPattern: RegExp | null = null;
+  private failSqlMatchesRemaining = 0;
+  private alarmAt: number | null = null;
+  readonly sql = {
+    exec: (query: string, ...bindings: unknown[]) => {
+      if (this.failSqlPattern?.test(query)) {
+        this.failSqlMatchesRemaining -= 1;
+        if (this.failSqlMatchesRemaining === 0) {
+          this.failSqlPattern = null;
+          throw new Error("injected telemetry state write failure");
+        }
+      }
+      const statement = this.database.prepare(query);
+      if (/^\s*(?:SELECT|WITH)\b/i.test(query) || /\bRETURNING\b/i.test(query)) {
+        return new SqlCursor(statement.all(...bindings) as Record<string, unknown>[]);
+      }
+      statement.run(...bindings);
+      return new SqlCursor<Record<string, unknown>>([]);
+    },
+  };
+
+  failNextSqlMatching(pattern: RegExp) {
+    this.failSqlPattern = pattern;
+    this.failSqlMatchesRemaining = 1;
+  }
+
+  failSqlMatchingAfter(pattern: RegExp, successfulMatches: number) {
+    this.failSqlPattern = pattern;
+    this.failSqlMatchesRemaining = successfulMatches + 1;
+  }
+  readonly kv = {
+    get: (key: string) => this.values.get(key),
+    put: (key: string, value: unknown) => this.values.set(key, structuredClone(value)),
+    delete: (key: string) => this.values.delete(key),
+  };
+
+  transactionSync<T>(callback: () => T) {
+    this.database.exec("BEGIN IMMEDIATE");
+    try {
+      const result = callback();
+      this.database.exec("COMMIT");
+      return result;
+    } catch (error) {
+      this.database.exec("ROLLBACK");
+      throw error;
+    }
+  }
+
+  scalar(query: string) {
+    return Number((this.database.prepare(query).get() as { value: number }).value);
+  }
+
+  exec(query: string) {
+    this.database.exec(query);
+  }
+
+  run(query: string, ...bindings: unknown[]) {
+    this.database.prepare(query).run(...bindings);
+  }
+
+  async get(key: string) {
+    return this.values.get(key);
+  }
+
+  async put(key: string, value: unknown) {
+    this.values.set(key, structuredClone(value));
+  }
+
+  async delete(key: string) {
+    this.values.delete(key);
+  }
+
+  async list(options?: { prefix?: string }) {
+    const prefix = options?.prefix || "";
+    return new Map(
+      [...this.values.entries()]
+        .filter(([key]) => key.startsWith(prefix))
+        .sort(([left], [right]) => left.localeCompare(right)),
+    );
+  }
+
+  async getAlarm() {
+    return this.alarmAt;
+  }
+
+  async setAlarm(at: number) {
+    this.alarmAt = at;
+  }
+
+  async deleteAlarm() {
+    this.alarmAt = null;
+  }
+
+  scheduledAlarm() {
+    return this.alarmAt;
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Addresses https://github.com/openclaw/clawsweeper/issues/1372. Production entered a queue-overload feedback loop on 2026-09-03: slow requests caused heartbeat/completion failures, retries grew the backlog, and each subsequent request did more work.

> Over 147 seconds: 389 storage-timeout resets, 52 internal-storage resets, one overloaded-object exception, 104 fetches ending `exceededWallTime`, and 154 canceled fetches. Fetch CPU totaled 89.7 seconds at about five fetches/second: complete 27,838 ms; stats 26,967 ms; lifecycle-bay 11,312 ms; lifecycle/router-receipt 10,619 ms; terminal-finalization/attempt 5,418 ms; heartbeat 2,091 ms; records/export 1,562 ms. The 34 stats calls averaged about 0.8 seconds CPU; fewer than 33 completes averaged about one second. Alarm wall times included 58, 38, 18.7, 12.6, and 10.5 seconds.

The observed deployment was `69ec53b00` (script version `f58e8349`), with about 200 pending publications and 50 leased reviews. The supplied raw tail was decoded as concatenated JSON objects, reduced to local aggregates, and deleted; it is not in this PR.

## Why

Queue reads eagerly decoded every decision, writes serialized every item, and fresh/superseded publication scans queried the durable head once per item. Scheduling repeated those scans on completions, receipt writes, and alarms. Stats also decoded every retained direct-publication operation solely to obtain its row count. Bay streamed and decoded lifecycle history and queried the newest revision separately for each sampled target.

The controlled benchmark exposes hundreds of SQLite crossings per request. It does **not** reproduce production's absolute one-second CPU or storage resets: local SQLite is in memory, and production transport/storage contention is absent. The measured reduction in SQLite calls is the strongest evidence for reducing overload amplification.

## What Changed

- Memoize stats for 10 seconds (`EXACT_REVIEW_STATS_CACHE_MS`, `0` disables), including concurrent same-parameter polls. Preserve the snapshot timestamp, headers, alarm repair, and invalidation on queue/auxiliary state writes.
- Count retained direct-publication rows in SQL. Read publication heads with one indexed set query per synchronous selection phase; reacquire across asynchronous fence boundaries.
- Lazily decode queue items and preserve unread rows' original JSON when writing a subset. Keep descriptors stable during enumeration; nested changes, replacement, and deletion still persist normally.
- Use a guarded, read-only scheduling projection that omits leased decision copies and prompt text only where no full decision is consumed. Reuse synchronous router/batch-completion state; retain fresh reads across telemetry awaits.
- Bound the Bay parsed-projection working set and batch sampled revision lookups. Existing ordinary terminal materialization was already incremental. Keep rare source-authoritative retraction rebuilds and lifecycle transactions intact.

OpenClaw Bay is unaffected: its public fields, counts, ordering, repository filtering, freshness semantics, and observer-only behavior remain identical. These are producer-side storage/read optimizations; no Bay application change is required. The public `/api/exact-review-queue` projection, bindings, migrations, and changelog are unchanged.

## pr-behavior-proof

**Head:** `5b1e93553a8d1941298e6426a1fd1d77cabe18e5`.

**Claim/surface:** lower CPU and bounded SQLite call counts in the actual queue handlers while preserving lease/revision fences, response shapes, and alarm scheduling.

**Fixture:** 300 pending publications plus 70 active review/publication/finalizer leases, 370 lifecycle projections, 320 retained direct-publication rows (including legacy inline operation payloads), and ten eight-member publication batches. Decisions use the existing fixture shape with bounded prompts. Mutated queue rows are restored outside the measurement so backlog remains constant.

**Command/environment:** `EXACT_REVIEW_CPU_BENCH=1 node --test --test-name-pattern='queue request CPU benchmark' test/exact-review-queue-cpu.test.ts`; macOS arm64, Node 26.8.1, existing SQLite-backed TestStorage. The identical final benchmark ran against an isolated archive of base `69ec53b00f118593cf878d21d2975c8a52a84e3c` and this worktree. Numbers are median process CPU milliseconds across ten calls, including handler completion and response consumption as coded; query counts cover only measured calls.

| Route | Before CPU ms | After CPU ms | SQL calls before → after |
|---|---:|---:|---:|
| `stats` | 34.52 | 0.12 | 404 → 1 |
| `stats-uncached` | 25.79 | 10.87 | 404 → 86 |
| `lifecycle-bay` | 5.15 | 6.04 | 26 → 3 |
| `complete` | 5.32 | 5.34 | 340 → 21 |
| `complete-publication` | 5.40 | 4.58 | 342 → 24 |
| `terminal-finalization/attempt` | 4.57 | 4.63 | 341 → 24 |
| `publication-batches/complete` | 7.90 | 5.48 | 368 → 55 |
| `lifecycle/router-receipt` | 7.10 | 4.93 | 353 → 32 |
| `alarm-housekeeping` | 9.18 | 6.45 | 976 → 29 |

**Observed:** cached and uncached stats are below 50 ms; completes/router receipts are below 150 ms; alarm housekeeping is below 200 ms. Bay/finalizer CPU is approximately unchanged at this size, while their SQL crossings drop substantially. No production-latency claim is made.

**Real runtime proof:** a local, ephemeral workerd 2026-07-01 / Miniflare 4.20260701.0 SQLite Durable Object served 300 pending publications, 50 review leases, and 350 lifecycle/300 direct rows. Stats reused the exact response, completion invalidated it and reduced the leased count, and lifecycle-bay/router-receipt returned successful results. All seven runtime requests passed. Provider `local-workerd`; no remote lease, deployment, credentials, or production workflow invocation. Local trace: `.artifacts/queue-cpu/workerd-proof.json`; fixture wrapper and runner remain local test artifacts.

**Regression tests:** `test/exact-review-queue-cpu.test.ts` covers TTL reuse/expiry/zero, cold concurrent polls and concurrent expired-entry renewal, queue/auxiliary write invalidation, Bay parameter separation, failed-computation recovery, preserved headers, lazy nested/replacement/deletion persistence, mixed full-vs-lean census equivalence, the lean-write guard, and Bay cache corruption/update visibility. The existing observer test now asserts one bounded sampled-target query.

**Validation:** all 462 tests passed in the requested eight-file suite plus the new regression file; the opt-in benchmark is skipped in ordinary runs. `pnpm run format`, `pnpm run build:all`, `pnpm run lint`, `pnpm run check:docs`, `pnpm run check:dashboard-queue-boundary`, `pnpm run check:dashboard-strict`, and `git diff --check` passed. Independent review identified a stats-renewal race: the added regression failed with eight scans before the fix and passes with one afterward. Fresh final review is scoped-clean through P2 and confirms the renewal fix; no accepted/actionable findings remain.

The broader local `pnpm run check` passed its static/build/lint stages but stalled twice at the unchanged action-ledger test `destination import transactions prevent concurrent opposing parent edges`. That test passes in isolation on the base commit; the complete local coverage run is therefore inconclusive. Exact-head CI is the full-suite gate.

**Limits/retained work:** no transaction was widened across an await; the immutable membership, generation, and revision checks remain. Head snapshots intentionally are not reused across asynchronous phases. Lifecycle claim/receipt transactions and rare Bay retraction rebuilds remain unchanged. Initialization, external calls, cloud storage contention, and production recovery are outside this benchmark. No merge, deployment, or live workflow run was performed.
