### PR TITLE
refactor(repair): deduplicate target validation command policy

### DIFF
--- a/src/repair/target-validation.ts
+++ b/src/repair/target-validation.ts
@@ -18,11 +18,7 @@ import {
   preparePinnedOpenClawValidationHelper,
   restorePinnedOpenClawValidationHelperCache,
 } from "./pinned-openclaw-validation-helper.js";
-import {
-  resolveTargetRepoToolchain,
-  type TargetChangedGate,
-  type TargetRepoToolchain,
-} from "./target-toolchain-config.js";
+import { resolveTargetRepoToolchain, type TargetRepoToolchain } from "./target-toolchain-config.js";
 import { compactText } from "./text-utils.js";
 import {
   isExpensivePnpmValidation,
@@ -32,6 +28,7 @@ import {
   packageManagerCommandIndex,
   packageManagerWorkspaceScoped,
   packageScriptRequirement,
+  type PackageScriptRequirement,
   parseAllowedValidationCommand,
   requireWorkspaceMatchFailure,
   stripEnvPrefix,
@@ -80,12 +77,6 @@ export type TargetValidationOptions = {
   pinnedBaseRef?: string;
   /** Trusted upstream override for deterministic local integration fixtures. */
   pinnedBaseRemoteUrl?: string;
-  /**
-   * Optional override of the per-repo toolchain (package manager, base validation
-   * commands, changed gate). If omitted, it is resolved from
-   * config/target-repositories.json via `resolveTargetRepoToolchain(targetRepo)`.
-   * Tests inject this directly to avoid touching the config file.
-   */
   toolchain?: TargetRepoToolchain;
 };
 
@@ -558,7 +549,7 @@ function openClawValidationNeedsPinnedHelper(
     return false;
   }
   const commands = requiredValidationCommands(validationCommands, cwd, options);
-  if (!commands.some((command) => isOpenClawChangedGateValidationCommand(command))) return false;
+  if (!commands.some(isOpenClawChangedGateValidationCommand)) return false;
   const changedPaths = options.pinnedBaseRef
     ? gitChangedFilesFromRef(cwd, options.pinnedBaseRef)
     : gitChangedFiles(cwd, DEFAULT_BASE_BRANCH);
@@ -594,17 +585,6 @@ function prepareBunToolchain({
   deadlineAt: number;
   installRegistry: string;
 }) {
-  // The repair execution workflow provisions pinned Bun before this path runs.
-  // Keep a clear fail-fast probe so local/manual runners surface setup gaps early.
-  //
-  // ClawSweeper itself runs under pnpm (e.g. `pnpm run repair:execute-fix`), so
-  // process.env carries pnpm-injected `npm_config_user_agent=pnpm/...`. When we
-  // shell out to `bun install` for a target repo whose package.json has a
-  // preinstall hook like `bunx only-allow bun` (e.g. openclaw/clawhub), bun
-  // forwards the parent env to the preinstall script and `only-allow` reads the
-  // pnpm user-agent and refuses to run. Strip caller identity/lifecycle metadata;
-  // the shared validation environment already removed credentials and
-  // execution-controlling path configuration.
   const bunEnv = sanitizeEnvForBun(validationEnv);
   run("bun", ["--version"], {
     cwd,
@@ -646,25 +626,19 @@ function prepareBunToolchain({
 function sanitizeEnvForBun(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const out: NodeJS.ProcessEnv = {};
   for (const [key, value] of Object.entries(env)) {
-    if (value === undefined) continue;
-    if (shouldStripBunInstallEnv(key)) continue;
+    if (
+      value === undefined ||
+      /^(?:PNPM_|npm_config_user_agent$|npm_execpath$|npm_node_execpath$|npm_lifecycle_|npm_package_)/i.test(
+        key,
+      )
+    )
+      continue;
     out[key] = value;
   }
   // Declare bun as the active package manager so target preinstall hooks
   // such as `bunx only-allow bun` recognise the caller.
   out.npm_config_user_agent = `bun/unknown npm/? node/${process.versions.node} ${process.platform} ${process.arch}`;
   return out;
-}
-
-function shouldStripBunInstallEnv(key: string): boolean {
-  return (
-    /^PNPM_/i.test(key) ||
-    /^npm_config_user_agent$/i.test(key) ||
-    /^npm_execpath$/i.test(key) ||
-    /^npm_node_execpath$/i.test(key) ||
-    /^npm_lifecycle_/i.test(key) ||
-    /^npm_package_/i.test(key)
-  );
 }
 
 function prepareNpmToolchain({
@@ -1329,8 +1303,7 @@ export function runAllowedValidationCommandsWithBinding(
       options.validationTimeoutMs ?? DEFAULT_TARGET_VALIDATION_TIMEOUT_MS,
       options.validationTimeoutMs,
     );
-    // Match the pre-change shape: each capture stage gets its own fresh window
-    // so ignored-path enumeration cannot starve the checkout identity capture.
+    // Separate windows keep ignored-path enumeration from starving identity capture.
     const identityCaptureWindowMs = Math.max(
       validationTimeoutMs,
       MIN_VALIDATION_IDENTITY_WINDOW_MS,
@@ -1671,7 +1644,7 @@ export function preflightTargetValidationPlan(
   const scripts = readPackageScriptSet(targetDir);
   const availableScripts = [...scripts].sort();
   const resolved: string[] = [];
-  const requiredScripts: LooseRecord[] = [];
+  const requiredScripts: PackageScriptRequirement[] = [];
   for (const command of requiredValidationCommands(
     fixArtifact.validation_commands ?? [],
     targetDir,
@@ -1703,7 +1676,7 @@ export function preflightTargetValidationPlan(
   }
 
   const missing = requiredScripts.find(
-    (script: JsonValue) => !targetPackageScriptIsAvailable(targetDir, scripts, script),
+    (script) => !targetPackageScriptIsAvailable(targetDir, scripts, script),
   );
   const bunInspection = requiredScripts
     .map((script) => unsafeBunLifecycleHook(targetDir, script))
@@ -1762,7 +1735,7 @@ export function requiredValidationCommands(
   const toolchain = getToolchain(options);
   const gate = toolchain.changedGate;
   const injectedChangedGate =
-    gate && !options.skipOpenClawChangedGate && requiresChangedGate(cwd, toolchain)
+    gate && !options.skipOpenClawChangedGate && readPackageScriptSet(cwd).has(gate.requiredScript)
       ? gate.command
       : null;
   const replacementCommands = [
@@ -1796,21 +1769,7 @@ function isMutatingFormatterValidationHint(command: LooseRecord): boolean {
   });
 }
 
-/**
- * Drop validation commands that look like "some other repo's changed gate"
- * when the current target repo does not have one. This protects against stale
- * fixArtifacts (most notably deterministic automerge artifacts authored before
- * per-repo toolchain config landed) that ship `pnpm check:changed` even when
- * the target is bun-based and has no `check:changed` script. Without this
- * guard preflight terminates with `validation_script_missing` and the
- * executor never tries the project's real validation command.
- *
- * We are deliberately conservative: we only drop commands that match the
- * fingerprint of a known changed-gate command and only when the active
- * toolchain has no gate of its own. If no repository-specific replacement
- * exists, fall back to `git diff --check`; unrelated commands still pass
- * through so genuinely missing scripts remain visible.
- */
+// Only the canonical OpenClaw gate is replaceable; unrelated missing scripts must block.
 function sanitizeStaleChangedGateCommands(
   commands: readonly LooseRecord[],
   toolchain: TargetRepoToolchain,
@@ -1829,14 +1788,7 @@ function sanitizeStaleChangedGateCommands(
 }
 
 function looksLikeStaleChangedGateCommand(command: LooseRecord): boolean {
-  const text = String(command ?? "").trim();
-  if (!text) return false;
-  // Matches the canonical openclaw/openclaw changed gate verbatim, with or
-  // without a leading `env` wrapper. Kept narrow on purpose so we only
-  // discard things we are confident are the stale gate.
-  return /^(?:env\s+(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*)?pnpm\s+(?:-s\s+|--silent\s+)?(?:run\s+)?check:changed$/.test(
-    text,
-  );
+  return isOpenClawChangedGateValidationCommand(String(command ?? ""));
 }
 
 export function repairDeltaValidationPlan(
@@ -2909,13 +2861,8 @@ function sameValidationSourceIdentity(
   expected: ValidationSourceIdentity,
 ) {
   return (
-    actual.contentTreeSha === expected.contentTreeSha &&
-    actual.gitAdminSha256 === expected.gitAdminSha256 &&
-    actual.headSha === expected.headSha &&
-    actual.runtimeInputsSha256 === expected.runtimeInputsSha256 &&
-    actual.treeSha === expected.treeSha &&
-    actual.status === expected.status &&
-    actual.worktreeSha256 === expected.worktreeSha256
+    sameValidationSourceIdentityExceptRuntime(actual, expected) &&
+    actual.runtimeInputsSha256 === expected.runtimeInputsSha256
   );
 }
 
@@ -3339,7 +3286,7 @@ function validationRuntimeInputsSha256(
       .split("\0")
       .filter(Boolean),
   );
-  const runtimePaths = validationRuntimeInputPaths(cwd, deadlineAt).filter(
+  const runtimePaths = ignoredValidationRuntimePaths(cwd, deadlineAt).filter(
     (relativePath) =>
       !excludedRuntimeRoots.some(
         (excludedRoot) =>
@@ -3418,10 +3365,6 @@ function validationRuntimeInputsSha256(
   }
   assertValidationIdentityDeadline(deadlineAt, "runtime input digest");
   return hash.digest("hex");
-}
-
-function validationRuntimeInputPaths(cwd: string, deadlineAt: number) {
-  return ignoredValidationRuntimePaths(cwd, deadlineAt);
 }
 
 function clearNewIgnoredValidationRuntimePaths(
@@ -5012,7 +4955,7 @@ function validationCommandInvokesRust(parts: readonly string[]) {
   return false;
 }
 
-function targetPackageScriptMayInvokeRust(cwd: string, requirement: LooseRecord) {
+function targetPackageScriptMayInvokeRust(cwd: string, requirement: PackageScriptRequirement) {
   const manifests = readWorkspacePackageManifests(cwd, requirement.packageManager);
   if (manifests === null) return true;
   const selected = requirement.workspaceScoped
@@ -5024,12 +4967,10 @@ function targetPackageScriptMayInvokeRust(cwd: string, requirement: LooseRecord)
     : manifests.filter((manifest) => manifest.relativeDir === ".");
   if (selected === null) return true;
   return selected.some((manifest) =>
-    shellCommandMayInvokeRust(manifest.scriptCommands.get(String(requirement.name)) ?? ""),
+    /(?:^|[\s;&|()])(?:cargo|rustc)(?=$|[\s;&|()])/.test(
+      manifest.scriptCommands.get(requirement.name) ?? "",
+    ),
   );
-}
-
-function shellCommandMayInvokeRust(command: string) {
-  return /(?:^|[\s;&|()])(?:cargo|rustc)(?=$|[\s;&|()])/.test(command);
 }
 
 type VerifiedRustupToolchain = {
@@ -5421,7 +5362,7 @@ const DEFAULT_WORKSPACE_SELECTOR_LIMITS: WorkspaceSelectorLimits = {
 function targetPackageScriptIsAvailable(
   cwd: string,
   rootScripts: ReadonlySet<string>,
-  requirement: LooseRecord,
+  requirement: PackageScriptRequirement,
 ) {
   if (!requirement.workspaceScoped) return rootScripts.has(requirement.name);
   const manifests = readWorkspacePackageManifests(cwd, requirement.packageManager);
@@ -5436,8 +5377,7 @@ function targetPackageScriptIsAvailable(
       requirement.packageManager === "pnpm" &&
       hasDeferredPnpmWorkspaceSelector(requirement.workspaceSelectors) &&
       manifests.some(
-        (manifest) =>
-          manifest.relativeDir !== "." && manifest.scripts.has(String(requirement.name)),
+        (manifest) => manifest.relativeDir !== "." && manifest.scripts.has(requirement.name),
       )
     );
   }
@@ -5473,13 +5413,13 @@ function assertNoUnsafeBunLifecycleHooks(cwd: string, parts: readonly string[]) 
 
 function unsafeBunLifecycleHook(
   cwd: string,
-  requirement: LooseRecord,
+  requirement: PackageScriptRequirement,
 ):
   | { status: "safe" }
   | { status: "unsafe"; command: string; hook: string }
   | { status: "inconclusive"; command: string; reason: string } {
   if (requirement.packageManager !== "bun") return { status: "safe" };
-  const command = String(requirement.command);
+  const command = requirement.command;
   const manifests = readWorkspacePackageManifests(cwd, requirement.packageManager);
   if (manifests === null) {
     return { status: "inconclusive", command, reason: "workspace metadata or traversal failed" };
@@ -5951,30 +5891,17 @@ function workspaceGlobMatches(value: string, pattern: string) {
   }
 }
 
-function requiresChangedGate(cwd: string, toolchain: TargetRepoToolchain) {
-  if (!toolchain.changedGate) return false;
-  return readPackageScriptSet(cwd).has(toolchain.changedGate.requiredScript);
-}
-
 function getToolchain(options: TargetValidationOptions): TargetRepoToolchain {
   return options.toolchain ?? resolveTargetRepoToolchain(options.targetRepo);
 }
 
 function isChangedGateCommand(parts: readonly string[], options: TargetValidationOptions) {
-  return changedGateCommandParts(getToolchain(options).changedGate, parts) !== null;
-}
-
-function changedGateCommandParts(
-  gate: TargetChangedGate | null,
-  parts: readonly string[],
-): readonly string[] | null {
-  if (!gate) return null;
+  const gate = getToolchain(options).changedGate;
+  if (!gate) return false;
   const gateParts = gate.command.split(/\s+/).filter(Boolean);
-  if (gateParts.length !== parts.length) return null;
-  for (let i = 0; i < gateParts.length; i += 1) {
-    if (gateParts[i] !== parts[i]) return null;
-  }
-  return gateParts;
+  return (
+    gateParts.length === parts.length && gateParts.every((part, index) => part === parts[index])
+  );
 }
 
 function changedFilesSinceRef(cwd: string, sourceRef: string) {

--- a/src/repair/validation-command-utils.ts
+++ b/src/repair/validation-command-utils.ts
@@ -9,16 +9,16 @@ export type PackageScriptRequirement = {
 
 type PackageManagerExecutable = "pnpm" | "npm" | "bun";
 
+type PackageManagerOption =
+  | { kind: "boolean"; name: string; value: string | null }
+  | { kind: "value"; name: string; value: string };
+
 type PackageManagerInvocation = {
   executable: PackageManagerExecutable;
   command: string;
   commandIndex: number;
   args: string[];
-  globalOptions: Array<{
-    kind: "boolean" | "value";
-    name: string;
-    value: string | null;
-  }>;
+  globalOptions: PackageManagerOption[];
 };
 
 const PACKAGE_MANAGER_GLOBAL_OPTIONS: Record<
@@ -524,9 +524,7 @@ export function packageScriptRequirement(
   const command = normalizedPackageCommand(invocation);
   const usesRunCommand = command === "run";
   const runInvocation = usesRunCommand ? packageRunInvocation(invocation) : null;
-  const script = usesRunCommand
-    ? runInvocation?.script
-    : implicitPackageScriptName(invocation, command);
+  const script = usesRunCommand ? runInvocation?.script : command;
   const supportsPackageScript =
     usesRunCommand ||
     invocation.executable === "pnpm" ||
@@ -550,7 +548,7 @@ export function packageScriptRequirement(
       : []),
   ].filter((option) => PACKAGE_MANAGER_WORKSPACE_OPTIONS[invocation.executable].has(option.name));
   const workspaceSelectors = workspaceOptions.flatMap((option) =>
-    option.kind === "value" && option.value !== null ? [option.value] : [],
+    option.kind === "value" ? [option.value] : [],
   );
   const workspaceAll = lastPackageBooleanOptionEnabled(workspaceOptions);
   return {
@@ -667,8 +665,7 @@ export function uniqueStrings(values: Iterable<unknown>): string[] {
 export function parseAllowedValidationCommand(command: unknown): string[] {
   const text = String(command ?? "").trim();
   if (!text) throw new Error("empty validation command");
-  const parts = normalizeEnvInvocation(splitValidationCommand(text));
-  return validateAllowedValidationCommandParts(parts, text);
+  return validateAllowedValidationCommandParts(splitValidationCommand(text), text);
 }
 
 export function validateAllowedValidationCommandParts(
@@ -816,29 +813,11 @@ function packageManagerInvocation(parts: readonly string[]): PackageManagerInvoc
   while (index < commandParts.length && commandParts[index]?.startsWith("-")) {
     const token = commandParts[index]!;
     const option = token.split("=", 1)[0]!;
-    if (allowed.boolean.has(option)) {
-      const value = token.includes("=") ? token.slice(token.indexOf("=") + 1) : null;
-      if (value !== null && !isPackageBooleanOptionValue(value)) return null;
-      globalOptions.push({
-        kind: "boolean",
-        name: option,
-        value,
-      });
-      index += 1;
-      continue;
-    }
-    if (allowed.value.has(option)) {
-      if (token.includes("=")) {
-        const value = token.slice(token.indexOf("=") + 1);
-        if (!value) return null;
-        globalOptions.push({ kind: "value", name: option, value });
-        index += 1;
-        continue;
-      }
-      const value = commandParts[index + 1];
-      if (!value || value.startsWith("-")) return null;
-      globalOptions.push({ kind: "value", name: option, value });
-      index += 2;
+    if (allowed.boolean.has(option) || allowed.value.has(option)) {
+      const parsed = packageOption(commandParts, index, allowed.boolean.has(option));
+      if (!parsed) return null;
+      globalOptions.push(parsed.option);
+      index += parsed.consumed;
       continue;
     }
     if (executable === "pnpm" && option.startsWith("--config.") && token.includes("=")) {
@@ -875,7 +854,13 @@ function packageRunInvocation(invocation: PackageManagerInvocation): {
     const token = invocation.args[scriptArgIndex]!;
     if (token === "--") return null;
     if (!token.startsWith("-")) break;
-    const parsed = packageRunWorkspaceOption(invocation, scriptArgIndex);
+    const name = token.split("=", 1)[0]!;
+    if (!PACKAGE_MANAGER_WORKSPACE_OPTIONS[invocation.executable].has(name)) return null;
+    const parsed = packageOption(
+      invocation.args,
+      scriptArgIndex,
+      PACKAGE_MANAGER_GLOBAL_OPTIONS[invocation.executable].boolean.has(name),
+    );
     if (!parsed) return null;
     workspaceOptions.push(parsed.option);
     scriptArgIndex += parsed.consumed;
@@ -899,33 +884,23 @@ function npmScriptOptions(args: readonly string[]) {
     if (token === "--") break;
     if (!token.startsWith("-")) continue;
     const name = token.split("=", 1)[0]!;
-    if (NPM_SCRIPT_BOOLEAN_OPTIONS.has(name)) {
-      const value = token.includes("=") ? token.slice(token.indexOf("=") + 1) : null;
-      if (value !== null && !isPackageBooleanOptionValue(value)) return null;
-      options.push({ kind: "boolean", name, value });
-      continue;
-    }
-    if (!NPM_SCRIPT_VALUE_OPTIONS.has(name)) return null;
-    if (token.includes("=")) {
-      const value = token.slice(token.indexOf("=") + 1);
-      if (!value) return null;
-      options.push({ kind: "value", name, value });
-      continue;
-    }
-    const value = args[index + 1];
-    if (!value || value === "--" || value.startsWith("-")) return null;
-    options.push({ kind: "value", name, value });
-    index += 1;
+    if (!NPM_SCRIPT_BOOLEAN_OPTIONS.has(name) && !NPM_SCRIPT_VALUE_OPTIONS.has(name)) return null;
+    const parsed = packageOption(args, index, NPM_SCRIPT_BOOLEAN_OPTIONS.has(name));
+    if (!parsed) return null;
+    options.push(parsed.option);
+    index += parsed.consumed - 1;
   }
   return options;
 }
 
-function packageRunWorkspaceOption(invocation: PackageManagerInvocation, index: number) {
-  const token = invocation.args[index]!;
+function packageOption(
+  args: readonly string[],
+  index: number,
+  boolean: boolean,
+): { consumed: number; option: PackageManagerOption } | null {
+  const token = args[index]!;
   const name = token.split("=", 1)[0]!;
-  const allowed = PACKAGE_MANAGER_WORKSPACE_OPTIONS[invocation.executable];
-  if (!allowed.has(name)) return null;
-  if (name === "-r" || name === "--recursive" || name === "--workspaces" || name === "--ws") {
+  if (boolean) {
     const value = token.includes("=") ? token.slice(token.indexOf("=") + 1) : null;
     if (value !== null && !isPackageBooleanOptionValue(value)) return null;
     return {
@@ -941,8 +916,8 @@ function packageRunWorkspaceOption(invocation: PackageManagerInvocation, index: 
       option: { kind: "value" as const, name, value },
     };
   }
-  const value = invocation.args[index + 1];
-  if (!value || value === "--" || value.startsWith("-")) return null;
+  const value = args[index + 1];
+  if (!value || value.startsWith("-")) return null;
   return {
     consumed: 2,
     option: { kind: "value" as const, name, value },
@@ -1048,18 +1023,25 @@ function hasUnsafePackageRunner(parts: readonly string[]) {
   }
   if (invocation?.executable === "pnpm" && packageCommand === "dlx") return true;
 
-  const wrapper =
-    invocation?.executable === "pnpm" && packageCommand === "exec"
-      ? invocation.args[0]
-      : executable === "uv" && commandParts[1] === "run"
-        ? commandParts[2]
-        : executable === "bundle" && commandParts[1] === "exec"
-          ? commandParts[2]
-          : executable === "composer" && commandParts[1] === "exec"
-            ? commandParts[2]
-            : "";
+  const wrapper = commandParts[wrappedValidationCommandStart(commandParts, invocation)];
   if (!wrapper) return false;
   return !SAFE_WRAPPED_VALIDATION_EXECUTABLES.has(wrapper);
+}
+
+function wrappedValidationCommandStart(
+  parts: readonly string[],
+  invocation: PackageManagerInvocation | null,
+) {
+  if (invocation?.executable === "pnpm" && normalizedPackageCommand(invocation) === "exec") {
+    return invocation.commandIndex + 1;
+  }
+  if (
+    (parts[0] === "uv" && parts[1] === "run") ||
+    (["bundle", "composer"].includes(parts[0] ?? "") && parts[1] === "exec")
+  ) {
+    return 2;
+  }
+  return -1;
 }
 
 function hasUnsupportedPackageManagerInvocation(parts: readonly string[]) {
@@ -1172,14 +1154,9 @@ function hasMutatingValidationFlag(parts: readonly string[]) {
   if (commandParts.some((part) => denied.has(part.split("=", 1)[0] ?? ""))) return true;
   const executable = commandParts[0] ?? "";
   const invocation = packageManagerInvocation(commandParts);
-  if (invocation?.executable === "pnpm" && normalizedPackageCommand(invocation) === "exec") {
-    return hasMutatingValidationFlag(commandParts.slice(invocation.commandIndex + 1));
-  }
-  if (
-    (executable === "uv" && commandParts[1] === "run") ||
-    (["bundle", "composer"].includes(executable) && commandParts[1] === "exec")
-  ) {
-    return hasMutatingValidationFlag(commandParts.slice(2));
+  const wrappedStart = wrappedValidationCommandStart(commandParts, invocation);
+  if (wrappedStart >= 0) {
+    return hasMutatingValidationFlag(commandParts.slice(wrappedStart));
   }
   if (executable === "prettier" && commandParts.slice(1).some((part) => /^-[^-]*w/.test(part))) {
     return true;
@@ -1191,21 +1168,7 @@ function hasSnapshotUpdateShortFlag(parts: readonly string[]): boolean {
   const commandParts = stripEnvPrefix(parts);
   const executable = commandParts[0] ?? "";
   const invocation = packageManagerInvocation(commandParts);
-  if (invocation?.executable === "pnpm" && normalizedPackageCommand(invocation) === "exec") {
-    return hasSnapshotUpdateShortFlag(commandParts.slice(invocation.commandIndex + 1));
-  }
-  if (
-    (executable === "uv" && commandParts[1] === "run") ||
-    (["bundle", "composer"].includes(executable) && commandParts[1] === "exec")
-  ) {
-    return hasSnapshotUpdateShortFlag(commandParts.slice(2));
-  }
-
-  const shortUpdateIndexes = commandParts
-    .map((part, index) => ({ index, option: part.split("=", 1)[0] ?? "" }))
-    .filter(({ index, option }) => index > 0 && option === "-u")
-    .map(({ index }) => index);
-  if (shortUpdateIndexes.length === 0) return false;
+  if (!commandParts.slice(1).some((part) => part.split("=", 1)[0] === "-u")) return false;
   if (invocation) {
     if (invocation.executable === "bun" && normalizedPackageCommand(invocation) === "test") {
       return true;
@@ -1222,14 +1185,7 @@ function hasMutatingValidationCommand(parts: readonly string[]): boolean {
   const invocation = packageManagerInvocation(commandParts);
   const subcommand = invocation ? normalizedPackageCommand(invocation) : (commandParts[1] ?? "");
   const packageScript = packageScriptRequirement(commandParts)?.name ?? "";
-  const wrappedCommandStart =
-    invocation?.executable === "pnpm" && subcommand === "exec"
-      ? invocation.commandIndex + 1
-      : executable === "uv" && subcommand === "run"
-        ? 2
-        : ["bundle", "composer"].includes(executable) && subcommand === "exec"
-          ? 2
-          : -1;
+  const wrappedCommandStart = wrappedValidationCommandStart(commandParts, invocation);
   if (wrappedCommandStart >= 0) {
     return hasMutatingValidationCommand(commandParts.slice(wrappedCommandStart));
   }
@@ -1380,20 +1336,6 @@ function isAbbreviatedNpmLifecycleOption(option: string) {
 function normalizedPackageCommand(invocation: PackageManagerInvocation): string {
   const classification = PACKAGE_MANAGER_COMMAND_CLASSIFICATION[invocation.executable];
   return classification.aliases.get(invocation.command) ?? invocation.command;
-}
-
-function implicitPackageScriptName(
-  invocation: PackageManagerInvocation,
-  normalizedCommand: string,
-) {
-  if (invocation.executable === "npm" && normalizedCommand === "test") return "test";
-  if (
-    invocation.executable === "pnpm" &&
-    !PACKAGE_MANAGER_COMMAND_CLASSIFICATION.pnpm.aliases.has(invocation.command)
-  ) {
-    return invocation.command;
-  }
-  return normalizedCommand;
 }
 
 const SAFE_WRAPPED_VALIDATION_EXECUTABLES = new Set([

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -183,22 +183,6 @@ test("ClawSweeper repairs preserve their configured changed gate from the real c
   }
 });
 
-test("validation preflight reports injected OpenClaw changed gate", () => {
-  const cwd = packageFixture({ "check:changed": "node check.js" });
-
-  assert.deepEqual(
-    preflightTargetValidationPlan(
-      { fixArtifact: { validation_commands: [] }, targetDir: cwd },
-      validationOptions("openclaw/openclaw"),
-    ),
-    {
-      status: "passed",
-      resolved_commands: ["pnpm check:changed"],
-      available_scripts: ["check:changed"],
-    },
-  );
-});
-
 test("validation preflight blocks targets without any validation command", () => {
   const cwd = packageFixture({});
 
@@ -2499,22 +2483,6 @@ test("bun-based target repos do not get pnpm check:changed injected", () => {
   );
 });
 
-test("bun-based target repos pass preflight when their script exists", () => {
-  const cwd = bunPackageFixture({ check: "bun x tsc --noEmit" });
-
-  assert.deepEqual(
-    preflightTargetValidationPlan(
-      { fixArtifact: { validation_commands: ["bun run check"] }, targetDir: cwd },
-      validationOptions("openclaw/clawhub", clawhubToolchain()),
-    ),
-    {
-      status: "passed",
-      resolved_commands: ["bun run check"],
-      available_scripts: ["check"],
-    },
-  );
-});
-
 test("bun-based target repos drop stale pnpm check:changed and pass on their real validation command", () => {
   // Regression guard for the stale-deterministic-artifact path: an automerge
   // artifact authored before per-repo toolchain config (or any future caller
@@ -4076,31 +4044,6 @@ if (args[0] === "enable") {
         assert.equal(subsequentPrefetches, previousPrefetches + 1);
       }),
     );
-  },
-);
-
-test(
-  "pnpm validation refreshes the prepared executable before every command",
-  { skip: process.platform === "win32" },
-  () => {
-    const { cwd, hostBin, logPath, maliciousMarker, options } = pnpmExecutableRefreshFixture();
-
-    withCommandOverridesUnset(["corepack", "pnpm"], () =>
-      withPathOnlyPrefix(hostBin, () => {
-        prepareTargetToolchain(cwd, options);
-        assert.deepEqual(
-          runAllowedValidationCommands(["pnpm first", "pnpm second"], cwd, options),
-          ["pnpm first", "pnpm second"],
-        );
-      }),
-    );
-
-    assert.equal(fs.existsSync(maliciousMarker), false);
-    assert.deepEqual(fs.readFileSync(logPath, "utf8").trim().split(/\r?\n/), [
-      "install --frozen-lockfile --prefer-offline --ignore-scripts --ignore-pnpmfile --config.registry=https://registry.npmjs.org/ --config.engine-strict=false --config.enable-pre-post-scripts=false",
-      "--config.verify-deps-before-run=false --config.enable-pre-post-scripts=false first",
-      "--config.verify-deps-before-run=false --config.enable-pre-post-scripts=false second",
-    ]);
   },
 );
 

--- a/test/repair/validation-command-utils.test.ts
+++ b/test/repair/validation-command-utils.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { packageScriptRequirement } from "../../dist/repair/validation-command-utils.js";
+import {
+  packageScriptRequirement,
+  parseAllowedValidationCommand,
+} from "../../dist/repair/validation-command-utils.js";
 
 test("pnpm built-ins and aliases cannot fall back to same-named package scripts", () => {
   const nonScriptCommands = [
@@ -49,4 +52,78 @@ test("pnpm script aliases resolve before implicit script fallback", () => {
   }
   assert.equal(packageScriptRequirement(["npm", "tst"])?.name, "test");
   assert.equal(packageScriptRequirement(["pnpm", "Check"])?.name, "Check");
+});
+
+test("workspace option values retain their meaning before and after run", () => {
+  for (const [manager, option] of [
+    ["pnpm", "--filter"],
+    ["npm", "--workspace"],
+    ["bun", "--filter"],
+  ]) {
+    for (const value of ["false", "app", "@example/app"]) {
+      for (const tokens of [[option, value], [`${option}=${value}`]]) {
+        const commands = [
+          [manager, ...tokens, "run", "check"],
+          [manager, "run", ...tokens, "check"],
+          ...(manager === "npm" ? [[manager, "run", "check", ...tokens]] : []),
+        ];
+        for (const parts of commands) {
+          assert.deepEqual(parseAllowedValidationCommand(parts.join(" ")), parts);
+          const requirement = packageScriptRequirement(parts);
+          assert.equal(requirement?.name, "check");
+          assert.equal(requirement?.workspaceAll, false);
+          assert.deepEqual(requirement?.workspaceSelectors, [value]);
+        }
+      }
+    }
+  }
+});
+
+test("package option parsing rejects missing values and invalid booleans in every option position", () => {
+  for (const command of [
+    "pnpm --filter= run check",
+    "pnpm --filter --silent run check",
+    "pnpm run --filter",
+    "pnpm run --filter= check",
+    "pnpm --recursive=maybe check",
+    "pnpm run --recursive=maybe check",
+    "npm --workspace= run check",
+    "npm run --workspace -- check",
+    "npm run check --workspace",
+    "npm run check --workspace=",
+    "npm --workspaces=maybe run check",
+    "npm run --workspaces=maybe check",
+    "npm run check --workspaces=maybe",
+    "bun --filter= run check",
+    "bun run --filter -- check",
+  ]) {
+    assert.throws(
+      () => parseAllowedValidationCommand(command),
+      /unsafe validation command/,
+      command,
+    );
+  }
+});
+
+test("wrapped validators retain mutation checks without rejecting read-only short flags", () => {
+  for (const wrapper of ["pnpm exec", "uv run", "bundle exec", "composer exec"]) {
+    for (const command of [
+      "vitest run -u",
+      "jest -u=true",
+      "ava -u",
+      "cargo fmt",
+      "prettier -w file.ts",
+    ]) {
+      assert.throws(
+        () => parseAllowedValidationCommand(`${wrapper} ${command}`),
+        /unsafe validation command/,
+      );
+    }
+    for (const command of ["cargo fmt --check", "python -u tests/check.py"]) {
+      assert.deepEqual(
+        parseAllowedValidationCommand(`${wrapper} ${command}`),
+        `${wrapper} ${command}`.split(" "),
+      );
+    }
+  }
 });


### PR DESCRIPTION
## What Problem This Solves

Target validation repeated package-option parsing, wrapped-command recognition, and changed-gate matching. Those copies made it harder to review the same command policy consistently.

## Why This Change Was Made

Share boolean/value option parsing while retaining the separate allowlists for global, pre-script, and npm post-script options. Represent parsed options as a closed union, share wrapper recognition across mutation checks, and remove redundant alias handling, forwarding helpers, and historical commentary. Target validation now uses the existing `PackageScriptRequirement` type internally. `validateAllowedValidationCommandParts` remains the single normalization and environment-policy boundary.

Three duplicate tests were removed; malformed-option, workspace-value, and wrapped-command boundaries remain covered explicitly. The change stays within four Node-side source/test files; no file split or new dependency is needed.

## User Impact

Behavior-neutral; no runtime contract, config, or workflow change. Exported entry points, accepted/rejected commands, error messages, lifecycle suppression, and checkout identity protections are preserved.

## Evidence

`pr-behavior-proof` contract:

- **Claim:** existing target validation behavior is preserved while duplicated command-policy mechanics are removed.
- **Exercised surface:** package command admission and execution arguments; target validation planning, toolchain preparation, fallback/retry handling, and checkout identity checks.
- **Scenario/fixture:** the repair suites' temporary Git/package/workspace fixtures, plus 5,189 command cases compared against the original parser at the branch base.
- **Command and environment:** macOS arm64, Node v26.8.1, pnpm 11.10.0. `pnpm run build:all`, `node scripts/run-node-tests.mjs repair`, `pnpm run check`, and `node /tmp/deslop-target-validation-differential.mjs`.
- **Observable result:** targeted repair suite: 1,393 passed, 7 skipped, zero failures. Full gate: 4,733 passed, 11 skipped, zero failures; coverage 83.69% lines, 76.40% branches, 88.67% functions. All 41,512 before/after API comparisons matched.
- **Artifact or trace:** exact pass summaries below; complete local logs retained as `/tmp/deslop-target-validation-{build,repair,check,differential}.log`. The differential harness and baseline are retained alongside them. `/tmp/deslop-target-validation-env-review-proof.log` records additional before/after checks rejecting bare/explicit `PATH` and `NODE_OPTIONS` overrides and preserving safe `CI=1` normalization.
- **Limits:** this is a behavior-neutral refactor; its proof is the full `pnpm run check` run plus the targeted repair suites. Tests include controlled subprocess/Git fixtures and mocked package-manager behavior, not a live production repair. Linux-specific containment/process tests and two opt-in CPU benchmarks were skipped.

```text
Targeted repair suite:
ℹ tests 1400
ℹ pass 1393
ℹ fail 0
ℹ cancelled 0
ℹ skipped 7

Full pnpm run check:
ℹ tests 4744
ℹ pass 4733
ℹ fail 0
ℹ cancelled 0
ℹ skipped 11
ℹ all files                                     |  83.69 |    76.40 |   88.67 |

PASS: 5189 command cases; 41512 before/after API comparisons; identical runtime exports.
```

Independent Codex autoreview: scoped-clean at P1, with no accepted/actionable findings, against the pinned branch merge base `72041f31e1d34cff19f50da4b23c4a22a78c828a`; the full command-policy module was supplied as dependency context.

OpenClaw Bay not affected: no dashboard changes.

| Category | Added | Removed | Net LOC |
| --- | ---: | ---: | ---: |
| Production | 88 | 219 | -131 |
| Tests | 78 | 58 | +20 |
| Docs | 0 | 0 | 0 |


### Update after ClawSweeper review (head 141d25cbd, unchanged)

**Finding "packageOption accepts `--` as an npm workspace value" is disproved on this head.** `packageOption` rejects any value that is missing or starts with `-`, which includes the bare `--` separator, so the prior fail-closed check is intact. Verified by executing the compiled module on this head and on `main`:

```text
"npm run check --workspace -- foo"  => THROWS unsafe validation command   (head and main)
"npm run check --workspace --"      => THROWS unsafe validation command   (head)
"npm run check -w -- x"             => THROWS unsafe validation command   (head)
"npm run --workspace -- check"      => THROWS unsafe validation command   (head)
"npm run check --workspace=--"      => accepted, selector ["--"]          (head and main, unchanged)
```

The `--workspace=--` form was accepted before this PR and still is; that pre-existing behavior is out of scope here. The new test "package option parsing rejects missing values and invalid booleans in every option position" already covers `npm run --workspace -- check` and `npm run check --workspace`.

**Real behavior proof (production command-chain harness, current head):** the documented automerge e2e harness (`docs/repair/automerge-e2e.md`, `--scenario all`) ran on this exact head in CI: https://github.com/openclaw/clawsweeper/actions/runs/33826886758 (job `production automerge flow`, success). It executes the compiled repair CLIs including target validation preflight and command admission (`validate-job`, `execute-fix-artifact` with changed-surface validation) against both fixtures; the `openclaw-shaped` fixture exercises the pinned pnpm toolchain and changed-gate path this PR touches. GitHub and Codex are the harness's simulators; the validation, install, and command execution are real.
