### PR TITLE
fix(queue): recover publication claims after transient failures

### DIFF
--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -7030,8 +7030,31 @@ export class ExactReviewQueue {
     // visibility can change while the lease is active. Re-probe each unfinished
     // repository before returning any credential-bearing work.
     let existingBatch = this.batchStore.fetch(claimId, leaseOwner, now);
-    if (existingBatch?.state === "leased") {
-      const unfinished = existingBatch.items.filter((item) => item.terminalOutcome === null);
+    const claimedResponse = async (
+      batch: NonNullable<typeof existingBatch>,
+      lifecycleBatch = batch,
+    ) => {
+      if (batch.items.length && lifecycleBatch.state === "leased") {
+        this.recordLifecycleBatchClaim(lifecycleBatch, state, now);
+      }
+      await this.scheduleNext(state, now);
+      const oldestCandidateAt = batch.items.reduce(
+        (oldest, membership) =>
+          Math.min(oldest, state.items[membership.itemKey]?.createdAt ?? batch.createdAt),
+        batch.createdAt,
+      );
+      return json({
+        ok: true,
+        claimed: true,
+        batch: exactReviewPublicationBatchJson(batch),
+        configured_batch_size: batch.configuredBatchSize,
+        batch_wait_ms: Math.max(0, now - oldestCandidateAt),
+        requested_max_items: requestedSize,
+        effective_max_items: leaseSize,
+      });
+    };
+    const replayExistingBatch = async (batch: NonNullable<typeof existingBatch>) => {
+      const unfinished = batch.items.filter((item) => item.terminalOutcome === null);
       const unfinishedRepos = new Map<string, string>(
         unfinished.flatMap((membership) => {
           const item = state.items[membership.itemKey];
@@ -7052,11 +7075,11 @@ export class ExactReviewQueue {
       );
       now = Date.now();
       state = this.readStateSync();
-      existingBatch = this.batchStore.fetch(claimId, leaseOwner, now);
-      if (!existingBatch || existingBatch.state !== "leased") {
+      batch = this.batchStore.fetch(claimId, leaseOwner, now)!;
+      if (!batch || batch.state !== "leased") {
         return json({ error: "batch_lease_not_active" }, 409);
       }
-      const completions = existingBatch.items.flatMap((membership) => {
+      const completions = batch.items.flatMap((membership) => {
         if (membership.terminalOutcome !== null) return [];
         const item = state.items[membership.itemKey];
         if (
@@ -7102,14 +7125,14 @@ export class ExactReviewQueue {
         });
         now = Date.now();
         state = this.readStateSync();
-        existingBatch = this.batchStore.fetch(claimId, leaseOwner, now);
-        if (!existingBatch) {
+        batch = this.batchStore.fetch(claimId, leaseOwner, now)!;
+        if (!batch) {
           return json({ error: "batch_lease_not_active" }, 409);
         }
       }
       const publicBatch = {
-        ...existingBatch,
-        items: existingBatch.items.filter((membership) => {
+        ...batch,
+        items: batch.items.filter((membership) => {
           if (membership.terminalOutcome !== null) return false;
           const item = state.items[membership.itemKey];
           return (
@@ -7119,25 +7142,9 @@ export class ExactReviewQueue {
           );
         }),
       };
-      if (publicBatch.items.length && existingBatch.state === "leased") {
-        this.recordLifecycleBatchClaim(existingBatch, state, now);
-      }
-      await this.scheduleNext(state, now);
-      const oldestCandidateAt = publicBatch.items.reduce(
-        (oldest, membership) =>
-          Math.min(oldest, state.items[membership.itemKey]?.createdAt ?? existingBatch.createdAt),
-        existingBatch.createdAt,
-      );
-      return json({
-        ok: true,
-        claimed: true,
-        batch: exactReviewPublicationBatchJson(publicBatch),
-        configured_batch_size: existingBatch.configuredBatchSize,
-        batch_wait_ms: Math.max(0, now - oldestCandidateAt),
-        requested_max_items: requestedSize,
-        effective_max_items: leaseSize,
-      });
-    }
+      return claimedResponse(publicBatch, batch);
+    };
+    if (existingBatch?.state === "leased") return replayExistingBatch(existingBatch);
     let probedPairs = exactReviewPublicationBatchReservedProbe(state, now, dispatch?.id);
     let candidates = this.publicationBatchClaimCandidates(
       state,
@@ -7156,6 +7163,8 @@ export class ExactReviewQueue {
     );
     now = Date.now();
     state = this.readStateSync();
+    existingBatch = this.batchStore.fetch(claimId, leaseOwner, now);
+    if (existingBatch?.state === "leased") return replayExistingBatch(existingBatch);
     probedPairs = exactReviewPublicationBatchReservedProbe(state, now, dispatch?.id);
     candidates = this.publicationBatchClaimCandidates(
       state,

--- a/src/repair/exact-review-batch-queue-client.ts
+++ b/src/repair/exact-review-batch-queue-client.ts
@@ -175,21 +175,25 @@ export class ExactReviewBatchQueueClient implements ExactReviewBatchQueue {
     dispatch?: { id: string; at: string };
     runner?: { runId: string; runAttempt: number; startedAt: string };
   }) {
-    const response = await this.post("claim", {
-      claim_id: input.claimId,
-      lease_owner: input.leaseOwner,
-      max_items: input.maxItems,
-      ...(input.dispatch
-        ? { dispatch_id: input.dispatch.id, dispatched_at: input.dispatch.at }
-        : {}),
-      ...(input.runner
-        ? {
-            runner_run_id: input.runner.runId,
-            runner_run_attempt: input.runner.runAttempt,
-            runner_started_at: input.runner.startedAt,
-          }
-        : {}),
-    });
+    const response = await this.postUrl(
+      "/internal/exact-review/publication-batches/claim",
+      {
+        claim_id: input.claimId,
+        lease_owner: input.leaseOwner,
+        max_items: input.maxItems,
+        ...(input.dispatch
+          ? { dispatch_id: input.dispatch.id, dispatched_at: input.dispatch.at }
+          : {}),
+        ...(input.runner
+          ? {
+              runner_run_id: input.runner.runId,
+              runner_run_attempt: input.runner.runAttempt,
+              runner_started_at: input.runner.startedAt,
+            }
+          : {}),
+      },
+      input.dispatch ? Date.now() + RETRY_DEADLINE_MS : undefined,
+    );
     if (response.claimed !== true) return null;
     const batch = parseLease(response.batch);
     const legacyConfiguredBatchSize =

--- a/test/dashboard-worker-queue-runtime.test.ts
+++ b/test/dashboard-worker-queue-runtime.test.ts
@@ -3091,6 +3091,106 @@ test("exact-review batch claim retries re-admit each target and return only publ
   }
 });
 
+test("concurrent identical batch claims replay after admission clears the reservation", async () => {
+  const releases: Array<() => void> = [];
+  const starts: Array<Promise<void>> = [];
+  let blockClaims = false;
+  let probes = 0;
+  const harness = createExactReviewAdmissionHarness(() => jsonResponse({ state: "open" }), {
+    publicationBatching: true,
+    captureBatchDispatch: true,
+    hostedPublicTargetProbe: async () => {
+      if (!blockClaims) return "public";
+      probes += 1;
+      let started!: () => void;
+      let release!: () => void;
+      starts.push(new Promise<void>((resolve) => (started = resolve)));
+      const blocked = new Promise<void>((resolve) => (release = resolve));
+      releases.push(release);
+      started();
+      await blocked;
+      return "public";
+    },
+  });
+  try {
+    assert.equal(
+      (
+        await harness.queue.fetch(
+          buildExactReviewQueueRequest(
+            "concurrent-claim",
+            9248,
+            "exact_review_artifact_publish",
+            "issue",
+            "openclaw/gogcli",
+            exactReviewPublicationOverrides(9248, "92480"),
+          ),
+        )
+      ).status,
+      202,
+    );
+    await harness.queue.alarm();
+    const reserved = (await harness.storage.get("exact-review-queue")) as {
+      dispatcher: {
+        publicationBatchDispatchId: string;
+        publicationBatchDispatchedAt: number;
+        publicationBatchDispatchPendingUntil?: number;
+      };
+    };
+    const request = () =>
+      new Request("https://clawsweeper-exact-review-queue/publication-batches/claim", {
+        method: "POST",
+        body: JSON.stringify({
+          claim_id: "concurrent-claim",
+          lease_owner: "concurrent-worker",
+          dispatch_id: reserved.dispatcher.publicationBatchDispatchId,
+          dispatched_at: new Date(reserved.dispatcher.publicationBatchDispatchedAt).toISOString(),
+        }),
+      });
+
+    blockClaims = true;
+    const firstPending = harness.queue.fetch(request());
+    while (starts.length < 1) await Promise.resolve();
+    await starts[0];
+    const secondPending = harness.queue.fetch(request());
+    while (starts.length < 2) await Promise.resolve();
+    await starts[1];
+
+    releases[0]();
+    const first = await (await firstPending).json();
+    assert.equal(first.claimed, true, JSON.stringify(first));
+    const afterFirst = (await harness.storage.get("exact-review-queue")) as {
+      dispatcher?: { publicationBatchDispatchPendingUntil?: number };
+    };
+    assert.equal(afterFirst.dispatcher?.publicationBatchDispatchPendingUntil, undefined);
+
+    releases[1]();
+    while (starts.length < 3) await Promise.resolve();
+    await starts[2];
+    releases[2]();
+    const second = await (await secondPending).json();
+    assert.equal(second.claimed, true, JSON.stringify(second));
+    assert.equal(probes, 3);
+    const { server_time: firstServerTime, ...firstLease } = first.batch;
+    const { server_time: secondServerTime, ...secondLease } = second.batch;
+    assert.ok(Date.parse(secondServerTime) >= Date.parse(firstServerTime));
+    assert.deepEqual(secondLease, firstLease);
+    assert.deepEqual(
+      second.batch.items.map((item) => ({
+        item_key: item.item_key,
+        revision: item.revision,
+        claim_generation: item.claim_generation,
+      })),
+      first.batch.items.map((item) => ({
+        item_key: item.item_key,
+        revision: item.revision,
+        claim_generation: item.claim_generation,
+      })),
+    );
+  } finally {
+    harness.restore();
+  }
+});
+
 test("exact-review batch retry rereads the membership fence after visibility I/O", async () => {
   let retry = false;
   let retryProbeBlocked = false;

--- a/test/exact-review-publication-batches.test.ts
+++ b/test/exact-review-publication-batches.test.ts
@@ -526,6 +526,31 @@ test("publication batches atomically select ready items without duplicate active
   assert.equal(batches.fetch("batch-1", "wrong-worker", 1_500), null);
 });
 
+test("publication batch store replays the exact lease for the same identity", () => {
+  const storage = new TestStorage();
+  const batches = new ExactReviewPublicationBatchStore(storage);
+  batches.ensureSchemaSync();
+
+  const first = batches.claim({
+    batchId: "batch-replay",
+    leaseOwner: "worker-replay",
+    leaseExpiresAt: 2_000,
+    now: 1_000,
+    maxItems: 2,
+    candidates,
+  });
+  const replay = batches.claim({
+    batchId: "batch-replay",
+    leaseOwner: "worker-replay",
+    leaseExpiresAt: 9_000,
+    now: 1_500,
+    maxItems: 4,
+    candidates: candidates.slice(2),
+  });
+
+  assert.deepEqual(replay, first);
+});
+
 test("publication batches allow a bounded number of disjoint active owners", () => {
   const storage = new TestStorage();
   const batches = new ExactReviewPublicationBatchStore(storage);

--- a/test/repair/exact-review-batch-queue-client.test.ts
+++ b/test/repair/exact-review-batch-queue-client.test.ts
@@ -12,6 +12,17 @@ const heartbeat = {
   leaseExpiresAt: new Date(now + 120_000).toISOString(),
   items: [],
 };
+const dispatchedClaim = {
+  claimId: "claim-proof",
+  leaseOwner: "worker-proof",
+  maxItems: 4,
+  dispatch: { id: "dispatch-proof", at: new Date(now - 60_000).toISOString() },
+  runner: {
+    runId: "123456",
+    runAttempt: 2,
+    startedAt: new Date(now - 30_000).toISOString(),
+  },
+};
 
 function fixture(t, respond) {
   t.mock.timers.enable({ apis: ["Date", "setTimeout"], now });
@@ -37,6 +48,107 @@ async function flush() {
 function unavailable(headers = {}) {
   return new Response("exact_review_queue_unavailable", { status: 500, headers });
 }
+
+test("dispatched claim retries timeout and HTTP 500 with unchanged identity", async (t) => {
+  const batch = {
+    batch_id: dispatchedClaim.claimId,
+    lease_owner: dispatchedClaim.leaseOwner,
+    lease_expires_at: new Date(now + 120_000).toISOString(),
+    items: [
+      {
+        item_key: "openclaw/example#1@publish:10:1",
+        revision: 3,
+        claim_generation: 7,
+      },
+    ],
+  };
+  const { client, calls } = fixture(t, (attempt, init) => {
+    if (attempt === 1) {
+      return new Promise((_resolve, reject) =>
+        init.signal.addEventListener("abort", () => reject(init.signal.reason), { once: true }),
+      );
+    }
+    if (attempt === 2) return unavailable();
+    return Response.json({
+      claimed: true,
+      batch,
+      configured_batch_size: 4,
+      batch_wait_ms: 125,
+    });
+  });
+
+  const result = client.claim(dispatchedClaim);
+  await flush();
+  t.mock.timers.tick(20_000);
+  await flush();
+  t.mock.timers.tick(1_000);
+  await flush();
+  t.mock.timers.tick(2_000);
+  await flush();
+
+  assert.deepEqual(await result, {
+    batchId: dispatchedClaim.claimId,
+    leaseOwner: dispatchedClaim.leaseOwner,
+    leaseExpiresAt: batch.lease_expires_at,
+    items: [
+      {
+        itemKey: "openclaw/example#1@publish:10:1",
+        revision: 3,
+        claimGeneration: 7,
+      },
+    ],
+    configuredBatchSize: 4,
+    batchWaitMs: 125,
+  });
+  assert.equal(calls.length, 3);
+  assert.equal(calls[0].body, calls[1].body);
+  assert.equal(calls[1].body, calls[2].body);
+  assert.deepEqual(calls[0].headers, calls[1].headers);
+  assert.deepEqual(calls[1].headers, calls[2].headers);
+  assert.deepEqual(JSON.parse(calls[0].body), {
+    claim_id: dispatchedClaim.claimId,
+    lease_owner: dispatchedClaim.leaseOwner,
+    max_items: dispatchedClaim.maxItems,
+    dispatch_id: dispatchedClaim.dispatch.id,
+    dispatched_at: dispatchedClaim.dispatch.at,
+    runner_run_id: dispatchedClaim.runner.runId,
+    runner_run_attempt: dispatchedClaim.runner.runAttempt,
+    runner_started_at: dispatchedClaim.runner.startedAt,
+  });
+  assert.equal(
+    calls[0].headers["x-clawsweeper-exact-review-signature"],
+    `sha256=${createHmac("sha256", "synthetic-test-secret").update(calls[0].body).digest("hex")}`,
+  );
+});
+
+test("dispatched claim does not retry HTTP 4xx", async (t) => {
+  const { client, calls, logs } = fixture(t, () => new Response(null, { status: 409 }));
+  await assert.rejects(client.claim(dispatchedClaim), /HTTP 409/);
+  assert.equal(calls.length, 1);
+  assert.deepEqual(logs, []);
+});
+
+test("undispatched claim and completion remain single-attempt", async (t) => {
+  const { client, calls, logs } = fixture(t, () => unavailable());
+  await assert.rejects(
+    client.claim({
+      claimId: dispatchedClaim.claimId,
+      leaseOwner: dispatchedClaim.leaseOwner,
+      maxItems: dispatchedClaim.maxItems,
+    }),
+    /HTTP 500/,
+  );
+  await assert.rejects(
+    client.complete({
+      batchId: dispatchedClaim.claimId,
+      leaseOwner: dispatchedClaim.leaseOwner,
+      items: [],
+    }),
+    /HTTP 500/,
+  );
+  assert.equal(calls.length, 2);
+  assert.deepEqual(logs, []);
+});
 
 test("post-effect HTTP 500 is attempted once", async (t) => {
   const { client, calls, logs } = fixture(t, () => unavailable());


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a dispatched publication workflow could lose a claim response during a transient Worker or network failure, exit without a lease, and leave already-reserved publication work waiting for later recovery.

## Why This Change Was Made

Dispatched claim requests now retry transient network, timeout, and HTTP 5xx failures up to three attempts within the existing 45-second request budget. Retries reuse the exact serialized body and signature.

The Worker rechecks for an already-created lease after asynchronous target admission and replays the complete existing-batch admission path. The batch store remains the single transactional owner, so the same batch ID and lease owner can create at most one lease.

Undispatched claims, completion requests, post-effects, workflow behavior, capacity, batch size, schema, and configuration remain unchanged.

## User Impact

Maintainers should see fewer failed publication runs and less delayed backlog recovery when a claim succeeded server-side but its response was lost.

## OpenClaw Bay Impact

Bay is unaffected. This changes only the signed internal claim transport and existing-batch replay path; public projections, fields, and observer behavior are unchanged.

## Documentation Impact

Reviewed `docs/live-dashboard.md`. No documentation change is required because the public queue contract, operator controls, configuration, and projection fields are unchanged. The retry is bounded internal transport recovery for dispatched claims.

## Evidence

- Signed head: `3a5ba4d056590aab12747d7be03c8c81559bef97`
- Base: `72041f31e1d34cff19f50da4b23c4a22a78c828a`
- Scope: five files.
- Production: `+56/-43`, net `+13`.
- Tests: `+237/-0`.
- `build`, `build:repair`, and `build:dashboard`: passed.
- Focused suites: 306 passed, 0 failed:
  - `test/repair/exact-review-batch-queue-client.test.ts`
  - `test/exact-review-publication-batches.test.ts`
  - `test/dashboard-worker-queue-runtime.test.ts`
- Targeted `oxlint`: passed.
- Targeted `oxfmt --check`: passed.
- `check-active-surface`, `check-dashboard-queue-boundary`, and `check-dashboard-strict`: passed.
- `git diff --check`: passed.

Regression coverage includes:

- a dispatched claim retries timeout and HTTP 500, then returns the lease with identical body and HMAC on every attempt;
- HTTP 4xx claims remain single-attempt;
- undispatched claims, completion, and post-effects remain single-attempt;
- concurrent same-identity claims replay the first committed lease after asynchronous admission clears the reservation;
- replay responses retain the original lease identity while allowing current main's per-response `server_time` to advance;
- batch-store same-identity replay returns the original lease without extending or replacing it.

The broad local `pnpm run check` was not rerun. A previous attempt on this worktree hung in unrelated test infrastructure after about 11 minutes; this branch instead uses the focused owner-boundary suites and targeted static gates above. Hosted CI remains required.

## Real Behavior Proof

**Claim:** the built queue client retries a transient dispatched-claim HTTP 500 while preserving the exact request identity, then accepts the returned lease.

**Surface:** Node 26.7.0 running `dist/repair/exact-review-batch-queue-client.js` against an ephemeral local HTTPS server. The server captured each received body and signature and returned HTTP 500 before a successful lease response.

**Command:** an inline Node ESM proof imported the built client, started an ephemeral loopback HTTPS server with a synthetic key and webhook secret, issued one dispatched claim, and asserted the received bytes, HMAC, attempt count, and returned batch identity.

**Observed result:**

```json
{"result":"pass","attempts":2,"identical_body":true,"identical_signature":true,"claimed_batch":"proof-claim","server_time_preserved":true}
```

**Limits:** this proves the built client and real HTTPS request boundary locally, including current main's internal `server_time` response field. The Worker concurrency and SQLite lease replay are covered by the focused production-queue harness tests; this draft does not claim deployment or a live queue mutation.

No deployment, queue dispatch, cancellation, retry, capacity change, or other live operation was performed.
