### PR TITLE
fix(queue): keep the stats memo consistent across in-flight writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Keep queue stats fresh when alarm or auxiliary-state writes overlap a memo computation, without changing the cache TTL or response fields.
+
 - Admit the reviewed OpenClaw MCP Apps sandbox-origin test fixture using exact URI, source-line, path, and decoder bindings so config reviews can proceed through the existing scanner rules.
 
 - Retain only Cloudflare failure flags in queue transport logs so backend faults can be diagnosed without exposing exception details.

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -838,12 +838,21 @@ export class ExactReviewQueue {
   private statsCache: {
     key: string;
     expiresAt: number;
+    body: string;
+    changes: number;
+  } | null = null;
+  private statsMutationGeneration = 0;
+  private statsComputation: {
+    key: string;
     body: Promise<string>;
-    changes: number | null;
+    changes: number;
+    generation: number;
   } | null = null;
 
   private invalidateStatsCache() {
+    this.statsMutationGeneration++;
     this.statsCache = null;
+    this.statsComputation = null;
   }
 
   private reviewCoverageCache: { at: number; summary: ReviewCoverageSummary } | null = null;
@@ -3888,62 +3897,78 @@ export class ExactReviewQueue {
   }
 
   private async statsResponse(url: URL) {
+    return cors(
+      new Response(await this.statsBody(url), {
+        headers: {
+          "content-type": "application/json; charset=utf-8",
+          "cache-control": "no-store",
+        },
+      }),
+    );
+  }
+
+  private async statsBody(url: URL): Promise<string> {
     const configured = Number(this.env.EXACT_REVIEW_STATS_CACHE_MS ?? 10_000);
     const ttl = Number.isFinite(configured) && configured >= 0 ? configured : 10_000;
-    if (!ttl) return this.computeStatsResponse(url);
+    if (!ttl) return this.computeStatsBody(url);
     // These parameters change the private Bay sample, so never share their responses.
     const key = JSON.stringify([
       exactReviewQueueBayPriorityKeys(url.searchParams.getAll("bay_priority_key")),
       exactReviewQueueBayActiveKeys(url.searchParams.getAll("bay_active_key")),
       exactReviewQueueBayActiveKeys(url.searchParams.getAll("bay_active_legacy_key")),
     ]);
-    const now = Date.now();
-    let cached = this.statsCache;
-    if (cached && cached.changes !== null) {
-      const alarm = await this.storage.getAlarm();
-      // Another poll may have renewed the entry while the alarm read yielded.
-      // Join that replacement, including its in-flight alarm repair.
-      cached = this.statsCache;
+    for (;;) {
+      const now = Date.now();
+      if (this.statsCache) {
+        const alarm = await this.storage.getAlarm();
+        // Re-read after yielding: another poll may have renewed the memo.
+        const cached = this.statsCache;
+        if (
+          cached &&
+          cached.key === key &&
+          cached.expiresAt > now &&
+          cached.changes === this.storageChangeCountSync() &&
+          (alarm === null || alarm > now) &&
+          (alarm !== null || this.scheduledAlarmDecision === null)
+        )
+          return cached.body;
+      }
+      const changes = this.storageChangeCountSync();
+      const generation = this.statsMutationGeneration;
+      const pending = this.statsComputation;
       if (
-        cached &&
-        cached.changes !== null &&
-        (cached.changes !== this.storageChangeCountSync() ||
-          (alarm !== null && alarm <= now) ||
-          (alarm === null && this.scheduledAlarmDecision !== null))
-      )
-        cached = null;
-    }
-    if (!cached || cached.key !== key || cached.expiresAt <= now) {
-      const entry = {
+        pending?.key === key &&
+        pending.changes === changes &&
+        pending.generation === generation
+      ) {
+        // Wait only to coalesce work; never serve an unvalidated pending body.
+        await pending.body;
+        continue;
+      }
+      const computation = {
         key,
-        expiresAt: now + ttl,
-        body: Promise.resolve(""),
-        changes: null as number | null,
+        changes,
+        generation,
+        // Publish the pending slot before computation can invalidate it.
+        body: Promise.resolve().then(() => this.computeStatsBody(url)),
       };
-      cached = entry;
-      this.statsCache = entry;
-      entry.body = this.computeStatsResponse(url).then(async (response) => {
-        const body = await response.text();
-        entry.changes = this.storageChangeCountSync();
+      this.statsComputation = computation;
+      try {
+        const body = await computation.body;
+        if (
+          this.statsComputation === computation &&
+          this.statsMutationGeneration === generation &&
+          this.storageChangeCountSync() === changes
+        )
+          this.statsCache = { key, expiresAt: now + ttl, body, changes };
         return body;
-      });
-    }
-    try {
-      return cors(
-        new Response(await cached.body, {
-          headers: {
-            "content-type": "application/json; charset=utf-8",
-            "cache-control": "no-store",
-          },
-        }),
-      );
-    } catch (error) {
-      if (this.statsCache === cached) this.invalidateStatsCache();
-      throw error;
+      } finally {
+        if (this.statsComputation === computation) this.statsComputation = null;
+      }
     }
   }
 
-  private async computeStatsResponse(url: URL) {
+  private async computeStatsBody(url: URL) {
     const bayPriorityKeys = exactReviewQueueBayPriorityKeys(
       url.searchParams.getAll("bay_priority_key"),
     );
@@ -4063,7 +4088,7 @@ export class ExactReviewQueue {
       bayActiveKeys,
       bayActiveLegacyKeys,
     );
-    return json({
+    const body = {
       ...stats,
       bay_projection: bayProjection,
       review_failure_health: reviewFailureHealth,
@@ -4172,7 +4197,8 @@ export class ExactReviewQueue {
       storage_schema_version: EXACT_REVIEW_QUEUE_STORAGE_SCHEMA_VERSION,
       legacy_rollback_available:
         !this.legacyMirrorDisabled && now < this.migratedAt + EXACT_REVIEW_QUEUE_LEGACY_ROLLBACK_MS,
-    });
+    };
+    return JSON.stringify(body, null, 2);
   }
 
   private readLifecycleAuditInventory(input: unknown) {

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -451,6 +451,8 @@ The object memoizes its private stats response for 10 seconds by default
 same Bay sample parameters share the computation and its original `generated_at`.
 Queue mutations and auxiliary SQLite writes invalidate the memo; a missing or
 overdue alarm also bypasses it so polling still repairs the queue heartbeat.
+Only completed snapshots whose mutation generation and storage change counter
+remain unchanged are memoized; polls waiting on invalidated work recompute.
 This only bounds observation freshness: the public projection's fields and
 meaning, admission, publication fences, and Bay behavior are unchanged.
 

--- a/test/exact-review-queue-cpu.test.ts
+++ b/test/exact-review-queue-cpu.test.ts
@@ -341,7 +341,9 @@ type QueueInternals = {
   readStateSync(): ExactReviewQueueState;
   readSchedulingStateSync(): ExactReviewQueueState;
   writeStateSync(state: ExactReviewQueueState): void;
+  invalidateStatsCache(): void;
   scheduleNext(state: ExactReviewQueueState, now: number): Promise<void>;
+  hostedTargetAdmission(): Promise<{ outcome: "terminal" }>;
 };
 const internals = (queue: ExactReviewQueue) => queue as unknown as QueueInternals;
 
@@ -411,6 +413,113 @@ test("stats memo TTL zero disables reuse and failures do not poison the memo", a
   storage.failNextSqlMatching(/SELECT item_key, item_json FROM/);
   await assert.rejects(queue.fetch(new Request("https://queue/stats")));
   assert.equal((await queue.fetch(new Request("https://queue/stats"))).status, 200);
+});
+
+for (const mutation of ["explicit invalidation", "auxiliary SQL write"] as const) {
+  test(`stats memo recomputes after ${mutation} during an in-flight computation`, async (t) => {
+    t.mock.method(Date, "now", () => NOW);
+    const { queue, storage, items } = await fixture(3);
+    const entered = Promise.withResolvers<void>();
+    const resume = Promise.withResolvers<void>();
+    const original = internals(queue).scheduleNext.bind(queue);
+    let computations = 0;
+    t.mock.method(internals(queue), "scheduleNext", async (state, now) => {
+      await original(state, now);
+      if (++computations === 1) {
+        entered.resolve();
+        await resume.promise;
+      }
+    });
+    internals(queue).invalidateStatsCache();
+    const first = queue.fetch(new Request("https://queue/stats"));
+    await entered.promise;
+    if (mutation === "explicit invalidation") {
+      internals(queue).invalidateStatsCache();
+    } else {
+      storage.run(
+        "DELETE FROM exact_review_direct_publication_plans WHERE item_key = ?",
+        items[0]!.key,
+      );
+    }
+    resume.resolve();
+    await first;
+    const next = await (await queue.fetch(new Request("https://queue/stats"))).json();
+    assert.equal(computations, 2);
+    assert.equal(
+      next.lanes.publication.direct.retained_receipts,
+      mutation === "explicit invalidation" ? 3 : 2,
+    );
+  });
+}
+
+test("stats memo observes an alarm removing a branch reservation mid-computation", async (t) => {
+  t.mock.method(Date, "now", () => NOW);
+  const { queue, storage } = await fixture(3);
+  for (const deliveryId of ["a", "b"]) {
+    storage.kv.put(`exact-review-branch-authority-reservation:v1:${deliveryId}`, {
+      deliveryId,
+      decision: {
+        targetRepo: "openclaw/openclaw",
+        itemNumber: 900,
+        itemKind: "issue",
+        sourceEvent: "issues",
+        sourceAction: "opened",
+        supersedesInProgress: false,
+      },
+      sourceAuthorityRequired: false,
+      attempts: 0,
+      nextAttemptAt: NOW,
+    });
+  }
+  const alarmEntered = Promise.withResolvers<void>();
+  const resumeAlarm = Promise.withResolvers<void>();
+  const removed = Promise.withResolvers<void>();
+  const finishAlarm = Promise.withResolvers<void>();
+  const statsEntered = Promise.withResolvers<void>();
+  const resumeStats = Promise.withResolvers<void>();
+  const deleteAlarm = storage.deleteAlarm.bind(storage);
+  t.mock.method(storage, "deleteAlarm", async () => {
+    await deleteAlarm();
+    alarmEntered.resolve();
+    await resumeAlarm.promise;
+  });
+  let admissions = 0;
+  t.mock.method(internals(queue), "hostedTargetAdmission", async () => {
+    if (++admissions === 2) {
+      removed.resolve();
+      await finishAlarm.promise;
+    }
+    return { outcome: "terminal" as const };
+  });
+  const scheduleNext = internals(queue).scheduleNext.bind(queue);
+  let computations = 0;
+  t.mock.method(internals(queue), "scheduleNext", async (state, now) => {
+    await scheduleNext(state, now);
+    if (++computations === 1) {
+      statsEntered.resolve();
+      await resumeStats.promise;
+    }
+  });
+  const alarm = queue.alarm();
+  try {
+    await alarmEntered.promise;
+    const first = queue.fetch(new Request("https://queue/stats"));
+    await statsEntered.promise;
+    resumeAlarm.resolve();
+    await removed.promise;
+    assert.equal(storage.kv.get("exact-review-branch-authority-reservation:v1:a"), undefined);
+    const next = queue.fetch(new Request("https://queue/stats"));
+    resumeStats.resolve();
+    assert.equal((await (await first).json()).lanes.review.authority_pending.branch_resolution, 2);
+    assert.equal((await (await next).json()).lanes.review.authority_pending.branch_resolution, 1);
+    const repeated = await (await queue.fetch(new Request("https://queue/stats"))).json();
+    assert.equal(repeated.lanes.review.authority_pending.branch_resolution, 1);
+  } finally {
+    resumeAlarm.resolve();
+    resumeStats.resolve();
+    finishAlarm.resolve();
+    await alarm;
+  }
 });
 
 test("lazy item writes retain unread bytes and persist replacement, deletion, and nested edits", async (t) => {


### PR DESCRIPTION
## What Problem This Solves

Follow-up to https://github.com/openclaw/clawsweeper/pull/1381 (merged before this fix could attach). The stats memo entry was populated across an await, so a poll could join an in-flight entry while an alarm mutated auxiliary state, serving stale counts and then recording the post-write change counter, which masked the write.

## What Changed

The memo is built synchronously from the already-serialized JSON, the storage change counter and a mutation generation are captured before computing and validated after, any invalidation during computation drops the in-flight entry, and requests never join an entry whose validation is incomplete. TTL and knob semantics unchanged.

## pr-behavior-proof

Regression tests (fail before the fix): invalidation during an in-flight stats computation forces a recompute; two branch reservations with the alarm removing one mid-computation yields one from the next stats request. Focused suites: 400 tests passing. Public projection unchanged; OpenClaw Bay unaffected.
