### PR TITLE
test: prune redundant cases and fixtures in large Node suites

### DIFF
--- a/test/action-ledger-runtime.test.ts
+++ b/test/action-ledger-runtime.test.ts
@@ -2346,32 +2346,6 @@ test("producer locks reclaim fresh dead owners and never evict a live holder by 
   assert.ok(Date.now() - deadStartedAt < 5_000);
   assert.doesNotThrow(releaseDead);
 
-  const reusedRoot = tempRoot();
-  const reusedEvent = recordReviewNumber(reusedRoot, 45);
-  assert.ok(reusedEvent);
-  const reusedTarget = prepareSafeWriteTarget(
-    reusedRoot,
-    producerLockRelativePath(reusedEvent),
-    "test reused producer lock",
-  );
-  const currentIncarnation = processIncarnationIdentitySha256();
-  assert.ok(currentIncarnation);
-  const reusedContent = `${actionLedgerJson({
-    schema: "clawsweeper.action-ledger-producer-lock",
-    schema_version: process.platform === "darwin" ? 2 : 1,
-    pid: process.pid,
-    process_incarnation_sha256:
-      currentIncarnation === "0".repeat(64) ? "1".repeat(64) : "0".repeat(64),
-    acquired_at_ms: Date.now(),
-    nonce: "00000000-0000-4000-8000-000000000002",
-  })}\n`;
-  const releaseReused = tryAcquireUtf8FileLockNoFollow(reusedTarget, reusedContent);
-  assert.ok(releaseReused);
-  const reusedStartedAt = Date.now();
-  assert.ok(recordReviewNumber(reusedRoot, 46));
-  assert.ok(Date.now() - reusedStartedAt < 5_000);
-  assert.doesNotThrow(releaseReused);
-
   const liveRoot = tempRoot();
   const outputRoot = trustedChildRoot(liveRoot, "state");
   const liveEvent = recordReviewNumber(liveRoot, 51);
@@ -2785,10 +2759,6 @@ test(
     assert.doesNotThrow(releaseCached);
   },
 );
