### PR TITLE
perf(queue): memoize Bay projection and lean claimed-run reads

### DIFF
--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -849,10 +849,25 @@ export class ExactReviewQueue {
     generation: number;
   } | null = null;
 
-  private invalidateStatsCache() {
+  private lifecycleBayCache: {
+    key: string;
+    expiresAt: number;
+    body: string;
+    changes: number;
+  } | null = null;
+  private lifecycleBayComputation: {
+    key: string;
+    body: Promise<string>;
+    changes: number;
+    generation: number;
+  } | null = null;
+
+  private invalidateReadCaches() {
     this.statsMutationGeneration++;
     this.statsCache = null;
     this.statsComputation = null;
+    this.lifecycleBayCache = null;
+    this.lifecycleBayComputation = null;
   }
 
   private reviewCoverageCache: { at: number; summary: ReviewCoverageSummary } | null = null;
@@ -923,14 +938,14 @@ export class ExactReviewQueue {
     hostedTargetMetadataToken = exactReviewHostedTargetMetadataTokenSource(this.env),
   ) {
     const mutating = request.method !== "GET";
-    if (mutating) this.invalidateStatsCache();
+    if (mutating) this.invalidateReadCaches();
     try {
       return await this.handleFetch(request, hostedTargetMetadataToken);
     } catch (error) {
       rethrowQueueFailure(error, "fetch", request);
     } finally {
       // Mutators can yield to a dashboard poll while awaiting external work.
-      if (mutating) this.invalidateStatsCache();
+      if (mutating) this.invalidateReadCaches();
     }
   }
 
@@ -945,19 +960,7 @@ export class ExactReviewQueue {
     // cleanup, queue reclamation, alarm scheduling, or GitHub work.
     if (request.method === "GET" && url.pathname === "/lifecycle-bay") {
       await this.lifecycleProjectionReady.catch(() => undefined);
-      const publicRepositories = url.searchParams
-        .getAll("public_repo")
-        .map((value) => value.trim().toLowerCase());
-      const validPublicRepositories =
-        publicRepositories.length <= 32 &&
-        publicRepositories.every((value) => /^[a-z0-9_.-]+\/[a-z0-9_.-]+$/.test(value));
-      return json({
-        durable_lifecycle_bay: !url.searchParams.has("public_repo")
-          ? this.lifecycleProjectionStore.readBaySnapshot()
-          : validPublicRepositories
-            ? this.lifecycleProjectionStore.readBaySnapshot(Date.now(), new Set(publicRepositories))
-            : this.lifecycleProjectionStore.readBaySnapshot(Date.now(), new Set()),
-      });
+      return this.lifecycleBayResponse(url);
     }
     if (request.method === "GET" && url.pathname === "/bay-lifecycle-metrics") {
       await this.lifecycleProjectionReady.catch(() => undefined);
@@ -2830,29 +2833,40 @@ export class ExactReviewQueue {
       // so corrupt duplicates remain ambiguous, and bound the snapshot to the global worker
       // budget so one reconciliation never becomes an unbounded GitHub API fan-out.
       const requestedRunIds = new Set(requestedRuns.map((run) => run.runId));
-      const matchesByRunId = new Map<string, ExactReviewQueueItem[]>();
-      const state = this.readStateSync();
-      for (const item of Object.values(state.items)) {
-        if (
-          item.state !== "leased" ||
-          !item.claimedRunId ||
-          (!includeAllClaimed && !requestedRunIds.has(item.claimedRunId))
-        ) {
-          continue;
-        }
-        const matches = matchesByRunId.get(item.claimedRunId) || [];
-        if (matches.length < 2) matches.push(item);
-        matchesByRunId.set(item.claimedRunId, matches);
+      const matchesByRunId = new Map<
+        string,
+        Array<{ run_id: string; run_attempt: number | null; claim_generation: number }>
+      >();
+      // Extract only lease identity fields. Reading the full state would parse
+      // every pending item's decision and retained publication payload too.
+      for (const row of this.storage.sql.exec(
+        `SELECT item_key,
+                json_extract(item_json, '$.key', '$.claimedRunId',
+                             '$.claimedRunAttempt', '$.claimGeneration') AS claim_json
+           FROM ${EXACT_REVIEW_QUEUE_ITEM_TABLE}
+          WHERE json_extract(item_json, '$.state') = 'leased'
+            ${includeAllClaimed ? "" : "AND json_extract(item_json, '$.claimedRunId') IN (SELECT value FROM json_each(?))"}
+          ORDER BY rowid`,
+        ...(includeAllClaimed ? [] : [JSON.stringify([...requestedRunIds])]),
+      ) as Iterable<{ item_key: string; claim_json: string }>) {
+        const [key, runId, runAttempt, generation] = JSON.parse(row.claim_json) as [
+          string,
+          string | null,
+          number | null,
+          number | null,
+        ];
+        if (key !== row.item_key) throw new Error("invalid exact-review queue claim item");
+        if (!runId || (!includeAllClaimed && !requestedRunIds.has(runId))) continue;
+        const matches = matchesByRunId.get(runId) || [];
+        if (matches.length < 2)
+          matches.push({
+            run_id: String(runId),
+            run_attempt: runAttempt ?? null,
+            claim_generation: exactReviewClaimGeneration(generation),
+          });
+        matchesByRunId.set(runId, matches);
       }
-      const runs = [...matchesByRunId.values()]
-        .flatMap((matches) =>
-          matches.map((item) => ({
-            run_id: String(item.claimedRunId),
-            run_attempt: item.claimedRunAttempt ?? null,
-            claim_generation: exactReviewClaimGeneration(item.claimGeneration),
-          })),
-        )
-        .slice(0, EXACT_REVIEW_RECONCILE_RUN_LIMIT);
+      const runs = [...matchesByRunId.values()].flat().slice(0, EXACT_REVIEW_RECONCILE_RUN_LIMIT);
       return json({ runs });
     }
 
@@ -3896,6 +3910,88 @@ export class ExactReviewQueue {
     );
   }
 
+  private computeLifecycleBayBody(repositories?: ReadonlySet<string>) {
+    return JSON.stringify(
+      {
+        durable_lifecycle_bay: this.lifecycleProjectionStore.readBaySnapshot(
+          Date.now(),
+          repositories,
+        ),
+      },
+      null,
+      2,
+    );
+  }
+
+  private async lifecycleBayResponse(url: URL) {
+    return cors(
+      new Response(await this.lifecycleBayBody(url), {
+        headers: {
+          "content-type": "application/json; charset=utf-8",
+          "cache-control": "no-store",
+        },
+      }),
+    );
+  }
+
+  private async lifecycleBayBody(url: URL): Promise<string> {
+    const publicRepositories = url.searchParams
+      .getAll("public_repo")
+      .map((value) => value.trim().toLowerCase());
+    const valid =
+      publicRepositories.length <= 32 &&
+      publicRepositories.every((value) => /^[a-z0-9_.-]+\/[a-z0-9_.-]+$/.test(value));
+    const repositories = !url.searchParams.has("public_repo")
+      ? undefined
+      : new Set(valid ? publicRepositories.sort() : []);
+    const configured = Number(this.env.EXACT_REVIEW_LIFECYCLE_BAY_CACHE_MS ?? 10_000);
+    const ttl = Number.isFinite(configured) && configured >= 0 ? configured : 10_000;
+    if (!ttl) {
+      this.lifecycleBayCache = null;
+      this.lifecycleBayComputation = null;
+      return this.computeLifecycleBayBody(repositories);
+    }
+    const key = JSON.stringify(repositories ? [...repositories] : null);
+    for (;;) {
+      const now = Date.now();
+      const changes = this.storageChangeCountSync();
+      const generation = this.statsMutationGeneration;
+      const cached = this.lifecycleBayCache;
+      if (cached?.key === key && cached.expiresAt > now && cached.changes === changes)
+        return cached.body;
+      const pending = this.lifecycleBayComputation;
+      if (
+        pending?.key === key &&
+        pending.changes === changes &&
+        pending.generation === generation
+      ) {
+        // An in-flight body is not a validated cache entry. A waiter must check
+        // again after yielding because writes can invalidate that computation.
+        await pending.body;
+        continue;
+      }
+      const computation = {
+        key,
+        changes,
+        generation,
+        body: Promise.resolve().then(() => this.computeLifecycleBayBody(repositories)),
+      };
+      this.lifecycleBayComputation = computation;
+      try {
+        const body = await computation.body;
+        if (
+          this.lifecycleBayComputation === computation &&
+          this.statsMutationGeneration === generation &&
+          this.storageChangeCountSync() === changes
+        )
+          this.lifecycleBayCache = { key, expiresAt: now + ttl, body, changes };
+        return body;
+      } finally {
+        if (this.lifecycleBayComputation === computation) this.lifecycleBayComputation = null;
+      }
+    }
+  }
+
   private async statsResponse(url: URL) {
     return cors(
       new Response(await this.statsBody(url), {
@@ -4297,11 +4393,11 @@ export class ExactReviewQueue {
   }
 
   async alarm() {
-    this.invalidateStatsCache();
+    this.invalidateReadCaches();
     try {
       await this.handleAlarm();
     } finally {
-      this.invalidateStatsCache();
+      this.invalidateReadCaches();
     }
   }
 
@@ -11414,7 +11510,7 @@ export class ExactReviewQueue {
 
   private writeStateSync(state: ExactReviewQueueState) {
     if (this.schedulingStates.has(state)) throw new Error("cannot persist a queue census");
-    this.invalidateStatsCache();
+    this.invalidateReadCaches();
     const baseline = this.baselines.get(state) || this.readStateBaselineSync();
     const nextItems = new Map<string, string>();
     let reviewEnqueued = 0;

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -464,6 +464,13 @@ remain unchanged are memoized; polls waiting on invalidated work recompute.
 This only bounds observation freshness: the public projection's fields and
 meaning, admission, publication fences, and Bay behavior are unchanged.
 
+The object's lifecycle Bay response also has a 10-second memo
+(`EXACT_REVIEW_LIFECYCLE_BAY_CACHE_MS`; set `0` to disable), scoped to the
+requested public repositories. Concurrent reads share the original snapshot
+and `generated_at`; lifecycle and queue state writes invalidate it, including
+writes during an in-flight read. This complements the Worker's existing
+20-second public response cache without changing Bay fields or freshness rules.
+
 For capacity displays, `/api/exact-review-queue` also exposes compatible
 `lanes.review` and `lanes.publication` objects. Each lane reports its own
 pending, ready, backoff, dispatching, leased, capacity, active, available-slot,

--- a/test/dashboard-worker-observability.test.ts
+++ b/test/dashboard-worker-observability.test.ts
@@ -276,9 +276,10 @@ test("durable lifecycle Bay is a pure, bounded public-reference reducer snapshot
   const queries: string[] = [];
   const queryBindings: unknown[][] = [];
   storage.sql.exec = (query: string, ...bindings: unknown[]) => {
+    assert.match(query, /^\s*SELECT\b/i, "Bay route must be read-only");
+    if (query === "SELECT total_changes() AS changes") return exec(query, ...bindings);
     queries.push(query);
     queryBindings.push(bindings);
-    assert.match(query, /^\s*SELECT\b/i, "Bay route must be read-only");
     assert.match(query, /FROM exact_review_lifecycle_projection_v1/);
     if (/MAX\(revision\) AS max_revision/.test(query)) {
       assert.match(query, /WHERE canonical_target_key IN \(SELECT value FROM json_each\(\?\)\)/);

--- a/test/exact-review-queue-cpu.test.ts
+++ b/test/exact-review-queue-cpu.test.ts
@@ -20,7 +20,7 @@ const post = (path: string, body: unknown) =>
 
 // Same publication/lease shape as the publication-batch fixtures. Historical direct
 // rows include the old inline base64 operations still readable after the cutover.
-async function fixture(size = 300, overrides = {}) {
+async function fixture(size = 300, overrides = {}, leasedCount = 50) {
   const storage = new TestStorage();
   const env: Record<string, unknown> = {
     EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
@@ -32,7 +32,7 @@ async function fixture(size = 300, overrides = {}) {
   await queue.fetch(new Request("https://queue/stats"));
   const lifecycle = new ExactReviewLifecycleProjectionStore(storage);
   const items: ExactReviewQueueItem[] = [];
-  for (let n = 1; n <= size + 50; n++) {
+  for (let n = 1; n <= size + leasedCount; n++) {
     const producerDecision = {
       targetRepo: "openclaw/openclaw",
       targetBranch: "main",
@@ -337,11 +337,71 @@ test(
   },
 );
 
+test(
+  "Bay and claimed-run CPU benchmark at 500 projections and 100 leases (opt in)",
+  { skip: process.env.EXACT_REVIEW_CPU_BENCH !== "1" },
+  async (t) => {
+    t.mock.method(Date, "now", () => NOW);
+    const { queue, storage, items, env } = await fixture(400, {}, 100);
+    const samples: Record<string, unknown>[] = [];
+    async function measure(route: string, request: () => Request) {
+      const times: number[] = [];
+      let queries = 0;
+      const exec = storage.sql.exec;
+      storage.sql.exec = (query, ...bindings) => {
+        queries++;
+        return exec(query, ...bindings);
+      };
+      try {
+        for (let i = 0; i < 20; i++) {
+          const start = process.cpuUsage();
+          const response = await queue.fetch(request());
+          assert.equal(response.status, 200);
+          const body = await response.json();
+          if (route.startsWith("lifecycle-bay")) {
+            assert.equal(body.durable_lifecycle_bay.collection.state, "complete");
+            assert.equal(body.durable_lifecycle_bay.inventory.lifecycle_records, 500);
+          } else assert.ok(body.runs.length > 0);
+          const cpu = process.cpuUsage(start);
+          times.push((cpu.user + cpu.system) / 1000);
+        }
+      } finally {
+        storage.sql.exec = exec;
+      }
+      times.sort((a, b) => a - b);
+      samples.push({
+        route,
+        median_cpu_ms: times[10],
+        max_cpu_ms: times.at(-1),
+        sql_per_call: queries / times.length,
+      });
+    }
+    const bayRequest = () =>
+      new Request("https://queue/lifecycle-bay?public_repo=openclaw/openclaw");
+    env.EXACT_REVIEW_LIFECYCLE_BAY_CACHE_MS = "0";
+    await measure("lifecycle-bay-uncached", bayRequest);
+    env.EXACT_REVIEW_LIFECYCLE_BAY_CACHE_MS = "10000";
+    await queue.fetch(bayRequest());
+    await measure("lifecycle-bay-cached", bayRequest);
+    await measure("claimed-runs-all", () =>
+      post("/claimed-runs", { runs: [], include_all_claimed: true }),
+    );
+    await measure("claimed-runs-filtered", () =>
+      post("/claimed-runs", {
+        runs: items.slice(400, 432).map((item) => ({ run_id: item.claimedRunId, run_attempt: 1 })),
+      }),
+    );
+    console.log(
+      JSON.stringify({ fixture: { pending: 400, leased: 100, lifecycle: 500 }, samples }),
+    );
+  },
+);
+
 type QueueInternals = {
   readStateSync(): ExactReviewQueueState;
   readSchedulingStateSync(): ExactReviewQueueState;
   writeStateSync(state: ExactReviewQueueState): void;
-  invalidateStatsCache(): void;
+  invalidateReadCaches(): void;
   scheduleNext(state: ExactReviewQueueState, now: number): Promise<void>;
   hostedTargetAdmission(): Promise<{ outcome: "terminal" }>;
 };
@@ -430,11 +490,11 @@ for (const mutation of ["explicit invalidation", "auxiliary SQL write"] as const
         await resume.promise;
       }
     });
-    internals(queue).invalidateStatsCache();
+    internals(queue).invalidateReadCaches();
     const first = queue.fetch(new Request("https://queue/stats"));
     await entered.promise;
     if (mutation === "explicit invalidation") {
-      internals(queue).invalidateStatsCache();
+      internals(queue).invalidateReadCaches();
     } else {
       storage.run(
         "DELETE FROM exact_review_direct_publication_plans WHERE item_key = ?",
@@ -667,4 +727,280 @@ test("concurrent renewal of an expired stats memo performs one queue scan", asyn
       .length,
     1,
   );
+});
+
+test("lifecycle Bay memo shares fresh polls, expires, and preserves headers and snapshot time", async (t) => {
+  let now = NOW;
+  t.mock.method(Date, "now", () => now);
+  const { queue, storage } = await fixture(3);
+  const exec = t.mock.method(storage.sql, "exec");
+  const read = () => queue.fetch(new Request("https://queue/lifecycle-bay"));
+  const responses = await Promise.all(Array.from({ length: 8 }, read));
+  const first = await responses[0]!.text();
+  assert.equal(responses[0]!.headers.get("cache-control"), "no-store");
+  assert.equal(responses[0]!.headers.get("content-type"), "application/json; charset=utf-8");
+  assert.equal(responses[0]!.headers.get("access-control-allow-origin"), "*");
+  for (const response of responses.slice(1)) assert.equal(await response.text(), first);
+  now += 9_999;
+  assert.equal(await (await read()).text(), first);
+  assert.equal(
+    exec.mock.calls.filter(({ arguments: [sql] }) => /SELECT projection_json,/.test(sql)).length,
+    1,
+  );
+  now++;
+  const renewed = await Promise.all(Array.from({ length: 8 }, async () => (await read()).text()));
+  assert.notEqual(renewed[0], first);
+  assert.ok(renewed.every((body) => body === renewed[0]));
+  assert.equal(
+    exec.mock.calls.filter(({ arguments: [sql] }) => /SELECT projection_json,/.test(sql)).length,
+    2,
+  );
+});
+
+test("lifecycle Bay memo separates repository scopes, including invalid and absent scopes", async (t) => {
+  t.mock.method(Date, "now", () => NOW);
+  const { queue, storage, lifecycle } = await fixture(3);
+  lifecycle.recordAdmission({
+    canonicalTargetKey: "openclaw/clawhub#1",
+    fenceKey: "hub-1",
+    revision: 1,
+    deliveryId: "hub-1",
+    sourceAction: "opened",
+    commandOriginated: false,
+    statusMarker: null,
+    statusCommentId: null,
+    observedAt: NOW,
+  });
+  const read = async (query = "") =>
+    (await (await queue.fetch(new Request(`https://queue/lifecycle-bay${query}`))).json())
+      .durable_lifecycle_bay;
+  const all = await read();
+  const scoped = await read("?public_repo=openclaw/openclaw");
+  assert.equal(all.inventory.lifecycle_records, scoped.inventory.lifecycle_records + 1);
+  assert.equal((await read("?public_repo=openclaw/clawhub")).inventory.lifecycle_records, 1);
+  assert.equal((await read("?public_repo=invalid")).inventory.lifecycle_records, 0);
+  assert.equal((await read("?public_repo=")).inventory.lifecycle_records, 0);
+  const exec = t.mock.method(storage.sql, "exec");
+  const combined = await read("?public_repo=openclaw/openclaw&public_repo=openclaw/clawhub");
+  const count = exec.mock.calls.length;
+  assert.deepEqual(
+    await read(
+      "?public_repo=OpenClaw/ClawHub&public_repo=openclaw/openclaw&public_repo=openclaw/clawhub",
+    ),
+    combined,
+  );
+  assert.equal(
+    exec.mock.calls.length,
+    count + 1,
+    "equivalent scopes only check the storage generation",
+  );
+  assert.deepEqual(await read(), all);
+  assert.equal(
+    (await read(`?${Array.from({ length: 33 }, () => "public_repo=openclaw/openclaw").join("&")}`))
+      .inventory.lifecycle_records,
+    0,
+  );
+});
+
+test("lifecycle Bay memo can be disabled and invalidates on queue state writes", async (t) => {
+  t.mock.method(Date, "now", () => NOW);
+  const { queue, storage, env } = await fixture(3);
+  const exec = t.mock.method(storage.sql, "exec");
+  const read = () => queue.fetch(new Request("https://queue/lifecycle-bay"));
+  await read();
+  await read();
+  const state = internals(queue).readStateSync();
+  storage.transactionSync(() => internals(queue).writeStateSync(state));
+  await read();
+  env.EXACT_REVIEW_LIFECYCLE_BAY_CACHE_MS = "0";
+  await read();
+  await read();
+  env.EXACT_REVIEW_LIFECYCLE_BAY_CACHE_MS = "10000";
+  await read();
+  await read();
+  assert.equal(
+    exec.mock.calls.filter(({ arguments: [sql] }) => /SELECT projection_json,/.test(sql)).length,
+    5,
+  );
+});
+
+test("lifecycle Bay writes during in-flight serialization cannot restore the older memo", async (t) => {
+  t.mock.method(Date, "now", () => NOW);
+  const { queue, lifecycle, items } = await fixture(3);
+  const target = queue as unknown as {
+    computeLifecycleBayBody(repositories?: ReadonlySet<string>): string | Promise<string>;
+  };
+  const compute = target.computeLifecycleBayBody.bind(target);
+  let release!: () => void;
+  let entered!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const started = new Promise<void>((resolve) => {
+    entered = resolve;
+  });
+  let calls = 0;
+  t.mock.method(target, "computeLifecycleBayBody", (repositories?: ReadonlySet<string>) => {
+    const body = compute(repositories);
+    if (++calls === 1) {
+      entered();
+      return gate.then(() => body);
+    }
+    return body;
+  });
+  const read = async () =>
+    (await (await queue.fetch(new Request("https://queue/lifecycle-bay"))).json())
+      .durable_lifecycle_bay;
+  const pending = read();
+  await started;
+  const waiter = read();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(calls, 1, "the second reader waits on the in-flight computation");
+  lifecycle.recordTerminalDisposition({
+    canonicalTargetKey: "openclaw/openclaw#1",
+    fenceKey: items[0]!.key,
+    revision: 1,
+    kind: "superseded",
+    observedAt: NOW,
+  });
+  const fresh = await read();
+  release();
+  const old = await pending;
+  assert.equal(fresh.lanes.superseded, old.lanes.superseded + 1);
+  assert.deepEqual(await waiter, fresh, "a waiting reader revalidates after an in-flight write");
+  assert.deepEqual(await read(), fresh);
+  assert.equal(calls, 2);
+});
+
+test("lifecycle Bay serialization failures do not poison or evict a replacement memo", async (t) => {
+  t.mock.method(Date, "now", () => NOW);
+  const { queue, lifecycle, items } = await fixture(3);
+  const target = queue as unknown as { computeLifecycleBayBody(): string | Promise<string> };
+  const compute = target.computeLifecycleBayBody.bind(target);
+  let reject!: (reason: Error) => void;
+  let entered!: () => void;
+  const started = new Promise<void>((resolve) => {
+    entered = resolve;
+  });
+  const gate = new Promise<string>((_resolve, fail) => {
+    reject = fail;
+  });
+  let calls = 0;
+  t.mock.method(target, "computeLifecycleBayBody", () => {
+    const body = compute();
+    if (++calls === 1) {
+      entered();
+      return gate;
+    }
+    return body;
+  });
+  const read = async () => (await queue.fetch(new Request("https://queue/lifecycle-bay"))).text();
+  const pending = read();
+  const rejected = assert.rejects(pending, /serialization failed/);
+  await started;
+  lifecycle.recordTerminalDisposition({
+    canonicalTargetKey: "openclaw/openclaw#1",
+    fenceKey: items[0]!.key,
+    revision: 1,
+    kind: "superseded",
+    observedAt: NOW,
+  });
+  const fresh = await read();
+  reject(new Error("serialization failed"));
+  await rejected;
+  assert.equal(await read(), fresh);
+  assert.equal(calls, 2);
+});
+
+test("lean claimed-run reads equal full reads across mixed leases, duplicates, legacy claims, and limits", async (t) => {
+  t.mock.method(Date, "now", () => NOW);
+  const { queue, storage, items } = await fixture(8, {}, 150);
+  const state = internals(queue).readStateSync();
+  const leased = items.slice(8);
+  for (const [index, original] of leased.entries()) {
+    const item = state.items[original.key]!;
+    if (index < 3) item.claimedRunId = "9999";
+    if (index === 3) {
+      delete item.claimedRunAttempt;
+      delete item.claimGeneration;
+    }
+    if (index === 4) {
+      item.claimGeneration = 0;
+      item.leaseExpiresAt = NOW - 1;
+    }
+    if (index === 5) delete item.claimedRunId;
+    if (index === 6) item.state = "pending";
+    if (index === 7) item.state = "dispatching";
+    if (index === 8) item.state = "parked";
+    if (index === 9)
+      item.terminalFinalization = {
+        disposition: "policy_noop",
+        statusState: "Complete",
+        statusDetail: "Done.",
+      };
+    item.decision.additionalPrompt = "Synthetic large decision. ".repeat(400);
+  }
+  storage.transactionSync(() => internals(queue).writeStateSync(state));
+  const full = Object.values(internals(queue).readStateSync().items);
+  function expected(runIds: string[], all: boolean) {
+    const grouped = new Map<string, ExactReviewQueueItem[]>();
+    for (const item of full) {
+      if (
+        item.state !== "leased" ||
+        !item.claimedRunId ||
+        (!all && !runIds.includes(item.claimedRunId))
+      )
+        continue;
+      const matches = grouped.get(item.claimedRunId) || [];
+      if (matches.length < 2) matches.push(item);
+      grouped.set(item.claimedRunId, matches);
+    }
+    return {
+      runs: [...grouped.values()]
+        .flatMap((matches) =>
+          matches.map((item) => ({
+            run_id: String(item.claimedRunId),
+            run_attempt: item.claimedRunAttempt ?? null,
+            claim_generation:
+              Number.isInteger(Number(item.claimGeneration)) && Number(item.claimGeneration) >= 0
+                ? Number(item.claimGeneration)
+                : 0,
+          })),
+        )
+        .slice(0, 128),
+    };
+  }
+  const exec = t.mock.method(storage.sql, "exec");
+  for (const [runIds, all] of [
+    [[], true],
+    [["9999", leased[3]!.claimedRunId!, leased[4]!.claimedRunId!], false],
+    [["999999999"], false],
+    [["9999"], true],
+  ] as const) {
+    const response = await queue.fetch(
+      post("/claimed-runs", {
+        runs: runIds.map((run_id) => ({ run_id, run_attempt: 7 })),
+        include_all_claimed: all,
+      }),
+    );
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), expected([...runIds], all));
+  }
+  assert.equal(exec.mock.calls.length, 4);
+  assert.ok(exec.mock.calls.every(({ arguments: [sql] }) => /AS claim_json/.test(sql)));
+  const owned = state.items[leased[3]!.key]!;
+  owned.claimGeneration = 12;
+  storage.transactionSync(() => internals(queue).writeStateSync(state));
+  const fresh = await queue.fetch(
+    post("/claimed-runs", { runs: [{ run_id: owned.claimedRunId }] }),
+  );
+  assert.equal(
+    (await fresh.json()).runs[0].claim_generation,
+    12,
+    "claim changes are immediately visible",
+  );
+  const invalid = await queue.fetch(
+    post("/claimed-runs", { runs: [], include_all_claimed: "true" }),
+  );
+  assert.equal(invalid.status, 400);
 });


### PR DESCRIPTION
## What Problem This Solves

Reduces read-side Durable Object CPU associated with https://github.com/openclaw/clawsweeper/issues/1372. The supplied production tail from 2026-09-03 23:16–23:18 UTC covered 106.6 seconds, approximately 61 seconds of object CPU, and 223 outer-Worker `platform_overloaded` logs. `/lifecycle-bay` accounted for 17,051 ms and `/claimed-runs` for 11,985 ms; `/records/export` contributed 9,049 ms across 640 calls and is separate work.

Streaming decoding of the raw tail found **two** Bay fetches (8,595 and 8,456 ms) and **five** claimed-run fetches (11,958, 7, 5, 6, and 9 ms). Those totals are dominated by outliers, rather than a steady 400/300 ms per request. The raw tail was deleted and is not included in this change.

## Why

The Worker makes one object call per `/api/durable-lifecycle-bay` cache miss and already caches its sanitized response for up to 20 seconds. The object still streams, validates, counts, and samples every lifecycle projection on each miss; its existing 512-entry parsed-projection cache does not avoid that work. Bay's browser poll runs every 20 seconds, while distinct Worker cache locations can each miss independently.

`/claimed-runs` previously read metadata and every queue item, then `Object.values()` forced every lazy JSON decision and publication payload to parse. The route needs only lease identities. It had two SQL calls, not a per-lease SQL lookup; the expensive full-state transfer and parsing are removed.

## What Changed

Added a repository-scoped 10-second object response memo, configurable with `EXACT_REVIEW_LIFECYCLE_BAY_CACHE_MS` (`0` disables it). It shares concurrent reads, preserves the original snapshot timestamp and headers, and invalidates on lifecycle/state changes, mutating requests, and alarms. Only completed serialized snapshots with unchanged storage and mutation generations enter the memo. Concurrent waiters revalidate after an in-flight write, preserving the stats-memo fix already on main.

Claimed-run inventory now uses one SQL query that extracts only identity fields from leased rows and optionally filters the requested run set. Existing order, two matches per run, the 128-result bound, null attempts, generation defaults, and reconciliation fences remain intact. No claimed-run memo or incremental lifecycle materialization was needed to reach the measured targets.

OpenClaw Bay is affected only in read cost and bounded observation freshness; its **public contract is unchanged**. No change is needed in Bay UI or projection consumers. `/api/exact-review-queue`, `/api/lifecycle`, and Bay field sets and meanings are unchanged. No changelog, binding, migration, admission, publication, or reconciliation-fence change is included.

## pr-behavior-proof

**Claim and exercised surface:** lower recurring CPU for the real `ExactReviewQueue.fetch()` Bay and claimed-run paths while preserving their projections and claim identities. Baseline: `0633e8cc1487dc9ce31d9ac24b3ab49b17c945c6`. Candidate: `d08c14817ca571d0ea2533697ed268c7de3892a3`.

**Scenario/environment:** 500 lifecycle projections, 400 pending items, and 100 leased items. The opt-in Node benchmark uses real in-memory SQLite, retained synthetic publication data, 20 requests per route, and `process.cpuUsage()`, including response parsing. Environment: macOS arm64, Node 26.8.1. Counts instrument `sql.exec`; no SQL calls are mocked.

```sh
EXACT_REVIEW_CPU_BENCH=1 node --test --test-name-pattern='Bay and claimed-run CPU benchmark' test/exact-review-queue-cpu.test.ts
```

| Route | Before median CPU | After median CPU | Before → after SQL/call |
| --- | ---: | ---: | ---: |
| Bay, uncached | 6.256 ms | 6.414 ms | 3 → 3 |
| Bay, repeated/cached | 5.293 ms | 0.072 ms | 3 → 1 |
| Claimed runs, all 100 leases | 2.482 ms | 1.173 ms | 2 → 1 |
| Claimed runs, 32 requested IDs | 2.528 ms | 0.927 ms | 2 → 1 |

After maxima were 15.586 ms uncached Bay, 0.131 ms cached Bay, 2.756 ms all claims, and 1.550 ms filtered claims. All requested CPU targets were met locally.

**Controlled runtime proof:** both baseline and candidate were bundled into isolated local workerd instances with real SQLite Durable Objects (Miniflare 4.20260701.0), seeded with 500 synthetic projections and 100 leases, and exercised over the Worker/DO binding. Temporary proof commands:

```sh
node /tmp/bay-cpu-proof/run.mjs /tmp/bay-cpu-proof/rebased-base /tmp/bay-cpu-proof before-rebase
node /tmp/bay-cpu-proof/run.mjs "$PWD" /tmp/bay-cpu-proof after-rebase
```

The normalized before/after Bay and claimed-run responses matched exactly; all-claims returned 100 identities, filtered claims returned 32, and a lifecycle terminal write immediately changed the cached Bay lane count. Median HTTP wall times were 7.16 → 1.72 ms for repeated Bay and 10.81 → 5.21 ms for all claims. Workerd SQL counts independently confirmed 3 → 1 for repeated Bay and 2 → 1 for claims. These are HTTP wall timings, not Worker CPU measurements.

**Artifacts/trace:** local `/tmp/bay-cpu-proof/evidence.json` contains source and bundle SHA-256 hashes, both runtime response traces, per-route timings, SQL counts, and tail aggregates; `/tmp/bay-cpu-before-rebase.txt` and `/tmp/bay-cpu-after-rebase.txt` contain benchmark output. The temporary runtime harness and bundles are retained beside that evidence for inspection. No production data was sent to the proof runtime.

**Limits:** synthetic local proof does not establish production CPU, cache hit rate under write load, or the cause/removal of the long cold-request outliers. Cache invalidation is conservative; sustained writes still require fresh reads. No live workflow run, deployment, or merge was performed.

**Validation:** memo freshness/expiry/disablement, normalized repository scopes, queue and lifecycle invalidation, in-flight write/failure races, malformed durable projections, and lean/full equivalence across duplicates, legacy claims, expired/finalizing leases, selection, and truncation. The requested seven-suite command passes, with the signed reconciliation policy suite also passing (578 passed, two opt-in benchmarks skipped). Independent pre-commit review of the rebased candidate found no actionable P0–P2 findings.

```sh
node --test test/exact-review-queue-cpu.test.ts test/exact-review-lifecycle-bay.test.ts test/dashboard-worker-publication-lifecycle.test.ts test/dashboard-worker-observability.test.ts test/dashboard-worker-queue-runtime.test.ts test/exact-review-publication-batches.test.ts test/dashboard-worker-bay-records-routes.test.ts
```

Passed gates: `pnpm run format`, `pnpm run build:all`, `pnpm run lint`, `pnpm run check:docs`, `pnpm run check:dashboard-queue-boundary`, `pnpm run check:dashboard-strict`, and `git diff --check`. The full `pnpm run check` was rerun after rebasing; its result is pending. An unrelated synthetic-fixture admission test failed during the first broad run and passed an isolated retry; queue-focused suites passed throughout.
