### PR TITLE
perf(queue): cap ETag broker bodies at 128 KiB and cheapen store housekeeping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Count oversized ETag responses as durable cache skips using size-only store requests, preserving telemetry without sending or storing the response bodies.
+
 - Bound standalone webhook bodies to 2 MiB before signature verification, preserving chunked deliveries and flushing rejection responses before closing oversized requests. Thanks @SebTardif.
 - Preserve committed lifecycle outcomes when later queue completions disagree, preventing terminal-state conflicts from failing completion callbacks and acknowledgement drivers.
 - Retain numeric queue failure source locations inside the Durable Object before remote transport discards the original stack, without logging private error text.

--- a/config/documentation-sync.json
+++ b/config/documentation-sync.json
@@ -14,9 +14,14 @@
         "EXACT_REVIEW_PUBLICATION_FRESH_LANE_ENABLED": "1",
         "EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_ITEMS": "2",
         "EXACT_REVIEW_TARGET_RATE_PER_HOUR": "300",
-        "EXACT_REVIEW_TARGET_BURST": "30"
+        "EXACT_REVIEW_TARGET_BURST": "30",
+        "EXACT_REVIEW_LIFECYCLE_BAY_CACHE_MS": "30000"
       },
       "claims": [
+        {
+          "document": "docs/live-dashboard.md",
+          "text": "`EXACT_REVIEW_LIFECYCLE_BAY_CACHE_MS = \"{{EXACT_REVIEW_LIFECYCLE_BAY_CACHE_MS}}\"`"
+        },
         {
           "document": "README.md",
           "text": "production overrides them with {{EXACT_REVIEW_PUBLICATION_MIN_CONCURRENT}}/{{EXACT_REVIEW_PUBLICATION_BASE_CONCURRENT}}/{{EXACT_REVIEW_PUBLICATION_MAX_CONCURRENT}} and enables direct publication plus up to {{EXACT_REVIEW_PUBLICATION_BATCH_MAX_CONCURRENT}} concurrent size-{{EXACT_REVIEW_PUBLICATION_BATCH_SIZE}}"

--- a/dashboard/github-etag-cache.ts
+++ b/dashboard/github-etag-cache.ts
@@ -1,15 +1,18 @@
 import {
+  GITHUB_ETAG_CACHE_MAX_BODY_BYTES,
   githubEtagCacheKeyFromValue,
   type GithubEtagCacheKey,
 } from "../src/github-etag-cache-contract.ts";
 
 export const GITHUB_ETAG_CACHE_TABLE = "github_etag_response_cache_v1";
 export const GITHUB_ETAG_CACHE_MAX_ENTRIES = 2_048;
-export const GITHUB_ETAG_CACHE_MAX_BODY_BYTES = 512 * 1_024;
+export { GITHUB_ETAG_CACHE_MAX_BODY_BYTES };
 export const GITHUB_ETAG_CACHE_RETENTION_MS = 30 * 24 * 60 * 60 * 1_000;
 
 const METRICS_TABLE = "github_etag_response_cache_metrics_v1";
 const CLEANUP_LIMIT = 128;
+const CLEANUP_INTERVAL_MS = 60_000;
+const ENTRY_COUNT_RECONCILE_STORES = 64;
 const ETAG_MAX_LENGTH = 1_024;
 const DIGEST_PATTERN = /^[0-9a-f]{64}$/;
 
@@ -29,6 +32,9 @@ export type GithubEtagCacheLookup = {
 
 export class GithubEtagResponseStore {
   private readonly storage: GithubEtagStorage;
+  private entryCount: number | null = null;
+  private storesSinceCount = 0;
+  private lastCleanupAt: number | null = null;
 
   constructor(storage: GithubEtagStorage) {
     this.storage = storage;
@@ -105,17 +111,28 @@ export class GithubEtagResponseStore {
     const responseBody = typeof body.body === "string" ? body.body : "";
     if (!key) return { ok: false, error: "invalid_github_etag_cache_key", status: 400 };
     if (!validEtag(etag)) return this.skipped(key, now, "missing_or_invalid_etag");
-    if (!validJsonBody(responseBody)) return this.skipped(key, now, "invalid_json_body");
-    const bodyBytes = new TextEncoder().encode(responseBody).byteLength;
-    if (bodyBytes < 1 || bodyBytes > GITHUB_ETAG_CACHE_MAX_BODY_BYTES) {
+    const encodedBody = new TextEncoder().encode(responseBody);
+    const bodyBytes = encodedBody.byteLength;
+    if (bodyBytes > GITHUB_ETAG_CACHE_MAX_BODY_BYTES) {
       return this.skipped(key, now, "body_size_bound");
     }
-    const bodyDigest = await sha256Text(responseBody);
+    if (!validJsonBody(responseBody)) return this.skipped(key, now, "invalid_json_body");
+    const bodyDigest = await sha256Bytes(encodedBody);
     const expiresAt = now + GITHUB_ETAG_CACHE_RETENTION_MS;
-    this.storage.transactionSync(() => {
-      this.deleteExpiredSync(now);
-      this.storage.sql.exec(
-        `INSERT INTO ${GITHUB_ETAG_CACHE_TABLE} (
+    const lastCleanupAt = this.lastCleanupAt;
+    try {
+      this.storage.transactionSync(() => {
+        this.deleteExpiredSync(now);
+        const existing =
+          this.entryCount !== null &&
+          firstRow(
+            this.storage.sql.exec(
+              `SELECT 1 AS found FROM ${GITHUB_ETAG_CACHE_TABLE} WHERE cache_key = ?`,
+              key.cacheKey,
+            ),
+          );
+        this.storage.sql.exec(
+          `INSERT INTO ${GITHUB_ETAG_CACHE_TABLE} (
            cache_key, credential_pool, route, media_type, page, etag, body,
            body_digest, body_bytes, response_at, validated_at, expires_at
          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -127,22 +144,30 @@ export class GithubEtagResponseStore {
            response_at = excluded.response_at,
            validated_at = excluded.validated_at,
            expires_at = excluded.expires_at`,
-        key.cacheKey,
-        key.credentialPool,
-        key.route,
-        key.mediaType,
-        key.page,
-        etag,
-        responseBody,
-        bodyDigest,
-        bodyBytes,
-        now,
-        now,
-        expiresAt,
-      );
-      this.enforceEntryCapSync();
-      this.recordMetricSync(now, key.credentialPool, "cache_200_stored");
-    });
+          key.cacheKey,
+          key.credentialPool,
+          key.route,
+          key.mediaType,
+          key.page,
+          etag,
+          responseBody,
+          bodyDigest,
+          bodyBytes,
+          now,
+          now,
+          expiresAt,
+        );
+        if (this.entryCount !== null && !existing) this.entryCount += 1;
+        this.enforceEntryCapSync();
+        this.recordMetricSync(now, key.credentialPool, "cache_200_stored");
+      });
+    } catch (error) {
+      // SQLite rolls back housekeeping too; discard the in-memory count.
+      this.entryCount = null;
+      this.storesSinceCount = 0;
+      this.lastCleanupAt = lastCleanupAt;
+      throw error;
+    }
     return {
       ok: true,
       stored: true,
@@ -222,26 +247,35 @@ export class GithubEtagResponseStore {
   }
 
   private deleteExpiredSync(now: number): void {
-    this.storage.sql.exec(
-      `DELETE FROM ${GITHUB_ETAG_CACHE_TABLE}
+    if (this.lastCleanupAt !== null && now - this.lastCleanupAt < CLEANUP_INTERVAL_MS) return;
+    const deleted = Array.from(
+      this.storage.sql.exec(
+        `DELETE FROM ${GITHUB_ETAG_CACHE_TABLE}
         WHERE cache_key IN (
           SELECT cache_key FROM ${GITHUB_ETAG_CACHE_TABLE}
            WHERE expires_at <= ? ORDER BY expires_at LIMIT ${CLEANUP_LIMIT}
-        )`,
-      now,
-    );
+        ) RETURNING cache_key`,
+        now,
+      ),
+    ).length;
+    if (this.entryCount !== null) this.entryCount -= deleted;
     this.storage.sql.exec(
       `DELETE FROM ${METRICS_TABLE} WHERE bucket_start < ?`,
       now - 30 * 86_400_000,
     );
+    this.lastCleanupAt = now;
   }
 
   private enforceEntryCapSync(): void {
-    const count = Number(
-      firstRow(this.storage.sql.exec(`SELECT COUNT(*) AS count FROM ${GITHUB_ETAG_CACHE_TABLE}`))
-        ?.count || 0,
-    );
-    const overflow = Math.max(0, count - GITHUB_ETAG_CACHE_MAX_ENTRIES);
+    this.storesSinceCount += 1;
+    if (this.entryCount === null || this.storesSinceCount >= ENTRY_COUNT_RECONCILE_STORES) {
+      this.entryCount = Number(
+        firstRow(this.storage.sql.exec(`SELECT COUNT(*) AS count FROM ${GITHUB_ETAG_CACHE_TABLE}`))
+          ?.count || 0,
+      );
+      this.storesSinceCount = 0;
+    }
+    const overflow = Math.max(0, this.entryCount - GITHUB_ETAG_CACHE_MAX_ENTRIES);
     if (!overflow) return;
     this.storage.sql.exec(
       `DELETE FROM ${GITHUB_ETAG_CACHE_TABLE}
@@ -251,6 +285,7 @@ export class GithubEtagResponseStore {
         )`,
       overflow,
     );
+    this.entryCount -= overflow;
   }
 
   private recordMetricSync(now: number, credentialPool: string, outcome: string): void {
@@ -280,8 +315,8 @@ function validJsonBody(value: string): boolean {
   }
 }
 
-async function sha256Text(value: string): Promise<string> {
-  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+async function sha256Bytes(value: Uint8Array<ArrayBuffer>): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", value);
   return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 

--- a/dashboard/github-etag-cache.ts
+++ b/dashboard/github-etag-cache.ts
@@ -110,6 +110,14 @@ export class GithubEtagResponseStore {
     const etag = String(body.etag || "").trim();
     const responseBody = typeof body.body === "string" ? body.body : "";
     if (!key) return { ok: false, error: "invalid_github_etag_cache_key", status: 400 };
+    if (
+      !("body" in body) &&
+      typeof body.body_bytes === "number" &&
+      Number.isSafeInteger(body.body_bytes) &&
+      body.body_bytes > GITHUB_ETAG_CACHE_MAX_BODY_BYTES
+    ) {
+      return this.skipped(key, now, "body_size_bound");
+    }
     if (!validEtag(etag)) return this.skipped(key, now, "missing_or_invalid_etag");
     const encodedBody = new TextEncoder().encode(responseBody);
     const bodyBytes = encodedBody.byteLength;

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -9,6 +9,7 @@ import { directReReviewIntake } from "../src/repair/direct-re-review-admission.t
 import { isExactReviewCloseGuardLabel } from "../src/repair/exact-review-guard-labels.ts";
 import { exactReviewSourceRevisionMaterial } from "./exact-review-source-revision.ts";
 import {
+  GITHUB_ETAG_CACHE_MAX_BODY_BYTES,
   githubEtagCacheKey,
   githubEtagCacheRequestBody,
 } from "../src/github-etag-cache-contract.ts";
@@ -11541,7 +11542,11 @@ async function githubJson(env, path) {
   }
   if (!response.ok) throw new Error(`GitHub ${response.status} for ${path}`);
   const body = await response.text();
-  if (etagBrokerEnabled && requestBody) {
+  if (
+    etagBrokerEnabled &&
+    requestBody &&
+    new TextEncoder().encode(body).byteLength <= GITHUB_ETAG_CACHE_MAX_BODY_BYTES
+  ) {
     const etag = response.headers.get("etag") || "";
     await githubEtagQueuePost(env, "store", { ...requestBody, etag, body }).catch(() => undefined);
   }

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -11542,13 +11542,14 @@ async function githubJson(env, path) {
   }
   if (!response.ok) throw new Error(`GitHub ${response.status} for ${path}`);
   const body = await response.text();
-  if (
-    etagBrokerEnabled &&
-    requestBody &&
-    new TextEncoder().encode(body).byteLength <= GITHUB_ETAG_CACHE_MAX_BODY_BYTES
-  ) {
+  if (etagBrokerEnabled && requestBody) {
     const etag = response.headers.get("etag") || "";
-    await githubEtagQueuePost(env, "store", { ...requestBody, etag, body }).catch(() => undefined);
+    const bodyBytes = new TextEncoder().encode(body).byteLength;
+    await githubEtagQueuePost(env, "store", {
+      ...requestBody,
+      etag,
+      ...(bodyBytes > GITHUB_ETAG_CACHE_MAX_BODY_BYTES ? { body_bytes: bodyBytes } : { body }),
+    }).catch(() => undefined);
   }
   return parseGithubJsonBody(body, path);
 }

--- a/dashboard/wrangler.toml
+++ b/dashboard/wrangler.toml
@@ -71,6 +71,8 @@ EXACT_REVIEW_DISPATCH_DEBOUNCE_MAX_MS = "180000"
 # parked review inputs a fresh bounded retry budget.
 EXACT_REVIEW_RETRY_POLICY_EPOCH = "1"
 EXACT_REVIEW_PENDING_SOFT_LIMIT = "600"
+# Bay is observer-only; 30 seconds of staleness is acceptable.
+EXACT_REVIEW_LIFECYCLE_BAY_CACHE_MS = "30000"
 # A full review consumes about 30 GitHub requests. Keep scheduled review demand
 # at or below 9,000 requests/hour so the 15,000-request installation bucket has
 # explicit capacity for exact ingress, comment routing, apply proof, publication,

--- a/docs/github-egress-telemetry.md
+++ b/docs/github-egress-telemetry.md
@@ -117,10 +117,12 @@ runner access uses the publisher-scoped webhook HMAC because publication jobs
 already hold that narrowly scoped credential; the operator secret stays
 reserved for human recovery.
 
-Publication clients skip oversized bodies before sending a store request and
-record the existing local `cache_skip` event. Dashboard health reads also skip
-these store requests; they do not emit local broker metrics. Requests that reach
-the store retain its `body_size_bound` skip reason and `cache_skip` metric.
+Publication clients and dashboard health reads count oversized bodies as skips
+via a size-only store request: `body_bytes` carries the UTF-8 byte count and
+`body` is omitted. The store records `cache_skip` with reason `body_size_bound`
+without accessing the body table. Publication clients also retain their local
+`cache_skip` event. Store requests that include a body keep the existing
+validation and storage behavior; `body_bytes` does not override that body.
 The store keeps an in-memory entry count, reconciling it with SQLite on the
 first store and every 64 stores thereafter. Inserts and expiry/oldest-validation
 evictions maintain that count so the 2,048-entry cap holds after every store.

--- a/docs/github-egress-telemetry.md
+++ b/docs/github-egress-telemetry.md
@@ -110,12 +110,22 @@ private pool identities are never persisted or exposed.
 
 Entries live in the exact-review queue Durable Object for 30 days, matching the
 artifact-receipt retention convention. The store is capped at 2,048 entries and
-512 KiB of UTF-8 JSON per body; missing ETags, malformed JSON, and larger bodies
+128 KiB of UTF-8 JSON per body; missing ETags, malformed JSON, and larger bodies
 are counted as `cache_skip` and read normally. Each entry retains its response
 timestamp, last validation timestamp, ETag, body digest, and body. Automated
 runner access uses the publisher-scoped webhook HMAC because publication jobs
 already hold that narrowly scoped credential; the operator secret stays
 reserved for human recovery.
+
+Publication clients skip oversized bodies before sending a store request and
+record the existing local `cache_skip` event. Dashboard health reads also skip
+these store requests; they do not emit local broker metrics. Requests that reach
+the store retain its `body_size_bound` skip reason and `cache_skip` metric.
+The store keeps an in-memory entry count, reconciling it with SQLite on the
+first store and every 64 stores thereafter. Inserts and expiry/oldest-validation
+evictions maintain that count so the 2,048-entry cap holds after every store.
+Expiry housekeeping runs at most once per minute per object instance; lookup
+and 304 confirmation still check expiry on every read.
 
 Lookup returns only ETag and digest. After GitHub returns 304, a separate
 confirmation must still match that ETag/digest before the Worker returns the

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -464,12 +464,14 @@ remain unchanged are memoized; polls waiting on invalidated work recompute.
 This only bounds observation freshness: the public projection's fields and
 meaning, admission, publication fences, and Bay behavior are unchanged.
 
-The object's lifecycle Bay response also has a 10-second memo
-(`EXACT_REVIEW_LIFECYCLE_BAY_CACHE_MS`; set `0` to disable), scoped to the
-requested public repositories. Concurrent reads share the original snapshot
+The object's lifecycle Bay response has a 30-second memo in production
+(`EXACT_REVIEW_LIFECYCLE_BAY_CACHE_MS = "30000"`; set `0` to disable), scoped to
+the requested public repositories. The source fallback remains 10 seconds.
+Bay is observer-only, so 30 seconds of staleness is acceptable.
+Concurrent reads share the original snapshot
 and `generated_at`; lifecycle and queue state writes invalidate it, including
 writes during an in-flight read. This complements the Worker's existing
-20-second public response cache without changing Bay fields or freshness rules.
+20-second public response cache without changing Bay fields or invalidation rules.
 
 For capacity displays, `/api/exact-review-queue` also exposes compatible
 `lanes.review` and `lanes.publication` objects. Each lane reports its own

--- a/docs/proof/etag-read-broker/README.md
+++ b/docs/proof/etag-read-broker/README.md
@@ -11,6 +11,12 @@ digest check, changed-resource replacement, independent page keys, unchanged
 wire-call count, and a final-guard-style read that always revalidates. The
 operator secret is rejected from the publisher-scoped data plane.
 
+The current runner also exercises the 128 KiB store limit: a 100 KiB response
+is stored over loopback HTTP, a 200 KiB response is returned intact without a
+client store request, and a direct 200 KiB store request returns
+`body_size_bound`. Historical receipts below describe their recorded revision;
+new runs report the current body limit from the shared contract.
+
 Run locally after `pnpm run build:all`:
 
 ```bash

--- a/docs/proof/etag-read-broker/README.md
+++ b/docs/proof/etag-read-broker/README.md
@@ -12,9 +12,9 @@ wire-call count, and a final-guard-style read that always revalidates. The
 operator secret is rejected from the publisher-scoped data plane.
 
 The current runner also exercises the 128 KiB store limit: a 100 KiB response
-is stored over loopback HTTP, a 200 KiB response is returned intact without a
-client store request, and a direct 200 KiB store request returns
-`body_size_bound`. Historical receipts below describe their recorded revision;
+is stored over loopback HTTP, a 200 KiB response is returned intact without
+transmitting the response body (one size-only store request records the skip),
+and a direct 200 KiB store request returns `body_size_bound`. Historical receipts below describe their recorded revision;
 new runs report the current body limit from the shared contract.
 
 Run locally after `pnpm run build:all`:

--- a/docs/proof/etag-read-broker/run-proof.mjs
+++ b/docs/proof/etag-read-broker/run-proof.mjs
@@ -11,12 +11,21 @@ import {
   githubEtagCacheRequestBody,
 } from "../../../dist/github-etag-cache-contract.js";
 import { durableGithubEtagReadSync } from "../../../dist/github-etag-read-broker.js";
+import { createGitHubRuntime } from "../../../dist/clawsweeper-github-runtime.js";
 
 const secret = "etag-proof-publisher-placeholder";
 const operatorSecret = "etag-proof-operator-placeholder";
 
 if (process.argv.includes("--server")) {
   await runServer();
+} else if (process.argv.includes("--github-cli")) {
+  const index = process.argv.indexOf("--github-cli");
+  const args = process.argv.slice(index + 2);
+  const conditional = args.find((arg) => arg.startsWith("If-None-Match: "));
+  const response = githubGet(process.argv[index + 1], args.at(-1), conditional?.slice(15));
+  process.stdout.write(
+    `HTTP/1.1 ${response.status} OK\r\n${response.etag ? `etag: ${response.etag}\r\n` : ""}\r\n${response.body}`,
+  );
 } else {
   await runProof();
 }
@@ -103,24 +112,48 @@ async function runProof() {
       ),
     );
     const bodyBounds = {};
-    for (const size of [100, 200]) {
-      const body = JSON.stringify({ body: "x".repeat(size * 1024 - 11) });
-      assert.equal(Buffer.byteLength(body), size * 1024);
-      await adminPost(baseUrl, "/admin/mutate", {
-        route: key1.route,
-        etag: `"size-${size}"`,
-        body,
-      });
-      const before = await (await fetch(`${baseUrl}/admin/store-requests`)).json();
-      assert.equal(read(key1), body);
-      const after = await (await fetch(`${baseUrl}/admin/store-requests`)).json();
-      assert.equal(after - before, size === 100 ? 1 : 0);
-      assert.equal(events.at(-1).outcome, size === 100 ? "cache_200_stored" : "cache_skip");
-      bodyBounds[`${size}_kib`] = {
-        returned_bytes: Buffer.byteLength(body),
-        store_requests: after - before,
-        outcome: events.at(-1).outcome,
-      };
+    for (const size of [100, 200, 600]) {
+      const surfaces = ["publication", "dashboard"];
+      if (size > 128) surfaces.push("publication_without_etag");
+      for (const surface of surfaces) {
+        const body = JSON.stringify({ body: "x".repeat(size * 1024 - 11) });
+        assert.equal(Buffer.byteLength(body), size * 1024);
+        const route = surface.startsWith("publication")
+          ? `/repos/openclaw/openclaw/issues/${size + (surface === "publication_without_etag" ? 1_000 : 0)}`
+          : `/repos/openclaw/clawsweeper/actions/runs?page=${size}&per_page=100`;
+        await adminPost(baseUrl, "/admin/mutate", {
+          route,
+          etag: surface === "publication_without_etag" ? "" : `"size-${size}"`,
+          body,
+        });
+        const before = await (await fetch(`${baseUrl}/admin/store-requests`)).json();
+        const metricsBefore = await (await fetch(`${baseUrl}/admin/metrics`)).json();
+        if (surface.startsWith("publication")) {
+          assert.equal(runnerRead(baseUrl, route), body);
+        } else {
+          const response = await fetch(
+            `${baseUrl}/admin/dashboard-read?route=${encodeURIComponent(route)}`,
+          );
+          assert.equal(response.status, 200);
+          assert.deepEqual(await response.json(), JSON.parse(body));
+        }
+        const after = await (await fetch(`${baseUrl}/admin/store-requests`)).json();
+        const metricsAfter = await (await fetch(`${baseUrl}/admin/metrics`)).json();
+        const outcome = size === 100 ? "cache_200_stored" : "cache_skip";
+        assert.equal(after.length - before.length, 1);
+        assert.equal(after.at(-1).body_wire_bytes, size === 100 ? size * 1024 : 0);
+        assert.equal(after.at(-1).body_bytes, size === 100 ? null : size * 1024);
+        assert.equal(metricsAfter.cache_miss - (metricsBefore.cache_miss || 0), 1);
+        assert.equal(metricsAfter[outcome] - (metricsBefore[outcome] || 0), 1);
+        bodyBounds[`${surface}_${size}_kib`] = {
+          returned_bytes: Buffer.byteLength(body),
+          store_requests: after.length - before.length,
+          body_wire_bytes: after.at(-1).body_wire_bytes,
+          reported_body_bytes: after.at(-1).body_bytes,
+          cache_miss: 1,
+          [outcome]: 1,
+        };
+      }
     }
     const rejected = signedPost(baseUrl, "store", {
       ...githubEtagCacheRequestBody(key1, "apply"),
@@ -171,13 +204,19 @@ async function runProof() {
 }
 
 async function runServer() {
-  const [{ default: worker, ExactReviewQueue }, harness] = await Promise.all([
+  const [
+    { default: worker, ExactReviewQueue, githubJsonForTest },
+    harness,
+    { GithubEtagResponseStore },
+  ] = await Promise.all([
     import("../../../dashboard/worker.ts"),
     import("../../../test/dashboard-worker-harness.ts"),
+    import("../../../dashboard/github-etag-cache.ts"),
   ]);
   const storage = new harness.MemoryDurableStorage();
   const queue = new ExactReviewQueue({ storage }, {});
   const env = {
+    GITHUB_TOKEN: "etag-proof-github-placeholder",
     CLAWSWEEPER_WEBHOOK_SECRET: secret,
     EXACT_REVIEW_OPERATOR_SECRET: operatorSecret,
     EXACT_REVIEW_QUEUE: new harness.MemoryDurableNamespace(queue),
@@ -193,18 +232,35 @@ async function runServer() {
     ],
   ]);
   const requests = [];
-  let storeRequests = 0;
+  const storeRequests = [];
+  const queueFetch = queue.fetch.bind(queue);
+  queue.fetch = async (request) => {
+    if (new URL(request.url).pathname === "/github-etag-cache/store") {
+      const value = await request.clone().json();
+      storeRequests.push({
+        body_wire_bytes: Buffer.byteLength(value.body || ""),
+        body_bytes: value.body_bytes ?? null,
+      });
+    }
+    return queueFetch(request);
+  };
   const server = createServer(async (request, response) => {
     const url = new URL(request.url || "/", "http://127.0.0.1");
     if (url.pathname === "/admin/requests") return sendJson(response, 200, requests);
     if (url.pathname === "/admin/store-requests") return sendJson(response, 200, storeRequests);
+    if (url.pathname === "/admin/metrics") {
+      return sendJson(response, 200, new GithubEtagResponseStore(storage).telemetry(Date.now()));
+    }
+    if (url.pathname === "/admin/dashboard-read") {
+      return sendJson(response, 200, await githubJsonForTest(env, url.searchParams.get("route")));
+    }
     if (url.pathname === "/admin/mutate") {
       const value = JSON.parse(await requestText(request));
       resources.set(value.route, { etag: value.etag, body: value.body });
       return sendJson(response, 200, { ok: true });
     }
-    if (url.pathname.startsWith("/github/")) {
-      const route = `${url.pathname.slice("/github".length)}${url.search}`;
+    if (url.pathname.startsWith("/github/") || url.pathname.startsWith("/repos/")) {
+      const route = `${url.pathname.replace(/^\/github/, "")}${url.search}`;
       const resource = resources.get(route);
       if (!resource) return sendJson(response, 404, { error: "missing_fixture" });
       const ifNoneMatch = request.headers["if-none-match"] || null;
@@ -215,7 +271,6 @@ async function runServer() {
       return;
     }
     if (url.pathname.startsWith("/internal/exact-review/github-etag-cache/")) {
-      if (url.pathname.endsWith("/store")) storeRequests += 1;
       const body = await requestText(request);
       const forwarded = new Request(`https://clawsweeper.openclaw.ai${url.pathname}`, {
         method: "POST",
@@ -236,8 +291,40 @@ async function runServer() {
   });
   await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
   const address = server.address();
+  env.GITHUB_API_URL = `http://127.0.0.1:${address.port}`;
   process.stdout.write(`${JSON.stringify({ url: `http://127.0.0.1:${address.port}` })}\n`);
   process.on("SIGTERM", () => server.close(() => process.exit(0)));
+}
+
+function runnerRead(baseUrl, route) {
+  const overrides = {
+    EXACT_EVENT_PUBLICATION: "true",
+    EXACT_REVIEW_QUEUE_URL: baseUrl,
+    CLAWSWEEPER_WEBHOOK_SECRET: secret,
+    GH_BIN: process.execPath,
+    GH_BIN_ARGS: JSON.stringify([new URL(import.meta.url).pathname, "--github-cli", baseUrl]),
+    CURL_BIN: "curl",
+    CURL_BIN_ARGS: "[]",
+  };
+  const previous = Object.fromEntries(Object.keys(overrides).map((key) => [key, process.env[key]]));
+  Object.assign(process.env, overrides);
+  try {
+    const runtime = createGitHubRuntime({
+      ROOT: process.cwd(),
+      targetRepo: () => "openclaw/openclaw",
+      run: () => {
+        throw new Error("unexpected unbrokered read");
+      },
+    });
+    return runtime.ghWithPreparedTimeout(["api", route], 5_000, {
+      GH_TOKEN: "etag-proof-github-placeholder",
+    });
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
 }
 
 function signedPost(baseUrl, operation, body) {

--- a/docs/proof/etag-read-broker/run-proof.mjs
+++ b/docs/proof/etag-read-broker/run-proof.mjs
@@ -5,7 +5,11 @@ import { createHash, createHmac } from "node:crypto";
 import { writeFileSync } from "node:fs";
 import { createServer } from "node:http";
 
-import { githubEtagCacheKey, githubEtagCacheRequestBody } from "../../../dist/github-etag-cache-contract.js";
+import {
+  GITHUB_ETAG_CACHE_MAX_BODY_BYTES,
+  githubEtagCacheKey,
+  githubEtagCacheRequestBody,
+} from "../../../dist/github-etag-cache-contract.js";
 import { durableGithubEtagReadSync } from "../../../dist/github-etag-read-broker.js";
 
 const secret = "etag-proof-publisher-placeholder";
@@ -98,13 +102,44 @@ async function runProof() {
         (outcome) => [outcome, events.filter((event) => event.outcome === outcome).length],
       ),
     );
+    const bodyBounds = {};
+    for (const size of [100, 200]) {
+      const body = JSON.stringify({ body: "x".repeat(size * 1024 - 11) });
+      assert.equal(Buffer.byteLength(body), size * 1024);
+      await adminPost(baseUrl, "/admin/mutate", {
+        route: key1.route,
+        etag: `"size-${size}"`,
+        body,
+      });
+      const before = await (await fetch(`${baseUrl}/admin/store-requests`)).json();
+      assert.equal(read(key1), body);
+      const after = await (await fetch(`${baseUrl}/admin/store-requests`)).json();
+      assert.equal(after - before, size === 100 ? 1 : 0);
+      assert.equal(events.at(-1).outcome, size === 100 ? "cache_200_stored" : "cache_skip");
+      bodyBounds[`${size}_kib`] = {
+        returned_bytes: Buffer.byteLength(body),
+        store_requests: after - before,
+        outcome: events.at(-1).outcome,
+      };
+    }
+    const rejected = signedPost(baseUrl, "store", {
+      ...githubEtagCacheRequestBody(key1, "apply"),
+      etag: '"direct-oversized"',
+      body: JSON.stringify({ body: "x".repeat(200 * 1024 - 11) }),
+    });
+    assert.deepEqual(rejected, { ok: true, stored: false, reason: "body_size_bound" });
+    bodyBounds.direct_200_kib = rejected;
     const report = {
       schema: "clawsweeper-etag-read-broker-proof/v1",
       generated_at: new Date().toISOString(),
       tested_head: head,
       merge_base: base,
       key_schema: "[1, credential_pool, route_with_sorted_query, media_type]",
-      storage: { max_entries: 2048, max_body_bytes: 524288, ttl_days: 30 },
+      storage: {
+        max_entries: 2048,
+        max_body_bytes: GITHUB_ETAG_CACHE_MAX_BODY_BYTES,
+        ttl_days: 30,
+      },
       results: {
         first_read: "200_stored",
         unchanged_read: "304_confirmed_body_served",
@@ -119,6 +154,7 @@ async function runProof() {
         telemetry: counts,
         publisher_hmac_status: publisherStatus,
         operator_hmac_status: operatorStatus,
+        body_bounds: bodyBounds,
       },
       limits: [
         "Loopback GitHub and credentials are deterministic fixtures.",
@@ -157,9 +193,11 @@ async function runServer() {
     ],
   ]);
   const requests = [];
+  let storeRequests = 0;
   const server = createServer(async (request, response) => {
     const url = new URL(request.url || "/", "http://127.0.0.1");
     if (url.pathname === "/admin/requests") return sendJson(response, 200, requests);
+    if (url.pathname === "/admin/store-requests") return sendJson(response, 200, storeRequests);
     if (url.pathname === "/admin/mutate") {
       const value = JSON.parse(await requestText(request));
       resources.set(value.route, { etag: value.etag, body: value.body });
@@ -177,6 +215,7 @@ async function runServer() {
       return;
     }
     if (url.pathname.startsWith("/internal/exact-review/github-etag-cache/")) {
+      if (url.pathname.endsWith("/store")) storeRequests += 1;
       const body = await requestText(request);
       const forwarded = new Request(`https://clawsweeper.openclaw.ai${url.pathname}`, {
         method: "POST",

--- a/src/clawsweeper-github-runtime.ts
+++ b/src/clawsweeper-github-runtime.ts
@@ -510,8 +510,7 @@ export function createGitHubRuntime(dependencies: CreateGitHubRuntimeDependencie
       store200: (_cacheKey, response) => {
         const stored = signedEtagBrokerPost("store", {
           ...requestBody,
-          etag: response.etag,
-          body: response.body,
+          ...response,
         });
         return { stored: stored.stored === true };
       },

--- a/src/github-etag-cache-contract.ts
+++ b/src/github-etag-cache-contract.ts
@@ -1,4 +1,5 @@
 export const GITHUB_ETAG_CACHE_KEY_VERSION = 1 as const;
+export const GITHUB_ETAG_CACHE_MAX_BODY_BYTES = 128 * 1_024;
 export const GITHUB_ETAG_DEFAULT_MEDIA_TYPE = "application/vnd.github+json";
 
 export const GITHUB_ETAG_CREDENTIAL_POOLS = [

--- a/src/github-etag-read-broker.ts
+++ b/src/github-etag-read-broker.ts
@@ -1,5 +1,8 @@
 import { createHash } from "node:crypto";
-import type { GithubEtagCacheKey } from "./github-etag-cache-contract.js";
+import {
+  GITHUB_ETAG_CACHE_MAX_BODY_BYTES,
+  type GithubEtagCacheKey,
+} from "./github-etag-cache-contract.js";
 
 export type GithubConditionalResponse = {
   status: number;
@@ -94,7 +97,7 @@ function acceptLive200(
   response: GithubConditionalResponse,
 ): string {
   const body = requireLive200(response);
-  if (!response.etag) {
+  if (!response.etag || Buffer.byteLength(body, "utf8") > GITHUB_ETAG_CACHE_MAX_BODY_BYTES) {
     options.record({ unit: "broker_lookup", outcome: "cache_skip" });
     return body;
   }

--- a/src/github-etag-read-broker.ts
+++ b/src/github-etag-read-broker.ts
@@ -44,7 +44,10 @@ export function durableGithubEtagReadSync(options: {
   lookup: (key: GithubEtagCacheKey) => GithubEtagLookupResponse;
   store200: (
     key: GithubEtagCacheKey,
-    response: { etag: string; body: string },
+    response: { etag: string } & (
+      | { body: string; body_bytes?: never }
+      | { body?: never; body_bytes: number }
+    ),
   ) => GithubEtagStoreResponse;
   confirm304: (
     key: GithubEtagCacheKey,
@@ -97,12 +100,17 @@ function acceptLive200(
   response: GithubConditionalResponse,
 ): string {
   const body = requireLive200(response);
-  if (!response.etag || Buffer.byteLength(body, "utf8") > GITHUB_ETAG_CACHE_MAX_BODY_BYTES) {
+  const bodyBytes = Buffer.byteLength(body, "utf8");
+  if (!response.etag && bodyBytes <= GITHUB_ETAG_CACHE_MAX_BODY_BYTES) {
     options.record({ unit: "broker_lookup", outcome: "cache_skip" });
     return body;
   }
   try {
-    if (options.store200(options.key, { etag: response.etag, body }).stored) {
+    const stored = options.store200(options.key, {
+      etag: response.etag || "",
+      ...(bodyBytes > GITHUB_ETAG_CACHE_MAX_BODY_BYTES ? { body_bytes: bodyBytes } : { body }),
+    });
+    if (stored.stored) {
       options.record({
         unit: "conditional_response",
         outcome: "cache_200_stored",

--- a/test/dashboard-worker-queue-policy.test.ts
+++ b/test/dashboard-worker-queue-policy.test.ts
@@ -273,6 +273,7 @@ test("production doubles exact review claims and canonical publication batches",
   assert.match(wrangler, /EXACT_REVIEW_TARGET_RATE_PER_HOUR = "300"/);
   assert.match(wrangler, /EXACT_REVIEW_TARGET_BURST = "30"/);
   assert.match(wrangler, /EXACT_REVIEW_PENDING_SOFT_LIMIT = "600"/);
+  assert.match(wrangler, /EXACT_REVIEW_LIFECYCLE_BAY_CACHE_MS = "30000"/);
 });
 
 test("exact-review lifecycle projection keeps immutable per-revision facts and terminal distinctions", () => {

--- a/test/github-etag-read-broker.test.ts
+++ b/test/github-etag-read-broker.test.ts
@@ -247,6 +247,38 @@ test("durable store accepts 100 KiB and skips 200 KiB UTF-8 bodies", async () =>
   assert.equal(store.telemetry(4).cache_skip, 2);
 });
 
+test("size-only stores count skips without accessing the body table", async () => {
+  const storage = new MemoryDurableStorage();
+  const store = new GithubEtagResponseStore(storage);
+  store.ensureSchemaSync();
+  const request = githubEtagCacheRequestBody(
+    requiredKey("target_app", "/repos/openclaw/openclaw/pulls/99"),
+    "apply",
+  );
+  await store.store200({ ...request, etag: '"existing"', body: "{}" }, 1);
+  storage.sql.resetQueryHistory();
+  for (const size of [200, 600]) {
+    assert.deepEqual(
+      await store.store200({ ...request, etag: '"large"', body_bytes: size * 1_024 }, 60_001),
+      { ok: true, stored: false, reason: "body_size_bound" },
+    );
+  }
+  assert.equal(storage.sql.queriesMatching(/\bgithub_etag_response_cache_v1\b/).length, 0);
+  assert.deepEqual(store.telemetry(60_001), { cache_200_stored: 1, cache_skip: 2 });
+  assert.equal(store.lookup(request, 60_002)?.etag, '"existing"');
+  const legacy = await store.store200(
+    { ...request, etag: '"legacy"', body: "{}", body_bytes: 600 * 1_024 },
+    60_003,
+  );
+  assert.equal(legacy.ok && legacy.stored, true, "a supplied body remains authoritative");
+  for (const bodyBytes of [undefined, null, "204800", -1, 128 * 1_024, 204800.5, Infinity]) {
+    assert.deepEqual(
+      await store.store200({ ...request, etag: '"invalid"', body_bytes: bodyBytes }, 60_004),
+      { ok: true, stored: false, reason: "invalid_json_body" },
+    );
+  }
+});
+
 test("durable store caps entries immediately and reconciles counts every 64 stores", async () => {
   const storage = new MemoryDurableStorage();
   let store = new GithubEtagResponseStore(storage);
@@ -350,59 +382,142 @@ test("expiry housekeeping runs at most once per minute without serving expired b
   );
 });
 
-test("publication client skips oversized UTF-8 bodies before issuing a store request", () => {
-  for (const size of [100, 128, 200]) {
+test("publication client reports oversized UTF-8 bodies through size-only stores", async (t) => {
+  for (const size of [100, 128, 200, 600]) {
     for (const character of ["x", "é"]) {
-      const body = jsonBodyBytes(size * 1_024, character);
-      const events: GithubEtagBrokerEvent[] = [];
-      let stores = 0;
-      assert.equal(
-        durableGithubEtagReadSync({
-          key: requiredKey("target_app", "/repos/openclaw/openclaw/pulls/99"),
-          lookup: () => ({ hit: false }),
-          store200: () => {
-            stores += 1;
-            return { stored: true };
-          },
-          confirm304: () => {
-            throw new Error("unexpected confirmation");
-          },
-          githubRequest: () => ({ status: 200, body, etag: '"v1"' }),
-          record: (event) => events.push(event),
-        }),
-        body,
-      );
-      assert.equal(stores, size <= 128 ? 1 : 0);
-      assert.equal(events.at(-1)?.outcome, size <= 128 ? "cache_200_stored" : "cache_skip");
+      await t.test(`${size} KiB ${character}`, async () => {
+        const body = jsonBodyBytes(size * 1_024, character);
+        const storage = new MemoryDurableStorage();
+        const store = new GithubEtagResponseStore(storage);
+        store.ensureSchemaSync();
+        const key = requiredKey("target_app", "/repos/openclaw/openclaw/pulls/99");
+        const request = githubEtagCacheRequestBody(key, "apply");
+        const events: GithubEtagBrokerEvent[] = [];
+        const stores: Record<string, unknown>[] = [];
+        const pending: ReturnType<typeof store.store200>[] = [];
+        assert.equal(
+          durableGithubEtagReadSync({
+            key,
+            lookup: () => ({ hit: Boolean(store.lookup(request, 1)) }),
+            store200: (_key, response) => {
+              const wire = JSON.parse(JSON.stringify({ ...request, ...response }));
+              stores.push(wire);
+              pending.push(store.store200(wire, 2));
+              return { stored: size <= 128 };
+            },
+            confirm304: () => {
+              throw new Error("unexpected confirmation");
+            },
+            githubRequest: () => ({ status: 200, body, etag: '"v1"' }),
+            record: (event) => events.push(event),
+          }),
+          body,
+        );
+        await Promise.all(pending);
+        assert.equal(stores.length, 1);
+        assert.deepEqual(stores[0], {
+          ...request,
+          etag: '"v1"',
+          ...(size <= 128 ? { body } : { body_bytes: size * 1_024 }),
+        });
+        assert.equal(
+          Buffer.byteLength(String(stores[0].body ?? "")),
+          size <= 128 ? size * 1_024 : 0,
+        );
+        assert.deepEqual(store.telemetry(2), {
+          cache_miss: 1,
+          [size <= 128 ? "cache_200_stored" : "cache_skip"]: 1,
+        });
+        assert.equal(events.filter((event) => event.outcome === "cache_miss").length, 1);
+        assert.equal(events.at(-1)?.outcome, size <= 128 ? "cache_200_stored" : "cache_skip");
+      });
     }
   }
 });
 
-test("dashboard health client skips oversized bodies before requesting the queue store", async () => {
-  const storage = new MemoryDurableStorage();
-  const queue = new ExactReviewQueue({ storage }, {});
-  const paths: string[] = [];
-  const originalQueueFetch = queue.fetch.bind(queue);
-  queue.fetch = (request) => {
-    paths.push(new URL(request.url).pathname);
-    return originalQueueFetch(request);
-  };
-  const env = {
-    GITHUB_TOKEN: "dashboard-token",
-    CLAWSWEEPER_WEBHOOK_SECRET: webhookSecret,
-    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
-  };
-  const originalFetch = globalThis.fetch;
-  const body = jsonBodyBytes(200 * 1_024, "é");
-  globalThis.fetch = async () => new Response(body, { headers: { etag: '"large"' } });
-  try {
-    assert.deepEqual(
-      await githubJsonForTest(env, "/repos/openclaw/clawsweeper/actions/runs"),
-      JSON.parse(body),
+test("publication client reports oversized bodies even without an ETag", async () => {
+  for (const size of [200, 600]) {
+    const storage = new MemoryDurableStorage();
+    const store = new GithubEtagResponseStore(storage);
+    store.ensureSchemaSync();
+    const key = requiredKey("target_app", "/repos/openclaw/openclaw/pulls/99");
+    const request = githubEtagCacheRequestBody(key, "apply");
+    const body = jsonBodyBytes(size * 1_024, "é");
+    const events: GithubEtagBrokerEvent[] = [];
+    const stores: Record<string, unknown>[] = [];
+    const pending: ReturnType<typeof store.store200>[] = [];
+    assert.equal(
+      durableGithubEtagReadSync({
+        key,
+        lookup: () => ({ hit: Boolean(store.lookup(request, 1)) }),
+        store200: (_key, response) => {
+          const wire = JSON.parse(JSON.stringify({ ...request, ...response }));
+          stores.push(wire);
+          pending.push(store.store200(wire, 2));
+          return { stored: false };
+        },
+        confirm304: () => {
+          throw new Error("unexpected confirmation");
+        },
+        githubRequest: () => ({ status: 200, body }),
+        record: (event) => events.push(event),
+      }),
+      body,
     );
-    assert.deepEqual(paths, ["/github-etag-cache/lookup"]);
-  } finally {
-    globalThis.fetch = originalFetch;
+    await Promise.all(pending);
+    assert.deepEqual(stores, [{ ...request, etag: "", body_bytes: size * 1_024 }]);
+    assert.deepEqual(store.telemetry(2), { cache_miss: 1, cache_skip: 1 });
+    assert.deepEqual(
+      events.map((event) => event.outcome),
+      ["cache_miss", "cache_skip"],
+    );
+  }
+});
+
+test("dashboard health client counts oversized bodies through size-only stores", async (t) => {
+  for (const size of [200, 600]) {
+    await t.test(`${size} KiB`, async () => {
+      const storage = new MemoryDurableStorage();
+      const queue = new ExactReviewQueue({ storage }, {});
+      const paths: string[] = [];
+      const stores: Record<string, unknown>[] = [];
+      const originalQueueFetch = queue.fetch.bind(queue);
+      queue.fetch = async (request) => {
+        const path = new URL(request.url).pathname;
+        paths.push(path);
+        if (path === "/github-etag-cache/store") stores.push(await request.clone().json());
+        return originalQueueFetch(request);
+      };
+      const env = {
+        GITHUB_TOKEN: "dashboard-token",
+        CLAWSWEEPER_WEBHOOK_SECRET: webhookSecret,
+        EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+      };
+      const originalFetch = globalThis.fetch;
+      const body = jsonBodyBytes(size * 1_024, "é");
+      globalThis.fetch = async () => new Response(body, { headers: { etag: '"large"' } });
+      try {
+        assert.deepEqual(
+          await githubJsonForTest(env, "/repos/openclaw/clawsweeper/actions/runs"),
+          JSON.parse(body),
+        );
+        assert.deepEqual(new GithubEtagResponseStore(storage).telemetry(Date.now()), {
+          cache_miss: 1,
+          cache_skip: 1,
+        });
+        assert.deepEqual(paths, ["/github-etag-cache/lookup", "/github-etag-cache/store"]);
+        assert.equal(stores.length, 1);
+        assert.equal(stores[0].body_bytes, size * 1_024);
+        assert.equal("body" in stores[0], false);
+        assert.equal(Buffer.byteLength(String(stores[0].body ?? "")), 0);
+        assert.equal(
+          Array.from(storage.sql.exec(`SELECT cache_key FROM ${GITHUB_ETAG_CACHE_TABLE}`)).length,
+          0,
+        );
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
   }
 });
 

--- a/test/github-etag-read-broker.test.ts
+++ b/test/github-etag-read-broker.test.ts
@@ -4,7 +4,9 @@ import test from "node:test";
 
 import {
   GITHUB_ETAG_CACHE_MAX_BODY_BYTES,
+  GITHUB_ETAG_CACHE_MAX_ENTRIES,
   GITHUB_ETAG_CACHE_RETENTION_MS,
+  GITHUB_ETAG_CACHE_TABLE,
   GithubEtagResponseStore,
 } from "../dashboard/github-etag-cache.ts";
 import worker, { ExactReviewQueue, githubJsonForTest } from "../dashboard/worker.ts";
@@ -220,6 +222,190 @@ test("durable store confirms 304 bodies by ETag and digest and enforces bounds",
   assert.equal(store.lookup(request, now + GITHUB_ETAG_CACHE_RETENTION_MS + 3), null);
 });
 
+test("durable store accepts 100 KiB and skips 200 KiB UTF-8 bodies", async () => {
+  const storage = new MemoryDurableStorage();
+  const store = new GithubEtagResponseStore(storage);
+  store.ensureSchemaSync();
+  const request = githubEtagCacheRequestBody(
+    requiredKey("target_app", "/repos/openclaw/openclaw/pulls/99"),
+    "apply",
+  );
+  for (const character of ["x", "é"]) {
+    const accepted = jsonBodyBytes(100 * 1_024, character);
+    const result = await store.store200({ ...request, etag: '"accepted"', body: accepted }, 1);
+    assert.equal(result.ok && result.stored, true);
+    assert.equal(store.lookup(request, 2)?.bodyDigest, sha256(accepted));
+    assert.deepEqual(
+      await store.store200(
+        { ...request, etag: '"oversized"', body: jsonBodyBytes(200 * 1_024, character) },
+        3,
+      ),
+      { ok: true, stored: false, reason: "body_size_bound" },
+    );
+    assert.equal(store.lookup(request, 4)?.etag, '"accepted"');
+  }
+  assert.equal(store.telemetry(4).cache_skip, 2);
+});
+
+test("durable store caps entries immediately and reconciles counts every 64 stores", async () => {
+  const storage = new MemoryDurableStorage();
+  let store = new GithubEtagResponseStore(storage);
+  store.ensureSchemaSync();
+  const request = (number: number) =>
+    githubEtagCacheRequestBody(
+      requiredKey("target_app", `/repos/openclaw/openclaw/pulls/${number}`),
+      "apply",
+    );
+  const put = (number: number, now: number) =>
+    store.store200({ ...request(number), etag: '"v1"', body: "{}" }, now);
+  storage.sql.resetQueryHistory();
+  for (let index = 0; index < GITHUB_ETAG_CACHE_MAX_ENTRIES; index += 1) {
+    await put(index, index);
+  }
+  const oldest = store.lookup(request(0), 3_000)!;
+  store.confirm304({ ...request(0), etag: oldest.etag, body_digest: oldest.bodyDigest }, 3_000);
+  for (let index = 0; index < 64; index += 1) {
+    await put(0, 3_001 + index);
+    await put(GITHUB_ETAG_CACHE_MAX_ENTRIES + index, 4_000 + index);
+    assert.equal(
+      Array.from(storage.sql.exec(`SELECT cache_key FROM ${GITHUB_ETAG_CACHE_TABLE}`)).length,
+      GITHUB_ETAG_CACHE_MAX_ENTRIES,
+    );
+  }
+  assert.ok(store.lookup(request(0), 5_000), "recently validated oldest entry survives");
+  for (let index = 1; index <= 64; index += 1) {
+    assert.equal(store.lookup(request(index), 5_000), null);
+  }
+  assert.ok(store.lookup(request(65), 5_000));
+  assert.equal(
+    storage.sql.queriesMatching(/SELECT COUNT\(\*\) AS count FROM github_etag_response_cache_v1/)
+      .length,
+    34,
+    "full counts must be amortized across at least 64 stores",
+  );
+  store = new GithubEtagResponseStore(storage);
+  await put(10_000, 6_000);
+  assert.equal(store.lookup(request(65), 6_001), null, "cold instances count persisted entries");
+  assert.ok(store.lookup(request(0), 6_001));
+  storage.sql.failNext(/INSERT INTO github_etag_response_cache_metrics_v1/);
+  await assert.rejects(put(10_001, 6_002), /injected SQL failure/);
+  assert.ok(store.lookup(request(66), 6_003), "failed stores roll back eviction");
+  await put(10_002, 6_004);
+  assert.equal(store.lookup(request(66), 6_005), null);
+  assert.ok(store.lookup(request(67), 6_005), "rollback must not drift the cached count");
+  assert.equal(
+    Array.from(storage.sql.exec(`SELECT cache_key FROM ${GITHUB_ETAG_CACHE_TABLE}`)).length,
+    GITHUB_ETAG_CACHE_MAX_ENTRIES,
+  );
+});
+
+test("expiry housekeeping runs at most once per minute without serving expired bodies", async () => {
+  const storage = new MemoryDurableStorage();
+  const store = new GithubEtagResponseStore(storage);
+  store.ensureSchemaSync();
+  const request = githubEtagCacheRequestBody(
+    requiredKey("target_app", "/repos/openclaw/openclaw/pulls/99"),
+    "apply",
+  );
+  await store.store200({ ...request, etag: '"v1"', body: "{}" }, 0);
+  const entry = store.lookup(request, 1)!;
+  const nearExpiry = GITHUB_ETAG_CACHE_RETENTION_MS - 1;
+  storage.sql.resetQueryHistory();
+  store.lookup(request, nearExpiry);
+  for (let index = 1; index <= 64; index += 1) {
+    await store.store200(
+      {
+        ...githubEtagCacheRequestBody(
+          requiredKey("target_app", `/repos/openclaw/openclaw/pulls/${100 + index}`),
+          "apply",
+        ),
+        etag: '"fresh"',
+        body: "{}",
+      },
+      nearExpiry + index,
+    );
+    assert.equal(store.lookup(request, nearExpiry + index), null);
+  }
+  assert.deepEqual(
+    store.confirm304(
+      { ...request, etag: entry.etag, body_digest: entry.bodyDigest },
+      nearExpiry + 65,
+    ),
+    { ok: true, confirmed: false, reason: "entry_changed_or_expired" },
+  );
+  store.lookup(request, nearExpiry + 59_999);
+  const cleanupCount = () =>
+    storage.sql.queriesMatching(/DELETE FROM github_etag_response_cache_v1[\s\S]*expires_at <=/)
+      .length;
+  assert.equal(cleanupCount(), 1);
+  assert.equal(
+    storage.sql.queriesMatching(/DELETE FROM github_etag_response_cache_metrics_v1/).length,
+    1,
+  );
+  store.lookup(request, nearExpiry + 60_000);
+  assert.equal(cleanupCount(), 2);
+  assert.equal(
+    storage.sql.queriesMatching(/DELETE FROM github_etag_response_cache_metrics_v1/).length,
+    2,
+  );
+});
+
+test("publication client skips oversized UTF-8 bodies before issuing a store request", () => {
+  for (const size of [100, 128, 200]) {
+    for (const character of ["x", "é"]) {
+      const body = jsonBodyBytes(size * 1_024, character);
+      const events: GithubEtagBrokerEvent[] = [];
+      let stores = 0;
+      assert.equal(
+        durableGithubEtagReadSync({
+          key: requiredKey("target_app", "/repos/openclaw/openclaw/pulls/99"),
+          lookup: () => ({ hit: false }),
+          store200: () => {
+            stores += 1;
+            return { stored: true };
+          },
+          confirm304: () => {
+            throw new Error("unexpected confirmation");
+          },
+          githubRequest: () => ({ status: 200, body, etag: '"v1"' }),
+          record: (event) => events.push(event),
+        }),
+        body,
+      );
+      assert.equal(stores, size <= 128 ? 1 : 0);
+      assert.equal(events.at(-1)?.outcome, size <= 128 ? "cache_200_stored" : "cache_skip");
+    }
+  }
+});
+
+test("dashboard health client skips oversized bodies before requesting the queue store", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  const paths: string[] = [];
+  const originalQueueFetch = queue.fetch.bind(queue);
+  queue.fetch = (request) => {
+    paths.push(new URL(request.url).pathname);
+    return originalQueueFetch(request);
+  };
+  const env = {
+    GITHUB_TOKEN: "dashboard-token",
+    CLAWSWEEPER_WEBHOOK_SECRET: webhookSecret,
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+  };
+  const originalFetch = globalThis.fetch;
+  const body = jsonBodyBytes(200 * 1_024, "é");
+  globalThis.fetch = async () => new Response(body, { headers: { etag: '"large"' } });
+  try {
+    assert.deepEqual(
+      await githubJsonForTest(env, "/repos/openclaw/clawsweeper/actions/runs"),
+      JSON.parse(body),
+    );
+    assert.deepEqual(paths, ["/github-etag-cache/lookup"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("publisher HMAC endpoints persist and confirm bodies while operator scope is rejected", async () => {
   const storage = new MemoryDurableStorage();
   const queue = new ExactReviewQueue({ storage }, {});
@@ -336,4 +522,15 @@ function signedRequest(url: string, body: string, secret: string) {
 
 function sha256(value: string): string {
   return createHash("sha256").update(value).digest("hex");
+}
+
+function jsonBodyBytes(bytes: number, character: string): string {
+  const empty = JSON.stringify({ body: "" });
+  const padding = bytes - Buffer.byteLength(empty);
+  const width = Buffer.byteLength(character);
+  const body = JSON.stringify({
+    body: character.repeat(Math.floor(padding / width)) + "x".repeat(padding % width),
+  });
+  assert.equal(Buffer.byteLength(body), bytes);
+  return body;
 }


### PR DESCRIPTION
## What Problem This Solves

Reduces ETag broker store work on the shared queue Durable Object, addressing the overload investigation in https://github.com/openclaw/clawsweeper/issues/1372.

The supplied production tail at 2026-09-04 00:00 UTC covered 144 seconds: `github-etag-cache/store` consumed 13,984 ms CPU across 62 calls (about 225 ms each), `lifecycle-bay` consumed 8,479 ms across fewer than 19 calls (about 450 ms per uncached build), `stats` consumed 1,593 ms, and `records/export` consumed 779 ms. Total object CPU was 28.6 seconds, with nine overload rejections. These are the motivating production observations, not a benchmark of this change.

## Why

Large JSON bodies make parsing, hashing, and SQLite writes expensive. Performing expiry deletes and a full entry count on every store adds work even when the cache is unchanged. Oversized bodies can be excluded before transport while their live GitHub responses are still returned intact. Bay is observer-only, so a 30-second memo is acceptable.

## What Changed

The shared body limit is 128 KiB of UTF-8 JSON. The store measures bytes once and reuses the encoded buffer for SHA-256. Publication and dashboard health clients send size-only store requests for oversized responses: `body_bytes` carries the UTF-8 count and `body` is omitted. The object records `cache_skip` with reason `body_size_bound` without accessing the body table; publication also retains its local `cache_skip` event. Body-bearing requests keep their existing validation and storage behavior, and their actual body remains authoritative. The runner transport adapter forwards the additive field unchanged.

An in-memory entry count is reconciled on the first store and every 64 stores thereafter. Indexed key checks distinguish replacement from insertion, expiry cleanup adjusts the count, and overflow still evicts the oldest validated entries immediately at 2,048 entries. Failed transactions discard the cached count and restore the cleanup timestamp. Expiry housekeeping runs at most once per minute across stores and lookups; lookup and 304 confirmation still enforce expiry on every request.

Production `EXACT_REVIEW_LIFECYCLE_BAY_CACHE_MS` is 30000, with its documentation-sync claim and Wrangler assertion updated. No bindings or migrations change. The changelog records the restored oversized-response telemetry.

## pr-behavior-proof

Claim: both callers return oversized GitHub responses intact, send zero response-body bytes to the broker, and record one durable miss plus one durable skip. Size-only stores never access the body table; requests with a body retain existing behavior.

Surface and scenario: `docs/proof/etag-read-broker/run-proof.mjs` exercises the actual publication runner adapter and signed broker HTTP transport, dashboard health reads over loopback HTTP, Worker routes, and the actual queue store backed by in-memory SQLite. Each caller handles synthetic 100 KiB, 200 KiB, and 600 KiB responses; the publication runner also handles 200/600 KiB without an ETag. Existing 200 → confirmed 304 → changed 200 behavior, page isolation, final live guards, and publisher/operator scope checks remain covered. Focused regressions also cover multibyte UTF-8, the exact 128 KiB boundary, invalid size metadata, body-field precedence, and zero body-table queries for size-only stores.

Environment for this fix round: local macOS, Node 26.8.1, synthetic credentials and loopback GitHub HTTP. No remote provider or lease was used for this round. Earlier housekeeping validation used Crabbox AWS as recorded in the previous proof; that is not claimed as execution evidence for this new head.

Commands:

```sh
pnpm run format
pnpm run build:all
pnpm run lint
pnpm run check:docs
pnpm run check
git diff --check
node --test test/github-etag-read-broker.test.ts test/github-egress-telemetry.test.ts test/dashboard-worker-queue-policy.test.ts test/dashboard-worker-queue-runtime.test.ts test/exact-review-queue-cpu.test.ts
node docs/proof/etag-read-broker/run-proof.mjs --output /tmp/pr-1387-behavior-report.json
node /tmp/pr-1387-missing-etag-proof.mjs --output /tmp/pr-1387-missing-etag-proof-report.json
```

The requested gates passed on the fix: format, all builds, lint, documentation checks, and `git diff --check`. The focused run passed 295 tests with two existing platform skips and zero failures. Independent review of the final patch is clean through P2. Exact-head CI is tracked in the PR checks; the fix-round handoff records its final conclusion and the additional full-suite result.

Finding disposition: the accepted P2 is fixed. Before the fix, both dashboard regression sizes recorded only `cache_miss=1`; all four oversized publication fixtures (200/600 KiB, ASCII/multibyte UTF-8) sent no store request; the direct size-only store returned `invalid_json_body` instead of `body_size_bound`. Those seven leaf scenarios now pass. Independent review found an additional early return for oversized publication responses without an ETag; that regression was reproduced before fixing it, then verified at 200/600 KiB through the real runner signing and transport path. The supplemental local proof `/tmp/pr-1387-missing-etag-proof.mjs` truly omits the HTTP ETag header and asserts an empty ETag in the signed store payload; this avoids the checked-in proof helper interpreting the following header as an empty ETag value. Smaller missing-ETag responses retain their previous local-skip behavior. The runner adapter forwards `body_bytes` unchanged.

Artifact: the reproducible runner is `docs/proof/etag-read-broker/run-proof.mjs`; the committed-head result is `/tmp/pr-1387-behavior-report.json`. Its normalized result is:

```json
{
  "tested_head": "ae96703713fc43a11a0730054760e26da8838886",
  "environment": "local macOS, Node 26.8.1, loopback HTTP, in-memory SQLite",
  "body_bounds": {
    "publication_100_kib": {
      "returned_bytes": 102400,
      "store_requests": 1,
      "body_wire_bytes": 102400,
      "reported_body_bytes": null,
      "cache_miss": 1,
      "cache_200_stored": 1
    },
    "dashboard_100_kib": {
      "returned_bytes": 102400,
      "store_requests": 1,
      "body_wire_bytes": 102400,
      "reported_body_bytes": null,
      "cache_miss": 1,
      "cache_200_stored": 1
    },
    "publication_200_kib": {
      "returned_bytes": 204800,
      "store_requests": 1,
      "body_wire_bytes": 0,
      "reported_body_bytes": 204800,
      "cache_miss": 1,
      "cache_skip": 1
    },
    "dashboard_200_kib": {
      "returned_bytes": 204800,
      "store_requests": 1,
      "body_wire_bytes": 0,
      "reported_body_bytes": 204800,
      "cache_miss": 1,
      "cache_skip": 1
    },
    "publication_without_etag_200_kib": {
      "returned_bytes": 204800,
      "store_requests": 1,
      "body_wire_bytes": 0,
      "reported_body_bytes": 204800,
      "cache_miss": 1,
      "cache_skip": 1
    },
    "publication_600_kib": {
      "returned_bytes": 614400,
      "store_requests": 1,
      "body_wire_bytes": 0,
      "reported_body_bytes": 614400,
      "cache_miss": 1,
      "cache_skip": 1
    },
    "dashboard_600_kib": {
      "returned_bytes": 614400,
      "store_requests": 1,
      "body_wire_bytes": 0,
      "reported_body_bytes": 614400,
      "cache_miss": 1,
      "cache_skip": 1
    },
    "publication_without_etag_600_kib": {
      "returned_bytes": 614400,
      "store_requests": 1,
      "body_wire_bytes": 0,
      "reported_body_bytes": 614400,
      "cache_miss": 1,
      "cache_skip": 1
    },
    "direct_200_kib": {
      "ok": true,
      "stored": false,
      "reason": "body_size_bound"
    }
  },
  "unchanged_revalidation_proof": "200 -> confirmed 304 -> changed 200; independent pages and final live guard passed"
}
```

Limits: synthetic GitHub responses and credentials; SQLite runs in the harness rather than the Cloudflare production runtime. This proves request contents, durable telemetry, and cache behavior, not production CPU savings or resolution of every overload source. No merge, deployment, or live workflow was initiated.

## OpenClaw Bay

OpenClaw Bay needs no additional change for this fix. The existing `cache_skip` metric is restored without changing any public fields, navigation, or action controls. The original PR's internal memo window remains 30 seconds; Bay stays observer-only.