-
-test("Linux zombie-lock polling rejects PID 0 before probing procfs", async () => {
-  await assert.rejects(waitForLinuxProcessState(0, "Z"), /invalid Linux process PID: 0/);
-});
 
 test(
   "Linux producer locks reclaim zombie owners",

--- a/test/apply-label-sync.test.ts
+++ b/test/apply-label-sync.test.ts
@@ -28,6 +28,16 @@ import {
   workPlanCandidateReport,
 } from "./helpers.ts";
 
+function createApplyDirectories(root: string) {
+  const itemsDir = join(root, "items");
+  const closedDir = join(root, "closed");
+  const plansDir = join(root, "plans");
+  const reportPath = join(root, "apply-report.json");
+  mkdirSync(itemsDir, { recursive: true });
+  mkdirSync(plansDir, { recursive: true });
+  return { itemsDir, closedDir, plansDir, reportPath };
+}
+
 test("apply-time implementation provenance keeps incomplete PR closeout metadata open", () => {
   const incomplete = `repository: openclaw/openclaw
 fixed_pr_url: unknown
@@ -147,13 +157,8 @@ test("closeout receipts ignore spoofed markers after posting the owned receipt",
 test("partial label-sync authentication failures preserve labels already applied", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     const labelState = join(root, "labels.json");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     writeFileSync(labelState, "[]");
     const synced = reportWithSyncedReviewComment(
       workPlanCandidateReport({
@@ -217,13 +222,8 @@ if (actual[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
 test("a lost mutation lease preserves labels already applied", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     const statePath = join(root, "state.json");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     const number = 321;
     const reviewedAt = new Date(Date.now() - 180_000).toISOString();
     const startedAt = new Date(Date.now() - 120_000).toISOString();
@@ -430,15 +430,10 @@ test("complete activity hydration distinguishes truncation from hidden human act
 test("apply-decisions publishes a detected bulk-filer label from a failed exact review artifact", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     const logPath = join(root, "gh.log");
     const number = 74486;
     const reviewedAt = new Date().toISOString();
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     writeFileSync(
       join(itemsDir, `${number}.md`),
       `${reportFrontMatter({
@@ -557,15 +552,10 @@ if (args[0] === "api" && /\\/issues\\/${number}$/.test(path)) {
 test("apply-decisions clears a stale bulk-filer label for a redacted maintain role", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     const logPath = join(root, "gh.log");
     const number = 74487;
     const reviewedAt = new Date().toISOString();
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     writeFileSync(
       join(itemsDir, `${number}.md`),
       `${reportFrontMatter({
@@ -698,13 +688,10 @@ test("exact event source drift includes a revision change while its apply lease 
   );
 });
 
-test("exact publication consumes its matching completed issue review lease", () => {
+function assertCompletedIssueLeaseAccepted(extraArgs: string[]): void {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     const number = 103599;
     const reviewedAt = new Date(Date.now() - 5 * 60_000).toISOString();
     const leaseUpdatedAt = new Date(Date.now() - 60_000).toISOString();
@@ -729,8 +716,6 @@ test("exact publication consumes its matching completed issue review lease", () 
       pull_request: null,
     };
     const sourceRevision = itemSourceRevisionSha256ForTest(issue, []);
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     const closeReport = implementedCloseReport({
       repository: "openclaw/clawsweeper",
       number,
@@ -805,7 +790,7 @@ if (args[0] === "api" && new RegExp("/issues/${number}/comments(?:\\\\?|$)").tes
         extraArgs: [
           "--dry-run",
           "--event-apply-proof",
-          "--exact-event-publication",
+          ...extraArgs,
           "--item-numbers",
           String(number),
           "--processed-limit",
@@ -830,15 +815,20 @@ if (args[0] === "api" && new RegExp("/issues/${number}/comments(?:\\\\?|$)").tes
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
+}
+
+test("exact publication consumes its matching completed issue review lease", () => {
+  assertCompletedIssueLeaseAccepted(["--exact-event-publication"]);
+});
+
+test("exact issue apply accepts its report-owned lease update after stable source proof", () => {
+  assertCompletedIssueLeaseAccepted([]);
 });
 
 test("exact publication rechecks after batched labels and again before close", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     const statePath = join(root, "state.json");
     const logPath = join(root, "gh.log");
     const number = 103701;
@@ -866,8 +856,6 @@ test("exact publication rechecks after batched labels and again before close", (
       pull_request: null,
     };
     const sourceRevision = itemSourceRevisionSha256ForTest(issue, []);
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     const closeReport = implementedCloseReport({
       repository: "openclaw/openclaw",
       number,
@@ -1104,10 +1092,7 @@ if (args[0] === "api" && new RegExp("/issues/comments/\\\\d+$").test(path) && ar
 test("exact metadata-only publication flushes recoverable labels and drops failed optional additions", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     const statePath = join(root, "state.json");
     const logPath = join(root, "gh.log");
     const patchedCommentPath = join(root, "patched-comment.md");
@@ -1135,8 +1120,6 @@ test("exact metadata-only publication flushes recoverable labels and drops faile
       pull_request: null,
     };
     const sourceRevision = itemSourceRevisionSha256ForTest(issue, []);
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     const sourceReport = workPlanCandidateReport({
       repository: "openclaw/openclaw",
       number,
@@ -1349,10 +1332,7 @@ for (const scenario of [
   test(`issue apply CAS and publisher preserve ${scenario.name} tuple evidence`, () => {
     const root = mkdtempSync(tmpPrefix);
     try {
-      const itemsDir = join(root, "items");
-      const closedDir = join(root, "closed");
-      const plansDir = join(root, "plans");
-      const reportPath = join(root, "apply-report.json");
+      const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
       const logPath = join(root, "gh.log");
       const commentReadCountPath = join(root, "comment-read-count");
       const number = 74490;
@@ -1376,8 +1356,6 @@ for (const scenario of [
         pull_request: null,
       };
       const sourceRevision = itemSourceRevisionSha256ForTest(issue, []);
-      mkdirSync(itemsDir, { recursive: true });
-      mkdirSync(plansDir, { recursive: true });
 
       const oldReport = workPlanCandidateReport({
         number,
@@ -1537,10 +1515,7 @@ if (args[0] === "api" && args[1] === "-i" && new RegExp("/issues/${number}/timel
 test("issue apply rejects a stable live source revision that differs from the report", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     const logPath = join(root, "gh.log");
     const number = 74492;
     const reviewedAt = "2026-05-01T00:00:00Z";
@@ -1564,8 +1539,6 @@ test("issue apply rejects a stable live source revision that differs from the re
     const reviewedIssue = { ...liveIssue, body: "Body at review time.", updated_at: reviewedAt };
     const reviewedRevision = itemSourceRevisionSha256ForTest(reviewedIssue, []);
     const liveRevision = itemSourceRevisionSha256ForTest(liveIssue, []);
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     writeFileSync(
       join(itemsDir, `${number}.md`),
       workPlanCandidateReport({
@@ -1638,10 +1611,7 @@ if (args[0] === "api" && new RegExp("/issues/${number}/comments(?:\\\\?|$)").tes
 test("issue apply preserves an owned active review lease for the live source revision", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     const logPath = join(root, "gh.log");
     const number = 74491;
     const reviewedAt = "2026-05-01T00:00:00Z";
@@ -1665,8 +1635,6 @@ test("issue apply preserves an owned active review lease for the live source rev
       pull_request: null,
     };
     const sourceRevision = itemSourceRevisionSha256ForTest(issue, []);
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     const report = workPlanCandidateReport({
       number,
       title: issue.title,
@@ -1763,153 +1731,11 @@ if (args[0] === "api" && new RegExp("/issues/${number}/comments(?:\\\\?|$)").tes
   }
 });
 
-test("exact issue apply accepts its report-owned lease update after stable source proof", () => {
-  for (const number of [103599, 103690]) {
-    const root = mkdtempSync(tmpPrefix);
-    try {
-      const itemsDir = join(root, "items");
-      const closedDir = join(root, "closed");
-      const plansDir = join(root, "plans");
-      const reportPath = join(root, "apply-report.json");
-      const reviewedAt = new Date(Date.now() - 5 * 60_000).toISOString();
-      const leaseUpdatedAt = new Date(Date.now() - 60_000).toISOString();
-      const leaseExpiresAt = new Date(Date.now() + 30 * 60_000).toISOString();
-      const leaseOwner = `exact-issue-${number}`;
-      const leaseCommentId = 700_000 + number;
-      const issue = {
-        number,
-        title: `Incident issue ${number}`,
-        body: "The reviewed issue source remains unchanged.",
-        html_url: `https://github.com/openclaw/openclaw/issues/${number}`,
-        created_at: "2026-04-01T00:00:00Z",
-        updated_at: leaseUpdatedAt,
-        closed_at: null,
-        state: "open",
-        locked: false,
-        active_lock_reason: null,
-        author_association: "CONTRIBUTOR",
-        user: { login: "reporter" },
-        labels: [],
-        comments: 2,
-        pull_request: null,
-      };
-      const sourceRevision = itemSourceRevisionSha256ForTest(issue, []);
-      mkdirSync(itemsDir, { recursive: true });
-      mkdirSync(plansDir, { recursive: true });
-      const closeReport = implementedCloseReport({
-        repository: "openclaw/clawsweeper",
-        number,
-        type: "issue",
-        title: issue.title,
-        reviewed_at: reviewedAt,
-        item_updated_at: reviewedAt,
-        item_source_revision: sourceRevision,
-        review_lease_owner: leaseOwner,
-        review_lease_comment_id: String(leaseCommentId),
-        labels: JSON.stringify([]),
-      });
-      const synced = reportWithSyncedReviewComment(closeReport, number, "implemented_on_main");
-      writeFileSync(join(itemsDir, `${number}.md`), synced.report, "utf8");
-      const leaseComment = renderReviewStartStatusComment({
-        number,
-        kind: "issue",
-        title: issue.title,
-        headSha: sourceRevision,
-        startedAt: leaseUpdatedAt,
-        leaseExpiresAt,
-        leaseOwner,
-      });
-      const comments = [
-        {
-          id: 9000 + number,
-          html_url: `https://github.com/openclaw/openclaw/issues/${number}#issuecomment-${
-            9000 + number
-          }`,
-          created_at: reviewedAt,
-          updated_at: reviewedAt,
-          user: { login: "clawsweeper[bot]" },
-          body: synced.comment,
-        },
-        {
-          id: leaseCommentId,
-          html_url: `https://github.com/openclaw/openclaw/issues/${number}#issuecomment-${leaseCommentId}`,
-          created_at: leaseUpdatedAt,
-          updated_at: leaseUpdatedAt,
-          user: { login: "clawsweeper[bot]" },
-          body: leaseComment,
-        },
-      ];
-
-      const ghMock = `
-const issue = ${JSON.stringify(issue)};
-const comments = ${JSON.stringify(comments)};
-const rawArgs = process.argv.slice(2);
-const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
-const path = args.includes("-i") ? args[args.indexOf("-i") + 1] : args[1] || "";
-const slurp = args.includes("--slurp");
-if (args[0] === "api" && new RegExp("/issues/${number}/comments(?:\\\\?|$)").test(path)) {
-  console.log(JSON.stringify(slurp ? [comments] : comments));
-} else if (args[0] === "api" && new RegExp("/issues/${number}/timeline(?:\\\\?|$)").test(path)) {
-  console.log(JSON.stringify(slurp ? [[]] : []));
-} else if (args[0] === "api" && new RegExp("/issues/${number}$").test(path)) {
-  console.log(JSON.stringify(issue));
-} else if (args[0] === "api" && path.startsWith("search/issues?")) {
-  console.log(JSON.stringify({ items: [] }));
-} else if (args[0] === "issue" && args[1] === "view") {
-  console.log(JSON.stringify({ closedByPullRequestsReferences: [] }));
-} else if (args[0] === "label" || args[0] === "issue") {
-  console.log("");
-} else {
-  console.error("unexpected gh args", JSON.stringify(args));
-  process.exit(1);
-}
-      `;
-      withMockGh(root, ghMock, () => {
-        runApplyDecisionsForTest({
-          itemsDir,
-          closedDir,
-          plansDir,
-          reportPath,
-          extraArgs: [
-            "--dry-run",
-            "--event-apply-proof",
-            "--item-numbers",
-            String(number),
-            "--processed-limit",
-            "2",
-          ],
-        });
-      });
-
-      assert.deepEqual(JSON.parse(readFileSync(reportPath, "utf8")), [
-        {
-          number,
-          action: "review_comment_synced",
-          reason: "would update durable Codex review comment",
-          durableReviewSynced: true,
-        },
-        {
-          number,
-          action: "closed",
-          reason: "dry-run: would close as already implemented on main",
-        },
-      ]);
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
-  }
-});
-
 test("apply-decisions rejects a changed close report even when an expired lease is newest", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     const logPath = join(root, "gh.log");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     writeFileSync(
       join(itemsDir, "321.md"),
       workPlanCandidateReport({
@@ -2019,14 +1845,9 @@ if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
 test("apply-decisions records PR label sync as ClawSweeper-owned churn", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     const logPath = join(root, "gh.log");
     const itemPath = join(itemsDir, "74478.md");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     writeFileSync(
       itemPath,
       `${reportFrontMatter({
@@ -2186,14 +2007,9 @@ if (args[0] === "api" && /\\/issues\\/74478$/.test(path)) {
 test("apply-decisions clears stale PR review labels when live head changed", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     const logPath = join(root, "gh.log");
     const itemPath = join(itemsDir, "74481.md");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     const staleLabels = [
       "P2",
       "rating: 🧂 unranked krab",
@@ -2377,14 +2193,9 @@ if (args[0] === "api" && /\\/issues\\/74481$/.test(path)) {
 test("apply-decisions skips stale label cleanup when the durable review comment is newer", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     const logPath = join(root, "gh.log");
     const itemPath = join(itemsDir, "74483.md");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     const readyLabel = "status: \u{1F440} ready for maintainer look";
     const mergeRiskLabel = "merge-risk: \u{1F6A8} message-delivery";
     const staleLabels = [
@@ -2566,10 +2377,7 @@ for (const scenario of [
   test(`exact publication reconciles labels only for a current review: ${scenario}`, () => {
     const root = mkdtempSync(tmpPrefix);
     try {
-      const itemsDir = join(root, "items");
-      const closedDir = join(root, "closed");
-      const plansDir = join(root, "plans");
-      const reportPath = join(root, "apply-report.json");
+      const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
       const logPath = join(root, "gh.log");
       const itemPath = join(itemsDir, "74482.md");
       const headSha = "bc60b889bc60b889bc60b889bc60b889bc60b889";
@@ -2603,8 +2411,6 @@ for (const scenario of [
           },
         ],
       );
-      mkdirSync(itemsDir, { recursive: true });
-      mkdirSync(plansDir, { recursive: true });
       const sourceReport = `${reportFrontMatter({
         repository: "openclaw/openclaw",
         type: "pull_request",
@@ -2843,14 +2649,9 @@ if (args[0] === "api" && /\\/issues\\/74482$/.test(path)) {
 test("apply-decisions skips fresh-head PR label sync when humans act after the review snapshot", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     const logPath = join(root, "gh.log");
     const itemPath = join(itemsDir, "74483.md");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     const sourceReport = `${reportFrontMatter({
       repository: "openclaw/openclaw",
       type: "pull_request",
@@ -3021,14 +2822,9 @@ if (args[0] === "api" && /\\/issues\\/74483$/.test(path)) {
 test("apply-decisions withholds fresh-head PR label sync from close proposals", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     const logPath = join(root, "gh.log");
     const itemPath = join(itemsDir, "74484.md");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     const sourceReport = `${reportFrontMatter({
       repository: "openclaw/openclaw",
       type: "pull_request",
@@ -3198,14 +2994,9 @@ if (args[0] === "api" && /\\/issues\\/74484$/.test(path)) {
 test("apply-decisions routes parsed security owner acceptance to maintainer review", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     const labelLogPath = join(root, "label-sync.log");
     const itemPath = join(itemsDir, "74480.md");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
 
     const sourceReport = `${reportFrontMatter({
       repository: "openclaw/openclaw",
@@ -3300,14 +3091,9 @@ Full review comments:
 test("apply-decisions clears a recovery escalation only after publishing a completed PR review", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     const logPath = join(root, "gh.log");
     const itemPath = join(itemsDir, "74479.md");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     writeFileSync(
       itemPath,
       `${reportFrontMatter({
@@ -3480,16 +3266,11 @@ if (args[0] === "api" && /\\/issues\\/74479$/.test(path)) {
 test("apply preserves an in-flight exact-head review lease and defers old report actions", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     const number = 74486;
     const headSha = "0123456789abcdef0123456789abcdef01234567";
     const startedAt = new Date(Date.now() - 60_000).toISOString();
     const expiresAt = new Date(Date.now() + 30 * 60_000).toISOString();
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
 
     const closeReport = lowSignalCloseReport({
       number,
@@ -3563,16 +3344,11 @@ test("apply preserves an in-flight exact-head review lease and defers old report
 test("a lease published during durable comment sync survives the write and blocks close", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     const number = 74489;
     const headSha = "0123456789abcdef0123456789abcdef01234567";
     const startedAt = new Date(Date.now() - 30_000).toISOString();
     const expiresAt = new Date(Date.now() + 30 * 60_000).toISOString();
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
 
     const closeReport = lowSignalCloseReport({
       number,
@@ -3692,18 +3468,13 @@ test("a lease published during durable comment sync survives the write and block
 test("durable publication never deletes a legacy lease that can refresh concurrently", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     const commentWriteLogPath = join(root, "comment-writes.log");
     const number = 74493;
     const headSha = "0123456789abcdef0123456789abcdef01234567";
     const startedAt = new Date(Date.now() - 2 * 60_000).toISOString();
     const expiredAt = new Date(Date.now() - 60_000).toISOString();
     const refreshedAt = new Date(Date.now() + 30 * 60_000).toISOString();
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
 
     const closeReport = lowSignalCloseReport({
       number,
@@ -3793,16 +3564,11 @@ test("durable publication never deletes a legacy lease that can refresh concurre
 test("apply defers incomplete old report actions when a same-head review finishes mid-run", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     const number = 74488;
     const headSha = "0123456789abcdef0123456789abcdef01234567";
     const oldReviewedAt = "2026-05-01T00:00:00Z";
     const newReviewedAt = new Date().toISOString();
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
 
     const closeReport = lowSignalCloseReport({
       number,
@@ -3883,13 +3649,8 @@ test("apply defers incomplete old report actions when a same-head review finishe
 test("apply-decisions does not advisory-label close proposals before close gates finish", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     const logPath = join(root, "gh.log");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     const closeReport = workPlanCandidateReport({
       decision: "close",
       action_taken: "proposed_close",
@@ -4021,7 +3782,6 @@ test("apply-decisions verifies provenance after a closeout note and before closi
     "paired_provenance_retargeted_before_close",
     "paired_human_activity_during_lease",
   ] as const) {
-    const lifecycleDrift = scenario === "lifecycle_drift";
     const multipleLinkedIssues = scenario === "multiple_linked_issues";
     const mismatchedCanonical = scenario === "mismatched_canonical";
     const mismatchedCanonicalRepository = scenario === "mismatched_canonical_repository";
@@ -4041,23 +3801,13 @@ test("apply-decisions verifies provenance after a closeout note and before closi
     const pairedProvenanceRetargetedBeforeClose =
       scenario === "paired_provenance_retargeted_before_close";
     const pairedHumanActivityDuringLease = scenario === "paired_human_activity_during_lease";
-    const lockedCloseoutComment = scenario === "locked_closeout_comment";
-    const betweenFreshnessAndCloseoutHumanActivity =
-      scenario === "between_freshness_and_closeout_human_activity";
-    const postCloseoutHumanActivity = scenario === "post_closeout_human_activity";
-    const postCloseoutPrReviewActivity = scenario === "post_closeout_pr_review_activity";
     const root = mkdtempSync(tmpPrefix);
     try {
-      const itemsDir = join(root, "items");
-      const closedDir = join(root, "closed");
-      const plansDir = join(root, "plans");
-      const reportPath = join(root, "apply-report.json");
+      const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
       const logPath = join(root, "gh.log");
       const postedBodiesPath = join(root, "posted-bodies.jsonl");
       const prCommentPath = join(root, "pr-review-comment");
       const linkedIssueCommentPath = join(root, "linked-issue-review-comment");
-      mkdirSync(itemsDir, { recursive: true });
-      mkdirSync(plansDir, { recursive: true });
       const reviewedSourceRevision = itemSourceRevisionSha256ForTest(
         {
           title: "Render work plans",
@@ -4123,12 +3873,7 @@ test("apply-decisions verifies provenance after a closeout note and before closi
 const { appendFileSync, existsSync, readFileSync, unlinkSync, writeFileSync } = require("fs");
 const logPath = ${JSON.stringify(logPath)};
 const postedBodiesPath = ${JSON.stringify(postedBodiesPath)};
-const graphqlStatePath = ${JSON.stringify(join(root, "graphql-reads"))};
 const closeoutPostedPath = ${JSON.stringify(join(root, "closeout-posted"))};
-const betweenFreshnessAndCloseoutHumanActivityPath = ${JSON.stringify(
-        join(root, "between-freshness-and-closeout-human-activity"),
-      )};
-const issueReadsAfterCloseoutPath = ${JSON.stringify(join(root, "issue-reads-after-closeout"))};
 const pairedIssueCloseoutPostedPath = ${JSON.stringify(join(root, "paired-issue-closeout-posted"))};
 const pairedIssueBotActivityPath = ${JSON.stringify(join(root, "paired-issue-bot-activity"))};
 const pairedIssueHumanActivityPath = ${JSON.stringify(join(root, "paired-issue-human-activity"))};
@@ -4137,18 +3882,12 @@ const pairedIssueLeasePath = ${JSON.stringify(join(root, "paired-issue-lease"))}
 const pairedIssueLeaseWritesPath = ${JSON.stringify(join(root, "paired-issue-lease-writes"))};
 const prCommentPath = ${JSON.stringify(prCommentPath)};
 const linkedIssueCommentPath = ${JSON.stringify(linkedIssueCommentPath)};
-const comment = ${JSON.stringify(synced.comment)};
 const linkedIssueComment = ${JSON.stringify(linkedIssueSynced.comment)};
 const rawArgs = process.argv.slice(2);
 const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
 appendFileSync(logPath, JSON.stringify(args) + "\\n");
 const path = args[1] || "";
-const lifecycleDrift = ${lifecycleDrift};
 const multipleLinkedIssues = ${multipleLinkedIssues};
-const lockedCloseoutComment = ${lockedCloseoutComment};
-const betweenFreshnessAndCloseoutHumanActivity = ${betweenFreshnessAndCloseoutHumanActivity};
-const postCloseoutHumanActivity = ${postCloseoutHumanActivity};
-const postCloseoutPrReviewActivity = ${postCloseoutPrReviewActivity};
 const pairedSourceChangeDuringCloseout = ${pairedSourceChangeDuringCloseout};
 const pairedMetadataChangeDuringCloseout = ${pairedMetadataChangeDuringCloseout};
 const pairedBotActivityDuringCloseout = ${pairedBotActivityDuringCloseout};
@@ -4162,24 +3901,13 @@ const pairedProvenanceRevokedBeforeClose = ${pairedProvenanceRevokedBeforeClose}
 const pairedProvenanceRetargetedBeforeClose = ${pairedProvenanceRetargetedBeforeClose};
 const pairedHumanActivityDuringLease = ${pairedHumanActivityDuringLease};
 if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$)/.test(args[2] || "")) {
-  const timeline = existsSync(betweenFreshnessAndCloseoutHumanActivityPath)
-    ? [{
-        id: 9323,
-        event: "commented",
-        created_at: readFileSync(betweenFreshnessAndCloseoutHumanActivityPath, "utf8"),
-        actor: { login: "contributor" }
-  }]
-    : [];
-  console.log("HTTP/2 200\\n\\n" + JSON.stringify(timeline));
+  console.log("HTTP/2 200\\n\\n[]");
 } else if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/456\\/timeline(?:\\?|$)/.test(args[2] || "")) {
   console.log("HTTP/2 200\\n\\n[]");
 } else if (args[0] === "issue" && args[1] === "view") {
   console.log(JSON.stringify({ closedByPullRequestsReferences: [] }));
 } else if (args[0] === "api" && args[1] === "graphql") {
-  const graphqlReads = existsSync(graphqlStatePath) ? Number(readFileSync(graphqlStatePath, "utf8")) : 0;
-  writeFileSync(graphqlStatePath, String(graphqlReads + 1), "utf8");
   const closingReferenceQuery = args.some((argument) => argument.includes("closingIssuesReferences"));
-  const currentState = closingReferenceQuery || lifecycleDrift ? "OPEN" : "CLOSED";
   const closingReferenceNodes = closingReferenceQuery
     ? pairedProvenanceRevokedBeforeClose && existsSync(pairedIssueLeasePath)
       ? []
@@ -4195,12 +3923,10 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
           repository: { nameWithOwner: "openclaw/clawsweeper" }
         }]
     : [];
-  const timelineNodes = lifecycleDrift
-    ? []
-    : [{ __typename: "ClosedEvent", createdAt: "2026-05-01T02:00:00Z", closer: { __typename: "PullRequest", number: 900, url: "https://github.com/openclaw/clawsweeper/pull/900", mergedAt: "2026-05-01T02:00:00Z", repository: { nameWithOwner: "openclaw/clawsweeper" } } }];
+  const timelineNodes = [{ __typename: "ClosedEvent", createdAt: "2026-05-01T02:00:00Z", closer: { __typename: "PullRequest", number: 900, url: "https://github.com/openclaw/clawsweeper/pull/900", mergedAt: "2026-05-01T02:00:00Z", repository: { nameWithOwner: "openclaw/clawsweeper" } } }];
   const repository = closingReferenceQuery
     ? { pullRequest: { closingIssuesReferences: { nodes: closingReferenceNodes } } }
-    : { issue: { state: currentState, timelineItems: { nodes: timelineNodes } } };
+    : { issue: { state: "CLOSED", timelineItems: { nodes: timelineNodes } } };
   console.log(JSON.stringify({ data: { repository } }));
 } else if (args[0] === "api" && /\\/commits\\/head-sha\\/(?:check-runs|status)(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify({ check_runs: [] }));
@@ -4295,21 +4021,11 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
   }
 } else if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
   if (args.includes("--method") && args.includes("POST")) {
-    if (lockedCloseoutComment) {
-      console.error("gh: conversation is locked (HTTP 403)");
-      process.exit(1);
-    }
     const input = args[args.indexOf("--input") + 1];
     const payload = JSON.parse(readFileSync(input, "utf8"));
     appendFileSync(postedBodiesPath, JSON.stringify(payload.body) + "\\n");
     writeFileSync(prCommentPath, payload.body, "utf8");
     writeFileSync(closeoutPostedPath, "true");
-    if (betweenFreshnessAndCloseoutHumanActivity) {
-      writeFileSync(
-        betweenFreshnessAndCloseoutHumanActivityPath,
-        new Date(Date.now() + 60_000).toISOString(),
-      );
-    }
     console.log(JSON.stringify({ id: 9322, html_url: "https://github.com/openclaw/clawsweeper/pull/321#issuecomment-9322" }));
   } else {
     const comments = [{
@@ -4320,16 +4036,6 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
       user: { login: "clawsweeper[bot]" },
       body: readFileSync(prCommentPath, "utf8")
     }];
-    if (existsSync(betweenFreshnessAndCloseoutHumanActivityPath)) {
-      comments.push({
-        id: 9323,
-        html_url: "https://github.com/openclaw/clawsweeper/pull/321#issuecomment-9323",
-        created_at: readFileSync(betweenFreshnessAndCloseoutHumanActivityPath, "utf8"),
-        updated_at: readFileSync(betweenFreshnessAndCloseoutHumanActivityPath, "utf8"),
-        user: { login: "contributor" },
-        body: "Please keep this PR open."
-      });
-    }
     console.log(JSON.stringify([comments]));
   }
 } else if (args[0] === "api" && /\\/issues\\/comments\\/9456$/.test(path) && args.includes("PATCH")) {
@@ -4363,27 +4069,14 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
 } else if (args[0] === "api" && /\\/issues\\/321\\/timeline(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "api" && /\\/issues\\/321$/.test(path)) {
-  const issueReadsAfterCloseout = existsSync(closeoutPostedPath)
-    ? (existsSync(issueReadsAfterCloseoutPath)
-        ? Number(readFileSync(issueReadsAfterCloseoutPath, "utf8") || "0")
-        : 0) + 1
-    : 0;
-  if (existsSync(closeoutPostedPath)) {
-    writeFileSync(issueReadsAfterCloseoutPath, String(issueReadsAfterCloseout));
-  }
-  const humanActivityLanded =
-    (postCloseoutHumanActivity && issueReadsAfterCloseout >= 2) ||
-    existsSync(betweenFreshnessAndCloseoutHumanActivityPath);
   console.log(JSON.stringify({
     number: 321,
     title: "Render work plans",
     html_url: "https://github.com/openclaw/clawsweeper/pull/321",
     created_at: "2026-05-01T00:00:00Z",
-    updated_at: humanActivityLanded
-      ? "2026-05-01T03:00:00Z"
-      : existsSync(closeoutPostedPath)
-        ? "2026-05-01T02:30:00Z"
-        : "2026-05-01T00:00:00Z",
+    updated_at: existsSync(closeoutPostedPath)
+      ? "2026-05-01T02:30:00Z"
+      : "2026-05-01T00:00:00Z",
     closed_at: null,
     state: "open",
     locked: false,
@@ -4464,11 +4157,7 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
     user: { login: "reporter" }
   }));
 } else if (args[0] === "api" && /\\/pulls\\/321\\/reviews(?:\\?|$)/.test(path)) {
-  console.log(JSON.stringify(
-    postCloseoutPrReviewActivity && existsSync(closeoutPostedPath)
-      ? [{ id: 7701, user: { login: "maintainer" }, state: "COMMENTED", submitted_at: "2026-08-20T00:00:00Z" }]
-      : []
-  ));
+  console.log("[]");
 } else if (args[0] === "api" && /\\/pulls\\/321\\/(files|commits|comments|reviews)(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "pr" && args[1] === "close" && args[2] === "321") {
@@ -4517,12 +4206,6 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
         .split("\n")
         .filter(Boolean)
         .map((line) => JSON.parse(line) as string[]);
-      const postIndex = calls.findIndex(
-        (args) =>
-          args[0] === "api" &&
-          (args[1] ?? "").endsWith("/issues/321/comments") &&
-          args.includes("POST"),
-      );
       const closeIndex = calls.findIndex(
         (args) => args[0] === "pr" && args[1] === "close" && args[2] === "321",
       );
@@ -4541,23 +4224,6 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
       const graphqlIndices = calls
         .map((args, index) => (args[0] === "api" && args[1] === "graphql" ? index : -1))
         .filter((index) => index >= 0);
-      if (lockedCloseoutComment) {
-        assert.equal(closeIndex, -1);
-        assert.equal(existsSync(join(closedDir, "321.md")), false);
-        const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
-          action: string;
-          reason: string;
-        }>;
-        assert.equal(
-          report.some(
-            (entry) =>
-              entry.action === "skipped_locked_conversation" &&
-              entry.reason === "conversation was locked while recording closeout evidence",
-          ),
-          true,
-        );
-        continue;
-      }
       if (pairedLockedCloseoutCleanup) {
         assert.ok(pairedIssueLeaseDeleteIndex >= 0);
         assert.equal(pairedIssueCloseIndex, -1);
@@ -4703,76 +4369,6 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
         );
         continue;
       }
-      if (lifecycleDrift) {
-        assert.ok(graphqlIndices.length >= 2);
-        assert.equal(closeIndex, -1);
-        assert.ok(postIndex >= 0);
-        assert.equal(existsSync(join(closedDir, "321.md")), false);
-        const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
-          action: string;
-          reason: string;
-        }>;
-        assert.equal(
-          report.some((entry) => entry.action === "closed"),
-          false,
-        );
-        continue;
-      }
-      if (postCloseoutHumanActivity) {
-        assert.ok(graphqlIndices.length >= 2);
-        assert.equal(closeIndex, -1);
-        assert.ok(postIndex >= 0);
-        assert.equal(existsSync(join(closedDir, "321.md")), false);
-        const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
-          action: string;
-          reason: string;
-        }>;
-        assert.equal(
-          report.some(
-            (entry) =>
-              entry.action === "skipped_changed_since_review" &&
-              entry.reason === "updated_at changed",
-          ),
-          true,
-        );
-        continue;
-      }
-      if (betweenFreshnessAndCloseoutHumanActivity) {
-        assert.equal(closeIndex, -1);
-        assert.ok(postIndex >= 0);
-        assert.equal(existsSync(join(closedDir, "321.md")), false);
-        const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
-          action: string;
-          reason: string;
-        }>;
-        assert.equal(
-          report.some(
-            (entry) =>
-              entry.action === "skipped_changed_since_review" &&
-              entry.reason === "closeout evidence freshness receipt could not be recorded",
-          ),
-          true,
-        );
-        continue;
-      }
-      if (postCloseoutPrReviewActivity) {
-        assert.equal(closeIndex, -1);
-        assert.ok(postIndex >= 0);
-        assert.equal(existsSync(join(closedDir, "321.md")), false);
-        const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
-          action: string;
-          reason: string;
-        }>;
-        assert.equal(
-          report.some(
-            (entry) =>
-              entry.action === "skipped_changed_since_review" &&
-              entry.reason === "closeout evidence freshness receipt could not be recorded",
-          ),
-          true,
-        );
-        continue;
-      }
       assert.ok(graphqlIndices.length >= 2);
       assert.ok(closeIndex >= 0, `${scenario}: ${readFileSync(reportPath, "utf8")}`);
       assert.ok(pairedIssueCloseIndex >= 0, scenario);
@@ -4816,13 +4412,8 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
 test("apply-decisions keeps low-signal PRs open when live maintainer comments exist", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     const logPath = join(root, "gh.log");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     const closeReport = lowSignalCloseReport({ number: 322, title: "Add provider clamp" });
     const synced = reportWithSyncedReviewComment(closeReport, 322, "low_signal_unmergeable_pr");
     writeFileSync(join(itemsDir, "322.md"), synced.report, "utf8");

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2359,6 +2359,24 @@ test("background review fanout keeps per-review transient recovery", () => {
   assert.match(workflow, /publish:[\s\S]*needs: \[plan, review\]/);
 });
 
+// Source guard: review surfaces must stay on the bounded agent runner, never a raw codex spawn.
+test("synchronous Codex review surfaces use the shared bounded runner", () => {
+  for (const file of [
+    "src/clawsweeper-review-runtime.ts",
+    "src/commit-sweeper.ts",
+    "src/pr-close-coverage-proof.ts",
+  ]) {
+    const source = readText(file);
+    assert.match(source, /runAgentProcess/);
+    assert.doesNotMatch(source, /runCodexProcess/);
+    assert.doesNotMatch(source, /spawnSync\(\s*"codex"/);
+  }
+  assert.match(
+    readText("src/clawsweeper-review-runtime.ts"),
+    /"--output-last-message",\s*outputPath,\s*"--json"/,
+  );
+});
+
 // Source guard: the planner sandbox and retry ceiling bound failed repair workers.
 test("failed Codex workers use bounded automatic retry paths", () => {
   const worker = readText("src/repair/run-worker.ts");

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -83,6 +83,16 @@ const maintainerDecision = {
   },
 };
 
+function createApplyDirectories(root: string) {
+  const itemsDir = join(root, "items");
+  const closedDir = join(root, "closed");
+  const plansDir = join(root, "plans");
+  const reportPath = join(root, "apply-report.json");
+  mkdirSync(itemsDir, { recursive: true });
+  mkdirSync(plansDir, { recursive: true });
+  return { itemsDir, closedDir, plansDir, reportPath };
+}
+
 test("review comments include a compact maintainer decision packet block", () => {
   const comment = renderReviewCommentFromReport(
     workPlanCandidateReport({
@@ -147,13 +157,8 @@ test("review-only comments omit actionable automation markers", () => {
 test("apply-decisions archives live-closed skipped records without reopening close gates", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     const logPath = join(root, "gh.log");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     const skippedReport = implementedCloseReport({
       action_taken: "skipped_open_closing_pr",
       close_reason: "duplicate_or_superseded",
@@ -216,13 +221,8 @@ if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
 test("apply-decisions records closed decision packet state during comment-only sync", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     const packetPath = join(root, "decision-packets", "321.json");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     writeFileSync(
       join(itemsDir, "321.md"),
       implementedCloseReport({
@@ -288,12 +288,7 @@ if (/\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
 test("apply-decisions writes decision packets for protected close-guard reports", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     writeFileSync(
       join(itemsDir, "321.md"),
       implementedCloseReport({
@@ -363,13 +358,8 @@ if (/\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
 test("apply-decisions keeps required maintainer decisions open", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     const packetPath = join(root, "decision-packets", "321.json");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     const synced = reportWithSyncedReviewComment(
       implementedCloseReport({
         labels: JSON.stringify(["clawsweeper:needs-product-decision"]),
@@ -458,12 +448,7 @@ if (/\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
 test("apply-decisions makes no GitHub mutation for malformed maintainer decisions", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     writeFileSync(
       join(itemsDir, "321.md"),
       implementedCloseReport({ maintainer_decision: "{" }),
@@ -528,13 +513,8 @@ process.exit(1);
 test("apply-decisions skips advisory labels for failed or stale kept-open reports", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     const logPath = join(root, "gh.log");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
 
     const failed = reportWithSyncedReviewComment(
       workPlanCandidateReport({
@@ -637,13 +617,8 @@ if (args[0] === "api" && commentMatch) {
 test("apply-decisions counts unverified local-checkout reports against the processed limit", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     const logPath = join(root, "gh.log");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
 
     const unverified = workPlanCandidateReport({ number: 321 }).replace(
       /^local_checkout_access: verified\n/m,
@@ -695,13 +670,8 @@ process.exit(1);
 test("apply-decisions counts advisory label-only syncs against the processed limit", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     const logPath = join(root, "gh.log");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
 
     const first = reportWithSyncedReviewComment(
       workPlanCandidateReport({
@@ -870,13 +840,8 @@ if (args[0] === "api" && /\\/issues\\/comments\\/9321$/.test(path) && args[args.
 test("apply-decisions syncs labels when first review placeholder advanced issue updated_at", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     const logPath = join(root, "gh.log");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
 
     const issue = {
       number: 321,
@@ -1048,13 +1013,8 @@ if (args[0] === "api" && /\\/issues\\/comments\\/\\d+$/.test(path) && args.inclu
 test("apply-decisions dry-run computes advisory labels without mutating GitHub labels", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     const logPath = join(root, "gh.log");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
 
     const synced = reportWithSyncedReviewComment(
       workPlanCandidateReport({
@@ -1150,13 +1110,8 @@ if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
 test("apply-decisions skips cleanly when ClawSweeper label sync loses authentication", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     const logPath = join(root, "gh.log");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
 
     const synced = reportWithSyncedReviewComment(
       workPlanCandidateReport({
@@ -1385,13 +1340,8 @@ test("comment-only sync creates or refreshes stale durable review comments", () 
 test("apply-decisions does not overwrite a newer durable review comment", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     const logPath = join(root, "gh.log");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
 
     const oldReview = reportWithSyncedReviewComment(
       workPlanCandidateReport({
@@ -1526,13 +1476,8 @@ if (args[0] === "api" && /\\/issues\\/comments\\/\\d+$/.test(path)) {
 test("apply-decisions ignores untrusted newer durable review markers", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     const logPath = join(root, "gh.log");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
 
     const oldReview = reportWithSyncedReviewComment(
       workPlanCandidateReport({
@@ -1682,13 +1627,8 @@ test("apply-decisions ignores forged newer markers outside the automation tail",
   const root = mkdtempSync(tmpPrefix);
   try {
     const headSha = "a".repeat(40);
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     const logPath = join(root, "gh.log");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
 
     const oldReview = reportWithSyncedReviewComment(
       workPlanCandidateReport({
@@ -1845,13 +1785,8 @@ if (args[0] === "api" && /\\/issues\\/comments\\/\\d+$/.test(path)) {
 test("apply-decisions does not use issue verdict-shaped tails for freshness", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+    const { itemsDir, closedDir, plansDir, reportPath } = createApplyDirectories(root);
     const logPath = join(root, "gh.log");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
 
     const oldReview = reportWithSyncedReviewComment(
       workPlanCandidateReport({
@@ -1980,6 +1915,7 @@ test("coverage proof timeout cannot exceed the remaining apply runtime", () => {
   assert.equal(timeoutWithinRuntimeBudget(1000, 600_000, 600_000, 601_000), null);
 });
 
+// Source guard: hydration must consume the runtime budget before launching the proof model.
 test("coverage proof refreshes its timeout after linked PR hydration", () => {
   const source = readText("src/clawsweeper-coverage-proof.ts");
   const gateStart = source.indexOf("function prCloseCoverageProofGateResult");
@@ -2037,6 +1973,7 @@ test("recorded label sync covers only matching automation-owned updates", () => 
     recordedLabelSyncCoversUpdate({ ...base, itemUpdatedAt: "2026-07-05T18:00:02Z" }),
     false,
   );
+  // Source guard: incomplete activity hydration must not authorize label reconciliation.
   assert.match(
     readText("src/clawsweeper-apply-source-freshness.ts"),
     /recordedLabelSyncMatches[\s\S]*truncationCountsAsActivity: true/,
@@ -2051,6 +1988,7 @@ test("runtime yield keeps the unfinished item out of the apply cursor trace", ()
   assert.deepEqual(examined, [10]);
 });
 
+// Workflow guard: cancellation must coalesce only deliveries for the same comment.
 test("spam comment intake coalesces duplicate comment deliveries", () => {
   const workflow = readText(".github/workflows/spam-comment-intake.yml");
 
@@ -2069,6 +2007,7 @@ test("spam comment intake coalesces duplicate comment deliveries", () => {
   assert.match(workflow, /cancel-in-progress: true/);
 });
 
+// Workflow guard: exact scans must publish disjoint comment records without cancelling other scans.
 test("spam scanner exact dispatches publish only per-comment audit records", () => {
   const workflow = readText(".github/workflows/spam-scanner.yml");
   const scanner = readText("src/repair/spam-scanner.ts");
@@ -2085,6 +2024,7 @@ test("spam scanner exact dispatches publish only per-comment audit records", () 
   assert.match(scanner, /reasoning: \{ effort: "high" \}/);
 });
 
+// Workflow guard: dispatch credentials must belong to the target owner.
 test("issue implementation workflow lets job intent choose dispatch capacity", () => {
   const workflow = readText(".github/workflows/repair-issue-implementation-intake.yml");
   const dispatchInputs = workflow.slice(
@@ -2121,6 +2061,7 @@ test("issue implementation workflow lets job intent choose dispatch capacity", (
   assert.doesNotMatch(workflow, /sparse-checkout:[\s\S]{0,120}records\//);
 });
 
+// Workflow guard: recovery dispatch and failure reporting depend on durable ledger/session outcomes.
 test("repair workers hydrate only durable jobs from generated state", () => {
   const workflow = readText(".github/workflows/repair-cluster-worker.yml");
   const requeue = readText("src/repair/requeue-job.ts");
@@ -2167,6 +2108,7 @@ test("viable issue implementation stays in the broad durable backfill lane", () 
   assert.ok((workflow.match(/vars\.CLAWSWEEPER_AUTO_IMPLEMENT_ISSUES == '1'/g) || []).length >= 5);
 });
 
+// Workflow guard: lease ownership and read-only review credentials fence execution and completion.
 test("sweep workflow executes only durable queue leases without runner-side admission", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const legacyIntakeBlock = workflow.slice(
@@ -2320,21 +2262,6 @@ test("sweep workflow executes only durable queue leases without runner-side admi
   assert.doesNotMatch(exactReviewStep, /--codex-timeout-ms 600000/);
 });
 
-test("target dispatcher documents opt-in cross-route identity", () => {
-  const dispatcher = readText("docs/target-dispatcher.md");
-
-  assert.match(dispatcher, /## Cross-route exact-review identity/);
-  assert.doesNotMatch(dispatcher, /maintainer decision required/i);
-  assert.match(dispatcher, /result\.ingress_route = "target_dispatcher"/);
-  assert.match(dispatcher, /ingress_fingerprint/);
-  assert.match(dispatcher, /recorded as stale source/);
-  assert.match(dispatcher, /later verified\s+direct decision promotes that same queue item/);
-  assert.match(dispatcher, /legacy-only delivery stays a safe\s+fallback/);
-  assert.match(dispatcher, /delayed matching counterpart is\s+also suppressed/);
-  assert.match(dispatcher, /rejects as stale is not an admission receipt/);
-  assert.match(dispatcher, /not a\s+head-SHA dedupe key/);
-});
-
 test("sweep workflow gives high-context Codex reviews twenty minutes by default", () => {
   const workflow = readText(".github/workflows/sweep.yml");
 
@@ -2345,6 +2272,7 @@ test("sweep workflow gives high-context Codex reviews twenty minutes by default"
   assert.doesNotMatch(workflow, /codex_timeout_ms=(?:600000|900000)/);
 });
 
+// Workflow guard: provider credentials stay step-scoped and setup cannot inherit model secrets.
 test("agent workflows install pinned CLI releases and keep runner models secret", () => {
   const action = readText(".github/actions/setup-codex/action.yml");
   const openclawAction = readText(".github/actions/setup-openclaw/action.yml");
@@ -2431,23 +2359,7 @@ test("background review fanout keeps per-review transient recovery", () => {
   assert.match(workflow, /publish:[\s\S]*needs: \[plan, review\]/);
 });
 
-test("synchronous Codex review surfaces use the shared bounded runner", () => {
-  for (const file of [
-    "src/clawsweeper-review-runtime.ts",
-    "src/commit-sweeper.ts",
-    "src/pr-close-coverage-proof.ts",
-  ]) {
-    const source = readText(file);
-    assert.match(source, /runAgentProcess/);
-    assert.doesNotMatch(source, /runCodexProcess/);
-    assert.doesNotMatch(source, /spawnSync\(\s*"codex"/);
-  }
-  assert.match(
-    readText("src/clawsweeper-review-runtime.ts"),
-    /"--output-last-message",\s*outputPath,\s*"--json"/,
-  );
-});
-
+// Source guard: the planner sandbox and retry ceiling bound failed repair workers.
 test("failed Codex workers use bounded automatic retry paths", () => {
   const worker = readText("src/repair/run-worker.ts");
   const outputCapture = readText("src/codex-output-capture.ts");
@@ -2474,6 +2386,7 @@ test("failed Codex workers use bounded automatic retry paths", () => {
   assert.match(selfHeal, /reason: "retry_limit_reached"/);
 });
 
+// Workflow guard: writable planner access must remain an explicit override of read-only isolation.
 test("repair workers expose an explicit sandbox fallback for trusted ephemeral runners", () => {
   const workflow = readText(".github/workflows/repair-cluster-worker.yml");
 
@@ -2483,6 +2396,7 @@ test("repair workers expose an explicit sandbox fallback for trusted ephemeral r
   assert.match(workflow, /CLAWSWEEPER_CODEX_PLANNER_SANDBOX: \$\{\{ inputs\.planner_sandbox \}\}/);
 });
 
+// Workflow guard: scheduled cluster intake must be gated before creating credentials.
 test("repair workflows preserve existing dispatch while scheduled cluster intake stays gated", () => {
   const cluster = readText(".github/workflows/repair-cluster-worker.yml");
   const clusterIntake = readText(".github/workflows/repair-cluster-intake.yml");
@@ -2523,6 +2437,7 @@ test("repair workflows preserve existing dispatch while scheduled cluster intake
   assert.doesNotMatch(importLowSignal, /CLAWSWEEPER_FEATURE_CLUSTER_REPAIR_ENABLED/);
 });
 
+// Workflow guard: jobs must be durable before any worker dispatch or dispatch recovery.
 test("cluster intake directly publishes git-only jobs before dispatch", () => {
   const workflow = readText(".github/workflows/repair-cluster-intake.yml");
   const stateTokenIndex = workflow.indexOf("uses: ./.github/actions/create-state-token");
@@ -2545,6 +2460,7 @@ test("cluster intake directly publishes git-only jobs before dispatch", () => {
   assert.doesNotMatch(workflow, /state-materializer\.yml|pnpm run repair:dispatch/);
 });
 
+// Source guard: publishing the exact-head job must precede the worker dispatch.
 test("conflict self-heal publishes exact-head jobs before worker dispatch", () => {
   const source = readText("src/repair/conflict-self-heal.ts");
   const writeIndex = source.indexOf("writeSelfHealJob(candidate);");
@@ -2609,6 +2525,7 @@ test("review prompts require reproduction and solution assessment details", () =
   assert.match(commitPrompt, /Is this the best way to solve the issue\?/);
 });
 
+// Workflow guard: terminal acknowledgements must not gain repository-content write access.
 test("sweep target write tokens retain merge and terminal acknowledgement scopes", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const targetWriteTokenBlocks = workflow
@@ -2647,6 +2564,7 @@ test("sweep target write tokens retain merge and terminal acknowledgement scopes
   }
 });
 
+// Workflow guard: recovery must use signed queue admission and remain review-only.
 test("sweep review recovery uses explicit failed shard artifacts", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const publishEventResult = readText("src/repair/publish-event-result.ts");
@@ -2726,6 +2644,7 @@ test("sweep review recovery uses explicit failed shard artifacts", () => {
   );
 });
 
+// Workflow guard: retries stay dry-run by default and publish state before artifact upload.
 test("sweep failed-review retry lane defaults to dry-run exact-item dispatch", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const retryBlock = workflow.slice(
@@ -2860,6 +2779,7 @@ test("dashboard operation counters include persisted failed-review retry sidecar
   }
 });
 
+// Workflow guard: status publication must not cross target repository boundaries.
 test("sweep dashboard status writes are scoped to the target repository", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const statusCalls = [...workflow.matchAll(new RegExp("pnpm run status -- \\\\", "g"))];
@@ -3135,15 +3055,6 @@ test("audit classifies missing open records by actionable reason", () => {
     ["eligible", "protected_label", "recently_created"],
   );
   assert.equal(auditHasStrictFailures(expectedQueueLag), true);
-
-  const actionableDrift = auditFromSnapshot({
-    ...base,
-    openItems: [item({ number: 4, createdAt: "2026-04-24T00:00:00.000Z" })],
-  });
-
-  assert.equal(actionableDrift.counts.missingEligibleOpen, 1);
-  assert.equal(actionableDrift.findings.missingEligibleOpen[0].missingReason, "eligible");
-  assert.equal(auditHasStrictFailures(actionableDrift), true);
 });
 
 test("audit health section summarizes strict status and actionable findings", () => {

--- a/test/live-proof.test.ts
+++ b/test/live-proof.test.ts
@@ -35,11 +35,7 @@ import {
   generatePlaywrightScript,
   terminalCommandPlan,
 } from "../dist/live-proof/drivers.js";
-import {
-  ensureLiveProofPackageManager,
-  executeLiveProof,
-  liveProofPackageManagerInstallCommand,
-} from "../dist/live-proof/execute.js";
+import { ensureLiveProofPackageManager, executeLiveProof } from "../dist/live-proof/execute.js";
 import { liveProofSetupCommand } from "../dist/live-proof/setup.js";
 import {
   assertLiveProofEnvironmentSanitized,
@@ -480,10 +476,6 @@ test("live-proof reports an unsupported package manager clearly", () => {
         PATH: "/usr/bin",
       }),
     /unsupported live-proof package manager "yarn"; expected bun, pnpm, or npm/,
-  );
-  assert.equal(
-    liveProofPackageManagerInstallCommand("bun"),
-    "curl -fsSL https://bun.sh/install | bash",
   );
 });
 
@@ -954,29 +946,6 @@ test("terminal nonzero and signal exits fail even when the expected marker is pr
     assert.equal(result.status, "failed");
     assert.equal(result.steps[0]?.status, "failed");
     assert.match(result.steps[0]?.detail ?? "", reason);
-  }
-});
-
-test("terminal pane signals fail even when expected output is present", () => {
-  for (const signal of ["term", "15"]) {
-    const result = driveTerminal({
-      plan: {
-        ...recommendedPlan("terminal"),
-        entry: "kill -TERM $$",
-        steps: [{ action: "expect_output", text: "Ready" }],
-      },
-      checkout: "/tmp/checkout",
-      rawVideoPath: "/tmp/live-proof.raw.webm",
-      maxRecordingSeconds: 90,
-      recordMedia: false,
-      runner: terminalLifecycleRunner([], {
-        commandSignal: signal,
-        terminalCaptures: ["Ready\n"],
-      }),
-    });
-
-    assert.equal(result.status, "failed");
-    assert.match(result.output, /terminated by a signal with exit status 143/);
   }
 });
 
@@ -1465,23 +1434,6 @@ test("terminal finalization catches a prompt failure before cleanup", () => {
     runner: terminalLifecycleRunner([], {
       commandExitStatus: 7,
       terminalCaptures: ["$ printf 'Ready\\n'; sleep 1; exit 7\nReady\n"],
-    }),
-  });
-
-  assert.equal(result.status, "failed");
-  assert.match(result.output, /failed with exit status 7/);
-});
-
-test("terminal detects an active shell that exits before publishing prompt status", () => {
-  const result = driveTerminal({
-    plan: { ...recommendedPlan("terminal"), entry: "exit 7", steps: [] },
-    checkout: "/tmp/checkout",
-    rawVideoPath: "/tmp/live-proof.raw.webm",
-    maxRecordingSeconds: 90,
-    recordMedia: false,
-    runner: terminalLifecycleRunner([], {
-      commandExitStatus: 7,
-      terminalCaptures: ["$ exit 7\n"],
     }),
   });
 
@@ -2171,7 +2123,6 @@ test("terminal entry executes once and publishes only its final visible viewport
   let commandExecuted = false;
   let capture:
     | {
-        captureScript: string;
         capture: string;
         captureTemporary: string;
         captureDone: string;
@@ -4150,10 +4101,9 @@ test("live-proof detach is a clean no-op when the record has no recording block"
   assert.match(fixture.logs.join("\n"), /has no recording block; no changes needed/);
 });
 
-test("live-proof maintenance syncs the marker-backed comment only after publication", () => {
+test("live-proof maintenance syncs a comment without the detached recording", () => {
   const fixture = recordedAttachmentFixture();
-  const calls: string[] = [];
-  calls.push("hydrate");
+  let publishedBody = "";
   const result = detachLiveProof(
     {
       recordPath: fixture.recordPath,
@@ -4170,7 +4120,6 @@ test("live-proof maintenance syncs the marker-backed comment only after publicat
       logs: fixture.logs,
     }),
   );
-  calls.push("detach", "publish", "comment");
   syncDetachedLiveProofComment(
     { recordPath: fixture.recordPath, repositorySlug: "example-repo", item: 42 },
     attachDependencies({
@@ -4179,7 +4128,7 @@ test("live-proof maintenance syncs the marker-backed comment only after publicat
         throw new Error("detach must not fetch the pull request");
       },
       upsertReviewComment: (_number, body) => {
-        assert.doesNotMatch(body, /clawsweeper-live-proof-recording|Live proof recording/);
+        publishedBody = body;
         return {};
       },
       logs: fixture.logs,
@@ -4187,7 +4136,8 @@ test("live-proof maintenance syncs the marker-backed comment only after publicat
   );
 
   assert.equal(result, "detached");
-  assert.deepEqual(calls, ["hydrate", "detach", "publish", "comment"]);
+  assert.match(publishedBody, /<!-- clawsweeper-review item=42 -->/);
+  assert.doesNotMatch(publishedBody, /clawsweeper-live-proof-recording|Live proof recording/);
 });
 
 test("live-proof comment sync requires the exact published bundle result", () => {
@@ -4388,6 +4338,7 @@ test("live-proof attach dry-run prints exact uploads and mutations without perfo
   assert.match(output, /dry-run: upsert marker-backed review comment/);
 });
 
+// Workflow guard: historical proof is folded before publication, and maintenance stays manual.
 test("automatic live proof is retired while historical artifact publication remains", () => {
   assert.throws(() => readFileSync(".github/workflows/live-proof.yml", "utf8"));
   assert.throws(() => readFileSync(".github/actions/dispatch-live-proofs/action.yml", "utf8"));
@@ -4708,7 +4659,6 @@ function terminalLifecycleRunner(
     keepsRunningCommands?: string[];
     heldCommandKeepsRunning?: boolean;
     commandCompletionAfterProbe?: number;
-    commandCompletionAfterProbes?: number[];
     recordedStatuses?: Array<number | string | null>;
     captureCompletion?: string;
     paneStatusDuringFinalize?: { status: "exited"; exitStatus: number };
@@ -4749,11 +4699,9 @@ function terminalLifecycleRunner(
         command: string;
         held: boolean;
         status: string;
-        statusTemporary: string;
         start: string;
         ready: string;
         readyTemporary: string;
-        lease: string;
         leaseIdentity: string;
         nonce: string;
       }
@@ -4761,7 +4709,6 @@ function terminalLifecycleRunner(
   let activeCleanup: TerminalCleanupInvocation | undefined;
   let activeFiles:
     | {
-        captureScript: string;
         capture: string;
         captureTemporary: string;
         captureDone: string;
@@ -4787,10 +4734,7 @@ function terminalLifecycleRunner(
     }
     const captures = options.terminalCapturesByCommand?.[typedCommand] ??
       options.terminalCaptures ?? ["command output\n"];
-    const completionAfter =
-      options.commandCompletionAfterProbes?.[commandLaunch - 1] ??
-      options.commandCompletionAfterProbe ??
-      captures.length - 1;
+    const completionAfter = options.commandCompletionAfterProbe ?? captures.length - 1;
     if (terminalCaptureProbe < completionAfter) return;
     const configured = options.recordedStatuses?.[commandLaunch - 1];
     if (configured === null) return;
@@ -5044,11 +4988,9 @@ function terminalCommandInvocation(args: readonly string[]):
       command: string;
       held: boolean;
       status: string;
-      statusTemporary: string;
       start: string;
       ready: string;
       readyTemporary: string;
-      lease: string;
       leaseIdentity: string;
       nonce: string;
     }
@@ -5062,13 +5004,11 @@ function terminalCommandInvocation(args: readonly string[]):
   return {
     command: invocation[1]!,
     held: shellCommand.includes("while :; do sleep 3600; done"),
-    statusTemporary: invocation[2]!,
     status: invocation[3]!,
     start: invocation[4]!,
     readyTemporary: invocation[5]!,
     ready: invocation[6]!,
     nonce: invocation[7]!,
-    lease: invocation[8]!,
     leaseIdentity: invocation[9]!,
   };
 }
@@ -5078,7 +5018,6 @@ interface TerminalCleanupInvocation {
   paneTty: string;
   panePid: string;
   nonce: string;
-  lease: string;
   leaseIdentity: string;
   request: string;
   resultTemporary: string;
@@ -5095,7 +5034,6 @@ function terminalCleanupInvocation(args: readonly string[]): TerminalCleanupInvo
     paneTty: invocation[2]!,
     panePid: invocation[3]!,
     nonce: invocation[4]!,
-    lease: invocation[5]!,
     leaseIdentity: invocation[6]!,
     request: invocation[7]!,
     resultTemporary: invocation[8]!,
@@ -5105,7 +5043,6 @@ function terminalCleanupInvocation(args: readonly string[]): TerminalCleanupInvo
 
 function terminalCaptureInvocation(args: readonly string[]):
   | {
-      captureScript: string;
       capture: string;
       captureTemporary: string;
       captureDone: string;
@@ -5118,7 +5055,6 @@ function terminalCaptureInvocation(args: readonly string[]):
   const files = quoted.slice(-5);
   if (files.length !== 5) return undefined;
   return {
-    captureScript: files[0]!,
     capture: files[1]!,
     captureTemporary: files[2]!,
     captureDone: files[3]!,


### PR DESCRIPTION
## What Problem This Solves

The large Node-side suites repeat fixture setup and assertions without exercising additional behavior. The closeout fixture also retained branches for scenarios that were no longer in its case table, making the test look more comprehensive than its executed coverage.

## Why This Change Was Made

Consolidate 41 copies of apply-directory setup and the duplicated completed-issue-lease fixture. Remove five redundant or implementation-detail tests, unreachable closeout fixture branches, an unused terminal fixture option, and unread fixture fields. Replace the detach test's self-authored ordering array with assertions on the actual published comment.

Both completed-lease publication modes and all 17 active closeout scenarios remain. Retain the distinct ledger immutability, process cleanup, proof/media validation, freshness, locked-conversation, maintainer, and credential-boundary cases. Add brief explanations to retained source checks that guard safety ordering or workflow authority.

## User Impact

Behavior-neutral; no runtime contract, config, or workflow change. Production LOC delta is 0, as required for this tests-only lane.

## Evidence

For this behavior-neutral refactor, the proof is the full `pnpm run check` run plus the directly executed touched suites.

`pr-behavior-proof` contract:

- Claim: remove redundant test scaffolding and assertions while preserving active safety behavior coverage and all coverage floors.
- Exercised surface: apply/comment/label publication, completed review leases, closeout provenance, action ledger recording/imports/locks, and historical live-proof execution/publication.
- Scenario/fixture: existing isolated filesystem and subprocess fixtures, mocked GitHub/media/projection boundaries, and the retained adversarial/race scenarios in the four touched suites.
- Command and environment: Node v26.8.1, pnpm 11.10.0, Bash 5.3.15 on macOS; `pnpm run build:all`, each direct suite command below, and `pnpm run check`.
- Observable result: pass summaries below; coverage floors remain 49% lines, 66% branches, and 57% functions.
- Artifact or trace: local logs `/tmp/deslop-tests2-{clawsweeper,apply-label-sync,live-proof,action-ledger-runtime,check}.log`; the relevant summaries are reproduced below.
- Limits: simulated external boundaries; no production mutation or deployment. The two Linux-only ledger tests are skipped on macOS.

OpenClaw Bay not affected: no dashboard changes.

`corepack enable >/dev/null 2>&1; pnpm install --prefer-offline`, `pnpm run build:all`, `pnpm run format --ignore-path /tmp/deslop-tests2-format.ignore`, and `git diff --check` all passed.

```text
node --test test/clawsweeper.test.ts
ℹ tests 75
ℹ pass 75
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
```

```text
node --test test/apply-label-sync.test.ts
ℹ tests 40
ℹ pass 40
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
```

```text
node --test test/live-proof.test.ts
ℹ tests 145
ℹ pass 145
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
```

```text
node --test test/action-ledger-runtime.test.ts
ℹ tests 95
ℹ pass 93
ℹ fail 0
ℹ cancelled 0
ℹ skipped 2
```

Full gate passed (first summary: focused coverage; second: all suites). Coverage columns are lines, branches, and functions.

```text
pnpm run check
ℹ tests 13
ℹ pass 13
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ all files               | 100.00 |    88.61 |  100.00 | 
ℹ tests 4764
ℹ pass 4752
ℹ fail 0
ℹ cancelled 0
ℹ skipped 12
ℹ all files                                     |  83.70 |    76.39 |   88.68 | 
```

Independent Codex autoreview: **scoped-clean**, no accepted/actionable findings in the selected Git scope and requested P1 threshold. Report: `/tmp/autoreview-deslop-tests2.md`.

```sh
~/Projects/openclaw/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main --max-priority P1 --output /tmp/autoreview-$(basename "$PWD").md
```

Verified head: `e93e8e05dfe5d9ccee269fe3c24e1b166fa8d2dc`. LOC totals from `git diff --numstat origin/main...HEAD`.

| LOC category | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Production | 0 | 0 | 0 |
| Tests | 103 | 695 | -592 |
| Docs | 0 | 0 | 0 |


### Update after ClawSweeper review (head f56561c3f)

The reviewed head adds one commit over the validated transcript: it restores the `synchronous Codex review surfaces use the shared bounded runner` source guard (16 lines) that the first commit had removed. Head-exact validation:

- `node --test test/clawsweeper.test.ts test/apply-label-sync.test.ts test/live-proof.test.ts test/action-ledger-runtime.test.ts` on `f56561c3f`: tests 356, pass 354, fail 0, skipped 2 (the two Linux-only procfs cases).
- Full gate on this head in CI: `pnpm check` https://github.com/openclaw/clawsweeper/actions/runs/33829603038/job/100889625010 (success), plus the rest of the required CI matrix.

Scoped proof decision: this PR changes only test files (production LOC delta 0; `git diff --numstat origin/main...HEAD` touches `test/**` only), so there is no changed runtime, workflow, queue, API, UI, package, or integration path to exercise; the proof surface is the touched suites plus the full check on the exact head, both recorded above. The one removed live-proof assertion (`liveProofPackageManagerInstallCommand("bun")`) pinned a literal install URL, not behavior. The five closeout-provenance scenario branches removed here were never listed in the scenario array (dead since written); re-enabling them as live scenarios is tracked as follow-up work in the campaign's bug-fix lane.
