### PR TITLE
refactor(core): consolidate coercion, hashing, and env readers

### DIFF
--- a/src/action-ledger.ts
+++ b/src/action-ledger.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { sha256 } from "./content-hash.js";
 import { isIP } from "node:net";
 import path from "node:path";
 
@@ -2682,10 +2682,6 @@ function highRiskCredentialField(value: string): boolean {
       normalized,
     )
   );
-}
-
-function sha256(value: string): string {
-  return createHash("sha256").update(value).digest("hex");
 }
 
 function containsConfidentialIdentifier(value: string): boolean {

--- a/src/assist-artifact.ts
+++ b/src/assist-artifact.ts
@@ -1,4 +1,8 @@
-import { createHash } from "node:crypto";
+import {
+  requireRecord as record,
+  requirePositiveInteger as positiveInteger,
+} from "./value-coerce.js";
+import { sha256 } from "./content-hash.js";
 
 export const ASSIST_ARTIFACT_SCHEMA_VERSION = 1 as const;
 export const ASSIST_ARTIFACT_MAX_BYTES = 128 * 1024;
@@ -412,17 +416,6 @@ function assistIdempotencyKey(options: {
   );
 }
 
-function sha256(value: string): string {
-  return createHash("sha256").update(value).digest("hex");
-}
-
-function record(value: unknown, name: string): Record<string, unknown> {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error(`${name} must be an object`);
-  }
-  return value as Record<string, unknown>;
-}
-
 function exactKeys(value: Record<string, unknown>, expected: string[]): void {
   const actual = Object.keys(value).sort();
   const allowed = [...expected].sort();
@@ -469,13 +462,6 @@ function digits(value: unknown, name: string, maxBytes: number): string {
 function optionalCommentId(value: unknown, name: string): string {
   if (value === "") return "";
   return digits(value, name, 30);
-}
-
-function positiveInteger(value: unknown, name: string): number {
-  if (typeof value !== "number" || !Number.isSafeInteger(value) || value <= 0) {
-    throw new Error(`${name} must be a positive safe integer`);
-  }
-  return value;
 }
 
 function digest(value: unknown, name: string): string {

--- a/src/clawsweeper-review-failure-diagnostics.ts
+++ b/src/clawsweeper-review-failure-diagnostics.ts
@@ -1,3 +1,4 @@
+import { stringOrEmpty as stringValue } from "./value-coerce.js";
 import { existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { AgentInputScanError } from "./agent-input-scan.js";
@@ -202,10 +203,6 @@ function unsafeControl(value: string): boolean {
 
 function safeCode(value: unknown, pattern: RegExp): string | null {
   return typeof value === "string" && pattern.test(value) ? value : null;
-}
-
-function stringValue(value: unknown): string {
-  return typeof value === "string" ? value : "";
 }
 
 function record(value: unknown): Record<string, unknown> {

--- a/src/clawsweeper-runtime.ts
+++ b/src/clawsweeper-runtime.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { createHash } from "node:crypto";
+import { sha256 } from "./content-hash.js";
 import { existsSync, mkdirSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -341,10 +341,6 @@ const {
   ghWithRetry,
   mutationErrorMessage,
 } = githubExecution;
-
-function sha256(text: string): string {
-  return createHash("sha256").update(text).digest("hex");
-}
 
 const CLAWSWEEPER_BOT_AUTHORS = new Set(
   [

--- a/src/codex-app-server-worker.ts
+++ b/src/codex-app-server-worker.ts
@@ -1,3 +1,4 @@
+import { errorMessage } from "./value-coerce.js";
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { createInterface } from "node:readline";
@@ -548,10 +549,6 @@ function readStdin(): Promise<string> {
     process.stdin.once("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
     process.stdin.once("error", reject);
   });
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }
 
 function serializedError(error: Error): { message: string; code?: string } {

--- a/src/content-hash.ts
+++ b/src/content-hash.ts
@@ -1,0 +1,5 @@
+import { createHash } from "node:crypto";
+
+export function sha256(value: string | Uint8Array): string {
+  return createHash("sha256").update(value).digest("hex");
+}

--- a/src/decision-packets.ts
+++ b/src/decision-packets.ts
@@ -1,3 +1,9 @@
+import { escapeRegExp } from "./clawsweeper-text.js";
+import {
+  requireRecord as objectValue,
+  requireString as stringValue,
+  rejectUnexpectedKeys,
+} from "./value-coerce.js";
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, unlinkSync, writeFileSync } from "node:fs";
 import { basename, dirname, relative } from "node:path";
@@ -354,27 +360,6 @@ function parseMaintainerDecisionOwner(value: unknown, path: string): MaintainerD
   };
 }
 
-function objectValue(value: unknown, path: string): Record<string, unknown> {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error(`${path} must be an object`);
-  }
-  return value as Record<string, unknown>;
-}
-
-function rejectUnexpectedKeys(
-  record: Record<string, unknown>,
-  allowed: ReadonlySet<string>,
-  path: string,
-): void {
-  const unexpected = Object.keys(record).filter((key) => !allowed.has(key));
-  if (unexpected.length) throw new Error(`${path} has unexpected keys: ${unexpected.join(", ")}`);
-}
-
-function stringValue(value: unknown, path: string): string {
-  if (typeof value !== "string") throw new Error(`${path} must be a string`);
-  return value;
-}
-
 function booleanValue(value: unknown, path: string): boolean {
   if (typeof value !== "boolean") throw new Error(`${path} must be a boolean`);
   return value;
@@ -484,8 +469,4 @@ function repoRelativePath(repoRoot: string, path: string): string {
 function reportNumberFromPath(reportPath: string): number | null {
   const match = basename(reportPath).match(/(?:^|-)([1-9]\d*)\.md$/);
   return numberValue(match?.[1]);
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/src/durable-cursor-store.ts
+++ b/src/durable-cursor-store.ts
@@ -1,3 +1,4 @@
+import { requireRecord as record, errorSummary as errorMessage } from "./value-coerce.js";
 import { createHmac } from "node:crypto";
 
 type JsonRecord = Record<string, unknown>;
@@ -102,17 +103,4 @@ function nonNegativeNumber(value: unknown, label: string): number {
   const parsed = Number(value);
   if (!Number.isSafeInteger(parsed) || parsed < 0) throw new Error(`${label} must be non-negative`);
   return parsed;
-}
-
-function record(value: unknown, label: string): JsonRecord {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error(`${label} must be an object`);
-  }
-  return value as JsonRecord;
-}
-
-function errorMessage(error: unknown): string {
-  return (error instanceof Error ? error.message : String(error))
-    .replace(/[\r\n]+/g, " ")
-    .slice(0, 300);
 }

--- a/src/github-etag-read-broker.ts
+++ b/src/github-etag-read-broker.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { sha256 } from "./content-hash.js";
 import {
   GITHUB_ETAG_CACHE_MAX_BODY_BYTES,
   type GithubEtagCacheKey,
@@ -138,8 +138,4 @@ function validLookupEntry(
   return Boolean(
     value?.etag && !/[\r\n]/.test(value.etag) && /^[0-9a-f]{64}$/.test(value.bodyDigest),
   );
-}
-
-function sha256(value: string): string {
-  return createHash("sha256").update(value).digest("hex");
 }

--- a/src/github-webhook-read-model-client.ts
+++ b/src/github-webhook-read-model-client.ts
@@ -1,3 +1,4 @@
+import { recordOrEmpty as record } from "./value-coerce.js";
 import { createHmac } from "node:crypto";
 import { spawnSync } from "node:child_process";
 
@@ -293,10 +294,6 @@ function parseResponse(value: string): GithubReadModelResponse | null {
   } catch {
     return null;
   }
-}
-
-function record(value: unknown): JsonRecord {
-  return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : {};
 }
 
 function positiveInteger(value: unknown): number | null {

--- a/src/limits.ts
+++ b/src/limits.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "./value-coerce.js";
 import { readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -246,10 +247,6 @@ function getOptionalPath(root: Record<string, unknown>, path: string): unknown {
     cursor = cursor[segment];
   }
   return cursor;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function repoRoot(): string {

--- a/src/live-proof/manifest.ts
+++ b/src/live-proof/manifest.ts
@@ -1,3 +1,4 @@
+import { requireRecord, rejectUnexpectedKeys, requirePositiveInteger } from "../value-coerce.js";
 import { statSync } from "node:fs";
 import { mediaProofSpawnDetail, ffprobeMedia } from "../clawsweeper-media-proof.js";
 import type { MediaProofCommandRunner } from "../clawsweeper-types.js";
@@ -194,34 +195,12 @@ export function validateAttachedMedia(options: {
   return video;
 }
 
-function requireRecord(value: unknown, label: string): Record<string, unknown> {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error(`${label} must be an object`);
-  }
-  return value as Record<string, unknown>;
-}
-
-function rejectUnexpectedKeys(
-  record: Record<string, unknown>,
-  allowed: ReadonlySet<string>,
-  label: string,
-): void {
-  const unexpected = Object.keys(record).filter((key) => !allowed.has(key));
-  if (unexpected.length) throw new Error(`${label} has unexpected keys: ${unexpected.join(", ")}`);
-}
-
+// Manifest strings must be trimmed and single-line.
 function requireString(value: unknown, label: string): string {
   if (typeof value !== "string" || !value.trim() || /[\r\n\u2028\u2029]/.test(value)) {
     throw new Error(`${label} must be a non-empty single-line string`);
   }
   return value.trim();
-}
-
-function requirePositiveInteger(value: unknown, label: string): number {
-  if (typeof value !== "number" || !Number.isSafeInteger(value) || value <= 0) {
-    throw new Error(`${label} must be a positive safe integer`);
-  }
-  return value;
 }
 
 function requireFiniteNumber(value: unknown, label: string): number {

--- a/src/live-proof/verification.ts
+++ b/src/live-proof/verification.ts
@@ -1,3 +1,9 @@
+import {
+  requireRecord,
+  rejectUnexpectedKeys,
+  requireString,
+  requirePositiveInteger,
+} from "../value-coerce.js";
 import { createHash } from "node:crypto";
 import type { LiveProofPlan, LiveProofStep } from "../clawsweeper-types.js";
 import { LIVE_VERIFICATION_MARKER } from "../clawsweeper-policy.js";
@@ -674,27 +680,6 @@ function truncateOutput(value: string, maxChars: number): string {
   return `${value.slice(0, headChars)}${separator}${value.slice(-tailChars)}`;
 }
 
-function requireRecord(value: unknown, label: string): Record<string, unknown> {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error(`${label} must be an object`);
-  }
-  return value as Record<string, unknown>;
-}
-
-function rejectUnexpectedKeys(
-  record: Record<string, unknown>,
-  allowed: ReadonlySet<string>,
-  label: string,
-): void {
-  const unexpected = Object.keys(record).filter((key) => !allowed.has(key));
-  if (unexpected.length) throw new Error(`${label} has unexpected keys: ${unexpected.join(", ")}`);
-}
-
-function requireString(value: unknown, label: string): string {
-  if (typeof value !== "string") throw new Error(`${label} must be a string`);
-  return value;
-}
-
 function requireBoundedString(value: unknown, label: string, maxChars: number): string {
   const string = requireString(value, label);
   if (string.length > maxChars) {
@@ -715,11 +700,4 @@ function requireSingleLine(value: unknown, label: string, maxChars: number): str
     );
   }
   return value.trim();
-}
-
-function requirePositiveInteger(value: unknown, label: string): number {
-  if (typeof value !== "number" || !Number.isSafeInteger(value) || value <= 0) {
-    throw new Error(`${label} must be a positive safe integer`);
-  }
-  return value;
 }

--- a/src/openclaw-process.ts
+++ b/src/openclaw-process.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "./value-coerce.js";
 import { randomUUID } from "node:crypto";
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
@@ -486,10 +487,6 @@ function openclawSessionId(label: string): string {
     .replace(/[^a-z0-9_-]+/g, "-")
     .slice(0, 48);
   return `${safeLabel || "clawsweeper"}-${randomUUID()}`;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
 function normalizedTailBytes(value: number | undefined): number {

--- a/src/pr-close-coverage-proof.ts
+++ b/src/pr-close-coverage-proof.ts
@@ -1,3 +1,4 @@
+import { requireRecord, requireString } from "./value-coerce.js";
 import { runAgentProcess } from "./agent-runner.js";
 import { codexLoginConfig } from "./codex-env.js";
 import { createHash } from "node:crypto";
@@ -555,13 +556,6 @@ function prCloseCoverageProofCoveredWorkIsConcrete(value: string): boolean {
   );
 }
 
-function requireRecord(value: unknown, path: string): Record<string, unknown> {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error(`${path} must be an object`);
-  }
-  return value as Record<string, unknown>;
-}
-
 function parseProofSnapshotBinding(
   value: unknown,
   path: string,
@@ -600,6 +594,7 @@ function requireSha256(value: unknown, path: string): string {
   return digest;
 }
 
+// Coverage-proof diagnostics retain their "had unexpected keys" wording.
 function rejectUnexpectedKeys(
   record: Record<string, unknown>,
   allowed: ReadonlySet<string>,
@@ -609,11 +604,6 @@ function rejectUnexpectedKeys(
   if (unexpected.length) {
     throw new Error(`${path} had unexpected keys: ${unexpected.join(", ")}`);
   }
-}
-
-function requireString(value: unknown, path: string): string {
-  if (typeof value !== "string") throw new Error(`${path} must be a string`);
-  return value;
 }
 
 function requireStringArray(value: unknown, path: string): string[] {

--- a/src/pr-hydration-snapshot.ts
+++ b/src/pr-hydration-snapshot.ts
@@ -1,3 +1,4 @@
+import { recordOrEmpty as record } from "./value-coerce.js";
 import type { ContextHydration } from "./clawsweeper-types.js";
 import { EXACT_REVIEW_DIRECT_PUBLICATION_MAX_FILE_BYTES } from "./exact-review-publication-limits.js";
 
@@ -554,12 +555,6 @@ function reviewCommentId(value: unknown): string | null {
   const id = record(value).id;
   if (typeof id === "number" && Number.isSafeInteger(id) && id > 0) return String(id);
   return typeof id === "string" && id.length > 0 ? id : null;
-}
-
-function record(value: unknown): Record<string, unknown> {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : {};
 }
 
 function positiveInteger(value: unknown): value is number {

--- a/src/queue-pressure.ts
+++ b/src/queue-pressure.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "./value-coerce.js";
 export const QUEUE_PRESSURE_SOFT_PENDING = 150;
 export const QUEUE_PRESSURE_HARD_PENDING = 400;
 export const QUEUE_PRESSURE_SOFT_AGE_MS = 30 * 60 * 1_000;
@@ -137,10 +138,6 @@ function malformedPressure(): ExactReviewQueuePressure {
 function errorReason(error: unknown): string {
   if (error instanceof Error && error.message.trim()) return error.message.trim();
   return "fetch_failed";
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function isNonNegativeNumber(value: unknown): value is number {

--- a/src/repair/action-session.ts
+++ b/src/repair/action-session.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { requiredEnv } from "../required-env.js";
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -200,12 +201,6 @@ function writeGitHubEnv(values: Record<string, string>): void {
     if (/[\r\n]/.test(value)) throw new Error(`${key} contains a newline`);
     fs.appendFileSync(envPath, `${key}=${value}\n`, "utf8");
   }
-}
-
-function requiredEnv(name: string): string {
-  const value = String(process.env[name] ?? "").trim();
-  if (!value) throw new Error(`${name} is required`);
-  return value;
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/src/repair/apply-result.ts
+++ b/src/repair/apply-result.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
+import { sha256 } from "../content-hash.js";
 import type { JsonValue, LooseRecord } from "./json-types.js";
 import fs from "node:fs";
 import path from "node:path";
-import { createHash } from "node:crypto";
 import {
   assertAllowedOwner,
   hasDeterministicSecuritySignal,
@@ -1841,8 +1841,4 @@ function positiveIntegerSetting(value: JsonValue, fallback: number) {
   const number = Number(value);
   if (!Number.isFinite(number) || number <= 0) return fallback;
   return Math.floor(number);
-}
-
-function sha256(text: string) {
-  return createHash("sha256").update(text).digest("hex");
 }

--- a/src/repair/automerge-status-timeline.ts
+++ b/src/repair/automerge-status-timeline.ts
@@ -1,3 +1,4 @@
+import { escapeRegExp } from "../clawsweeper-text.js";
 import type { JsonValue, LooseRecord } from "./json-types.js";
 
 const TIMELINE_START = "<!-- clawsweeper-automerge-timeline:start -->";
@@ -159,8 +160,4 @@ function compact(value: JsonValue, max: number): string {
   if (!text) return "";
   if (text.length <= max) return text;
   return `${text.slice(0, Math.max(0, max - 1)).trimEnd()}...`;
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/src/repair/cluster-intake-dispatch.ts
+++ b/src/repair/cluster-intake-dispatch.ts
@@ -1,3 +1,4 @@
+import { errorMessage } from "../value-coerce.js";
 import { createHash } from "node:crypto";
 import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { resolve, sep } from "node:path";
@@ -362,8 +363,4 @@ export function observeClusterDispatch(
 
 function clusterIntakeLedgerPath(intent: ClusterIntakeIntent): string {
   return `results/cluster-repair-intake/${intent.repo_slug}.json`;
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }

--- a/src/repair/cluster-intake-state.ts
+++ b/src/repair/cluster-intake-state.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "../value-coerce.js";
 import { createHash, createHmac, timingSafeEqual } from "node:crypto";
 import { parseSimpleYaml, validateJob } from "./lib.js";
 
@@ -1342,8 +1343,4 @@ function isoDate(value: unknown, label: string): string {
 
 function escapeRegex(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }

--- a/src/repair/comment-router-ledger-merge.ts
+++ b/src/repair/comment-router-ledger-merge.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "../value-coerce.js";
 type JsonRecord = Record<string, unknown>;
 
 const MAX_COMMANDS = 1000;
@@ -128,8 +129,4 @@ function latestTimestamp(left: string | null, right: string | null): string | nu
 function timestamp(value: unknown): number {
   const parsed = typeof value === "string" ? Date.parse(value) : Number.NaN;
   return Number.isFinite(parsed) ? parsed : 0;
-}
-
-function isRecord(value: unknown): value is JsonRecord {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }

--- a/src/repair/exact-review-bundle-cli.ts
+++ b/src/repair/exact-review-bundle-cli.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { requiredEnv } from "../required-env.js";
 import {
   createExactReviewBundle,
   exactReviewDecisionSha256,
@@ -12,7 +13,7 @@ if (command !== "create" && command !== "validate") {
 }
 
 const context = contextFromEnv(process.env);
-const bundleDir = requiredEnv(process.env, "EXACT_REVIEW_BUNDLE_DIR");
+const bundleDir = requiredEnv("EXACT_REVIEW_BUNDLE_DIR", process.env);
 if (command === "create") {
   const reviewPath = optionalEnv(process.env, "EXACT_REVIEW_REPORT_PATH");
   const actionLedgerRoot = optionalEnv(process.env, "EXACT_REVIEW_ACTION_LEDGER_ROOT");
@@ -35,17 +36,17 @@ function contextFromEnv(env: NodeJS.ProcessEnv): ExactReviewBundleContext {
     throw new Error("EXACT_REVIEW_PROTOCOL_VERSION must be 1 or 2");
   }
   return {
-    repository: requiredEnv(env, "GITHUB_REPOSITORY"),
-    sourceSha: optionalEnv(env, "EXACT_REVIEW_SOURCE_SHA") || requiredEnv(env, "GITHUB_SHA"),
-    runId: optionalEnv(env, "EXACT_REVIEW_PRODUCER_RUN_ID") || requiredEnv(env, "GITHUB_RUN_ID"),
+    repository: requiredEnv("GITHUB_REPOSITORY", env),
+    sourceSha: optionalEnv(env, "EXACT_REVIEW_SOURCE_SHA") || requiredEnv("GITHUB_SHA", env),
+    runId: optionalEnv(env, "EXACT_REVIEW_PRODUCER_RUN_ID") || requiredEnv("GITHUB_RUN_ID", env),
     runAttempt: positiveIntegerEnv(env, "EXACT_REVIEW_GENERATION_ATTEMPT"),
-    producerJob: requiredEnv(env, "EXACT_REVIEW_PRODUCER_JOB"),
-    decisionSha256: exactReviewDecisionSha256(requiredEnv(env, "EXACT_REVIEW_DECISION")),
-    targetRepo: requiredEnv(env, "EXACT_REVIEW_TARGET_REPO"),
-    targetBranch: requiredEnv(env, "EXACT_REVIEW_TARGET_BRANCH"),
+    producerJob: requiredEnv("EXACT_REVIEW_PRODUCER_JOB", env),
+    decisionSha256: exactReviewDecisionSha256(requiredEnv("EXACT_REVIEW_DECISION", env)),
+    targetRepo: requiredEnv("EXACT_REVIEW_TARGET_REPO", env),
+    targetBranch: requiredEnv("EXACT_REVIEW_TARGET_BRANCH", env),
     itemNumber: positiveIntegerEnv(env, "EXACT_REVIEW_ITEM_NUMBER"),
     itemKind: itemKindEnv(env),
-    itemKey: requiredEnv(env, "EXACT_REVIEW_ITEM_KEY"),
+    itemKey: requiredEnv("EXACT_REVIEW_ITEM_KEY", env),
     protocolVersion,
     leaseRevision: optionalPositiveIntegerEnv(env, "EXACT_REVIEW_LEASE_REVISION"),
     claimGeneration: optionalPositiveIntegerEnv(env, "EXACT_REVIEW_CLAIM_GENERATION"),
@@ -56,18 +57,12 @@ function contextFromEnv(env: NodeJS.ProcessEnv): ExactReviewBundleContext {
   };
 }
 
-function requiredEnv(env: NodeJS.ProcessEnv, name: string): string {
-  const value = optionalEnv(env, name);
-  if (!value) throw new Error(`${name} is required`);
-  return value;
-}
-
 function optionalEnv(env: NodeJS.ProcessEnv, name: string): string {
   return String(env[name] ?? "").trim();
 }
 
 function positiveIntegerEnv(env: NodeJS.ProcessEnv, name: string): number {
-  const value = Number(requiredEnv(env, name));
+  const value = Number(requiredEnv(name, env));
   if (!Number.isInteger(value) || value < 1) throw new Error(`${name} must be a positive integer`);
   return value;
 }
@@ -81,14 +76,14 @@ function optionalPositiveIntegerEnv(env: NodeJS.ProcessEnv, name: string): numbe
 }
 
 function booleanEnv(env: NodeJS.ProcessEnv, name: string): boolean {
-  const value = requiredEnv(env, name);
+  const value = requiredEnv(name, env);
   if (value === "true") return true;
   if (value === "false") return false;
   throw new Error(`${name} must be true or false`);
 }
 
 function itemKindEnv(env: NodeJS.ProcessEnv): "issue" | "pull_request" {
-  const value = requiredEnv(env, "EXACT_REVIEW_ITEM_KIND");
+  const value = requiredEnv("EXACT_REVIEW_ITEM_KIND", env);
   if (value === "issue" || value === "pull_request") return value;
   throw new Error("EXACT_REVIEW_ITEM_KIND must be issue or pull_request");
 }

--- a/src/repair/exact-review-bundle.ts
+++ b/src/repair/exact-review-bundle.ts
@@ -1,4 +1,6 @@
-import { createHash } from "node:crypto";
+import { requireRecord as record } from "../value-coerce.js";
+import { sha256 } from "../content-hash.js";
+
 import fs from "node:fs";
 import path from "node:path";
 
@@ -503,13 +505,6 @@ function canonicalTimestamp(value: string): string {
   return value;
 }
 
-function record(value: unknown, label: string): Record<string, unknown> {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error(`${label} must be an object`);
-  }
-  return value as Record<string, unknown>;
-}
-
 function exactKeys(value: Record<string, unknown>, expected: readonly string[]): void {
   const actual = Object.keys(value).sort();
   const sortedExpected = [...expected].sort();
@@ -518,6 +513,7 @@ function exactKeys(value: Record<string, unknown>, expected: readonly string[]):
   }
 }
 
+// Bundle strings reject empty text but preserve whitespace.
 function stringValue(value: unknown, label: string): string {
   if (typeof value !== "string" || !value) throw new Error(`${label} must be a string`);
   return value;
@@ -544,8 +540,4 @@ function positiveInteger(value: number, label: string): void {
 
 function nullablePositiveInteger(value: number | null, label: string): void {
   if (value !== null) positiveInteger(value, label);
-}
-
-function sha256(value: string | Buffer): string {
-  return createHash("sha256").update(value).digest("hex");
 }

--- a/src/repair/exact-review-direct-publication.ts
+++ b/src/repair/exact-review-direct-publication.ts
@@ -1,3 +1,4 @@
+import { requiredEnv } from "../required-env.js";
 import { createHmac } from "node:crypto";
 import fs from "node:fs";
 
@@ -245,12 +246,6 @@ function boundedAttempts(value: number) {
   if (!Number.isSafeInteger(value) || value < 1 || value > 5) {
     throw new Error("Direct publication attempts must be between 1 and 5");
   }
-  return value;
-}
-
-function requiredEnv(name: string) {
-  const value = String(process.env[name] || "").trim();
-  if (!value) throw new Error(`${name} is required`);
   return value;
 }
 

--- a/src/repair/external-messages.ts
+++ b/src/repair/external-messages.ts
@@ -1,3 +1,4 @@
+import { escapeRegExp } from "../clawsweeper-text.js";
 import type { JsonValue, LooseRecord } from "./json-types.js";
 import { randomInt } from "node:crypto";
 import { repairCodexReasoningEffort } from "./process-env.js";
@@ -397,10 +398,6 @@ function compactForComment(value: JsonValue, max: JsonValue) {
   if (!text) return "";
   if (text.length <= max) return text;
   return `${text.slice(0, Math.max(0, max - 1)).trimEnd()}...`;
-}
-
-function escapeRegExp(value: string) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 export function replacementSourceCloseComment({

--- a/src/repair/gitcrawl-cluster-history.ts
+++ b/src/repair/gitcrawl-cluster-history.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "../value-coerce.js";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -88,8 +89,4 @@ function addPositiveInteger(values: Set<number>, value: unknown): void {
 
 function frontmatterRepo(frontmatter: string): string {
   return /^repo:\s*["']?([^\s"']+)["']?\s*$/m.exec(frontmatter)?.[1] ?? "";
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }

--- a/src/repair/issue-implementation-intake.ts
+++ b/src/repair/issue-implementation-intake.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { escapeRegExp } from "../clawsweeper-text.js";
 import type { JsonValue, LooseRecord } from "./json-types.js";
 import crypto from "node:crypto";
 import fs from "node:fs";
@@ -1530,10 +1531,6 @@ function stripQuotes(value: string) {
     return trimmed.slice(1, -1);
   }
   return trimmed;
-}
-
-function escapeRegExp(value: string) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function relative(filePath: string) {

--- a/src/repair/publish-main.ts
+++ b/src/repair/publish-main.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { sha256 } from "../content-hash.js";
 import { createHash } from "node:crypto";
 import {
   appendFileSync,
@@ -794,10 +795,6 @@ function collectRecordFiles(root: string, relativePath: string, files: Map<strin
   for (const entry of readdirSync(absolute, { withFileTypes: true })) {
     collectRecordFiles(root, `${relativePath}/${entry.name}`, files);
   }
-}
-
-function sha256(content: string): string {
-  return createHash("sha256").update(content).digest("hex");
 }
 
 function readContainedRegularFile(root: string, path: string): string {

--- a/src/repair/state-append-client.ts
+++ b/src/repair/state-append-client.ts
@@ -1,3 +1,4 @@
+import { isRecord, errorMessage } from "../value-coerce.js";
 import { createHmac } from "node:crypto";
 
 export type CanonicalRecordTupleOperation = {
@@ -183,14 +184,6 @@ function parseConflictState(value: unknown): CanonicalRecordTupleConflictState |
     });
   }
   return { key, revision, deliveryId, operations };
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }
 
 let stateAppendSecretsToRedact: string[] = [];

--- a/src/repair/state-writer-coordinator.ts
+++ b/src/repair/state-writer-coordinator.ts
@@ -1,3 +1,4 @@
+import { errorMessage } from "../value-coerce.js";
 import { spawn, spawnSync } from "node:child_process";
 import { createHmac, randomUUID } from "node:crypto";
 
@@ -396,8 +397,4 @@ function positiveInteger(value: string | undefined, fallback: number): number {
 
 function sleepSync(milliseconds: number): void {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }

--- a/src/repair/target-fanout.ts
+++ b/src/repair/target-fanout.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { requireRecord as record, errorSummary as errorMessage } from "../value-coerce.js";
 import { execFileSync } from "node:child_process";
 import { createHmac } from "node:crypto";
 import { existsSync, readFileSync, readdirSync } from "node:fs";
@@ -21,8 +22,6 @@ import {
 import { fetchExactReviewQueuePressure } from "../queue-pressure.js";
 import { coverageTrackedCountsFromManifest } from "../review-coverage-manifest.js";
 import { parseArgs, repoRoot } from "./lib.js";
-
-type JsonRecord = Record<string, unknown>;
 
 export type FanoutMode = "hot-intake" | "normal-review" | "audit";
 
@@ -983,12 +982,6 @@ function nonNegativeNumber(value: unknown, label: string): number {
   return parsed;
 }
 
-function errorMessage(error: unknown): string {
-  return (error instanceof Error ? error.message : String(error))
-    .replace(/[\r\n]+/g, " ")
-    .slice(0, 300);
-}
-
 function positiveNumber(value: string, label: string): number {
   const parsed = Number(value);
   if (!Number.isInteger(parsed) || parsed < 1) throw new Error(`--${label} must be positive`);
@@ -1023,13 +1016,6 @@ function stringValue(value: unknown, label: string): string {
 
 function booleanValue(value: unknown, fallback: boolean): boolean {
   return typeof value === "boolean" ? value : fallback;
-}
-
-function record(value: unknown, label: string): JsonRecord {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error(`${label} must be an object`);
-  }
-  return value as JsonRecord;
 }
 
 if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { stringOrEmpty as stringValue } from "../value-coerce.js";
+import { escapeRegExp } from "../clawsweeper-text.js";
 import type { JsonValue, LooseRecord } from "./json-types.js";
 import fs from "node:fs";
 import path from "node:path";
@@ -2670,14 +2672,6 @@ function sectionValue(markdown: string, heading: string): string {
 function sectionLineValue(markdown: string, key: string): string {
   const match = markdown.match(new RegExp(`^${escapeRegExp(key)}:\\s*(.+)$`, "m"));
   return match?.[1]?.trim() ?? "";
-}
-
-function stringValue(value: JsonValue): string {
-  return typeof value === "string" ? value : "";
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function repoFor(markdown: string, name: string): string {

--- a/src/repository-profiles.ts
+++ b/src/repository-profiles.ts
@@ -1,3 +1,4 @@
+import { requireRecord as record } from "./value-coerce.js";
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -454,6 +455,7 @@ function packageManagerValue(value: unknown, label: string): RepositoryPackageMa
   return packageManager;
 }
 
+// Profile strings reject whitespace-only text without trimming accepted values.
 function stringValue(value: unknown, label: string): string {
   if (typeof value !== "string" || value.trim() === "")
     throw new Error(`${label} must be a string`);
@@ -507,13 +509,6 @@ function numberValue(value: unknown, label: string): number {
 function arrayValue(value: unknown, label: string): unknown[] {
   if (!Array.isArray(value)) throw new Error(`${label} must be an array`);
   return value;
-}
-
-function record(value: unknown, label: string): Record<string, unknown> {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error(`${label} must be an object`);
-  }
-  return value as Record<string, unknown>;
 }
 
 function repoRoot(): string {

--- a/src/required-env.ts
+++ b/src/required-env.ts
@@ -1,0 +1,5 @@
+export function requiredEnv(name: string, env: NodeJS.ProcessEnv = process.env): string {
+  const value = String(env[name] ?? "").trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}

--- a/src/review-activity-cursor.ts
+++ b/src/review-activity-cursor.ts
@@ -1,3 +1,4 @@
+import { recordOrEmpty as record } from "./value-coerce.js";
 import { createHash } from "node:crypto";
 
 import { stableJsonCodeUnit } from "./stable-json.js";
@@ -505,12 +506,6 @@ function compactReviewThread(value: unknown) {
     id: scalar(thread.id),
     is_resolved: scalar(thread.isResolved ?? thread.is_resolved),
   };
-}
-
-function record(value: unknown): Record<string, unknown> {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : {};
 }
 
 function scalar(value: unknown): string {

--- a/src/review-structural-cache.ts
+++ b/src/review-structural-cache.ts
@@ -1,4 +1,6 @@
-import { createHash } from "node:crypto";
+import { recordOrEmpty as asRecord } from "./value-coerce.js";
+import { sha256 } from "./content-hash.js";
+import { escapeRegExp } from "./clawsweeper-text.js";
 
 import { REVIEW_CACHE_MAX_AGE_DAYS } from "./scheduler-policy.js";
 import { stableJsonCodeUnit as stableJson } from "./stable-json.js";
@@ -331,12 +333,6 @@ export function reviewStructuralQuery(kind: ReviewStructuralKind): string {
   `;
 }
 
-function asRecord(value: unknown): Record<string, unknown> {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : {};
-}
-
 function stringOrUndefined(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
 }
@@ -478,10 +474,6 @@ function relatedItemReference(value: unknown, repo: string, currentNumber: numbe
     if (Number.isInteger(number) && number > 0 && number !== currentNumber) return true;
   }
   return false;
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function commentRelationSensitivity(
@@ -730,10 +722,6 @@ export function reviewStructuralRecordFromGraphql(
     reviewPolicy: options.reviewPolicy,
     reviewModel: options.reviewModel,
   });
-}
-
-function sha256(value: string): string {
-  return createHash("sha256").update(value).digest("hex");
 }
 
 function compareCodeUnits(left: string, right: string): number {

--- a/src/review-tool-bootstrap.ts
+++ b/src/review-tool-bootstrap.ts
@@ -1,5 +1,6 @@
+import { sha256 } from "./content-hash.js";
 import { spawnSync } from "node:child_process";
-import { createHash, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 import {
   lstatSync,
   mkdirSync,
@@ -117,10 +118,6 @@ const ARTIFACTS: Readonly<Record<string, ReviewToolArtifact>> = {
     sha256: "dc1759892a41d64ee0d46cd5d4391dad7f916f54257154aa1b0732f9c50901b2",
   },
 };
-
-function sha256(bytes: Uint8Array): string {
-  return createHash("sha256").update(bytes).digest("hex");
-}
 
 async function boundedResponseBytes(response: Response): Promise<Buffer> {
   const contentLength = response.headers.get("content-length");

--- a/src/value-coerce.ts
+++ b/src/value-coerce.ts
@@ -1,0 +1,47 @@
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function recordOrEmpty(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? value : {};
+}
+
+export function stringOrEmpty(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+export function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  return value;
+}
+
+export function requireString(value: unknown, label: string): string {
+  if (typeof value !== "string") throw new Error(`${label} must be a string`);
+  return value;
+}
+
+export function requirePositiveInteger(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${label} must be a positive safe integer`);
+  }
+  return value;
+}
+
+export function rejectUnexpectedKeys(
+  record: Record<string, unknown>,
+  allowed: ReadonlySet<string>,
+  label: string,
+): void {
+  const unexpected = Object.keys(record).filter((key) => !allowed.has(key));
+  if (unexpected.length) throw new Error(`${label} has unexpected keys: ${unexpected.join(", ")}`);
+}
+
+export function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function errorSummary(error: unknown): string {
+  return errorMessage(error)
+    .replace(/[\r\n]+/g, " ")
+    .slice(0, 300);
+}

--- a/tsconfig.repair.json
+++ b/tsconfig.repair.json
@@ -17,6 +17,10 @@
   },
   "include": [
     "src/repair/**/*.ts",
+    "src/value-coerce.ts",
+    "src/content-hash.ts",
+    "src/clawsweeper-text.ts",
+    "src/required-env.ts",
     "src/repository-profiles.ts",
     "src/codex-output-capture.ts",
     "src/codex-spawn.ts",


### PR DESCRIPTION
## What Problem This Solves

Value guards, hashes, environment reads, and regex escaping were repeated across the review and repair lanes. This change consolidates 55 local helper implementations while preserving their accepted inputs, fallback values, whitespace handling, and error messages.

## Why This Change Was Made

`value-coerce.ts` owns the matching record, scalar-validation, and error-text contracts. `content-hash.ts` replaces all nine local SHA-256 wrappers, `required-env.ts` replaces the three matching trimming readers, and the string-only regex escaping copies use the existing text module. The repair compiler allowlist includes the shared modules.

The inventory covered all 149 declarations of the 25 requested names under `src/**`. Different integer, timestamp, string, array, and loosely typed contracts remain separate. No `parseArgs` copy matches `repair/lib.ts`: the main parser rewrites flag names and the other repair parsers have distinct option schemas. Source-loaded admission, ETag, telemetry, and coverage-manifest modules stay self-contained so direct TypeScript consumers keep working without compiler or workflow changes.

## User Impact

Behavior-neutral; no runtime contract, config, or workflow change. No dependency or environment-variable additions.

## Evidence

The `pr-behavior-proof` contract for this behavior-neutral refactor is the full `pnpm run check` run plus the targeted suites, as specified by the work order.

- **Claim:** extracted helpers preserve values, validation decisions, error text, hashes, and CLI environment handling.
- **Exercised surface:** compiled review and repair modules, their existing fixture suites, direct-source consumers, and both TypeScript compilation boundaries.
- **Scenario/fixture:** existing artifact, cursor, cache, admission, repair, and publication fixtures; 1,192 before/after comparisons against the original helper bodies, including invalid values, arrays, whitespace, integer boundaries, binary input, and synthetic environment reads.
- **Command and environment:** Node 26.8.1, pnpm 11.10.0, macOS arm64; `pnpm run build:all`, `pnpm run format`, the test commands below, and `pnpm run check`.
- **Observable result:** full gate passed with 4,733 passing tests, 11 skips, zero failures/cancellations, and coverage of 83.71% lines, 76.39% branches, and 88.68% functions. The focused rerun passed all 170 tests; all 1,192 before/after helper comparisons matched.
- **Artifact or trace:** local `/tmp/deslop-helpers-check.log`, `/tmp/deslop-helpers-focused.log`, `/tmp/deslop-helpers-equivalence.log`, and `/tmp/autoreview-deslop-helpers.md`; exhaustive declaration inventory at `/tmp/deslop-helpers-inventory.md`.
- **Limits:** fixture-based proof of behavior preservation; no live service mutation or deployment. The broad targeted run had one pinned-Knip fixture timeout; that exact case passed on rerun. An earlier import-resolution failure identified the direct-source boundary and was removed before the final gate.

```sh
node scripts/run-node-tests.mjs all -- --test-name-pattern='assist|structural|hydration|coverage|etag|hosted target|state writer|state append|canonical|bundle|action session|cluster|live proof|live verification|OpenClaw|openclaw|Codex|ledger|timeline|external message|repository profile'
node scripts/run-node-tests.mjs repair -- --test-name-pattern='stages pinned Knip|fanout|cursor'
pnpm run check
```

```text
Full check, focused coverage gate:
ℹ tests 13
ℹ pass 13
ℹ fail 0
ℹ cancelled 0

Full check, complete suite:
ℹ tests 4744
ℹ pass 4733
ℹ fail 0
ℹ cancelled 0
ℹ skipped 11
ℹ duration_ms 1536912.213875
ℹ all files | 83.71 | 76.39 | 88.68 |

Focused repair rerun:
ℹ tests 170
ℹ pass 170
ℹ fail 0
ℹ cancelled 0

PASS: 1192 before/after helper comparisons; values, error text, whitespace, arrays, integers, hashes, regex escaping, and synthetic environment reads match.
```

Independent Codex review: **scoped-clean at P1**, with no accepted/actionable findings. Review base pinned to the branch merge base (`72041f31e1d34cff19f50da4b23c4a22a78c828a`) after `origin/main` advanced during validation; this keeps unrelated upstream work out of the local candidate review.

OpenClaw Bay not affected: no dashboard changes.

| Scope | Added | Removed | Net LOC |
| --- | ---: | ---: | ---: |
| Production (`src/**`) | 131 | 312 | -181 |
| Tests | 0 | 0 | 0 |
| Docs | 0 | 0 | 0 |
| Repair build allowlist | 4 | 0 | +4 |
| Total | 135 | 312 | -177 |


### Update after ClawSweeper review (head 738beb51e, rebased onto main; unchanged content)

**Real behavior proof (production command-chain harness, current head):** the documented automerge e2e harness (`docs/repair/automerge-e2e.md`, `--scenario all`) ran on this exact head in CI: https://github.com/openclaw/clawsweeper/actions/runs/33827474822 (job `production automerge flow`, success, all scenarios across both fixtures). It runs the compiled repair entrypoints that consume the consolidated modules (`validate-job`, `run-worker`, `review-results`, `execute-fix-artifact`, report-only publication, `apply-result`, `post-flight`, and the comment router), so the shared `value-coerce`, `content-hash`, and `required-env` modules are exercised on real Git, real compiled CLIs, and real artifact handoff. GitHub and Codex are the harness's simulators. Review-lane entrypoints (`clawsweeper-runtime`, structural cache, decision packets) are covered by the full `pnpm run check` suite on this head plus the 1,192-case equivalence comparison recorded above.

Rebase note: the only conflict with `main` was the import block in `src/github-etag-read-broker.ts` after the ETag body cap landed; resolved by keeping `GITHUB_ETAG_CACHE_MAX_BODY_BYTES` and importing `sha256` from `content-hash`. Full `pnpm run check` re-run locally on the rebased head passed (one unrelated `target-validation` fixture timed out once under machine load and passed on rerun; that test is untouched by this PR).
