### PR TITLE
perf(queue): cut completion and receipt CPU in the exact-review queue object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Preserve legacy review lease completions without lifecycle admission rows and reschedule queue alarms even when a lifecycle update fails.
+
 - Reduce cold Bay snapshot work by reading full projections through the existing parser, preserving the 30-second TTL memo and edge cache.
 
 - Keep queue stats fresh when alarm or auxiliary-state writes overlap a memo computation, without changing the cache TTL or response fields.

--- a/dashboard/exact-review-lifecycle-telemetry.ts
+++ b/dashboard/exact-review-lifecycle-telemetry.ts
@@ -1663,12 +1663,17 @@ export class ExactReviewLifecycleTelemetryStore {
     );
   }
 
-  hasBayLifecyclePending() {
+  hasBayLifecyclePending(includeSource = false) {
     try {
       return (
         Array.from(
           this.storage.sql.exec(
-            `SELECT 1 AS pending FROM ${EXACT_REVIEW_LIFECYCLE_BAY_PENDING_TABLE} LIMIT 1`,
+            includeSource
+              ? `SELECT 1 AS pending WHERE
+                   EXISTS(SELECT 1 FROM ${EXACT_REVIEW_LIFECYCLE_PROJECTION_TABLE}
+                           WHERE bay_telemetry_pending = 1)
+                   OR EXISTS(SELECT 1 FROM ${EXACT_REVIEW_LIFECYCLE_BAY_PENDING_TABLE})`
+              : `SELECT 1 AS pending FROM ${EXACT_REVIEW_LIFECYCLE_BAY_PENDING_TABLE} LIMIT 1`,
           ),
         ).length > 0
       );
@@ -2387,8 +2392,12 @@ function sameBayLifecycleEvent(left: BayLifecycleEvent, right: BayLifecycleEvent
 }
 
 function hadBayLifecycleTerminalEvent(projection: ExactReviewLifecycleProjection) {
+  // A routed receipt can precede the first final-effect receipt. With no
+  // immutable timing boundary it has never contributed to either tide. Keep
+  // legacy/materialized markers conservative, including after event retention.
+  if (projection.bayTelemetryEventId !== undefined) return true;
   return projection.terminalDispositions.some(
-    (terminal) => terminal.kind === "review_completed_routed" || terminal.kind === "failure",
+    (terminal) => bayLifecycleEvent({ ...projection, terminalDisposition: terminal }) !== null,
   );
 }
 

--- a/dashboard/exact-review-lifecycle.ts
+++ b/dashboard/exact-review-lifecycle.ts
@@ -443,15 +443,16 @@ export class ExactReviewLifecycleProjectionStore {
     requirePresent = false,
   ) {
     this.validateIdentity(input);
-    if (!positiveInteger(input.claimGeneration) || !validRunId(input.runId)) {
-      throw new Error("invalid lifecycle review result");
-    }
-    if (input.runAttempt !== null && !positiveInteger(input.runAttempt)) {
-      throw new Error("invalid lifecycle review result attempt");
-    }
     return this.mutate<ExactReviewLifecycleProjection | null>(
       input,
       (projection) => {
+        // Legacy leases without admission rows have no lifecycle metadata to validate.
+        if (!positiveInteger(input.claimGeneration) || !validRunId(input.runId)) {
+          throw new Error("invalid lifecycle review result");
+        }
+        if (input.runAttempt !== null && !positiveInteger(input.runAttempt)) {
+          throw new Error("invalid lifecycle review result attempt");
+        }
         const fact: LifecycleReviewResultFact = {
           fenceKey: input.fenceKey,
           claimGeneration: input.claimGeneration,

--- a/dashboard/exact-review-lifecycle.ts
+++ b/dashboard/exact-review-lifecycle.ts
@@ -434,6 +434,14 @@ export class ExactReviewLifecycleProjectionStore {
         observedAt: number;
       },
   ) {
+    return this.recordReviewResultIfPresent(input, true)!;
+  }
+
+  recordReviewResultIfPresent(
+    input: ProjectionIdentity &
+      Omit<LifecycleReviewResultFact, "fenceKey" | "observedAt"> & { observedAt: number },
+    requirePresent = false,
+  ) {
     this.validateIdentity(input);
     if (!positiveInteger(input.claimGeneration) || !validRunId(input.runId)) {
       throw new Error("invalid lifecycle review result");
@@ -441,21 +449,26 @@ export class ExactReviewLifecycleProjectionStore {
     if (input.runAttempt !== null && !positiveInteger(input.runAttempt)) {
       throw new Error("invalid lifecycle review result attempt");
     }
-    return this.mutate(input, (projection) => {
-      const fact: LifecycleReviewResultFact = {
-        fenceKey: input.fenceKey,
-        claimGeneration: input.claimGeneration,
-        runId: input.runId,
-        runAttempt: input.runAttempt,
-        outcome: input.outcome,
-        observedAt: input.observedAt,
-      };
-      const existing = projection.reviewResults.find((candidate) =>
-        sameReviewResult(candidate, fact),
-      );
-      if (!existing) projection.reviewResults.push(fact);
-      return projection;
-    });
+    return this.mutate<ExactReviewLifecycleProjection | null>(
+      input,
+      (projection) => {
+        const fact: LifecycleReviewResultFact = {
+          fenceKey: input.fenceKey,
+          claimGeneration: input.claimGeneration,
+          runId: input.runId,
+          runAttempt: input.runAttempt,
+          outcome: input.outcome,
+          observedAt: input.observedAt,
+        };
+        const existing = projection.reviewResults.find((candidate) =>
+          sameReviewResult(candidate, fact),
+        );
+        if (!existing) projection.reviewResults.push(fact);
+        return projection;
+      },
+      true,
+      requirePresent ? undefined : () => null,
+    );
   }
 
   recordGithubEffect(
@@ -1366,18 +1379,25 @@ export class ExactReviewLifecycleProjectionStore {
     input: ProjectionIdentity,
     apply: (projection: ExactReviewLifecycleProjection) => T,
     writeResult = true,
+    onMissing?: () => T,
   ): T {
-    return this.storage.transactionSync(() => this.mutateSync(input, apply, writeResult));
+    return this.storage.transactionSync(() =>
+      this.mutateSync(input, apply, writeResult, onMissing),
+    );
   }
 
   private mutateSync<T>(
     input: ProjectionIdentity,
     apply: (projection: ExactReviewLifecycleProjection) => T,
     writeResult = true,
+    onMissing?: () => T,
   ): T {
     this.ensureSchemaSync();
     const projection = this.readSync(input.canonicalTargetKey, input.fenceKey, input.revision);
-    if (!projection) throw new Error("missing lifecycle admission fact");
+    if (!projection) {
+      if (onMissing) return onMissing();
+      throw new Error("missing lifecycle admission fact");
+    }
     this.assertIdentity(projection, input);
     const result = apply(projection);
     if (writeResult) {

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -2620,11 +2620,13 @@ export class ExactReviewQueue {
         fenceKey: lifecycleItem.key,
         revision: lifecycleRevision,
       };
-      const projectionBeforeTerminalCommit = this.lifecycleProjectionStore.read(
-        lifecycleIdentity.canonicalTargetKey,
-        lifecycleIdentity.fenceKey,
-        lifecycleIdentity.revision,
-      );
+      const projectionBeforeTerminalCommit = publicationCompletionOwnedByLease
+        ? this.lifecycleProjectionStore.read(
+            lifecycleIdentity.canonicalTargetKey,
+            lifecycleIdentity.fenceKey,
+            lifecycleIdentity.revision,
+          )
+        : null;
       const terminalDisposition = exactReviewLifecycleCompletionDisposition({
         projection: projectionBeforeTerminalCommit,
         outcome,
@@ -2729,7 +2731,7 @@ export class ExactReviewQueue {
           : undefined,
         completionResult.deadLetter,
       );
-      this.recordLifecycleCompletion({
+      const projectionAfterCompletion = this.recordLifecycleCompletion({
         item: lifecycleItem,
         revision: lifecycleRevision,
         claimGeneration: lifecycleClaimGeneration,
@@ -2752,11 +2754,6 @@ export class ExactReviewQueue {
           observedAt: now,
         });
       }
-      const projectionAfterCompletion = this.lifecycleProjectionStore.read(
-        lifecycleIdentity.canonicalTargetKey,
-        lifecycleIdentity.fenceKey,
-        lifecycleIdentity.revision,
-      );
       if (projectionAfterCompletion?.terminalDisposition?.kind === "requeue") {
         if (this.cancelTerminalFinalizationDrivers(state, lifecycleIdentity)) {
           await this.writeState(state);
@@ -8402,10 +8399,7 @@ export class ExactReviewQueue {
   }
 
   private bayTelemetryRecoveryPendingSync() {
-    return (
-      this.lifecycleProjectionStore.hasBayTelemetryPending() ||
-      this.lifecycleTelemetryStore.hasBayLifecyclePending()
-    );
+    return this.lifecycleTelemetryStore.hasBayLifecyclePending(true);
   }
 
   private reconcileBayTelemetryInternalSync(now = Date.now()) {
@@ -8519,13 +8513,7 @@ export class ExactReviewQueue {
       fenceKey: item.key,
       revision,
     };
-    const projection = this.lifecycleProjectionStore.read(
-      identity.canonicalTargetKey,
-      identity.fenceKey,
-      identity.revision,
-    );
-    if (!projection || projection.fenceKey !== identity.fenceKey) return;
-    this.lifecycleProjectionStore.recordReviewResult({
+    const reviewed = this.lifecycleProjectionStore.recordReviewResultIfPresent({
       ...identity,
       claimGeneration,
       runId,
@@ -8533,8 +8521,9 @@ export class ExactReviewQueue {
       outcome: outcome === "success" ? "completed" : outcome === "failure" ? "failed" : outcome,
       observedAt: now,
     });
+    if (!reviewed) return;
     const disposition = exactReviewLifecycleCompletionDisposition({
-      projection,
+      projection: reviewed,
       outcome,
       publicationCompletion,
       requeued,
@@ -8549,7 +8538,9 @@ export class ExactReviewQueue {
         observedAt: now,
       });
       this.syncBayLifecycle(terminal);
+      return terminal;
     }
+    return reviewed;
   }
 
   private recordLifecycleCanonicalReceipt(value: unknown) {
@@ -10480,12 +10471,23 @@ export class ExactReviewQueue {
       (oldest, item) => (oldest === null ? item.createdAt : Math.min(oldest, item.createdAt)),
       null,
     );
-    const flow = this.publicationFlowSummarySync(now).last_15_minutes;
+    // Admission needs only the drain rate, not the diagnostic cause inventory
+    // or the longer observation window.
+    const flow = Array.from(
+      this.storage.sql.exec(
+        `SELECT COALESCE(SUM(publication_enqueued), 0) AS enqueued,
+              COALESCE(SUM(publication_resolved), 0) AS resolved
+         FROM ${EXACT_REVIEW_QUEUE_METRIC_BUCKET_TABLE}
+        WHERE bucket_start >= ?`,
+        now - 15 * 60_000,
+      ),
+    )[0] as { enqueued: number; resolved: number } | undefined;
     const next = exactReviewPublicationControlAfterDemand(this.env, current, {
       at: now,
       backlog: pending.length,
       oldestPendingAgeMs: oldestPendingAt === null ? 0 : Math.max(0, now - oldestPendingAt),
-      netDrainRatePerHour: flow.net_drain_rate_per_hour,
+      netDrainRatePerHour:
+        Math.round((Number(flow?.resolved || 0) - Number(flow?.enqueued || 0)) * 4 * 10) / 10,
     });
     if (stableJson(next) !== stableJson(objectValue(stored))) {
       this.storage.kv.put(EXACT_REVIEW_PUBLICATION_CONTROL_KEY, next);
@@ -10612,8 +10614,29 @@ export class ExactReviewQueue {
     ) {
       return;
     }
-    this.storage.sql.exec(
-      `UPDATE ${EXACT_REVIEW_QUEUE_METRICS_TABLE}
+    // Review retry has a time bucket but no cumulative total column.
+    if (
+      !(
+        reviewRetried &&
+        !reviewEnqueued &&
+        !reviewCompleted &&
+        !reviewSuperseded &&
+        !reviewSemanticDeduped &&
+        !reviewShed &&
+        !reviewShedBackpressure &&
+        !reviewShedScheduledRate &&
+        !publicationEnqueued &&
+        !publicationCompleted &&
+        !publicationPublished &&
+        !publicationSuperseded &&
+        !publicationSemanticDeduped &&
+        !publicationRetried &&
+        !publicationDeadLettered &&
+        !publicationRefreshed
+      )
+    ) {
+      this.storage.sql.exec(
+        `UPDATE ${EXACT_REVIEW_QUEUE_METRICS_TABLE}
           SET review_enqueued_total = review_enqueued_total + ?,
               review_completed_total = review_completed_total + ?,
               review_superseded_total = review_superseded_total + ?,
@@ -10630,22 +10653,23 @@ export class ExactReviewQueue {
               publication_dead_lettered_total = publication_dead_lettered_total + ?,
               publication_refreshed_total = publication_refreshed_total + ?
         WHERE singleton_id = 1`,
-      reviewEnqueued,
-      reviewCompleted,
-      reviewSuperseded,
-      reviewSemanticDeduped,
-      reviewShed,
-      reviewShedBackpressure,
-      reviewShedScheduledRate,
-      publicationEnqueued,
-      publicationCompleted,
-      publicationPublished,
-      publicationSuperseded,
-      publicationSemanticDeduped,
-      publicationRetried,
-      publicationDeadLettered,
-      publicationRefreshed,
-    );
+        reviewEnqueued,
+        reviewCompleted,
+        reviewSuperseded,
+        reviewSemanticDeduped,
+        reviewShed,
+        reviewShedBackpressure,
+        reviewShedScheduledRate,
+        publicationEnqueued,
+        publicationCompleted,
+        publicationPublished,
+        publicationSuperseded,
+        publicationSemanticDeduped,
+        publicationRetried,
+        publicationDeadLettered,
+        publicationRefreshed,
+      );
+    }
     this.incrementQueueMetricBucketSync({
       reviewEnqueued,
       reviewCompleted,
@@ -12484,11 +12508,44 @@ export class ExactReviewQueue {
     }
   }
 
-  private async scheduleNext(state: ExactReviewQueueState, now: number) {
+  private scheduleNext(state: ExactReviewQueueState, now: number, forceScan = false) {
+    return this.scheduleNextFromState(state, now, forceScan);
+  }
+
+  private async scheduleNextFromState(
+    state: ExactReviewQueueState,
+    now: number,
+    forceScan: boolean,
+  ) {
+    // Materialize the lazy properties once; repeated Object.values over their
+    // accessor dictionary is substantially more expensive than a plain census.
+    state = { ...state, items: { ...state.items } };
     const publicationControl = this.refreshPublicationControlSync(state, now);
     const batchOwnership = this.batchStore.activeLeaseSnapshot(now);
+    const preservedWakeAt = this.scheduledAlarmDecision?.[1];
+    // With every pending item delayed past the alarm and every active lease
+    // still valid then, neither admission nor batch departure can wake earlier.
+    // Parked/unknown states use the full path. Auxiliary wake-ups are always
+    // read below, and the actual alarm is checked again after the awaits.
+    const preserveQueueWake =
+      !forceScan &&
+      preservedWakeAt !== undefined &&
+      preservedWakeAt > now &&
+      state.dispatcher?.state !== "paused" &&
+      state.dispatcher?.state !== "blocked" &&
+      Object.keys(state.items).length > 0 &&
+      Object.values(state.items).every((item) =>
+        item.state === "pending"
+          ? item.nextAttemptAt >= preservedWakeAt
+          : (item.state === "leased" || item.state === "dispatching") &&
+            exactReviewEffectiveLeaseExpiresAt(
+              item,
+              exactReviewPublicationDispatchLeaseMs(this.env),
+              exactReviewHeartbeatGraceMs(this.env),
+            ) >= preservedWakeAt,
+      );
     const legacyExcludedItemKeys = new Set<string>(batchOwnership.itemKeys);
-    if (exactReviewPublicationBatchingEnabled(this.env)) {
+    if (!preserveQueueWake && exactReviewPublicationBatchingEnabled(this.env)) {
       for (const item of Object.values(state.items)) {
         // Block only new legacy admission. In-flight legacy publications must
         // retain their dispatch/lease expiry wake-ups while the rollout drains.
@@ -12501,37 +12558,41 @@ export class ExactReviewQueue {
         }
       }
     }
-    const queueNext = exactReviewQueueNextWakeAt(
-      state,
-      now,
-      exactReviewQueueCapacity(this.env),
-      exactReviewTargetCapacity(this.env),
-      exactReviewPublicationCapacityForState(
-        this.env,
-        state,
-        now,
-        publicationControl.capacityCeiling,
-        true,
-        publicationControl.demandCapacity,
-      ),
-      exactReviewPublicationDispatchLeaseMs(this.env),
-      exactReviewHeartbeatGraceMs(this.env),
-      legacyExcludedItemKeys,
-      batchOwnership.nextLeaseExpiresAt,
-      Number(state.dispatcher?.reviewAdmissionNextAt || 0) > now
-        ? Number(state.dispatcher?.reviewAdmissionNextAt)
-        : null,
-    );
-    const heads = this.publicationHeadsSync(state);
-    const batchDeparture = exactReviewPublicationBatchDeparture(
-      this.env,
-      state,
-      now,
-      new Set(batchOwnership.itemKeys),
-      batchOwnership.activeBatches,
-      this.freshPublicationItemKeysSync(state, now, heads),
-      this.supersededPublicationItemKeysSync(state, heads),
-    );
+    const queueNext = preserveQueueWake
+      ? preservedWakeAt
+      : exactReviewQueueNextWakeAt(
+          state,
+          now,
+          exactReviewQueueCapacity(this.env),
+          exactReviewTargetCapacity(this.env),
+          exactReviewPublicationCapacityForState(
+            this.env,
+            state,
+            now,
+            publicationControl.capacityCeiling,
+            true,
+            publicationControl.demandCapacity,
+          ),
+          exactReviewPublicationDispatchLeaseMs(this.env),
+          exactReviewHeartbeatGraceMs(this.env),
+          legacyExcludedItemKeys,
+          batchOwnership.nextLeaseExpiresAt,
+          Number(state.dispatcher?.reviewAdmissionNextAt || 0) > now
+            ? Number(state.dispatcher?.reviewAdmissionNextAt)
+            : null,
+        );
+    const heads = preserveQueueWake ? new Map<string, number>() : this.publicationHeadsSync(state);
+    const batchDeparture = preserveQueueWake
+      ? null
+      : exactReviewPublicationBatchDeparture(
+          this.env,
+          state,
+          now,
+          new Set(batchOwnership.itemKeys),
+          batchOwnership.activeBatches,
+          this.freshPublicationItemKeysSync(state, now, heads),
+          this.supersededPublicationItemKeysSync(state, heads),
+        );
     const sourceAuthorityNext = await this.nextSourceAuthorityVerificationAt();
     const commandIntakeNext = this.commandIntakeStore.nextAttemptAt();
     const credentialCircuitNext = exactReviewGithubCircuitNextWakeAt(state, now);
@@ -12560,6 +12621,15 @@ export class ExactReviewQueue {
     }
     const next = selected[1]!;
     const scheduled = await this.storage.getAlarm();
+    if (
+      preserveQueueWake &&
+      (scheduled === null || scheduled <= now || scheduled > preservedWakeAt)
+    ) {
+      // An alarm was consumed/replaced while we awaited another authority.
+      // Re-read durable state instead of reusing the earlier request snapshot.
+      await this.scheduleNextFromState(this.readSchedulingStateSync(), Date.now(), true);
+      return;
+    }
     if (scheduled === null || scheduled <= now || next < scheduled) {
       await this.storage.setAlarm(next);
       this.scheduledAlarmDecision = [

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -2731,35 +2731,39 @@ export class ExactReviewQueue {
           : undefined,
         completionResult.deadLetter,
       );
-      const projectionAfterCompletion = this.recordLifecycleCompletion({
-        item: lifecycleItem,
-        revision: lifecycleRevision,
-        claimGeneration: lifecycleClaimGeneration,
-        runId,
-        runAttempt,
-        outcome,
-        publicationCompletion,
-        requeued: lifecycleRequeued,
-        parked: Boolean(completionResult.parked),
-        deadLetter: Boolean(completionResult.deadLetter),
-        lifecycleTerminal,
-        now,
-      });
-      if (publicationItem && publicationCompletion) {
-        this.recordLifecycleTelemetryNonBatchPublication({
-          identity: lifecycleIdentity,
+      try {
+        const projectionAfterCompletion = this.recordLifecycleCompletion({
+          item: lifecycleItem,
+          revision: lifecycleRevision,
           claimGeneration: lifecycleClaimGeneration,
-          completion: publicationCompletion,
-          projection: projectionBeforeTerminalCommit,
-          observedAt: now,
+          runId,
+          runAttempt,
+          outcome,
+          publicationCompletion,
+          requeued: lifecycleRequeued,
+          parked: Boolean(completionResult.parked),
+          deadLetter: Boolean(completionResult.deadLetter),
+          lifecycleTerminal,
+          now,
         });
-      }
-      if (projectionAfterCompletion?.terminalDisposition?.kind === "requeue") {
-        if (this.cancelTerminalFinalizationDrivers(state, lifecycleIdentity)) {
-          await this.writeState(state);
+        if (publicationItem && publicationCompletion) {
+          this.recordLifecycleTelemetryNonBatchPublication({
+            identity: lifecycleIdentity,
+            claimGeneration: lifecycleClaimGeneration,
+            completion: publicationCompletion,
+            projection: projectionBeforeTerminalCommit,
+            observedAt: now,
+          });
         }
+        if (projectionAfterCompletion?.terminalDisposition?.kind === "requeue") {
+          if (this.cancelTerminalFinalizationDrivers(state, lifecycleIdentity)) {
+            await this.writeState(state);
+          }
+        }
+      } finally {
+        // The queue transition is durable even when its lifecycle update fails.
+        await this.scheduleNext(state, now);
       }
-      await this.scheduleNext(state, now);
       return json({
         ok: true,
         requeued,

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -139,6 +139,11 @@ travels as structured apply evidence; reason text is diagnostic only. Ambiguous
 or mixed results cannot terminalize the artifact, and legacy tupleless artifacts
 retain the existing fresh-review path.
 
+Legacy protocol-v1 review leases without lifecycle admission rows complete without
+writing lifecycle facts. Once a completion commits its queue transition, alarm
+scheduling runs even if the subsequent lifecycle update fails, so persisted
+retries retain their scheduled wake-up.
+
 Review publication and apply/comment sync use separate non-dropping queues.
 Apply treats a typed GitHub installation or abuse-rate-limit response as a
 bounded yield, not a failed scan. It checkpoints completed item work, records

--- a/scripts/proof-queue-completion.mjs
+++ b/scripts/proof-queue-completion.mjs
@@ -1,0 +1,209 @@
+// Controlled workerd proof; tooling is the repository-pinned Wrangler installed
+// outside the checkout. No deployment, credentials, or external calls are used.
+// node scripts/proof-queue-completion.mjs BASE TOOL_PREFIX FRESH_OUTPUT_DIR
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { cpSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+const [baseRef, toolPrefix, output] = process.argv.slice(2);
+assert.ok(baseRef && toolPrefix && output, "expected BASE TOOL_PREFIX FRESH_OUTPUT_DIR");
+const require = createRequire(path.resolve(toolPrefix, "package.json"));
+const { Miniflare } = require("miniflare");
+const { build } = require("esbuild");
+const root = process.cwd();
+const out = path.resolve(output);
+mkdirSync(out);
+const git = (...args) => execFileSync("git", args, { encoding: "utf8" }).trim();
+const base = git("rev-parse", `${baseRef}^{commit}`);
+const head = git("rev-parse", "HEAD");
+const now = Date.parse("2030-01-01T12:00:00Z");
+const changed = [
+  "dashboard/exact-review-queue.ts",
+  "dashboard/exact-review-lifecycle.ts",
+  "dashboard/exact-review-lifecycle-telemetry.ts",
+];
+const results = {};
+const manifest = {
+  base,
+  head,
+  runtime: "workerd / SQLite Durable Object",
+  fixture: { pending_publications: 300, leased_reviews: 50, pending_reviews: 15 },
+  sources: {},
+};
+for (const variant of ["baseline", "patched"]) {
+  const dir = path.join(out, variant);
+  mkdirSync(dir);
+  execFileSync("tar", ["-x", "-C", dir], {
+    input: execFileSync("git", ["archive", base], { maxBuffer: 128 * 1024 * 1024 }),
+  });
+  if (variant === "patched")
+    for (const file of changed) cpSync(path.join(root, file), path.join(dir, file));
+  manifest.sources[variant] = Object.fromEntries(
+    changed.map((file) => [
+      file,
+      createHash("sha256")
+        .update(readFileSync(path.join(dir, file)))
+        .digest("hex"),
+    ]),
+  );
+  const entry = `
+import { ExactReviewQueue } from './dashboard/exact-review-queue.ts';
+Date.now = () => ${now};
+export class ProofQueue extends ExactReviewQueue {
+  constructor(ctx, env) {
+    const counts = { sql: 0 };
+    const storage = new Proxy(ctx.storage, { get(target, key) {
+      if (key === 'sql') return { exec: (...args) => { counts.sql++; return target.sql.exec(...args); } };
+      const value = target[key];
+      return typeof value === 'function' ? value.bind(target) : value;
+    }});
+    super({storage, blockConcurrencyWhile: ctx.blockConcurrencyWhile.bind(ctx)}, {...env, EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: '1', hostedTargetPredicate: () => true, hostedPublicTargetProbe: async () => 'public'}, () => 0.5);
+    this.counts = counts;
+  }
+  async fetch(request) {
+    const body = await request.json();
+    if (body.seed) {
+      await super.fetch(new Request('https://queue/stats'));
+      for (let n = 1; n <= 365; n++) {
+        const key = 'openclaw/openclaw#' + n;
+        const producerDecision = {targetRepo: 'openclaw/openclaw', targetBranch: 'main', itemNumber: n, itemKind: 'issue', sourceEvent: 'issues', sourceAction: 'opened', supersedesInProgress: false, ...(n % 5 === 0 ? {additionalPrompt: 'Synthetic source evidence. '.repeat(160)} : {})};
+        const publication = {artifactName: 'exact-review-' + (10000+n) + '-1', producerRunId: String(10000+n), producerRunAttempt: 1, sourceSha: 'a'.repeat(40), itemKey: key, protocolVersion: 2, leaseRevision: 1, claimGeneration: 1, liveProceeded: true, liveTerminalNoop: false, liveTerminalMissing: false, liveGuardedOpen: false, producerDecision};
+        const decision = n <= 300 ? {...producerDecision, sourceAction: 'exact_review_artifact_publish', publication} : producerDecision;
+        const item = {key: n <= 300 ? key + '@publish:' + (10000+n) + ':1' : key, decision, state: n <= 300 || n > 350 ? 'pending' : 'leased', revision: 1, attempts: 0, createdAt: Date.now()-60000-n, updatedAt: Date.now()-60000, nextAttemptAt: Date.now()+60000,
+          ...(n > 300 && n <= 350 ? {leaseDecision: decision, leaseId: 'lease-'+n, leaseRevision: 1, leaseExpiresAt: Date.now()+3600000, claimedRunId: String(10000+n), claimedRunAttempt: 1, claimGeneration: 1, claimProtocolVersion: 2} : {})};
+        this.storage.sql.exec('INSERT INTO exact_review_queue_items (item_key,item_json) VALUES (?,?)', item.key, JSON.stringify(item));
+        this.storage.sql.exec('INSERT INTO exact_review_publication_heads (target_key,source_revision,updated_at) VALUES (?,1,?)', key, Date.now());
+        this.lifecycleProjectionStore.recordAdmission({canonicalTargetKey: key, fenceKey: item.key, revision: 1, deliveryId: 'fixture-'+n, sourceAction: 'opened', commandOriginated: n === 41, statusMarker: null, statusCommentId: n === 41 ? 41 : null, observedAt: Date.now()-60000});
+        if (body.terminal && n === 301) {
+          const driver = {...item, key: item.key+'@finalizer', decision: {...decision, sourceAction: 'exact_review_artifact_publish', publication, statusCommentId: 41}, terminalFinalization: {disposition: 'policy_noop', statusState: 'Complete', statusDetail: 'No action required.', projection: {canonicalTargetKey: 'openclaw/openclaw#41', fenceKey: 'openclaw/openclaw#41@publish:10041:1', revision: 1}}};
+          this.storage.sql.exec('INSERT INTO exact_review_queue_items (item_key,item_json) VALUES (?,?)', driver.key, JSON.stringify(driver));
+        }
+      }
+      this.storage.sql.exec('UPDATE exact_review_queue_meta SET migrated_at = ?', Date.now()-172800000);
+      this.migratedAt = Date.now()-172800000;
+      this.storage.kv.delete('exact-review-queue');
+      await super.fetch(new Request('https://queue/stats'));
+      return Response.json({seeded: true});
+    }
+    if (body.snapshot) {
+      const tables = ['exact_review_queue_items', 'exact_review_queue_metrics', 'exact_review_queue_metric_buckets', 'exact_review_lifecycle_projection_v1'];
+      return Response.json({tables: Object.fromEntries(tables.map(table => [table, [...this.storage.sql.exec('SELECT * FROM '+table+' ORDER BY rowid')]])), alarm: await this.storage.getAlarm(), stats: await (await super.fetch(new Request('https://queue/stats'))).json()});
+    }
+    this.counts.sql = 0;
+    const response = await super.fetch(new Request('https://queue'+body.path, {method: 'POST', headers: {'content-type':'application/json'}, body: JSON.stringify(body.payload)}));
+    return Response.json({status: response.status, body: await response.json(), sql: this.counts.sql});
+  }
+}
+export default { fetch(request, env) { return env.QUEUE.get(env.QUEUE.idFromName(new URL(request.url).pathname)).fetch(request); } };
+`;
+  writeFileSync(path.join(dir, "proof-worker.ts"), entry);
+  const bundle = await build({
+    entryPoints: [path.join(dir, "proof-worker.ts")],
+    bundle: true,
+    write: false,
+    format: "esm",
+    platform: "browser",
+    target: "es2022",
+    external: ["node:*", "cloudflare:*"],
+  });
+  let externalCalls = 0;
+  const mf = new Miniflare({
+    modules: true,
+    script: bundle.outputFiles[0].text,
+    compatibilityDate: "2026-07-08",
+    compatibilityFlags: ["nodejs_compat"],
+    durableObjects: { QUEUE: { className: "ProofQueue", useSQLite: true } },
+    outboundService: () => {
+      externalCalls++;
+      throw new Error("proof forbids external requests");
+    },
+  });
+  try {
+    results[variant] = {};
+    for (const route of [
+      "complete-success",
+      "complete-failure",
+      "lifecycle/router-receipt",
+      "terminal-finalization/attempt",
+      "heartbeat",
+    ]) {
+      const call = async (body) =>
+        (
+          await mf.dispatchFetch("http://proof/" + route, {
+            method: "POST",
+            body: JSON.stringify(body),
+          })
+        ).json();
+      assert.deepEqual(
+        await call({ seed: true, terminal: route === "terminal-finalization/attempt" }),
+        { seeded: true },
+      );
+      const tuple = {
+        item_key:
+          "openclaw/openclaw#301" + (route === "terminal-finalization/attempt" ? "@finalizer" : ""),
+        lease_id: "lease-301",
+        lease_revision: 1,
+        claim_generation: 1,
+        run_id: "10301",
+        run_attempt: 1,
+      };
+      const payload = route.startsWith("complete-")
+        ? { ...tuple, outcome: route === "complete-success" ? "success" : "failure" }
+        : route === "lifecycle/router-receipt"
+          ? {
+              canonical_target_key: "openclaw/openclaw#1",
+              fence_key: "openclaw/openclaw#1@publish:10001:1",
+              revision: 1,
+              receipt_id: "proof-receipt",
+            }
+          : {
+              ...tuple,
+              ...(route === "terminal-finalization/attempt" ? { status_comment_id: 41 } : {}),
+            };
+      const result = await call({
+        path: route.startsWith("complete-") ? "/complete" : "/" + route,
+        payload,
+      });
+      assert.equal(result.status, 200, JSON.stringify(result));
+      const snapshot = await call({ snapshot: true });
+      // No trace ids, credentials, or production data enter the artifacts.
+      writeFileSync(
+        path.join(out, variant + "-" + route.replaceAll("/", "-") + ".json"),
+        JSON.stringify({ result, snapshot }, null, 2) + "\n",
+      );
+      results[variant][route] = { result, snapshot };
+    }
+    assert.equal(externalCalls, 0);
+  } finally {
+    await mf.dispose();
+  }
+}
+for (const route of Object.keys(results.baseline)) {
+  assert.deepEqual(
+    results.patched[route].result.body,
+    results.baseline[route].result.body,
+    route + " response",
+  );
+  assert.deepEqual(
+    results.patched[route].snapshot,
+    results.baseline[route].snapshot,
+    route + " durable state / admission / alarm",
+  );
+}
+manifest.results = Object.fromEntries(
+  Object.keys(results.baseline).map((route) => [
+    route,
+    {
+      equivalent: true,
+      before_sql: results.baseline[route].result.sql,
+      after_sql: results.patched[route].result.sql,
+    },
+  ]),
+);
+manifest.limits =
+  "Synthetic local workerd, no network effects or production CPU prediction; one extra publication driver for terminal-finalization.";
+writeFileSync(path.join(out, "manifest.json"), JSON.stringify(manifest, null, 2) + "\n");
+console.log(JSON.stringify(manifest, null, 2));

--- a/scripts/proof-queue-completion.mjs
+++ b/scripts/proof-queue-completion.mjs
@@ -74,9 +74,13 @@ export class ProofQueue extends ExactReviewQueue {
         const decision = n <= 300 ? {...producerDecision, sourceAction: 'exact_review_artifact_publish', publication} : producerDecision;
         const item = {key: n <= 300 ? key + '@publish:' + (10000+n) + ':1' : key, decision, state: n <= 300 || n > 350 ? 'pending' : 'leased', revision: 1, attempts: 0, createdAt: Date.now()-60000-n, updatedAt: Date.now()-60000, nextAttemptAt: Date.now()+60000,
           ...(n > 300 && n <= 350 ? {leaseDecision: decision, leaseId: 'lease-'+n, leaseRevision: 1, leaseExpiresAt: Date.now()+3600000, claimedRunId: String(10000+n), claimedRunAttempt: 1, claimGeneration: 1, claimProtocolVersion: 2} : {})};
+        if (body.legacy && n === 301) {
+          delete item.claimGeneration;
+          item.claimProtocolVersion = 1;
+        }
         this.storage.sql.exec('INSERT INTO exact_review_queue_items (item_key,item_json) VALUES (?,?)', item.key, JSON.stringify(item));
         this.storage.sql.exec('INSERT INTO exact_review_publication_heads (target_key,source_revision,updated_at) VALUES (?,1,?)', key, Date.now());
-        this.lifecycleProjectionStore.recordAdmission({canonicalTargetKey: key, fenceKey: item.key, revision: 1, deliveryId: 'fixture-'+n, sourceAction: 'opened', commandOriginated: n === 41, statusMarker: null, statusCommentId: n === 41 ? 41 : null, observedAt: Date.now()-60000});
+        if (!body.legacy || n !== 301) this.lifecycleProjectionStore.recordAdmission({canonicalTargetKey: key, fenceKey: item.key, revision: 1, deliveryId: 'fixture-'+n, sourceAction: 'opened', commandOriginated: n === 41, statusMarker: null, statusCommentId: n === 41 ? 41 : null, observedAt: Date.now()-60000});
         if (body.terminal && n === 301) {
           const driver = {...item, key: item.key+'@finalizer', decision: {...decision, sourceAction: 'exact_review_artifact_publish', publication, statusCommentId: 41}, terminalFinalization: {disposition: 'policy_noop', statusState: 'Complete', statusDetail: 'No action required.', projection: {canonicalTargetKey: 'openclaw/openclaw#41', fenceKey: 'openclaw/openclaw#41@publish:10041:1', revision: 1}}};
           this.storage.sql.exec('INSERT INTO exact_review_queue_items (item_key,item_json) VALUES (?,?)', driver.key, JSON.stringify(driver));
@@ -86,6 +90,7 @@ export class ProofQueue extends ExactReviewQueue {
       this.migratedAt = Date.now()-172800000;
       this.storage.kv.delete('exact-review-queue');
       await super.fetch(new Request('https://queue/stats'));
+      if (body.legacy) await this.storage.setAlarm(Date.now()+3600000);
       return Response.json({seeded: true});
     }
     if (body.snapshot) {
@@ -126,6 +131,8 @@ export default { fetch(request, env) { return env.QUEUE.get(env.QUEUE.idFromName
     for (const route of [
       "complete-success",
       "complete-failure",
+      "complete-legacy-success",
+      "complete-legacy-failure",
       "lifecycle/router-receipt",
       "terminal-finalization/attempt",
       "heartbeat",
@@ -138,7 +145,11 @@ export default { fetch(request, env) { return env.QUEUE.get(env.QUEUE.idFromName
           })
         ).json();
       assert.deepEqual(
-        await call({ seed: true, terminal: route === "terminal-finalization/attempt" }),
+        await call({
+          seed: true,
+          terminal: route === "terminal-finalization/attempt",
+          legacy: route.startsWith("complete-legacy-"),
+        }),
         { seeded: true },
       );
       const tuple = {
@@ -150,25 +161,54 @@ export default { fetch(request, env) { return env.QUEUE.get(env.QUEUE.idFromName
         run_id: "10301",
         run_attempt: 1,
       };
-      const payload = route.startsWith("complete-")
-        ? { ...tuple, outcome: route === "complete-success" ? "success" : "failure" }
-        : route === "lifecycle/router-receipt"
-          ? {
-              canonical_target_key: "openclaw/openclaw#1",
-              fence_key: "openclaw/openclaw#1@publish:10001:1",
-              revision: 1,
-              receipt_id: "proof-receipt",
-            }
-          : {
-              ...tuple,
-              ...(route === "terminal-finalization/attempt" ? { status_comment_id: 41 } : {}),
-            };
+      const payload = route.startsWith("complete-legacy-")
+        ? {
+            lease_id: tuple.lease_id,
+            run_id: tuple.run_id,
+            run_attempt: tuple.run_attempt,
+            outcome: route.endsWith("success") ? "success" : "failure",
+            ...(route.endsWith("failure")
+              ? { retry_at: new Date(now + 30_000).toISOString() }
+              : {}),
+          }
+        : route.startsWith("complete-")
+          ? { ...tuple, outcome: route === "complete-success" ? "success" : "failure" }
+          : route === "lifecycle/router-receipt"
+            ? {
+                canonical_target_key: "openclaw/openclaw#1",
+                fence_key: "openclaw/openclaw#1@publish:10001:1",
+                revision: 1,
+                receipt_id: "proof-receipt",
+              }
+            : {
+                ...tuple,
+                ...(route === "terminal-finalization/attempt" ? { status_comment_id: 41 } : {}),
+              };
       const result = await call({
         path: route.startsWith("complete-") ? "/complete" : "/" + route,
         payload,
       });
       assert.equal(result.status, 200, JSON.stringify(result));
       const snapshot = await call({ snapshot: true });
+      if (route.startsWith("complete-legacy-")) {
+        const failed = route.endsWith("failure");
+        assert.deepEqual(result.body, { ok: true, requeued: failed });
+        assert.equal(snapshot.alarm, now + (failed ? 30_000 : 60_000));
+        const completed = snapshot.tables.exact_review_queue_items.find(
+          (row) => row.item_key === tuple.item_key,
+        );
+        if (failed) {
+          const item = JSON.parse(completed.item_json);
+          assert.equal(item.state, "pending");
+          assert.equal(item.nextAttemptAt, now + 30_000);
+        } else assert.equal(completed, undefined);
+        assert.equal(
+          snapshot.tables.exact_review_lifecycle_projection_v1.some(
+            (row) => row.fence_key === tuple.item_key,
+          ),
+          false,
+        );
+      }
       // No trace ids, credentials, or production data enter the artifacts.
       writeFileSync(
         path.join(out, variant + "-" + route.replaceAll("/", "-") + ".json"),

--- a/test/exact-review-queue-cpu.test.ts
+++ b/test/exact-review-queue-cpu.test.ts
@@ -407,6 +407,83 @@ type QueueInternals = {
 };
 const internals = (queue: ExactReviewQueue) => queue as unknown as QueueInternals;
 
+for (const outcome of ["success", "failure"] as const) {
+  for (const claimGeneration of [undefined, 1]) {
+    test(`legacy v1 ${outcome} completion without lifecycle row reschedules the alarm (generation ${claimGeneration})`, async (t) => {
+      t.mock.method(Date, "now", () => NOW);
+      const h = await fixture(0, {}, 2);
+      const q = internals(h.queue);
+      const state = q.readStateSync();
+      const item = state.items[h.items[0]!.key]!;
+      item.claimProtocolVersion = 1;
+      item.claimGeneration = claimGeneration;
+      const pending = state.items[h.items[1]!.key]!;
+      pending.state = "pending";
+      pending.nextAttemptAt = NOW + 60_000;
+      h.storage.transactionSync(() => q.writeStateSync(state));
+      h.storage.run(
+        `DELETE FROM ${EXACT_REVIEW_LIFECYCLE_PROJECTION_TABLE} WHERE fence_key = ?`,
+        item.key,
+      );
+      await h.storage.setAlarm(NOW + 3_600_000);
+
+      const response = await h.queue.fetch(
+        post("/complete", {
+          lease_id: item.leaseId,
+          run_id: item.claimedRunId,
+          run_attempt: item.claimedRunAttempt,
+          outcome,
+          ...(outcome === "failure" ? { retry_at: new Date(NOW + 30_000).toISOString() } : {}),
+        }),
+      );
+
+      assert.equal(response.status, 200);
+      assert.deepEqual(await response.json(), { ok: true, requeued: outcome === "failure" });
+      const completed = q.readStateSync().items[item.key];
+      if (outcome === "success") {
+        assert.equal(completed, undefined);
+        assert.equal(h.storage.scheduledAlarm(), NOW + 60_000);
+      } else {
+        assert.equal(completed?.state, "pending");
+        assert.equal(completed?.nextAttemptAt, NOW + 30_000);
+        assert.equal(h.storage.scheduledAlarm(), completed.nextAttemptAt);
+      }
+      assert.equal(h.lifecycle.read(item.key, item.key, item.revision), null);
+    });
+  }
+}
+
+test("completion reschedules a committed retry even when lifecycle validation throws", async (t) => {
+  t.mock.method(Date, "now", () => NOW);
+  const h = await fixture(0, {}, 1);
+  const q = internals(h.queue);
+  const state = q.readStateSync();
+  const item = state.items[h.items[0]!.key]!;
+  item.claimProtocolVersion = 1;
+  item.claimGeneration = undefined;
+  h.storage.transactionSync(() => q.writeStateSync(state));
+  await h.storage.setAlarm(NOW + 3_600_000);
+
+  await assert.rejects(
+    h.queue.fetch(
+      post("/complete", {
+        lease_id: item.leaseId,
+        run_id: item.claimedRunId,
+        run_attempt: item.claimedRunAttempt,
+        outcome: "failure",
+        retry_at: new Date(NOW + 30_000).toISOString(),
+      }),
+    ),
+    /invalid lifecycle review result/,
+  );
+
+  const retried = q.readStateSync().items[item.key]!;
+  assert.equal(retried.state, "pending");
+  assert.equal(retried.nextAttemptAt, NOW + 30_000);
+  assert.equal(h.storage.scheduledAlarm(), retried.nextAttemptAt);
+  assert.deepEqual(h.lifecycle.read(item.key, item.key, item.revision)?.reviewResults, []);
+});
+
 test("stats memo shares concurrent polls, expires, and retains the snapshot timestamp", async (t) => {
   let now = NOW;
   t.mock.method(Date, "now", () => now);

--- a/test/exact-review-queue-cpu.test.ts
+++ b/test/exact-review-queue-cpu.test.ts
@@ -1066,3 +1066,299 @@ test(
     console.log(JSON.stringify({ fixture: { lifecycle: 20_000 }, samples }));
   },
 );
+
+// Inclusive method timings overlap; SQL counts include every request query but
+// exclude fixture restoration. CPU is process CPU on Node/SQLite, not edge CPU.
+test(
+  "completion and receipt CPU breakdown (opt in)",
+  {
+    skip: process.env.EXACT_REVIEW_COMPLETION_CPU_BENCH !== "1",
+  },
+  async (t) => {
+    t.mock.method(Date, "now", () => NOW);
+    const samples = [];
+    for (const route of [
+      "complete-success",
+      "complete-failure",
+      "lifecycle/router-receipt",
+      "terminal-finalization/attempt",
+      "heartbeat",
+    ]) {
+      const h = await fixture(300, {}, 65);
+      for (const item of h.items.slice(350)) {
+        item.state = "pending";
+        for (const key of [
+          "leaseDecision",
+          "leaseId",
+          "leaseRevision",
+          "leaseExpiresAt",
+          "claimedRunId",
+          "claimedRunAttempt",
+          "claimGeneration",
+          "claimProtocolVersion",
+        ])
+          delete item[key];
+        h.storage.run(
+          "UPDATE exact_review_queue_items SET item_json = ? WHERE item_key = ?",
+          JSON.stringify(item),
+          item.key,
+        );
+      }
+      const metrics: Record<string, { cpu_ms: number; calls: number }> = {};
+      const instrument = (object, name, label = name) => {
+        const original = object[name];
+        object[name] = function (...args) {
+          const start = process.cpuUsage();
+          const finish = () => {
+            const cpu = process.cpuUsage(start);
+            const entry = (metrics[label] ??= { cpu_ms: 0, calls: 0 });
+            entry.cpu_ms += (cpu.user + cpu.system) / 1000;
+            entry.calls++;
+          };
+          try {
+            const result = original.apply(this, args);
+            if (result instanceof Promise) return result.finally(finish);
+            finish();
+            return result;
+          } catch (error) {
+            finish();
+            throw error;
+          }
+        };
+      };
+      for (const name of [
+        "readStateSync",
+        "readSchedulingStateSync",
+        "writeStateSync",
+        "scheduleNext",
+        "refreshPublicationControlSync",
+        "publicationHeadsSync",
+        "freshPublicationItemKeysSync",
+        "supersededPublicationItemKeysSync",
+        "syncBayLifecycle",
+        "incrementQueueMetricsSync",
+      ])
+        instrument(h.queue, name);
+      instrument(h.queue["lifecycleProjectionStore"], "writeSync", "lifecycleWrite");
+      const exec = h.storage.sql.exec;
+      let queries = 0;
+      const queryCounts = new Map<string, number>();
+      h.storage.sql.exec = (query, ...bindings) => {
+        queries++;
+        const normalized = query.replace(/\s+/g, " ").trim();
+        queryCounts.set(normalized, (queryCounts.get(normalized) || 0) + 1);
+        return exec(query, ...bindings);
+      };
+      const times = [];
+      for (let i = 0; i < 10; i++) {
+        // Terminal finalization needs one extra owned publication driver; all
+        // other routes retain exactly 300 publications / 50 leases / 15 pending.
+        const item = structuredClone(h.items[route === "lifecycle/router-receipt" ? i : 300 + i]!);
+        if (route === "terminal-finalization/attempt") {
+          item.key += "@finalizer";
+          item.decision = {
+            ...h.items[40]!.decision,
+            itemNumber: item.decision.itemNumber,
+            statusCommentId: 41,
+          };
+          item.terminalFinalization = {
+            disposition: "policy_noop",
+            statusState: "Complete",
+            statusDetail: "No action required.",
+            projection: {
+              canonicalTargetKey: "openclaw/openclaw#41",
+              fenceKey: h.items[40]!.key,
+              revision: 1,
+            },
+          };
+          h.storage.run(
+            "INSERT OR REPLACE INTO exact_review_queue_items (item_key,item_json) VALUES (?,?)",
+            item.key,
+            JSON.stringify(item),
+          );
+        }
+        const tuple = {
+          item_key: item.key,
+          lease_id: item.leaseId,
+          lease_revision: 1,
+          claim_generation: 1,
+          run_id: item.claimedRunId,
+          run_attempt: 1,
+        };
+        const request = route.startsWith("complete-")
+          ? post("/complete", {
+              ...tuple,
+              outcome: route === "complete-success" ? "success" : "failure",
+            })
+          : route === "lifecycle/router-receipt"
+            ? post(`/${route}`, {
+                canonical_target_key: `openclaw/openclaw#${i + 1}`,
+                fence_key: item.key,
+                revision: 1,
+                receipt_id: `breakdown-${i}`,
+              })
+            : post(`/${route}`, {
+                ...tuple,
+                ...(route === "terminal-finalization/attempt" ? { status_comment_id: 41 } : {}),
+              });
+        const start = process.cpuUsage();
+        const response = await h.queue.fetch(request);
+        const body = await response.json();
+        const cpu = process.cpuUsage(start);
+        times.push((cpu.user + cpu.system) / 1000);
+        assert.equal(response.status, 200, JSON.stringify(body));
+        if (route.startsWith("complete-"))
+          assert.equal(body.requeued, route === "complete-failure");
+        if (route === "terminal-finalization/attempt")
+          h.storage.run("DELETE FROM exact_review_queue_items WHERE item_key = ?", item.key);
+        else
+          h.storage.run(
+            "INSERT OR REPLACE INTO exact_review_queue_items (item_key,item_json) VALUES (?,?)",
+            item.key,
+            JSON.stringify(item),
+          );
+      }
+      times.sort((a, b) => a - b);
+      samples.push({
+        route,
+        median_cpu_ms: times[5],
+        max_cpu_ms: times.at(-1),
+        sql_per_call: queries / 10,
+        inclusive_methods: Object.fromEntries(
+          Object.entries(metrics).map(([key, value]) => [
+            key,
+            { cpu_ms: value.cpu_ms / 10, calls: value.calls / 10 },
+          ]),
+        ),
+        queries: [...queryCounts].map(([query, count]) => ({ query, per_call: count / 10 })),
+      });
+    }
+    console.log(
+      JSON.stringify({
+        fixture: { pending_publications: 300, leased_reviews: 50, pending_reviews: 15 },
+        samples,
+      }),
+    );
+  },
+);
+
+test("retained-alarm scheduling equals full scans across queue transitions and admission gates", async (t) => {
+  t.mock.method(Date, "now", () => NOW);
+  const scenarios = [
+    "unchanged",
+    "success",
+    "retry-later",
+    "retry-earlier",
+    "heartbeat",
+    "finalizing",
+    "ready-batch",
+    "expired-lease",
+    "parked",
+    "paused",
+    "target-cap",
+    "empty",
+  ];
+  for (const scenario of scenarios) {
+    const h = await fixture(300, {}, 65);
+    const q = h.queue as unknown as QueueInternals & {
+      scheduleNext(state: ExactReviewQueueState, now: number, forceScan?: boolean): Promise<void>;
+    };
+    const state = q.readStateSync();
+    for (const item of Object.values(state.items).slice(350)) {
+      item.state = "pending";
+      item.nextAttemptAt = NOW + 60_000;
+    }
+    const leased = state.items[h.items[300]!.key]!;
+    if (scenario === "success") delete state.items[leased.key];
+    if (scenario.startsWith("retry-")) {
+      leased.state = "pending";
+      leased.nextAttemptAt = NOW + (scenario === "retry-later" ? 120_000 : 5_000);
+    }
+    if (scenario === "heartbeat" || scenario === "finalizing") {
+      leased.leaseHeartbeatAt = NOW;
+      leased.leasePhase = scenario === "heartbeat" ? "review" : "finalizing";
+    }
+    if (scenario === "ready-batch")
+      for (const item of Object.values(state.items).slice(0, 8)) item.nextAttemptAt = NOW;
+    if (scenario === "expired-lease") leased.leaseExpiresAt = NOW - 1;
+    if (scenario === "parked") {
+      leased.state = "parked";
+      leased.parkedReason = "review_retry_exhausted";
+      leased.updatedAt = NOW;
+    }
+    if (scenario === "paused")
+      state.dispatcher = { ...state.dispatcher, state: "paused", retryAt: NOW + 10_000 };
+    if (scenario === "target-cap") h.env.EXACT_REVIEW_TARGET_MAX_CONCURRENT = "1";
+    if (scenario === "empty") state.items = {};
+    h.storage.transactionSync(() => q.writeStateSync(state));
+    const alarmBefore = h.storage.scheduledAlarm();
+    const controlsBefore = structuredClone(h.storage.kv.get("exact-review-publication-control:v1"));
+    const before = exactReviewQueueStats(q.readStateSync(), NOW, 128, 120, 32);
+    await q.scheduleNext(q.readStateSync(), NOW);
+    const actual = h.storage.scheduledAlarm();
+    const controlsAfter = structuredClone(h.storage.kv.get("exact-review-publication-control:v1"));
+    if (alarmBefore === null) await h.storage.deleteAlarm();
+    else await h.storage.setAlarm(alarmBefore);
+    if (controlsBefore === undefined) h.storage.kv.delete("exact-review-publication-control:v1");
+    else h.storage.kv.put("exact-review-publication-control:v1", controlsBefore);
+    await q.scheduleNext(q.readStateSync(), NOW, true);
+    assert.equal(actual, h.storage.scheduledAlarm(), scenario);
+    assert.deepEqual(
+      controlsAfter,
+      h.storage.kv.get("exact-review-publication-control:v1"),
+      scenario,
+    );
+    assert.deepEqual(before, exactReviewQueueStats(q.readStateSync(), NOW, 128, 120, 32), scenario);
+  }
+});
+
+test("retained alarm falls back to a fresh durable census after an await consumes the alarm", async (t) => {
+  t.mock.method(Date, "now", () => NOW);
+  const h = await fixture(10);
+  const q = internals(h.queue);
+  const original = h.storage.getAlarm.bind(h.storage);
+  let consumed = false;
+  t.mock.method(h.storage, "getAlarm", async () => {
+    if (!consumed) {
+      consumed = true;
+      await h.storage.deleteAlarm();
+      const item = { ...h.items[0]!, nextAttemptAt: NOW + 1_000 };
+      h.storage.run(
+        "UPDATE exact_review_queue_items SET item_json = ? WHERE item_key = ?",
+        JSON.stringify(item),
+        item.key,
+      );
+    }
+    return original();
+  });
+  await q.scheduleNext(q.readStateSync(), NOW);
+  assert.equal(h.storage.scheduledAlarm(), NOW + 1_000);
+});
+
+test("receipt without a final timing boundary updates only its lifecycle row and never rebuilds tides", async (t) => {
+  t.mock.method(Date, "now", () => NOW);
+  const h = await fixture(300);
+  const sql = t.mock.method(h.storage.sql, "exec");
+  const item = h.items[0]!;
+  const response = await h.queue.fetch(
+    post("/lifecycle/router-receipt", {
+      canonical_target_key: "openclaw/openclaw#1",
+      fence_key: item.key,
+      revision: 1,
+      receipt_id: "no-final-boundary",
+    }),
+  );
+  assert.equal(response.status, 200);
+  const queries = sql.mock.calls.map((call) => call.arguments[0]);
+  assert.equal(queries.filter((query) => /WITH lifecycle_events/.test(query)).length, 0);
+  for (const call of sql.mock.calls.filter((call) =>
+    /(?:INSERT INTO|UPDATE) exact_review_lifecycle_projection_v1/.test(call.arguments[0]),
+  )) {
+    assert.ok(call.arguments.includes("openclaw/openclaw#1"));
+    assert.ok(call.arguments.includes(item.key));
+  }
+  assert.equal(
+    h.lifecycle.read("openclaw/openclaw#2", h.items[1]!.key, 1)!.terminalDisposition,
+    null,
+  );
+});


### PR DESCRIPTION
Related: https://github.com/openclaw/clawsweeper/issues/1372

Production tail from 2026-09-04 01:35–01:38 UTC (146 seconds): `/complete` consumed 24,752 ms CPU, `/lifecycle/router-receipt` 8,773 ms, `/terminal-finalization/attempt` 3,114 ms, and `/heartbeat` 1,017 ms. Streaming the supplied objects found 20 completions (1,238 ms/call), six router receipts (1,462 ms/call), one terminal-finalization attempt, and 81 heartbeats. The 22,980 ms in `/records/export` belongs to separate work. Raw tail evidence was deleted and is not in this change.

## What Changed

Retain an existing future alarm when every pending item and active lease proves that queue work cannot wake earlier. Ready work, parked/unknown states, and paused/blocked dispatchers use the full scheduling path. Batch ownership and auxiliary wake-ups are still read; an alarm consumed or replaced across an await triggers a fresh durable census. Materialize lazy properties once for the remaining scheduling passes.

Read only the 15-minute publication drain-rate counters required by admission, omit the zero-delta cumulative update for review retries, and combine the two Bay recovery checks. Read/update a review result in its existing transaction and reuse its returned projection where no await intervenes. Unread queue items retain their original serialized bytes, and lifecycle writes remain confined to the affected row.

Avoid rebuilding the full historical tide for a receipt that has never had an immutable final-effect timing boundary. Existing materialization markers and actual historical terminal events retain the retraction path, including after retention. Revision/generation fences, transaction boundaries, post-await reads, bindings, migrations, and public field sets are unchanged.

## Before / After Benchmark

Node 26.8.1 with real SQLite on macOS; 10 measured requests per scenario, 300 pending publications, 50 leased reviews, and 15 pending reviews. Terminal-finalization additionally has one owned publication driver. Fixture restoration is outside CPU/SQL instrumentation. CPU values are per-call medians; SQL values are means (the first full scheduling pass can differ from retained-alarm passes).

| Route | CPU ms before → after | SQL calls before → after |
| --- | ---: | ---: |
| `complete-success` | 6.15 → 3.44 | 21 → 13 |
| `complete-failure` | 5.96 → 4.17 | 32 → 23.1 |
| `lifecycle/router-receipt` | 5.60 → 2.90 | 32 → 18 |
| `terminal-finalization/attempt` | 6.64 → 3.64 | 23.1 → 18.1 |
| `heartbeat` | 3.62 → 1.92 | 14 → 9 |

All measured patched calls were below 40 ms; heartbeat maximum was 5.68 ms. The separate workerd run measured 13/24/18/19/9 SQL calls for success/failure/receipt/terminal/heartbeat. This is controlled synthetic evidence, not a prediction of production edge CPU or a live deployment measurement.

The test-only profiler also records inclusive method CPU and SQL text/counts. Before the change, scheduling averaged 4.05/2.17/3.20/2.36/3.26 ms across those routes. `readStateSync` averaged 1.29/1.54/0.95/0.83/1.64 ms; queue writes were 0.17/0.24/0/0/0.25 ms; lifecycle writes 0.08/0.09/0.10/0.13/0 ms; Bay sync 0/0.35/1.30/0.39/0 ms; metrics 0.14/0.17/0/0/0.02 ms. Terminal-finalization also read its lean scheduling census. These inclusive averages overlap and must not be summed or compared directly with the total median.

Reproduce the benchmark:

```sh
EXACT_REVIEW_COMPLETION_CPU_BENCH=1 node --test --test-name-pattern='completion and receipt CPU breakdown' test/exact-review-queue-cpu.test.ts
```

## Behavior Proof and Tests

Claim: queue transitions, admission decisions, wake-ups, and lifecycle projection semantics remain equivalent with less per-request work. `scripts/proof-queue-completion.mjs` bundles the pinned base and patched source into isolated workerd instances backed by SQLite Durable Objects. It exercises the actual request handlers and compares response bodies, persisted queue/lifecycle/counter rows, admission stats, and alarms for all seven scenarios. All seven comparisons pass, including legacy protocol-v1 success and failure without a claim generation or admission row, and outbound network calls are forbidden. Source hashes are included in the proof manifest; the local committed-head rerun also passes for `ff3759a98ae5c57fefbde74ddda96f7da0a09dc8`. No production credentials or data are used.

The scheduling regression matrix compares the shortcut with the full path across completion, earlier/later retry, heartbeat/finalization, ready batches, expiry, parked work, dispatcher pause, target capacity, and empty queues, plus an alarm consumed during an await. Existing Bay retention/requeue tests pass.

Original optimization validation: `pnpm run format`, `pnpm run build:all`, `pnpm run lint`, `pnpm run check:docs`, `pnpm run check:dashboard-queue-boundary`, `pnpm run check:dashboard-strict`, `git diff --check`, and all eight requested test files plus `test/dashboard-worker-bay-records-routes.test.ts` (561 pass, four opt-in benchmarks skipped). Independent review found no actionable findings through P2.

Prior-head full `pnpm run check` passed: 4,755 tests plus 13 focused coverage tests; 18 opt-in tests skipped. Provider `aws`, lease `cbx_8eb0b462d3c3`, image `ami-0461d919be7deb53c`; check run `run_a01debc4869f`, runtime-proof run `run_3f619fd3164e`. That prior-head `manifest.json` proves the original five handler comparisons; the committed-head local rerun above supersedes it for this fix. Runtime proof used the repository-pinned Wrangler 4.107.0 in a temporary tooling prefix, without Actions hydration or external requests.

OpenClaw Bay is unaffected: observer-only behavior, timing meanings, response fields, and UI are unchanged; the internal materializer skips only a proven no-event rebuild. No Bay client change is needed. The scheduler documentation now states the legacy completion and alarm guarantees.

## Legacy completion fix round

Current head: `ff3759a98ae5c57fefbde74ddda96f7da0a09dc8`.

Accepted P2 finding addressed: optional lifecycle completion used to validate a missing legacy claim generation before checking for an admission row. That threw after the queue transition and counters committed, skipping alarm scheduling. The existing single-read transaction now checks row presence before validating completion metadata. A `finally` block schedules the next alarm after lifecycle work and terminal-driver cleanup, including when lifecycle processing throws.

Five regression cases pass. Before the fix, both generation-less legacy completion cases threw `invalid lifecycle review result`, and a third case persisted a retry at 30 seconds while retaining an alarm one hour away. Now legacy success returns 200 and advances the alarm to pending work; legacy failure returns 200 and schedules the persisted retry at 30 seconds. Present-row validation still throws when metadata is invalid, with the alarm rescheduled for committed work.

Current validation: all eight requested test files pass (451 passed, four opt-in benchmarks skipped), plus all five opt-in completion/receipt/heartbeat benchmark scenarios. CPU medians were 4.499 / 5.725 / 3.449 / 4.566 / 2.682 ms for success / failure / receipt / terminal-finalization / heartbeat; maximum across measured calls was 11.660 ms. SQL means remain 13 / 23.1 / 18 / 18.1 / 9. Formatting, all builds, lint, queue-boundary, dashboard-strict, documentation checks, and `git diff --check` pass. Independent review found no actionable findings through P2.

The committed-head workerd proof uses synthetic SQLite Durable Objects and compares seven handlers/scenarios against base `6f229a508dd718a406651e1b3744a5c02617265e`. Both legacy cases explicitly verify HTTP 200, persisted completion/retry state, no fabricated lifecycle row, and an alarm at 60 seconds for remaining work or 30 seconds for the retry. The existing five scenarios retain equivalent responses, durable state, admission statistics, and alarms. It makes no outbound requests and is not production CPU evidence. OpenClaw Bay needs no client change: no observer fields or timing meanings changed.
