### PR TITLE
refactor(repair): simplify comment router plumbing

### DIFF
--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -198,7 +198,6 @@ export function createCachedIssueCommentsLookup<T = JsonValue>(
     const cached = cache.get(key);
     if (cached) return [...cached];
     const comments = fetchComments(key);
-    if (!Array.isArray(comments)) return [];
     cache.set(key, comments);
     return [...comments];
   };
@@ -218,7 +217,6 @@ export function createCachedIssueCommentsLookupAsync<T = JsonValue>(
     if (pending) return [...(await pending)];
     const next = fetchComments(key)
       .then((comments) => {
-        if (!Array.isArray(comments)) return [];
         cache.set(key, comments);
         return comments;
       })
@@ -735,28 +733,7 @@ export function automergeRebaseRepairReason(target: LooseRecord = {}): string | 
   if (mergeable === "CONFLICTING")
     return "PR has merge conflicts and needs a cloud rebase repair before automerge";
 
-  // GitHub can safely merge an otherwise-ready BEHIND head with a three-way
-  // merge. Let the exact-head merge call enforce repository policy instead of
-  // rewriting a contributor branch solely because main advanced.
-  if (mergeStateStatus === "BEHIND") return null;
-  return null;
-}
-
-export function automergeActivationRepairReason({
-  intent,
-  repo,
-  title,
-  files,
-  target = {},
-}: LooseRecord): string | null {
-  const failedChecksRepairReason = automergeFailedChecksRepairReason(target.checks ?? {});
-  if (failedChecksRepairReason) return failedChecksRepairReason;
-
-  const rebaseRepairReason = automergeRebaseRepairReason(target);
-  if (rebaseRepairReason) return rebaseRepairReason;
-
-  if (String(intent ?? "") !== "automerge") return null;
-  automergeChangelogBlockReason({ repo, title, files });
+  // BEHIND alone allows a three-way merge; the exact-head merge call enforces repo policy.
   return null;
 }
 
