### PR TITLE
perf(state): export canonical records in 200-record pages

### DIFF
--- a/dashboard/exact-review-direct-publication.ts
+++ b/dashboard/exact-review-direct-publication.ts
@@ -554,7 +554,16 @@ export class ExactReviewDirectPublicationStore {
     section: ExactReviewTupleRecordSection,
     itemId: number,
   ): CanonicalRecord | null {
-    const metadata = this.readCanonicalMetadataSync(repoSlug, section, itemId);
+    return this.readCanonicalContentSync(repoSlug, section, itemId);
+  }
+
+  private readCanonicalContentSync(
+    repoSlug: string,
+    section: ExactReviewTupleRecordSection,
+    itemId: number,
+    sourceRow?: Record<string, unknown>,
+  ): CanonicalRecord | null {
+    const metadata = this.readCanonicalMetadataSync(repoSlug, section, itemId, sourceRow);
     if (!metadata) return null;
     if (metadata.deleted) return { ...metadata, content: null };
     if (metadata.content !== null) return metadata;
@@ -878,10 +887,15 @@ export class ExactReviewDirectPublicationStore {
       selectedRows.push(row);
       sourceBytes += byteLength;
     }
+    const sourceRows = this.readExportSourceRowsSync(options.repoSlug, selectedRows);
     const records: RecordExportEntry[] = [];
     let responseBytes = 0;
     for (const row of selectedRows) {
-      const entry = this.recordExportEntrySync(row);
+      const sourceRow = sourceRows.get(`${String(row.section)}/${String(row.record_id)}`);
+      if (Number(row.deleted) !== 1 && !sourceRow) {
+        throw new RecordExportConsistencyError("record export source missing");
+      }
+      const entry = this.recordExportEntrySync(row, sourceRow);
       const entryBytes = new TextEncoder().encode(JSON.stringify(entry)).byteLength;
       if (records.length && responseBytes + entryBytes > options.maxBytes) break;
       records.push(entry);
@@ -1051,17 +1065,20 @@ export class ExactReviewDirectPublicationStore {
     repoSlug: string,
     section: ExactReviewTupleRecordSection,
     itemId: number,
+    sourceRow?: Record<string, unknown>,
   ) {
-    const row = Array.from(
-      this.storage.sql.exec(
-        `SELECT content, digest, byte_length, chunk_count, deleted, revision, updated_at
+    const row =
+      sourceRow ??
+      Array.from(
+        this.storage.sql.exec(
+          `SELECT content, digest, byte_length, chunk_count, deleted, revision, updated_at
            FROM ${EXACT_REVIEW_CANONICAL_RECORD_TABLE}
           WHERE repo_slug = ? AND section = ? AND item_id = ?`,
-        repoSlug,
-        section,
-        itemId,
-      ),
-    )[0];
+          repoSlug,
+          section,
+          itemId,
+        ),
+      )[0];
     if (!row) return null;
     return {
       repoSlug,
@@ -1239,7 +1256,52 @@ export class ExactReviewDirectPublicationStore {
     return revision;
   }
 
-  private recordExportEntrySync(row: Record<string, unknown>): RecordExportEntry {
+  private readExportSourceRowsSync(repoSlug: string, rows: Record<string, unknown>[]) {
+    const canonical: Array<[string, number]> = [];
+    const backfill: Array<[string, string]> = [];
+    for (const row of rows) {
+      if (Number(row.deleted) === 1) continue;
+      if (String(row.source) === "canonical" && row.section !== "commits") {
+        canonical.push([String(row.section), Number(row.record_id)]);
+      } else {
+        backfill.push([String(row.section), String(row.record_id)]);
+      }
+    }
+    if (!canonical.length && !backfill.length) return new Map<string, Record<string, unknown>>();
+    // Load only the byte-budgeted identities. JSON arrays keep the binding
+    // count fixed even for 200 records; chunks still use the existing reader.
+    return new Map(
+      Array.from(
+        this.storage.sql.exec(
+          `SELECT section, CAST(item_id AS TEXT) AS record_id, content, digest,
+                  byte_length, chunk_count, deleted, revision, updated_at
+             FROM ${EXACT_REVIEW_CANONICAL_RECORD_TABLE}
+            WHERE repo_slug = ? AND (section, item_id) IN (
+              SELECT json_extract(value, '$[0]'), json_extract(value, '$[1]')
+                FROM json_each(?)
+            )
+            UNION ALL
+           SELECT section, record_id, content, digest, byte_length, chunk_count,
+                  0 AS deleted, 0 AS revision, updated_at
+             FROM ${EXACT_REVIEW_RECORD_BACKFILL_TABLE}
+            WHERE repo_slug = ? AND (section, record_id) IN (
+              SELECT json_extract(value, '$[0]'), json_extract(value, '$[1]')
+                FROM json_each(?)
+            )`,
+          repoSlug,
+          JSON.stringify(canonical),
+          repoSlug,
+          JSON.stringify(backfill),
+        ),
+        (row) => [`${String(row.section)}/${String(row.record_id)}`, row] as const,
+      ),
+    );
+  }
+
+  private recordExportEntrySync(
+    row: Record<string, unknown>,
+    sourceRow?: Record<string, unknown>,
+  ): RecordExportEntry {
     const repoSlug = String(row.repo_slug);
     const section = String(row.section) as RecordSection;
     const id = String(row.record_id);
@@ -1255,7 +1317,7 @@ export class ExactReviewDirectPublicationStore {
         }
         let canonical: CanonicalRecord | null;
         try {
-          canonical = this.readCanonical(repoSlug, section, itemId);
+          canonical = this.readCanonicalContentSync(repoSlug, section, itemId, sourceRow);
         } catch (error) {
           if (error instanceof RecordExportConsistencyError) throw error;
           throw new RecordExportConsistencyError("canonical export content is malformed", {
@@ -1269,7 +1331,7 @@ export class ExactReviewDirectPublicationStore {
         }
         content = canonical.content;
       } else {
-        content = this.readBackfillContentSync(repoSlug, section, id);
+        content = this.readBackfillContentSync(repoSlug, section, id, sourceRow);
       }
     }
     return {
@@ -1319,17 +1381,24 @@ export class ExactReviewDirectPublicationStore {
     }
   }
 
-  private readBackfillContentSync(repoSlug: string, section: RecordSection, id: string) {
-    const row = Array.from(
-      this.storage.sql.exec(
-        `SELECT content, byte_length, chunk_count
+  private readBackfillContentSync(
+    repoSlug: string,
+    section: RecordSection,
+    id: string,
+    sourceRow?: Record<string, unknown>,
+  ) {
+    const row =
+      sourceRow ??
+      Array.from(
+        this.storage.sql.exec(
+          `SELECT content, byte_length, chunk_count
            FROM ${EXACT_REVIEW_RECORD_BACKFILL_TABLE}
           WHERE repo_slug = ? AND section = ? AND record_id = ?`,
-        repoSlug,
-        section,
-        id,
-      ),
-    )[0];
+          repoSlug,
+          section,
+          id,
+        ),
+      )[0];
     if (!row) {
       throw new RecordExportConsistencyError(
         `backfill export content missing: ${repoSlug}/${section}/${id}`,

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -745,11 +745,11 @@ type AlarmScheduleDecision = readonly [AlarmWakeReason, number, number, boolean 
 // hung runner into a permanent queue owner. The Git fence blocks any in-flight
 // push that outlives this absolute coordinator horizon.
 const DEFAULT_STATE_WRITER_COORDINATOR_MAX_LEASE_AGE_MS = 30 * 60_000;
-const RECORD_EXPORT_DEFAULT_LIMIT = 100;
+const RECORD_EXPORT_DEFAULT_LIMIT = 200;
 const RECORD_EXPORT_MAX_LIMIT = 200;
 const RECORD_EXPORT_MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
 const RECORD_EXPORT_MAX_SOURCE_BYTES = EXACT_REVIEW_DIRECT_PUBLICATION_MAX_FILE_BYTES;
-const RECORD_EXPORT_MAX_RECONSTRUCTION_RECORDS = 50;
+const RECORD_EXPORT_MAX_RECONSTRUCTION_RECORDS = 200;
 const RECORD_INGEST_MAX_RECORDS = 100;
 const RECORD_INGEST_MAX_REQUEST_BYTES = 4 * 1024 * 1024;
 const RECORD_INGEST_MAX_FILE_BYTES = 2 * 1024 * 1024;

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -356,6 +356,27 @@ and hot intake `14`. Existing repair lanes keep their
 40% derived caps, while imported cluster repair remains separately bounded until
 `lanes.repair.cluster_max_live_runs` is raised.
 
+## Canonical record export
+
+`/internal/state/records/export` defaults to 200 records and accepts at most
+200 per request. Its reconstruction cap is also 200, and the hydration client
+requests 200 by default. A replay of 111,000 small records therefore needs
+555 requests instead of 2,220 with the former 50-record cap.
+
+The source-content budget remains 2 MiB and the serialized-entry budget remains
+4 MiB. Byte preflight selects identities before a single batched source read;
+chunked records retain their existing reassembly. Large records can end a page
+before the count limit, and `nextCursor` advances only through returned records.
+The existing single-record progress exception is retained: the first record is
+returned even if it exceeds a page byte budget, preventing an unexportable record
+from pinning the cursor. The serialized budget measures entries, not the outer
+JSON envelope.
+
+These limits are owned by `dashboard/exact-review-queue.ts`, implemented in
+`dashboard/exact-review-direct-publication.ts`, and consumed by
+`scripts/worker-records.ts`. Regression coverage lives in
+`test/record-export-bounds.test.ts` and `test/worker-records-request.test.ts`.
+
 ## Runtime Overrides
 
 - `EXACT_REVIEW_HOSTED_TARGET_ADMISSION_FRESH_MS`: intake's no-probe public-admission cache window (default 60,000 ms).

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -11,6 +11,14 @@
 Read when changing the Cloudflare status dashboard, status ingest contract, or
 operator-facing ClawSweeper observability.
 
+The signed internal canonical-record export route serves up to 200 records per
+page (also the Worker and hydration-client default), bounded by 2 MiB of source
+content and 4 MiB of serialized entries. Large-record pages stop early and resume
+from the last returned record; the existing first-record progress exception
+remains. See [canonical record export limits](limits.md#canonical-record-export).
+This changes hydration request volume only; OpenClaw Bay's observer projection
+and public data contract are unaffected.
+
 The live dashboard is observer-only. ClawSweeper still owns review, repair,
 apply, merge, comments, labels, and all GitHub mutations. The Cloudflare Worker
 reads GitHub workflow state, projects it into closed status and Bay views, and

--- a/scripts/worker-records.ts
+++ b/scripts/worker-records.ts
@@ -137,7 +137,7 @@ type SignedPostOptions = Omit<SignedRequestOptions, "method"> & {
 // Cold hydration (no stored snapshot yet) replays the full journal from
 // revision 0, so it must stay a small-repo affordance: a slug whose record set
 // outgrows this bound has earned a real snapshot and still refuses cutover.
-// 2000 records is ~20 export pages and covers hundreds of reviewed items,
+// 2000 small records is ~10 export pages and covers hundreds of reviewed items,
 // giving a newly onboarded repository long runway before the first manual
 // snapshot sweep is required.
 export const COLD_HYDRATION_MAX_RECORDS = 2000;
@@ -183,7 +183,7 @@ export async function exportWorkerRecords(options: {
         sections,
         sinceRevision,
         cursor,
-        limit: options.limit ?? 100,
+        limit: options.limit ?? 200,
       },
       fetch: options.fetch,
       validateResponse: (value) => {

--- a/test/record-export-bounds.test.ts
+++ b/test/record-export-bounds.test.ts
@@ -1,8 +1,11 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import { mkdirSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
 import path from "node:path";
 import test from "node:test";
+
+import { exportWorkerRecords } from "../scripts/worker-records.ts";
 
 import {
   EXACT_REVIEW_CANONICAL_CHUNK_BYTES,
@@ -27,7 +30,7 @@ const EXPORT_PATH = "/internal/state/records/export";
 const REPO_SLUG = "openclaw-openclaw";
 const SECRET = "bounded-record-export-secret";
 const EXPECTED_SOURCE_BYTE_BUDGET = 2 * 1024 * 1024;
-const EXPECTED_RECORD_WORK_BUDGET = 50;
+const EXPECTED_RECORD_WORK_BUDGET = 200;
 const proofPath = process.env.RECORD_EXPORT_PROOF_PATH;
 const behaviorProof: {
   claim: string;
@@ -41,6 +44,7 @@ const behaviorProof: {
     reconstructionQueries: number;
   }>;
   manifestParity: boolean;
+  hydration: { records: number; requests: number; pageSizes: number[]; limits: number[] } | null;
   expectedManifest: Array<{ path: string; digest: string }>;
   materializedManifest: Array<{ path: string; digest: string }>;
   oversizedFirst: {
@@ -66,6 +70,7 @@ const behaviorProof: {
   limits: "local controlled fixture; no production Cloudflare CPU claim",
   pages: [],
   manifestParity: false,
+  hydration: null,
   expectedManifest: [],
   materializedManifest: [],
   oversizedFirst: null,
@@ -104,6 +109,7 @@ async function exportHarness() {
     env,
   );
   assert.equal(initialized.status, 200);
+  storage.sql.setBindingLimit(100);
   storage.sql.resetQueryHistory();
   return { env, storage };
 }
@@ -216,15 +222,32 @@ function reconstructedRecords(
   storage: MemoryDurableStorage,
   recordsByIdentity: ReadonlyMap<string, FixtureRecord>,
 ) {
-  const queries = storage.sql.queriesMatching(
-    /SELECT content, (?:digest, )?byte_length, chunk_count(?:, deleted, revision, updated_at)?\s+FROM (?:exact_review_canonical_records|exact_review_record_backfill)/,
+  assert.equal(
+    storage.sql.queriesMatching(
+      /SELECT content, (?:digest, )?byte_length, chunk_count(?:, deleted, revision, updated_at)?\s+FROM (?:exact_review_canonical_records|exact_review_record_backfill)/,
+    ).length,
+    0,
+    "export must not perform per-record source reads",
   );
-  return queries.map(({ bindings }) => {
-    const identity = `${String(bindings[1])}/${String(bindings[2])}`;
-    const record = recordsByIdentity.get(identity);
-    assert.ok(record, `unexpected reconstruction query for ${identity}`);
-    return record;
+  const queries = sourceBatchQueries(storage);
+  assert.equal(queries.length, 1);
+  return queries.flatMap(({ bindings }) => {
+    const identities = [1, 3].flatMap(
+      (index) => JSON.parse(String(bindings[index])) as Array<[string, string | number]>,
+    );
+    return identities.map(([section, id]) => {
+      const identity = `${section}/${id}`;
+      const record = recordsByIdentity.get(identity);
+      assert.ok(record, `unexpected reconstruction query for ${identity}`);
+      return record;
+    });
   });
+}
+
+function sourceBatchQueries(storage: MemoryDurableStorage) {
+  return storage.sql.queriesMatching(
+    /SELECT section, CAST\(item_id AS TEXT\) AS record_id, content/,
+  );
 }
 
 function exportResponse(
@@ -261,10 +284,97 @@ async function exportPage(
   }>;
 }
 
+test("client hydrates 800 records through signed HTTP and SQLite in four requests", async (t) => {
+  const { env, storage } = await exportHarness();
+  const fixtures = Array.from({ length: 800 }, (_, index) =>
+    fixtureRecord({
+      source: "canonical",
+      section: "items",
+      id: String(index + 1),
+      content: `record-${index + 1}`,
+      storeRevision: index + 1,
+    }),
+  );
+  for (const record of fixtures) seedFixtureRecord(storage, record);
+  const pages: Array<{
+    cursor: number;
+    limit: number;
+    records: number;
+    nextCursor: number | null;
+  }> = [];
+  const server = createServer(async (incoming, outgoing) => {
+    try {
+      const chunks: Buffer[] = [];
+      for await (const chunk of incoming) chunks.push(Buffer.from(chunk));
+      const body = Buffer.concat(chunks).toString("utf8");
+      const headers = new Headers();
+      for (const [key, value] of Object.entries(incoming.headers)) {
+        if (value !== undefined) headers.set(key, Array.isArray(value) ? value.join(", ") : value);
+      }
+      const response = await worker.fetch(
+        new Request(`http://localhost${incoming.url}`, {
+          method: incoming.method,
+          headers,
+          body,
+        }),
+        env,
+      );
+      const text = await response.text();
+      const page = JSON.parse(text);
+      const request = JSON.parse(body);
+      pages.push({
+        cursor: request.cursor,
+        limit: request.limit,
+        records: page.records?.length ?? 0,
+        nextCursor: page.nextCursor,
+      });
+      outgoing.writeHead(response.status, Object.fromEntries(response.headers));
+      outgoing.end(text);
+    } catch (error) {
+      outgoing.writeHead(500);
+      outgoing.end(String(error));
+    }
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  t.after(
+    () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      ),
+  );
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  const snapshot = await exportWorkerRecords({
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    webhookSecret: SECRET,
+    repoSlug: REPO_SLUG,
+  });
+  assert.equal(snapshot.revision, 800);
+  assert.deepEqual(
+    snapshot.records
+      .toSorted((a, b) => Number(a.id) - Number(b.id))
+      .map(({ id, content, digest }) => ({ id, content, digest })),
+    fixtures.map(({ id, content, digest }) => ({ id, content, digest })),
+  );
+  assert.deepEqual(pages, [
+    { cursor: 0, limit: 200, records: 200, nextCursor: 200 },
+    { cursor: 200, limit: 200, records: 200, nextCursor: 400 },
+    { cursor: 400, limit: 200, records: 200, nextCursor: 600 },
+    { cursor: 600, limit: 200, records: 200, nextCursor: null },
+  ]);
+  assert.equal(sourceBatchQueries(storage).length, 4);
+  behaviorProof.hydration = {
+    records: snapshot.records.length,
+    requests: pages.length,
+    pageSizes: pages.map((page) => page.records),
+    limits: pages.map((page) => page.limit),
+  };
+});
+
 test("signed record export bounds reconstruction work and source bytes while paginating exactly", async () => {
   const { env, storage } = await exportHarness();
   const fixtures: FixtureRecord[] = [];
-  for (let index = 1; index <= 55; index += 1) {
+  for (let index = 1; index <= 205; index += 1) {
     const canonical = index % 2 === 1;
     fixtures.push(
       fixtureRecord({
@@ -276,13 +386,13 @@ test("signed record export bounds reconstruction work and source bytes while pag
       }),
     );
   }
-  for (let index = 56; index <= 58; index += 1) {
+  for (let index = 206; index <= 208; index += 1) {
     fixtures.push(
       fixtureRecord({
         source: index % 2 === 0 ? "canonical" : "backfill",
         section: index % 2 === 0 ? "items" : "commits",
         id: index % 2 === 0 ? String(index) : index.toString(16).padStart(40, "0"),
-        content: String.fromCharCode(65 + index).repeat(1_600_000),
+        content: String.fromCharCode(65 + (index % 26)).repeat(1_600_000),
         storeRevision: index,
       }),
     );
@@ -314,7 +424,7 @@ test("signed record export bounds reconstruction work and source bytes while pag
       nextCursor: page.nextCursor,
       records: page.records.length,
       sourceBytes: reconstructedBytes,
-      reconstructionQueries: reconstructed.length,
+      reconstructionQueries: sourceBatchQueries(storage).length,
     });
     for (const record of page.records) {
       assert.equal(record.deleted, false);
@@ -326,7 +436,7 @@ test("signed record export bounds reconstruction work and source bytes while pag
     nextCursor = page.nextCursor;
   }
 
-  assert.deepEqual(pageSizes, [50, 6, 1, 1]);
+  assert.deepEqual(pageSizes, [200, 6, 1, 1]);
   assert.deepEqual(
     received.map(({ section, id, digest }) => ({ section, id, digest })),
     fixtures.map(({ section, id, digest }) => ({ section, id, digest })),
@@ -356,7 +466,7 @@ test("signed record export does not advertise an empty page at the record bounda
     );
   }
 
-  for (let index = EXPECTED_RECORD_WORK_BUDGET + 1; index <= 150; index += 1) {
+  for (let index = EXPECTED_RECORD_WORK_BUDGET + 1; index <= 300; index += 1) {
     seedFixtureRecord(
       storage,
       fixtureRecord({
@@ -393,6 +503,34 @@ test("signed record export does not advertise an empty page at the record bounda
     (row) => String(row.detail),
   ).join("\n");
   assert.match(plan, /exact_review_record_export_by_repo_section_revision/);
+  const batch = sourceBatchQueries(storage)[0]!;
+  const sourcePlan = Array.from(
+    storage.sql.exec(`EXPLAIN QUERY PLAN ${batch.query}`, ...batch.bindings),
+    (row) => String(row.detail),
+  ).join("\n");
+  assert.match(
+    sourcePlan,
+    /SEARCH exact_review_canonical_records .*\(repo_slug=\? AND section=\? AND item_id=\?\)/,
+  );
+  assert.match(
+    sourcePlan,
+    /SEARCH exact_review_record_backfill .*\(repo_slug=\? AND section=\? AND record_id=\?\)/,
+  );
+
+  const defaultResponse = await worker.fetch(
+    signedStateAppendRequest(EXPORT_PATH, { repoSlug: REPO_SLUG, sections: ["items"] }, SECRET),
+    env,
+  );
+  assert.equal(defaultResponse.status, 200);
+  const defaultPage = (await defaultResponse.json()) as {
+    records: unknown[];
+    nextCursor: number | null;
+    limit: number;
+  };
+  assert.equal(defaultPage.limit, 200);
+  assert.equal(defaultPage.records.length, 200);
+  assert.equal(defaultPage.nextCursor, null);
+  assert.equal((await exportResponse(env, 0, ["items"], 201)).status, 400);
 });
 
 test("signed record export preserves historical backfill items and canonical tombstones", async () => {
@@ -452,7 +590,8 @@ test("signed record export preserves historical backfill items and canonical tom
   ]);
   assert.equal(first.nextCursor, 1);
   assert.equal(storage.sql.queriesMatching(/FROM exact_review_record_backfill\s/).length, 1);
-  assert.equal(storage.sql.queriesMatching(/FROM exact_review_canonical_records\s/).length, 0);
+  assert.equal(sourceBatchQueries(storage).length, 1);
+  assert.equal(sourceBatchQueries(storage)[0]?.bindings[1], "[]");
 
   storage.sql.resetQueryHistory();
   const second = await exportPage(env, first.nextCursor, ["items"]);
@@ -511,7 +650,7 @@ test("signed record export returns one oversized serialized record and advances"
     sourceBytes: firstReconstructed[0]!.byteLength,
     serializedBytes: new TextEncoder().encode(JSON.stringify(first.records[0])).byteLength,
     records: first.records.length,
-    reconstructionQueries: firstReconstructed.length,
+    reconstructionQueries: sourceBatchQueries(storage).length,
     nextCursor: first.nextCursor,
   };
 
@@ -520,6 +659,60 @@ test("signed record export returns one oversized serialized record and advances"
   assert.equal(second.records.length, 1);
   assert.equal(second.records[0]?.id, "2");
   assert.equal(second.nextCursor, null);
+});
+
+test("signed record export stops on serialized bytes and resumes at the unreturned record", async () => {
+  const { env, storage } = await exportHarness();
+  const fixtures = [
+    fixtureRecord({
+      source: "canonical",
+      section: "items",
+      id: "1",
+      content: "\u0000".repeat(600_000),
+      storeRevision: 1,
+    }),
+    fixtureRecord({
+      source: "backfill",
+      section: "commits",
+      id: "a".repeat(40),
+      content: "\u0000".repeat(600_000),
+      storeRevision: 2,
+    }),
+    fixtureRecord({
+      source: "canonical",
+      section: "items",
+      id: "3",
+      content: "after-byte-stop",
+      storeRevision: 3,
+    }),
+  ];
+  for (const record of fixtures) seedFixtureRecord(storage, record);
+  assert.ok(
+    fixtures.reduce((sum, record) => sum + record.byteLength, 0) < EXPECTED_SOURCE_BYTE_BUDGET,
+  );
+
+  const first = await exportPage(env, 0);
+  assert.deepEqual(
+    first.records.map((record) => record.id),
+    ["1"],
+  );
+  assert.equal(first.nextCursor, 1);
+  const second = await exportPage(env, first.nextCursor);
+  assert.deepEqual(
+    second.records.map((record) => record.id),
+    ["a".repeat(40), "3"],
+  );
+  assert.equal(second.nextCursor, null);
+  for (const page of [first, second]) {
+    assert.ok(
+      page.records.reduce((sum, record) => sum + Buffer.byteLength(JSON.stringify(record)), 0) <=
+        4 * 1024 * 1024,
+    );
+  }
+  assert.deepEqual(
+    [...first.records, ...second.records].map((record) => record.content),
+    fixtures.map((record) => record.content),
+  );
 });
 
 test("signed record export hides missing and invalid logical byte metadata", async () => {

--- a/test/worker-records-request.test.ts
+++ b/test/worker-records-request.test.ts
@@ -112,6 +112,7 @@ test("canonical record export recovers through a signed loopback HTTP transport"
   for (const request of requests) {
     assert.equal(request.method, "POST");
     assert.equal(request.path, "/internal/state/records/export");
+    assert.equal(JSON.parse(request.body).limit, 200);
     assert.equal(
       request.signature,
       `sha256=${createHmac("sha256", webhookSecret).update(request.body).digest("hex")}`,


### PR DESCRIPTION
## What Problem This Solves

Resolves the export request amplification reported in https://github.com/openclaw/clawsweeper/issues/1372. The production tail on 2026-09-03 at 23:0x UTC recorded 1,091 `records/export` requests out of 1,378 Durable Object requests in 97 seconds (about 11 export requests/second), alongside 112 outer-Worker `platform_overloaded` rejections. Replaying approximately 111,000 changed records from a stale snapshot previously needed about 2,220 sequential requests because reconstruction stopped at 50 records.

## Why

Small-record pages now carry 200 records, reducing the same replay to about 555 requests: 75% fewer requests. The handler maximum remains 200 because this provides the requested fourfold count improvement while retaining a bounded amount of per-request work. Large-record pages still stop on the existing byte budgets.

## What Changed

- Raise the reconstruction cap, Worker default, and hydration-client default to 200; retain the handler maximum of 200.
- After the 2 MiB source-byte preflight, fetch canonical and backfill source rows in one indexed SQL query. Two JSON identity lists keep the query at four bindings; chunk reassembly remains unchanged.
- Preserve the 4 MiB serialized-entry budget and return a cursor for the last emitted record when either byte budget ends the page. Retain the existing first-record progress exception so an oversized individual record cannot pin export forever; the serialized budget counts entries rather than the outer envelope.
- Extend count, byte-stop, client transport, SQL binding/index, tombstone, backfill, and hydration regression coverage. Update the active limits and live-dashboard documentation.

## User Impact

Full hydration spends four times fewer export requests when record size permits 200-record pages. Record contents, ordering within export pages, deletion propagation, authentication, and checkpoint semantics are preserved.

## OpenClaw Bay Impact

OpenClaw Bay is unaffected. This changes the signed internal hydration route and its client, without changing the public observer projection, status schema, or navigation.

## Documentation Impact

Updated active references `docs/limits.md` and `docs/live-dashboard.md`; the cold-hydration comment now reflects ten small-record pages for 2,000 records. The shared 2 MiB file limit remains unchanged. No changelog change is included.

## Real Behavior Proof

`pr-behavior-proof`

Head: `47d88695087ba7824d9ae833595bffb7a50fbdfd`. Runtime bundle SHA-256: `ee9763efd1779d62daf39ff2f81107507359e9898108c57bdb8732e39340e8a6`.

Claim: 200 small canonical records fit in one export response, full client hydration uses four times fewer requests, and source/serialized byte stops resume without omissions or duplicate records.

Surface and environment: the actual hydration client over loopback HTTP into the production Worker route and export handler, running in local workerd / Miniflare 4.20260701.0 with a SQLite-backed Durable Object and compatibility date 2026-05-11. A local-only wrapper seeds synthetic canonical records; all export requests use the existing signed route. Host: macOS, Node 26.8.1, pnpm 11.10.0. No deployment, production data, or live workflow dispatch was used.

Command: `node .artifacts/export-pages/runtime-proof.mjs` (task-local simulator harness). Durable trace:

| Scenario | Records | Returned page sizes | Continuation cursors | Result |
| --- | ---: | --- | --- | --- |
| Small records | 800 | 200, 200, 200, 200 | 200, 400, 600, null | Exact content/digest parity; four signed HTTP requests |
| Source-byte stop | 208 | 200, 6, 1, 1 | 200, 206, 207, null | Exact content/digest parity; 2 MiB preflight stops before the next large record |
| Serialized-byte stop | 3 | 1, 2 | 1, null | Exact content/digest parity; JSON escaping triggers the 4 MiB entry budget before 2 MiB of source |

The source-byte fixture has 205 one-KiB records followed by three 1,600,000-byte chunked records. The serialized-byte fixture has two 600,000-byte NUL strings followed by a small record. Full local trace: `.artifacts/export-pages/runtime-proof.json`. The checked-in `test/record-export-bounds.test.ts` also exercises signed HTTP hydration and real SQLite, mixed canonical/backfill pages, tombstones, byte bounds, query plans, and the 100-binding ceiling; it emits `.artifacts/export-pages/behavior.json` when `RECORD_EXPORT_PROOF_PATH` is set.

Limits: this proves local runtime behavior and request counts, not production CPU, overload recovery, concurrent-workflow capacity, or the size distribution of the production backlog. The first-record progress exception is unchanged.

## Evidence

Before implementation, the regression run failed on three assertions: candidate count `50 !== 200`, returned count `50 !== 200`, and client request limit `100 !== 200`. After the fix, all 309 tests in the four requested files pass:

```sh
node --test test/record-export-bounds.test.ts test/worker-records-request.test.ts test/exact-review-publication-batches.test.ts test/dashboard-worker-queue-runtime.test.ts
```

`pnpm run format`, `pnpm run build:all`, `pnpm run lint`, `pnpm run check:docs`, `pnpm run check:limits`, and `git diff --check` pass. Independent review completed without actionable findings. The exact-head CI run passed, including its full `pnpm run check`, Windows, and sparse-build jobs: https://github.com/openclaw/clawsweeper/actions/runs/33817007839. CodeQL also passed: https://github.com/openclaw/clawsweeper/actions/runs/33817007834. No CI fix or retry was needed. The additional local full-suite run was intentionally stopped after CI turned green, as requested. It exited 143 and emitted cancellation output for remaining tests, including the still-running target-validation file; it is not counted as a completed local pass. The full check passed in exact-head CI.