@@ -1708,6 +1685,7 @@ type AutoRepairDispatchEntry = {
   status?: unknown;
   target?: { head_sha?: unknown } | null;
   comment_updated_at?: unknown;
+  actions?: readonly { action?: unknown; status?: unknown }[];
 };
 
 export function autoRepairHeadKey({
@@ -1759,11 +1737,8 @@ export function autoRepairBlockReason({
     return "ClawSweeper auto repair already planned for this PR head in this scan";
   }
 
-  const priorHeadDispatches = entries.filter(
-    (entry) =>
-      isAutoRepairDispatchForPr(entry, repo, issueNumber) &&
-      String(entry.target?.head_sha ?? "") === String(headSha ?? "") &&
-      isAfterAutoRepairResumeBoundary(entry, resumeBoundary),
+  const priorHeadDispatches = priorPrDispatches.filter(
+    (entry) => String(entry.target?.head_sha ?? "") === String(headSha ?? ""),
   );
   if (priorHeadDispatches.length >= maxRepairsPerHead) {
     return `ClawSweeper auto repair already dispatched ${priorHeadDispatches.length} time(s) for this PR head`;
@@ -1777,8 +1752,8 @@ function isAutoRepairDispatchForPr(
   repo: unknown,
   issueNumber: unknown,
 ) {
-  const hasRepairDispatchAction = (entry as LooseRecord).actions?.some(
-    (action: JsonValue) => action?.action === "dispatch_repair" && action?.status === "executed",
+  const hasRepairDispatchAction = entry.actions?.some(
+    (action) => action?.action === "dispatch_repair" && action?.status === "executed",
   );
   return (
     entry.repo === repo &&
@@ -1839,7 +1814,7 @@ export function parseTrustedAutomation(
   if (actionMarker?.action === "close-required" || verdict?.action === "close") {
     const marker = actionMarker ?? verdict;
     if (marker) {
-      return trustedClose({
+      return trustedCommand("autoclose", {
         author,
         reason: `structured ClawSweeper close marker: ${marker.action}${markerReasonSuffix(marker.attrs)}`,
         marker,
@@ -1847,28 +1822,28 @@ export function parseTrustedAutomation(
     }
   }
   if (verdict?.action === "human-review") {
-    return trustedHumanReview({
+    return trustedCommand("clawsweeper_needs_human", {
       author,
       reason: trustedHumanReviewReason(body, verdict),
       marker: verdict,
     });
   }
   if (verdict?.action === "needs-human" && securityMarker?.action === "security-sensitive") {
-    return trustedHumanReview({
+    return trustedCommand("clawsweeper_needs_human", {
       author,
       reason: trustedHumanReviewReason(body, verdict),
       marker: verdict,
     });
   }
   if (verdict?.action === "needs-human" && trustedCommentHasPriorityFinding(body)) {
-    return trustedRepair({
+    return trustedCommand("clawsweeper_auto_repair", {
       author,
       reason: `structured ClawSweeper needs-human verdict with repairable P-severity findings${markerReasonSuffix(verdict.attrs)}`,
       marker: verdict,
     });
   }
   if (verdict?.action === "needs-human") {
-    return trustedHumanReview({
+    return trustedCommand("clawsweeper_needs_human", {
       author,
       reason: trustedHumanReviewReason(body, verdict),
       marker: verdict,
@@ -1878,7 +1853,7 @@ export function parseTrustedAutomation(
     actionMarker &&
     ["fix-required", "repair-required", "address-review", "fix-ci"].includes(actionMarker.action)
   ) {
-    return trustedRepair({
+    return trustedCommand("clawsweeper_auto_repair", {
       author,
       reason: `structured ClawSweeper marker: ${actionMarker.action}${markerReasonSuffix(actionMarker.attrs)}`,
       marker: actionMarker,
@@ -1894,14 +1869,14 @@ export function parseTrustedAutomation(
       "repair-required",
     ].includes(verdict.action)
   ) {
-    return trustedRepair({
+    return trustedCommand("clawsweeper_auto_repair", {
       author,
       reason: `structured ClawSweeper verdict: ${verdict.action}${markerReasonSuffix(verdict.attrs)}`,
       marker: verdict,
     });
   }
   if (trustedCommentHasPriorityFinding(body)) {
-    return trustedRepair({
+    return trustedCommand("clawsweeper_auto_repair", {
       author,
       reason: `trusted ClawSweeper review contains P-severity findings${markerReasonSuffix(verdict?.attrs)}`,
       marker: verdict,
@@ -1910,14 +1885,14 @@ export function parseTrustedAutomation(
   if (verdict && ["pass", "approved", "no-changes"].includes(verdict.action)) {
     const liveVerification = markerLiveVerificationState(verdict);
     if (liveVerification === "failed" || liveVerification === "malformed") {
-      return trustedHumanReview({
+      return trustedCommand("clawsweeper_needs_human", {
         author,
         reason: `attached live verification is ${liveVerification}`,
         marker: verdict,
       });
     }
     if (liveVerification === "unknown") return null;
-    return trustedMerge({
+    return trustedCommand("clawsweeper_auto_merge", {
       author,
       reason: `structured ClawSweeper verdict: ${verdict.action}${markerReasonSuffix(verdict.attrs)}`,
       marker: verdict,
@@ -2620,25 +2595,7 @@ export function renderResponse(command: LooseRecord, dispatched: LooseRecord) {
       "",
       `Source: \`${commandSource(command)}\``,
       `Feedback: ${command.repair_reason ?? "ClawSweeper reported a passing review."}`,
-      ...(dispatched?.merge?.reason ? [`Merge status: ${dispatched.merge.reason}`] : []),
-      ...(dispatched?.merge?.merged_at ? [`Merged at: ${dispatched.merge.merged_at}`] : []),
-      ...(dispatched?.merge?.merge_commit_sha
-        ? [`Merge commit: ${markdownCommitLink(command.repo, dispatched.merge.merge_commit_sha)}`]
-        : []),
-      ...(dispatched?.merge?.summary_lines?.length
-        ? ["", "What merged:", ...dispatched.merge.summary_lines.map((line: string) => `- ${line}`)]
-        : []),
-      ...(dispatched?.merge?.fixup_lines?.length
-        ? [
-            "",
-            "Automerge notes:",
-            ...dispatched.merge.fixup_lines.map((line: string) => `- ${line}`),
-          ]
-        : []),
-      "",
-      dispatched?.merge?.status === "executed"
-        ? "The automerge loop is complete."
-        : "I left the PR open for the remaining gate instead of bypassing it.",
+      ...mergeResponseLines(command.repo, dispatched?.merge),
     ].join("\n");
   }
   if (command.intent === "maintainer_approve_automerge") {
@@ -2650,25 +2607,7 @@ export function renderResponse(command: LooseRecord, dispatched: LooseRecord) {
       "",
       `Approver: \`${command.author ?? "maintainer"}\``,
       `Head: ${markdownCommitLink(command.repo, command.expected_head_sha ?? command.target?.head_sha) || "`unknown`"}`,
-      ...(dispatched?.merge?.reason ? [`Merge status: ${dispatched.merge.reason}`] : []),
-      ...(dispatched?.merge?.merged_at ? [`Merged at: ${dispatched.merge.merged_at}`] : []),
-      ...(dispatched?.merge?.merge_commit_sha
-        ? [`Merge commit: ${markdownCommitLink(command.repo, dispatched.merge.merge_commit_sha)}`]
-        : []),
-      ...(dispatched?.merge?.summary_lines?.length
-        ? ["", "What merged:", ...dispatched.merge.summary_lines.map((line: string) => `- ${line}`)]
-        : []),
-      ...(dispatched?.merge?.fixup_lines?.length
-        ? [
-            "",
-            "Automerge notes:",
-            ...dispatched.merge.fixup_lines.map((line: string) => `- ${line}`),
-          ]
-        : []),
-      "",
-      dispatched?.merge?.status === "executed"
-        ? "The automerge loop is complete."
-        : "I left the PR open for the remaining gate instead of bypassing it.",
+      ...mergeResponseLines(command.repo, dispatched?.merge),
     ].join("\n");
   }
   if (command.intent === "clawsweeper_needs_human") {
@@ -2711,6 +2650,26 @@ export function renderResponse(command: LooseRecord, dispatched: LooseRecord) {
     "",
     "I will keep the change narrow and update the PR branch if the repair worker finds a safe fix.",
   ].join("\n");
+}
+
+function mergeResponseLines(repo: string, merge: LooseRecord) {
+  return [
+    ...(merge?.reason ? [`Merge status: ${merge.reason}`] : []),
+    ...(merge?.merged_at ? [`Merged at: ${merge.merged_at}`] : []),
+    ...(merge?.merge_commit_sha
+      ? [`Merge commit: ${markdownCommitLink(repo, merge.merge_commit_sha)}`]
+      : []),
+    ...(merge?.summary_lines?.length
+      ? ["", "What merged:", ...merge.summary_lines.map((line: string) => `- ${line}`)]
+      : []),
+    ...(merge?.fixup_lines?.length
+      ? ["", "Automerge notes:", ...merge.fixup_lines.map((line: string) => `- ${line}`)]
+      : []),
+    "",
+    merge?.status === "executed"
+      ? "The automerge loop is complete."
+      : "I left the PR open for the remaining gate instead of bypassing it.",
+  ];
 }
 
 export function buildClawSweeperAssistDispatchPayload(command: LooseRecord) {
@@ -2800,7 +2759,7 @@ function commandFromText(trigger: JsonValue, value: JsonValue) {
   if (intent === "autoclose") parsed.autoclose_message = autocloseReasonFromCommand(rawCommand);
   if (intent === "freeform_assist") parsed.freeform_prompt = assistPromptFromCommand(rawCommand);
   if (intent === "re_review") {
-    const prompt = reviewPromptFromCommand(rawText);
+    const prompt = reviewPromptFromClawSweeperCommandText(rawText);
     if (prompt) parsed.freeform_prompt = prompt;
   }
   if (intent === "visualize") parsed.visual_lens = visualLensFromCommand(rawCommand);
@@ -2867,10 +2826,6 @@ function isIssueImplementationOverride(command: string) {
 function assistPromptFromCommand(command: LooseRecord) {
   const prompt = String(command ?? "").trim();
   return prompt.replace(/^(?:ask|explain)\b[:\s-]*/i, "").trim() || prompt;
-}
-
-function reviewPromptFromCommand(command: LooseRecord) {
-  return reviewPromptFromClawSweeperCommandText(command);
 }
 
 export const VISUAL_LENSES = new Set([
@@ -3009,8 +2964,6 @@ export function staleClosedItemCommandReason({
   return `PR closed after this ${intent} command`;
 }
 
-export const staleAutomergeActivationReason = staleClosedItemCommandReason;
-
 export function repairLoopStopPauseReason({ command, entries = [] }: LooseRecord): string | null {
   const stopAt = latestRepairLoopControlTime(entries, command, ["stop"]);
   if (!stopAt) return null;
@@ -3075,83 +3028,46 @@ function inlineQuote(value: JsonValue): string {
     : "_No request text provided._";
 }
 
-function trustedRepair({ author, reason, marker = null }: LooseRecord) {
+function trustedCommand(
+  intent:
+    | "clawsweeper_auto_repair"
+    | "clawsweeper_auto_merge"
+    | "clawsweeper_needs_human"
+    | "autoclose",
+  {
+    author,
+    reason,
+    marker = null,
+  }: {
+    author: string;
+    reason: string;
+    marker?: { action: string; attrs: Record<string, string> } | null;
+  },
+) {
+  const attrs = marker?.attrs;
   return {
     trigger: "trusted_bot",
-    command: "clawsweeper auto repair",
-    intent: "clawsweeper_auto_repair",
+    command: intent === "autoclose" ? `autoclose ${reason}` : intent.replaceAll("_", " "),
+    intent,
     trusted_bot: true,
     trusted_bot_author: author,
     automation_source: "clawsweeper",
     repair_reason: reason,
-    expected_head_sha: marker?.attrs?.sha ?? null,
-    reviewed_at: marker?.attrs?.reviewed_at ?? null,
-    review_lease_owner: marker?.attrs?.lease_owner ?? null,
-    review_lease_comment_id: marker?.attrs?.lease_comment_id ?? null,
-    expected_source_revision: marker?.attrs?.source_revision ?? null,
-    finding_id: marker?.attrs?.finding ?? null,
-    live_verification: markerLiveVerificationState(marker),
-  };
-}
-
-function trustedMerge({ author, reason, marker = null }: LooseRecord) {
-  return {
-    trigger: "trusted_bot",
-    command: "clawsweeper auto merge",
-    intent: "clawsweeper_auto_merge",
-    trusted_bot: true,
-    trusted_bot_author: author,
-    automation_source: "clawsweeper",
-    repair_reason: reason,
-    expected_head_sha: marker?.attrs?.sha ?? null,
-    reviewed_at: marker?.attrs?.reviewed_at ?? null,
-    review_lease_owner: marker?.attrs?.lease_owner ?? null,
-    review_lease_comment_id: marker?.attrs?.lease_comment_id ?? null,
-    expected_source_revision: marker?.attrs?.source_revision ?? null,
-    finding_id: marker?.attrs?.finding ?? null,
-    live_verification: markerLiveVerificationState(marker),
-  };
-}
-
-function trustedClose({ author, reason, marker = null }: LooseRecord) {
-  return {
-    trigger: "trusted_bot",
-    command: `autoclose ${reason}`,
-    intent: "autoclose",
-    trusted_bot: true,
-    trusted_bot_author: author,
-    automation_source: "clawsweeper",
-    repair_reason: reason,
-    autoclose_message: reason,
-    expected_head_sha: marker?.attrs?.sha ?? null,
-    close_reason: marker?.attrs?.reason ?? null,
-    close_confidence: marker?.attrs?.confidence ?? null,
-    close_action_taken: marker?.attrs?.action_taken ?? null,
-    reviewed_at: marker?.attrs?.reviewed_at ?? null,
-    review_lease_owner: marker?.attrs?.lease_owner ?? null,
-    review_lease_comment_id: marker?.attrs?.lease_comment_id ?? null,
-    expected_item_updated_at: marker?.attrs?.updated_at ?? null,
-    expected_source_revision: marker?.attrs?.source_revision ?? null,
-    finding_id: marker?.attrs?.finding ?? null,
-  };
-}
-
-function trustedHumanReview({ author, reason, marker = null }: LooseRecord) {
-  return {
-    trigger: "trusted_bot",
-    command: "clawsweeper needs human",
-    intent: "clawsweeper_needs_human",
-    trusted_bot: true,
-    trusted_bot_author: author,
-    automation_source: "clawsweeper",
-    repair_reason: reason,
-    expected_head_sha: marker?.attrs?.sha ?? null,
-    reviewed_at: marker?.attrs?.reviewed_at ?? null,
-    review_lease_owner: marker?.attrs?.lease_owner ?? null,
-    review_lease_comment_id: marker?.attrs?.lease_comment_id ?? null,
-    expected_source_revision: marker?.attrs?.source_revision ?? null,
-    finding_id: marker?.attrs?.finding ?? null,
-    live_verification: markerLiveVerificationState(marker),
+    expected_head_sha: attrs?.sha ?? null,
+    reviewed_at: attrs?.reviewed_at ?? null,
+    review_lease_owner: attrs?.lease_owner ?? null,
+    review_lease_comment_id: attrs?.lease_comment_id ?? null,
+    expected_source_revision: attrs?.source_revision ?? null,
+    finding_id: attrs?.finding ?? null,
+    ...(intent === "autoclose"
+      ? {
+          autoclose_message: reason,
+          close_reason: attrs?.reason ?? null,
+          close_confidence: attrs?.confidence ?? null,
+          close_action_taken: attrs?.action_taken ?? null,
+          expected_item_updated_at: attrs?.updated_at ?? null,
+        }
+      : { live_verification: markerLiveVerificationState(marker) }),
   };
 }
 

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -27,9 +27,7 @@ import {
   autocloseReasonFromCommand,
   autoRepairBlockReason,
   autoRepairHeadKey,
-  automergeChangelogBlockReason,
   automergeFailedChecksRepairReason,
-  automergeActivationRepairReason,
   automergeGateBlockReason,
   automergeClusterId,
   automergeJobPath,
@@ -1143,16 +1141,7 @@ function classifyCommand(command: LooseRecord): JsonValue {
     const pauseLabels = pauseLabelsOn(target);
     const failedChecksRepairReason = automergeFailedChecksRepairReason(target.checks);
     const rebaseRepairReason = automergeRebaseRepairReason(target);
-    const activationRepairReason =
-      failedChecksRepairReason ??
-      rebaseRepairReason ??
-      automergeActivationRepairReason({
-        intent: command.intent,
-        repo: command.repo,
-        title: target.title,
-        files: target.files,
-        target,
-      });
+    const activationRepairReason = failedChecksRepairReason ?? rebaseRepairReason;
     if (
       command.trusted_bot &&
       command.automation_source === "repair_loop_label_sweep" &&
@@ -2110,21 +2099,7 @@ function executeCommand(command: LooseRecord) {
         .map((action: JsonValue) => String(action.label ?? ""))
         .filter(Boolean);
       for (const pausedLabel of labelsToRemove) {
-        runGitHubBestEffortMutation(
-          command,
-          "label_remove",
-          { repository: command.repo, number: command.issue_number, label: pausedLabel },
-          [
-            "issue",
-            "edit",
-            String(command.issue_number),
-            "--repo",
-            command.repo,
-            "--remove-label",
-            pausedLabel,
-          ],
-          githubNotFoundNoMutation,
-        );
+        editIssueLabel(command, pausedLabel, "remove");
       }
       command.actions = command.actions.map((action: JsonValue) => {
         if (
@@ -2170,54 +2145,12 @@ function executeCommand(command: LooseRecord) {
       const job = ensureAutomergeJob(command);
       ensureRepairLoopLabel(command, modeLabel);
       for (const pausedLabel of pauseLabelsOn(command.target)) {
-        runGitHubBestEffortMutation(
-          command,
-          "label_remove",
-          { repository: command.repo, number: command.issue_number, label: pausedLabel },
-          [
-            "issue",
-            "edit",
-            String(command.issue_number),
-            "--repo",
-            command.repo,
-            "--remove-label",
-            pausedLabel,
-          ],
-          githubNotFoundNoMutation,
-        );
+        editIssueLabel(command, pausedLabel, "remove");
       }
       if (hasLabel(command.target, oppositeModeLabel)) {
-        runGitHubBestEffortMutation(
-          command,
-          "label_remove",
-          { repository: command.repo, number: command.issue_number, label: oppositeModeLabel },
-          [
-            "issue",
-            "edit",
-            String(command.issue_number),
-            "--repo",
-            command.repo,
-            "--remove-label",
-            oppositeModeLabel,
-          ],
-          githubNotFoundNoMutation,
-        );
+        editIssueLabel(command, oppositeModeLabel, "remove");
       }
-      runGitHubBestEffortMutation(
-        command,
-        "label_add",
-        { repository: command.repo, number: command.issue_number, label: modeLabel },
-        [
-          "issue",
-          "edit",
-          String(command.issue_number),
-          "--repo",
-          command.repo,
-          "--add-label",
-          modeLabel,
-        ],
-        githubAlreadyExistsNoMutation,
-      );
+      editIssueLabel(command, modeLabel, "add");
       const dispatchDecision = reviewDispatchDecisionForCommand(command);
       if (dispatchDecision.action !== "dispatch") {
         const verdictRouter =
@@ -2381,58 +2314,13 @@ function executeCommand(command: LooseRecord) {
       }
     }
     if (
-      command.intent === "clawsweeper_needs_human" &&
+      ["clawsweeper_needs_human", "stop"].includes(command.intent) &&
       command.issue_number &&
       shouldApplyHumanReviewLabel
     ) {
+      if (command.intent === "stop") applyRemoveLabelActions(command);
       ensureHumanReviewLabel(command);
-      runGitHubBestEffortMutation(
-        command,
-        "label_add",
-        {
-          repository: command.repo,
-          number: command.issue_number,
-          label: HUMAN_REVIEW_LABEL,
-        },
-        [
-          "issue",
-          "edit",
-          String(command.issue_number),
-          "--repo",
-          command.repo,
-          "--add-label",
-          HUMAN_REVIEW_LABEL,
-        ],
-        githubAlreadyExistsNoMutation,
-      );
-      command.actions = command.actions.map((action: JsonValue) =>
-        action.action === "label"
-          ? { ...action, status: "executed", label: HUMAN_REVIEW_LABEL }
-          : action,
-      );
-    }
-    if (command.intent === "stop" && command.issue_number && shouldApplyHumanReviewLabel) {
-      applyRemoveLabelActions(command);
-      ensureHumanReviewLabel(command);
-      runGitHubBestEffortMutation(
-        command,
-        "label_add",
-        {
-          repository: command.repo,
-          number: command.issue_number,
-          label: HUMAN_REVIEW_LABEL,
-        },
-        [
-          "issue",
-          "edit",
-          String(command.issue_number),
-          "--repo",
-          command.repo,
-          "--add-label",
-          HUMAN_REVIEW_LABEL,
-        ],
-        githubAlreadyExistsNoMutation,
-      );
+      editIssueLabel(command, HUMAN_REVIEW_LABEL, "add");
       command.actions = command.actions.map((action: JsonValue) =>
         action.action === "label"
           ? { ...action, status: "executed", label: HUMAN_REVIEW_LABEL }
@@ -2689,6 +2577,24 @@ function githubNotFoundNoMutation(error: unknown) {
   return isGitHubNotFoundError(error);
 }
 
+function editIssueLabel(command: LooseRecord, label: string, operation: "add" | "remove") {
+  runGitHubBestEffortMutation(
+    command,
+    operation === "add" ? "label_add" : "label_remove",
+    { repository: command.repo, number: command.issue_number, label },
+    [
+      "issue",
+      "edit",
+      String(command.issue_number),
+      "--repo",
+      command.repo,
+      `--${operation}-label`,
+      label,
+    ],
+    operation === "add" ? githubAlreadyExistsNoMutation : githubNotFoundNoMutation,
+  );
+}
+
 function applyRemoveLabelActions(command: LooseRecord) {
   const labelsToRemove = (command.actions ?? [])
     .filter((action: JsonValue) => action.action === "remove_label")
@@ -2696,21 +2602,7 @@ function applyRemoveLabelActions(command: LooseRecord) {
     .filter(Boolean);
   if (labelsToRemove.length === 0) return;
   for (const label of labelsToRemove) {
-    runGitHubBestEffortMutation(
-      command,
-      "label_remove",
-      { repository: command.repo, number: command.issue_number, label },
-      [
-        "issue",
-        "edit",
-        String(command.issue_number),
-        "--repo",
-        command.repo,
-        "--remove-label",
-        label,
-      ],
-      githubNotFoundNoMutation,
-    );
+    editIssueLabel(command, label, "remove");
   }
   command.target = {
     ...command.target,
@@ -2733,13 +2625,7 @@ function applyLabelActions(command: LooseRecord) {
   if (labels.length === 0) return;
   for (const label of labels) {
     if (label === AUTOMERGE_LABEL || label === AUTOFIX_LABEL) ensureRepairLoopLabel(command, label);
-    runGitHubBestEffortMutation(
-      command,
-      "label_add",
-      { repository: command.repo, number: command.issue_number, label },
-      ["issue", "edit", String(command.issue_number), "--repo", command.repo, "--add-label", label],
-      githubAlreadyExistsNoMutation,
-    );
+    editIssueLabel(command, label, "add");
   }
   command.target = {
     ...command.target,
@@ -2819,56 +2705,14 @@ function applyRepairLoopOptIn(command: LooseRecord) {
 
   const labels = new Set((command.target?.labels ?? []).map((label: JsonValue) => String(label)));
   for (const pausedLabel of pauseLabelsOn(command.target)) {
-    runGitHubBestEffortMutation(
-      command,
-      "label_remove",
-      { repository: command.repo, number: command.issue_number, label: pausedLabel },
-      [
-        "issue",
-        "edit",
-        String(command.issue_number),
-        "--repo",
-        command.repo,
-        "--remove-label",
-        pausedLabel,
-      ],
-      githubNotFoundNoMutation,
-    );
+    editIssueLabel(command, pausedLabel, "remove");
     labels.delete(pausedLabel);
   }
   if (labels.has(oppositeModeLabel)) {
-    runGitHubBestEffortMutation(
-      command,
-      "label_remove",
-      { repository: command.repo, number: command.issue_number, label: oppositeModeLabel },
-      [
-        "issue",
-        "edit",
-        String(command.issue_number),
-        "--repo",
-        command.repo,
-        "--remove-label",
-        oppositeModeLabel,
-      ],
-      githubNotFoundNoMutation,
-    );
+    editIssueLabel(command, oppositeModeLabel, "remove");
     labels.delete(oppositeModeLabel);
   }
-  runGitHubBestEffortMutation(
-    command,
-    "label_add",
-    { repository: command.repo, number: command.issue_number, label: modeLabel },
-    [
-      "issue",
-      "edit",
-      String(command.issue_number),
-      "--repo",
-      command.repo,
-      "--add-label",
-      modeLabel,
-    ],
-    githubAlreadyExistsNoMutation,
-  );
+  editIssueLabel(command, modeLabel, "add");
   labels.add(modeLabel);
   command.target = { ...command.target, labels: [...labels] };
 }
@@ -4228,25 +4072,7 @@ function executeAutomerge(command: LooseRecord): LooseRecord {
       };
     }
     ensureMergeReadyLabel(command);
-    runGitHubBestEffortMutation(
-      command,
-      "label_add",
-      {
-        repository: command.repo,
-        number: command.issue_number,
-        label: MERGE_READY_LABEL,
-      },
-      [
-        "issue",
-        "edit",
-        String(command.issue_number),
-        "--repo",
-        command.repo,
-        "--add-label",
-        MERGE_READY_LABEL,
-      ],
-      githubAlreadyExistsNoMutation,
-    );
+    editIssueLabel(command, MERGE_READY_LABEL, "add");
     return {
       action: "merge",
       status: "blocked",
@@ -4450,12 +4276,6 @@ function validateAutomergeReadiness({ command, view, target, comments }: LooseRe
     allowHumanApproval,
   });
   if (reviewBlock) return reviewBlock;
-  const changelogBlock = automergeChangelogBlockReason({
-    repo: command.repo,
-    title: view.title,
-    files: view.files,
-  });
-  if (changelogBlock) return changelogBlock;
   return "";
 }
 
@@ -4921,41 +4741,42 @@ function fetchIssueAsync(number: JsonValue) {
 }
 
 function fetchPullRequestView(number: JsonValue) {
-  return ghJson(
+  return ghJson(pullRequestViewArgs(number), { attempts: TARGET_LOOKUP_RETRY_ATTEMPTS });
+}
+
+function pullRequestViewArgs(number: JsonValue) {
+  return [
+    "pr",
+    "view",
+    String(number),
+    "--repo",
+    targetRepo,
+    "--json",
     [
-      "pr",
-      "view",
-      String(number),
-      "--repo",
-      targetRepo,
-      "--json",
-      [
-        "additions",
-        "headRefName",
-        "headRefOid",
-        "author",
-        "baseRefName",
-        "body",
-        "changedFiles",
-        "closingIssuesReferences",
-        "commits",
-        "deletions",
-        "files",
-        "isDraft",
-        "labels",
-        "mergeable",
-        "mergeCommit",
-        "mergeStateStatus",
-        "mergedAt",
-        "reviewDecision",
-        "state",
-        "statusCheckRollup",
-        "title",
-        "url",
-      ].join(","),
-    ],
-    { attempts: TARGET_LOOKUP_RETRY_ATTEMPTS },
-  );
+      "additions",
+      "headRefName",
+      "headRefOid",
+      "author",
+      "baseRefName",
+      "body",
+      "changedFiles",
+      "closingIssuesReferences",
+      "commits",
+      "deletions",
+      "files",
+      "isDraft",
+      "labels",
+      "mergeable",
+      "mergeCommit",
+      "mergeStateStatus",
+      "mergedAt",
+      "reviewDecision",
+      "state",
+      "statusCheckRollup",
+      "title",
+      "url",
+    ].join(","),
+  ];
 }
 
 function fetchPullRequestApi(number: JsonValue) {
@@ -4971,41 +4792,9 @@ function fetchPullRequestApi(number: JsonValue) {
 }
 
 function fetchPullRequestViewAsync(number: JsonValue) {
-  return ghJsonAsync<LooseRecord>(
-    [
-      "pr",
-      "view",
-      String(number),
-      "--repo",
-      targetRepo,
-      "--json",
-      [
-        "additions",
-        "headRefName",
-        "headRefOid",
-        "author",
-        "baseRefName",
-        "body",
-        "changedFiles",
-        "closingIssuesReferences",
-        "commits",
-        "deletions",
-        "files",
-        "isDraft",
-        "labels",
-        "mergeable",
-        "mergeCommit",
-        "mergeStateStatus",
-        "mergedAt",
-        "reviewDecision",
-        "state",
-        "statusCheckRollup",
-        "title",
-        "url",
-      ].join(","),
-    ],
-    { attempts: TARGET_LOOKUP_RETRY_ATTEMPTS },
-  );
+  return ghJsonAsync<LooseRecord>(pullRequestViewArgs(number), {
+    attempts: TARGET_LOOKUP_RETRY_ATTEMPTS,
+  });
 }
 
 function compactGhError(error: unknown): string {
@@ -5567,89 +5356,51 @@ function isOwnCommentReaction(reaction: LooseRecord, content: string) {
   return isAllowedMutationActor(login, DEFAULT_TRUSTED_BOTS);
 }
 
-function ensureAutomergeLabel(command: LooseRecord) {
-  runGitHubBestEffortMutation(
-    command,
-    "label_create",
-    { repository: command.repo, label: AUTOMERGE_LABEL },
-    [
-      "label",
-      "create",
-      AUTOMERGE_LABEL,
-      "--repo",
-      command.repo,
-      "--color",
-      "1A7F37",
-      "--description",
-      "Maintainer opted this ClawSweeper PR into bounded ClawSweeper-reviewed automerge",
-    ],
-    githubAlreadyExistsNoMutation,
-  );
-}
-
-function ensureAutofixLabel(command: LooseRecord) {
-  runGitHubBestEffortMutation(
-    command,
-    "label_create",
-    { repository: command.repo, label: AUTOFIX_LABEL },
-    [
-      "label",
-      "create",
-      AUTOFIX_LABEL,
-      "--repo",
-      command.repo,
-      "--color",
-      "0A3069",
-      "--description",
-      "Maintainer opted this PR into bounded ClawSweeper-reviewed autofix without merge",
-    ],
-    githubAlreadyExistsNoMutation,
-  );
-}
-
 function ensureRepairLoopLabel(command: LooseRecord, label: string) {
-  if (label === AUTOFIX_LABEL) {
-    ensureAutofixLabel(command);
-    return;
-  }
-  ensureAutomergeLabel(command);
+  const autofix = label === AUTOFIX_LABEL;
+  ensureLabel(
+    command,
+    autofix ? AUTOFIX_LABEL : AUTOMERGE_LABEL,
+    autofix ? "0A3069" : "1A7F37",
+    autofix
+      ? "Maintainer opted this PR into bounded ClawSweeper-reviewed autofix without merge"
+      : "Maintainer opted this ClawSweeper PR into bounded ClawSweeper-reviewed automerge",
+  );
 }
 
 function ensureHumanReviewLabel(command: LooseRecord) {
-  runGitHubBestEffortMutation(
+  ensureLabel(
     command,
-    "label_create",
-    { repository: command.repo, label: HUMAN_REVIEW_LABEL },
-    [
-      "label",
-      "create",
-      HUMAN_REVIEW_LABEL,
-      "--repo",
-      command.repo,
-      "--color",
-      "B60205",
-      "--description",
-      "ClawSweeper automerge is paused for maintainer review",
-    ],
-    githubAlreadyExistsNoMutation,
+    HUMAN_REVIEW_LABEL,
+    "B60205",
+    "ClawSweeper automerge is paused for maintainer review",
   );
 }
 
 function ensureMergeReadyLabel(command: LooseRecord) {
+  ensureLabel(
+    command,
+    MERGE_READY_LABEL,
+    "57606A",
+    "ClawSweeper found the PR merge-ready but a human gate is still closed",
+  );
+}
+
+function ensureLabel(command: LooseRecord, label: string, color: string, description: string) {
   runGitHubBestEffortMutation(
     command,
     "label_create",
-    { repository: command.repo, label: MERGE_READY_LABEL },
+    { repository: command.repo, label },
     [
       "label",
       "create",
-      MERGE_READY_LABEL,
+      label,
       "--repo",
       command.repo,
       "--color",
-      "57606A",
+      color,
       "--description",
-      "ClawSweeper found the PR merge-ready but a human gate is still closed",
+      description,
     ],
     githubAlreadyExistsNoMutation,
   );

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -2404,6 +2404,69 @@ test("review dispatch coordination guards label sweeps and maintainer mode comma
   assert.match(trustedVerdictGuard, /trustedAutomationPredatesReviewStartLease\(\{/);
 });
 
+test("proof override authorization is durable before merge while pause labels remain success-only", () => {
+  const source = readFileSync("src/repair/comment-router.ts", "utf8");
+  const mergeExecution = source.slice(
+    source.indexOf("if (\n      MERGE_INTENTS.has(command.intent)"),
+    source.indexOf('if (\n      ["clawsweeper_needs_human", "stop"].includes(command.intent)'),
+  );
+  const executeIndex = mergeExecution.indexOf("const merge = executeAutomerge(command)");
+  const successIndex = mergeExecution.indexOf('if (merge.status === "executed")');
+  const labelRemovalIndex = mergeExecution.indexOf("applyRemoveLabelActions(command)");
+  const automergeOwner = source.slice(
+    source.indexOf("function executeAutomerge"),
+    source.indexOf("function latestAutomergeTarget"),
+  );
+  const initialReadinessIndex = automergeOwner.indexOf("validateAutomergeReadiness");
+  const descriptionIndex = automergeOwner.indexOf("applyDescriptionNoteActions(command)");
+  const finalSnapshotIndex = automergeOwner.indexOf(
+    "const finalSnapshot = finalAutomergeSnapshot(command)",
+  );
+  const mergeMessageIndex = automergeOwner.indexOf(
+    "const mergeMessage = buildAutomergeSquashMessage",
+  );
+  const mergeIndex = automergeOwner.indexOf("runGitHubSpawnMutation");
+  const finalSnapshotOwner = source.slice(
+    source.indexOf("function finalAutomergeSnapshot"),
+    source.indexOf("function blockedAutomergeResult"),
+  );
+  const pullBeforeIndex = finalSnapshotOwner.indexOf(
+    "const before = fetchPullRequestView(command.issue_number)",
+  );
+  const commentsIndex = finalSnapshotOwner.indexOf(
+    "const comments = freshIssueCommentsFor(command.issue_number)",
+  );
+  const pullAfterIndex = finalSnapshotOwner.indexOf(
+    "const after = fetchPullRequestView(command.issue_number)",
+  );
+  const leaseIndex = finalSnapshotOwner.indexOf("trustedAutomationPullReviewLeaseBlockReason");
+  const readinessIndex = finalSnapshotOwner.indexOf("validateAutomergeReadiness");
+
+  assert.ok(executeIndex >= 0);
+  assert.ok(successIndex > executeIndex);
+  assert.ok(labelRemovalIndex > successIndex);
+  assert.doesNotMatch(mergeExecution, /applyDescriptionNoteActions/);
+  assert.ok(initialReadinessIndex >= 0);
+  assert.ok(descriptionIndex > initialReadinessIndex);
+  assert.ok(finalSnapshotIndex > descriptionIndex);
+  assert.ok(mergeMessageIndex > finalSnapshotIndex);
+  assert.ok(mergeIndex > mergeMessageIndex);
+  assert.ok(pullBeforeIndex >= 0);
+  assert.ok(commentsIndex > pullBeforeIndex);
+  assert.ok(pullAfterIndex > commentsIndex);
+  assert.ok(leaseIndex > pullAfterIndex);
+  assert.ok(readinessIndex > leaseIndex);
+  assert.match(finalSnapshotOwner, /status: "not_ready"/);
+  assert.doesNotMatch(
+    automergeOwner.slice(mergeMessageIndex, mergeIndex),
+    /trustedAutomationReviewLeaseBlockReason/,
+  );
+  assert.doesNotMatch(automergeOwner, /applyRemoveLabelActions/);
+  assert.match(source, /waive only the missing real behavior proof requirement/);
+  assert.match(source, /does not state that the PR is ready or merged/);
+  assert.match(source, /does not bypass any current or later review finding/);
+});
+
 test("comment router durably claims dispatch commands and recovers exact workflow receipts", () => {
   const source = readFileSync("src/repair/comment-router.ts", "utf8");
   const sweepWorkflow = readFileSync(".github/workflows/sweep.yml", "utf8");

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -9,7 +9,6 @@ import {
   autocloseReasonFromCommand,
   autoRepairBlockReason,
   autoRepairHeadKey,
-  automergeActivationRepairReason,
   automergeChangelogBlockReason,
   automergeFailedChecksRepairReason,
   automergeClusterId,
@@ -72,7 +71,6 @@ import {
   renderResponse,
   selectPullRepairJob,
   sharedAutomergeStatusMarkerPrefix,
-  staleAutomergeActivationReason,
   staleClosedItemCommandReason,
   syncAutomergeJobRepairMode,
   shouldClearMaintainerCommandReaction,
@@ -540,29 +538,6 @@ test("cached async issue comments lookup shares cache and in-flight fetches", as
   assert.deepEqual(calls, [12]);
 });
 
-test("cached issue comments lookup does not cache malformed fetch results", async () => {
-  const cache = new Map<number, { id: number }[]>();
-  let syncCalls = 0;
-  const syncLookup = createCachedIssueCommentsLookup(() => {
-    syncCalls += 1;
-    return "bad" as never;
-  }, cache);
-
-  assert.deepEqual(syncLookup(12), []);
-  assert.deepEqual(syncLookup(12), []);
-  assert.equal(syncCalls, 2);
-
-  let asyncCalls = 0;
-  const asyncLookup = createCachedIssueCommentsLookupAsync(async () => {
-    asyncCalls += 1;
-    return "bad" as never;
-  }, cache);
-
-  assert.deepEqual(await asyncLookup(12), []);
-  assert.deepEqual(await asyncLookup(12), []);
-  assert.equal(asyncCalls, 2);
-});
-
 test("autoclose reason parser preserves maintainer wording", () => {
   assert.equal(
     autocloseReasonFromCommand("autoclose We don't want this feature"),
@@ -729,7 +704,7 @@ test("command response markers can match across head changes", () => {
 
 test("stale automerge activation commands after merge are skipped silently", () => {
   assert.equal(
-    staleAutomergeActivationReason({
+    staleClosedItemCommandReason({
       command: {
         intent: "automerge",
         comment_created_at: "2026-05-01T01:27:37Z",
@@ -740,7 +715,7 @@ test("stale automerge activation commands after merge are skipped silently", () 
     "automerge already completed after this command",
   );
   assert.equal(
-    staleAutomergeActivationReason({
+    staleClosedItemCommandReason({
       command: {
         intent: "automerge",
         comment_created_at: "2026-05-01T01:50:00Z",
@@ -1172,44 +1147,6 @@ test("automerge changelog gate ignores docs-only and tests-only changes", () => 
       repo: "openclaw/openclaw",
       title: "fix(sdk): align test expectation",
       files: [{ path: "packages/sdk/src/index.test.ts" }],
-    }),
-    null,
-  );
-});
-
-test("automerge activation does not send missing changelog to repair", () => {
-  assert.equal(
-    automergeActivationRepairReason({
-      intent: "automerge",
-      repo: "openclaw/openclaw",
-      title: "Preserve session corpus labels",
-      files: [
-        { path: "extensions/memory-core/src/tools.ts" },
-        { path: "extensions/memory-core/src/tools.test.ts" },
-      ],
-      target: { checks: { blockers: [] }, merge_state_status: "CLEAN", mergeable: "MERGEABLE" },
-    }),
-    null,
-  );
-
-  assert.equal(
-    automergeActivationRepairReason({
-      intent: "autofix",
-      repo: "openclaw/openclaw",
-      title: "fix(memory): preserve session corpus labels",
-      files: [{ path: "extensions/memory-core/src/tools.ts" }],
-      target: { checks: { blockers: [] }, merge_state_status: "CLEAN", mergeable: "MERGEABLE" },
-    }),
-    null,
-  );
-
-  assert.equal(
-    automergeActivationRepairReason({
-      intent: "automerge",
-      repo: "openclaw/openclaw",
-      title: "fix(memory): preserve session corpus labels",
-      files: [{ path: "extensions/memory-core/src/tools.ts" }],
-      target: { checks: { blockers: [] }, merge_state_status: "BEHIND", mergeable: "MERGEABLE" },
     }),
     null,
   );
@@ -2467,69 +2404,6 @@ test("review dispatch coordination guards label sweeps and maintainer mode comma
   assert.match(trustedVerdictGuard, /trustedAutomationPredatesReviewStartLease\(\{/);
 });
 
-test("proof override authorization is durable before merge while pause labels remain success-only", () => {
-  const source = readFileSync("src/repair/comment-router.ts", "utf8");
-  const mergeExecution = source.slice(
-    source.indexOf("if (\n      MERGE_INTENTS.has(command.intent)"),
-    source.indexOf('if (\n      command.intent === "clawsweeper_needs_human"'),
-  );
-  const executeIndex = mergeExecution.indexOf("const merge = executeAutomerge(command)");
-  const successIndex = mergeExecution.indexOf('if (merge.status === "executed")');
-  const labelRemovalIndex = mergeExecution.indexOf("applyRemoveLabelActions(command)");
-  const automergeOwner = source.slice(
-    source.indexOf("function executeAutomerge"),
-    source.indexOf("function latestAutomergeTarget"),
-  );
-  const initialReadinessIndex = automergeOwner.indexOf("validateAutomergeReadiness");
-  const descriptionIndex = automergeOwner.indexOf("applyDescriptionNoteActions(command)");
-  const finalSnapshotIndex = automergeOwner.indexOf(
-    "const finalSnapshot = finalAutomergeSnapshot(command)",
-  );
-  const mergeMessageIndex = automergeOwner.indexOf(
-    "const mergeMessage = buildAutomergeSquashMessage",
-  );
-  const mergeIndex = automergeOwner.indexOf("runGitHubSpawnMutation");
-  const finalSnapshotOwner = source.slice(
-    source.indexOf("function finalAutomergeSnapshot"),
-    source.indexOf("function blockedAutomergeResult"),
-  );
-  const pullBeforeIndex = finalSnapshotOwner.indexOf(
-    "const before = fetchPullRequestView(command.issue_number)",
-  );
-  const commentsIndex = finalSnapshotOwner.indexOf(
-    "const comments = freshIssueCommentsFor(command.issue_number)",
-  );
-  const pullAfterIndex = finalSnapshotOwner.indexOf(
-    "const after = fetchPullRequestView(command.issue_number)",
-  );
-  const leaseIndex = finalSnapshotOwner.indexOf("trustedAutomationPullReviewLeaseBlockReason");
-  const readinessIndex = finalSnapshotOwner.indexOf("validateAutomergeReadiness");
-
-  assert.ok(executeIndex >= 0);
-  assert.ok(successIndex > executeIndex);
-  assert.ok(labelRemovalIndex > successIndex);
-  assert.doesNotMatch(mergeExecution, /applyDescriptionNoteActions/);
-  assert.ok(initialReadinessIndex >= 0);
-  assert.ok(descriptionIndex > initialReadinessIndex);
-  assert.ok(finalSnapshotIndex > descriptionIndex);
-  assert.ok(mergeMessageIndex > finalSnapshotIndex);
-  assert.ok(mergeIndex > mergeMessageIndex);
-  assert.ok(pullBeforeIndex >= 0);
-  assert.ok(commentsIndex > pullBeforeIndex);
-  assert.ok(pullAfterIndex > commentsIndex);
-  assert.ok(leaseIndex > pullAfterIndex);
-  assert.ok(readinessIndex > leaseIndex);
-  assert.match(finalSnapshotOwner, /status: "not_ready"/);
-  assert.doesNotMatch(
-    automergeOwner.slice(mergeMessageIndex, mergeIndex),
-    /trustedAutomationReviewLeaseBlockReason/,
-  );
-  assert.doesNotMatch(automergeOwner, /applyRemoveLabelActions/);
-  assert.match(source, /waive only the missing real behavior proof requirement/);
-  assert.match(source, /does not state that the PR is ready or merged/);
-  assert.match(source, /does not bypass any current or later review finding/);
-});
-
 test("comment router durably claims dispatch commands and recovers exact workflow receipts", () => {
   const source = readFileSync("src/repair/comment-router.ts", "utf8");
   const sweepWorkflow = readFileSync(".github/workflows/sweep.yml", "utf8");
@@ -2682,7 +2556,7 @@ test("exact comment fast path converges terminal acknowledgement before own reac
   assert.doesNotMatch(ackConvergence, /clearTerminalMaintainerCommandReaction/);
   const reactionCleanup = source.slice(
     source.indexOf("function removeOwnCommentReaction"),
-    source.indexOf("function ensureAutomergeLabel"),
+    source.indexOf("function ensureRepairLoopLabel"),
   );
   assert.match(reactionCleanup, /isOwnCommentReaction\(reaction, content\)/);
   assert.match(reactionCleanup, /reactions\/\$\{reaction\.id\}/);


### PR DESCRIPTION
## What Problem This Solves

The comment router repeats label creation and mutation requests, trusted-command metadata, merge status text, and PR lookup arguments. It also rechecks the same repair conditions through an activation wrapper whose remaining changelog gate is a no-op.

## Why This Change Was Made

Share the repeated request and response construction while keeping action-ledger identities, GitHub arguments, error classification, and mutation ordering intact. Remove the redundant activation wrapper, stale alias, forwarding helper, and impossible array-result guards. Give repair dispatch actions a concrete type and reuse the already-filtered dispatch history.

Retain the public command grammar, authorization boundaries, and marker tests. Remove tests of deleted wrappers and a source-layout proof-ordering test that duplicates the existing runtime harness. Marker parsers with different accepted inputs remain separate; the no-op changelog export retains its non-router caller.

## User Impact

Behavior-neutral; no runtime contract, config, or workflow change. Commands, aliases, permission decisions, label metadata, status text, and parsed markers keep their existing behavior.

## Evidence

Validated commit: `edc8689c6529bbb3e66125f796f1729d05fb0bfc` (identical source contents to the tested worktree). Independent Codex autoreview: scoped-clean at P0/P1, with no accepted or actionable findings.

The `pr-behavior-proof` contract for this behavior-neutral refactor is the full `pnpm run check` run plus the targeted suites.

- Claim: the simplified router preserves command decisions, trusted marker metadata, status output, and mutation plumbing.
- Exercised surface and fixtures: existing router grammar, authorization, cache, dispatch, ledger, throttle, marker, and response fixtures; the complete repository gate; 1,176 baseline/candidate comparisons of trusted-marker outputs and exact merge response text.
- Commands and environment: `corepack enable`; `pnpm install --prefer-offline`; `pnpm run build:all`; `node scripts/run-node-tests.mjs repair`; `pnpm run check`. Linux proof used Crabbox `provider=aws`, lease `cbx_09a94a02e173`, image `ami-0461d919be7deb53c`, Node 24.18.1, pnpm 11.10.0. Native macOS Node 26.8.1 also passed `node --test test/repair/comment-router*.test.ts dist/repair/comment-router-core.test.js`.
- Observable result: all required checks passed, with the original coverage floors unchanged. The comparison harness found identical outputs in all 1,176 cases.
- Artifact/trace: retained local logs `/tmp/deslop-comment-router-focused.log`, `/tmp/deslop-comment-router-crabbox.log`, `/tmp/deslop-comment-router-gate.log`, and `/tmp/deslop-comment-router-differential.log`; pass summaries are reproduced below.
- Limits: no live GitHub mutations or production workflow execution were exercised. Extra `resume-intent-persistence` end-to-end attempts on native macOS, Linux, and the repository Docker harness stopped during prerequisite process containment before reaching the router. The Docker attempt reported `namespace_setup exit=1`; the subsequent approve scenario did not run. These optional attempts are not claimed as passing proof.

```text
Native focused router suites: tests 214; pass 214; fail 0; skipped 0
Linux repair suite:          tests 1397; pass 1390; fail 0; skipped 7
Full check, focused cover:   tests 13; pass 13; fail 0; skipped 0
Full check, complete suite:  tests 4741; pass 4725; fail 0; skipped 16
Full check coverage:         lines 83.66%; branches 76.38%; functions 88.67%
Baseline comparisons:        PASS 1176
```

OpenClaw Bay not affected: no dashboard changes.

| Scope | Added | Removed | Net LOC |
| --- | ---: | ---: | ---: |
| Production | 166 | 499 | -333 |
| Tests | 3 | 129 | -126 |
| Docs | 0 | 0 | 0 |
| Total | 169 | 628 | -459 |


### Real behavior proof (production command-chain harness, current head)

The documented automerge end-to-end harness (`docs/repair/automerge-e2e.md`, workflow `automerge-e2e.yml`, `--scenario all`) ran on this exact head `1000e7ed8e2dc9f341bfd7896e588b7ac78f3ce9`:

- Run: https://github.com/openclaw/clawsweeper/actions/runs/33825224778 (job `production automerge flow`, steps `Run hermetic automerge scenarios` and `Upload automerge proof`, conclusion success).
- Artifact: `automerge-e2e-33825224778-1` (per-step stdout/stderr logs, `github-state.json`, `run/result.json`, `summary.json` per scenario).
- Result: all 28 scenarios passed (`summary.json` `status: "passed"`) across both fixtures (`tiny`, `openclaw-shaped`): approve-intent-persistence, ci-regression-29623139111, completed-verdict-resume, completed-verdict-source-drift, dependency-setup-mutation, final-review-failed-race, final-review-malformed-race, github-api-quota-fail-fast, happy-path, pending-checks, planning-head-drift, resume-intent-persistence, verdict-head-drift, workflow-scheduler-convergence.
- Router coverage: the artifact contains 54 `comment-router` step logs (`08-comment-router`, `08-comment-router-approve`, `09-comment-router-approve-durable`, `10-comment-router-idempotent`) exercising the trusted-command parser, label add/remove mutations, automerge decision, squash merge, and idempotent replay through the refactored code, with recorded `idempotency_key`, action `status: executed`/`skipped`, and `merge_commit` values in each scenario summary.
- Limits: GitHub and Codex are the harness's stateful simulators (as documented); Git, the compiled CLIs, token separation, and the merge are real. No live GitHub mutation was performed.
