### PR TITLE
refactor(repair): simplify executor and apply-result plumbing

### DIFF
--- a/src/repair/apply-result.ts
+++ b/src/repair/apply-result.ts
@@ -192,18 +192,18 @@ function findLatestResultPath() {
   if (!fs.existsSync(runsRoot)) {
     throw new Error("no run directory exists");
   }
-  const candidates: LooseRecord[] = [];
+  const candidates: { path: string; mtimeMs: number }[] = [];
   for (const runName of fs.readdirSync(runsRoot)) {
     const candidate = path.join(runsRoot, runName, "result.json");
     if (!fs.existsSync(candidate)) continue;
     candidates.push({ path: candidate, mtimeMs: fs.statSync(candidate).mtimeMs });
   }
-  candidates.sort((left: JsonValue, right: JsonValue) => right.mtimeMs - left.mtimeMs);
+  candidates.sort((left, right) => right.mtimeMs - left.mtimeMs);
   if (!candidates[0]) throw new Error("no result.json files found");
   return candidates[0].path;
 }
 
-function readFixExecutionReport(_result?: JsonValue) {
+function readFixExecutionReport() {
   const reportPath = path.join(path.dirname(resultPath), "fix-execution-report.json");
   if (!fs.existsSync(reportPath)) return null;
   return JSON.parse(fs.readFileSync(reportPath, "utf8"));
@@ -429,25 +429,8 @@ function applyCloseAction({
   }
 
   const expectedUpdatedAt = action.target_updated_at ?? action.live_updated_at;
-  if (!expectedUpdatedAt && !allowMissingUpdatedAt) {
-    return {
-      ...base,
-      status: "blocked",
-      reason: "missing target_updated_at; rerun the worker against live GitHub state",
-      live_state: live.state,
-      live_updated_at: live.updated_at,
-    };
-  }
-  if (expectedUpdatedAt && expectedUpdatedAt !== live.updated_at) {
-    return {
-      ...base,
-      status: "blocked",
-      reason: "target changed since worker review",
-      expected_updated_at: expectedUpdatedAt,
-      live_updated_at: live.updated_at,
-      live_state: live.state,
-    };
-  }
+  const revisionBlock = targetRevisionBlock(expectedUpdatedAt, live, allowMissingUpdatedAt);
+  if (revisionBlock) return { ...base, ...revisionBlock };
 
   const comment = renderCloseComment({ action, classification, result, target, live });
   const marker = idempotencyMarker(result.cluster_id, target, idempotencyKey);
@@ -496,16 +479,12 @@ function applyCloseAction({
       live_state: live.state,
     };
   }
-  if (expectedUpdatedAt && expectedUpdatedAt !== live.updated_at) {
-    return {
-      ...base,
-      status: "blocked",
-      reason: "target changed since worker review",
-      expected_updated_at: expectedUpdatedAt,
-      live_updated_at: live.updated_at,
-      live_state: live.state,
-    };
-  }
+  const postProofRevisionBlock = targetRevisionBlock(
+    expectedUpdatedAt,
+    live,
+    allowMissingUpdatedAt,
+  );
+  if (postProofRevisionBlock) return { ...base, ...postProofRevisionBlock };
   if (proofValidation?.status === "covered") {
     const postProofCoveringFreshnessBlock = validatePrCloseCoverageCoveringFreshness({
       result,
@@ -579,9 +558,34 @@ function applyCloseAction({
 function prCloseCoverageProofActionReport(proofValidation: PrCloseCoverageProofValidation): {
   pr_close_coverage_proof?: PrCloseCoverageProofModelResult;
 } {
-  return proofValidation?.status === "covered" && proofValidation.proof
+  return proofValidation?.status === "covered"
     ? { pr_close_coverage_proof: proofValidation.proof }
     : {};
+}
+
+function targetRevisionBlock(
+  expectedUpdatedAt: unknown,
+  live: { state?: unknown; updated_at?: unknown },
+  allowMissingUpdatedAt: boolean,
+) {
+  if (!expectedUpdatedAt && !allowMissingUpdatedAt) {
+    return {
+      status: "blocked",
+      reason: "missing target_updated_at; rerun the worker against live GitHub state",
+      live_state: live.state,
+      live_updated_at: live.updated_at,
+    };
+  }
+  if (expectedUpdatedAt && expectedUpdatedAt !== live.updated_at) {
+    return {
+      status: "blocked",
+      reason: "target changed since worker review",
+      expected_updated_at: expectedUpdatedAt,
+      live_updated_at: live.updated_at,
+      live_state: live.state,
+    };
+  }
+  return null;
 }
 
 function applyMergeAction({
@@ -593,7 +597,7 @@ function applyMergeAction({
   target,
   base,
 }: LooseRecord) {
-  const policyBlock = validateMergePolicy({ job, action });
+  const policyBlock = validateMergePolicy(job);
   if (policyBlock) return { ...base, status: "blocked", reason: policyBlock };
   if (!allowedRefs.has(target)) {
     return { ...base, status: "blocked", reason: "merge target is not listed in job refs" };
@@ -622,25 +626,8 @@ function applyMergeAction({
   }
 
   const expectedUpdatedAt = action.target_updated_at ?? action.live_updated_at;
-  if (!expectedUpdatedAt && !allowMissingUpdatedAt) {
-    return {
-      ...base,
-      status: "blocked",
-      reason: "missing target_updated_at; rerun the worker against live GitHub state",
-      live_state: live.state,
-      live_updated_at: live.updated_at,
-    };
-  }
-  if (expectedUpdatedAt && expectedUpdatedAt !== live.updated_at) {
-    return {
-      ...base,
-      status: "blocked",
-      reason: "target changed since worker review",
-      expected_updated_at: expectedUpdatedAt,
-      live_updated_at: live.updated_at,
-      live_state: live.state,
-    };
-  }
+  const revisionBlock = targetRevisionBlock(expectedUpdatedAt, live, allowMissingUpdatedAt);
+  if (revisionBlock) return { ...base, ...revisionBlock };
 
   const pullRequest = fetchPullRequest(result.repo, target);
   const view = fetchPullRequestView(result.repo, target);
@@ -802,7 +789,7 @@ function validateFixFirstClose({
     return "fixed_by_candidate close requires a merged fix PR unless allow_unmerged_fix_close: true";
   }
 
-  const fixReport = readFixExecutionReport(result);
+  const fixReport = readFixExecutionReport();
   const fixLanded = (fixReport?.actions ?? []).some(
     (entry: JsonValue) =>
       ["open_fix_pr", "repair_contributor_branch"].includes(String(entry.action ?? "")) &&
@@ -821,14 +808,11 @@ function isMergedCandidateFix(repo: string, candidateFix: LooseRecord) {
   }
 }
 
-function validateMergePolicy({ job, action }: LooseRecord) {
+function validateMergePolicy(job: LooseRecord) {
   if (!job.frontmatter.allowed_actions.includes("merge")) return "job does not allow merge";
   if ((job.frontmatter.blocked_actions ?? []).includes("merge"))
     return "merge is blocked by job frontmatter";
   if (job.frontmatter.allow_merge !== true) return "merge requires allow_merge: true";
-  if (!["merge_candidate", "merge_canonical"].includes(String(action.action ?? ""))) {
-    return "unsupported merge action";
-  }
   return "";
 }
 
@@ -1010,7 +994,7 @@ function validatePrCloseCoverageProof({
       return { status: "blocked", reason: coveringSafetyBlock };
     }
   } catch (error) {
-    return prCloseCoverageProofSetupFailureBlock(error);
+    return { status: "blocked", ...prCloseCoverageProofFailureBlock(error) };
   }
 
   try {
@@ -1054,12 +1038,6 @@ function validatePrCloseCoverageProof({
       reason: prCloseCoverageProofFailureReason(error),
     };
   }
-}
-
-function prCloseCoverageProofSetupFailureBlock(
-  error: unknown,
-): Extract<PrCloseCoverageProofValidation, { status: "blocked" }> {
-  return { status: "blocked", ...prCloseCoverageProofFailureBlock(error) };
 }
 
 function prCloseCoverageProofFailureBlock(error: unknown): PrCloseCoverageProofBlock {
@@ -1290,17 +1268,9 @@ function hydratePrCloseCoveragePullRequest(
     mergedAt: stringOrNull(pull.merged_at ?? pull.mergedAt),
     body: compactPrCloseCoverageProofText(pull.body),
     updatedAt: stringOrNull(pull.updated_at ?? pull.updatedAt ?? issue.updated_at),
-    comments: compactPrCloseCoverageProofCommentWindow(
-      comments,
-      comments.length,
-      PR_CLOSE_COVERAGE_PROOF_COMMENT_LIMIT,
-    ),
+    comments: compactPrCloseCoverageProofCommentWindow(comments),
     commentsTruncated: commentsWindow.total > PR_CLOSE_COVERAGE_PROOF_COMMENT_LIMIT,
   };
-}
-
-function rawCommentBody(value: JsonValue): string {
-  return stringFromUnknown(value?.body);
 }
 
 function isClawSweeperComment(value: JsonValue): boolean {
@@ -1309,7 +1279,7 @@ function isClawSweeperComment(value: JsonValue): boolean {
 }
 
 function isClawSweeperNoiseComment(value: JsonValue): boolean {
-  const body = rawCommentBody(value);
+  const body = stringFromUnknown(value?.body);
   if (CLAWSWEEPER_COMMAND_ONLY_PATTERN.test(body.trim())) return true;
   if (!body.trim() || !isClawSweeperComment(value)) return false;
   if (/<!--\s*clawsweeper-review\s+item=/i.test(body)) return true;
@@ -1335,20 +1305,13 @@ function fetchPrCloseCoverageProofCommentWindow(
   if (total === 0 || limit <= 0) {
     return { comments: [], total };
   }
-  if (total <= limit) {
+  if (total <= limit || total <= GITHUB_MAX_PAGE_SIZE) {
     return {
       comments: fetchPrCloseCoverageProofCommentPage(
         apiPath,
         Math.min(total, GITHUB_MAX_PAGE_SIZE),
         1,
       ),
-      total,
-    };
-  }
-
-  if (total <= GITHUB_MAX_PAGE_SIZE) {
-    return {
-      comments: fetchPrCloseCoverageProofCommentPage(apiPath, total, 1),
       total,
     };
   }
@@ -1473,25 +1436,18 @@ function githubLastPageNumber(headers: string): number | null {
   return null;
 }
 
-function compactPrCloseCoverageProofCommentWindow(
-  comments: JsonValue[],
-  total: number,
-  limit: number,
-): unknown[] {
-  const boundedLimit = Math.max(0, Math.floor(limit));
-  const boundedTotal = Math.max(0, Math.floor(total));
-  if (boundedTotal <= boundedLimit && comments.length <= boundedLimit) {
+function compactPrCloseCoverageProofCommentWindow(comments: JsonValue[]): unknown[] {
+  if (comments.length <= PR_CLOSE_COVERAGE_PROOF_COMMENT_LIMIT) {
     return comments.map(compactPrCloseCoverageProofComment);
   }
-  if (boundedLimit === 0) {
-    return [{ omitted: boundedTotal, note: "comments omitted from proof context" }];
-  }
-  const keepStart = Math.floor(boundedLimit / 2);
-  const keepEnd = Math.max(0, boundedLimit - keepStart);
-  const omitted = Math.max(0, boundedTotal - keepStart - keepEnd);
+  const keepStart = Math.floor(PR_CLOSE_COVERAGE_PROOF_COMMENT_LIMIT / 2);
+  const keepEnd = PR_CLOSE_COVERAGE_PROOF_COMMENT_LIMIT - keepStart;
   return [
     ...comments.slice(0, keepStart).map(compactPrCloseCoverageProofComment),
-    ...(omitted > 0 ? [{ omitted, note: "middle comments omitted from proof context" }] : []),
+    {
+      omitted: comments.length - PR_CLOSE_COVERAGE_PROOF_COMMENT_LIMIT,
+      note: "middle comments omitted from proof context",
+    },
     ...comments.slice(comments.length - keepEnd).map(compactPrCloseCoverageProofComment),
   ];
 }

--- a/src/repair/execute-fix-artifact.ts
+++ b/src/repair/execute-fix-artifact.ts
@@ -4,11 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { adaptiveReviewBudgetForPullRequest } from "./adaptive-review-budget.js";
-import {
-  spawn,
-  type ChildProcess,
-  type SpawnSyncOptionsWithStringEncoding,
-} from "node:child_process";
+import { spawn } from "node:child_process";
 import { assertAllowedOwner, parseArgs, parseJob, repoRoot, validateJob } from "./lib.js";
 import {
   automergeRepairOutcomeComment,
@@ -37,7 +33,7 @@ import {
 import { runAgentProcess } from "../agent-runner.js";
 import { AgentInputScanError, type AgentScanSource } from "../agent-input-scan.js";
 import { withTargetReviewSnapshot } from "./target-validation.js";
-import { codexAppServerProcessOptionsFromEnv } from "../codex-process.js";
+import { codexAppServerProcessOptionsFromEnv, type CodexProcessResult } from "../codex-process.js";
 import {
   branchHasBaseDiff,
   currentHead,
@@ -356,38 +352,59 @@ function currentCodexTimeoutMs(preserveLateWorkerBudget = false) {
   });
 }
 
-function spawnCodexSyncWithHeartbeat(
-  label: string,
-  args: string[],
-  options: SpawnSyncOptionsWithStringEncoding & {
-    stdoutPath?: string;
-    stderrPath?: string;
-    scanSource: AgentScanSource;
-  },
-) {
+function runCodexWithHeartbeat({
+  label,
+  targetDir,
+  prompt,
+  timeoutMs,
+  outputPath,
+  logPrefix,
+  review,
+}: {
+  label: string;
+  targetDir: string;
+  prompt: string;
+  timeoutMs: number;
+  outputPath: string;
+  logPrefix: string;
+  review?: { schemaPath: string; scanSource: AgentScanSource };
+}) {
+  const sandbox = review ? codexReviewSandbox : codexWriteSandbox;
+  const networkAccess = review ? codexReviewNetworkAccess : codexWriteNetworkAccess;
+  const codexExtraArgs = [
+    "--cd",
+    targetDir,
+    ...executionModelArgs,
+    "--sandbox",
+    sandbox,
+    ...codexWorkspaceSandboxConfigArgs(sandbox, networkAccess),
+    ...codexConfigArgs(),
+    ...(review ? ["--output-schema", review.schemaPath] : []),
+    "--output-last-message",
+    outputPath,
+    "--json",
+    "-",
+  ];
+  const env = codexEnv();
   const heartbeat = startCodexHeartbeat(label);
   try {
-    if (typeof options.cwd !== "string" || typeof options.input !== "string") {
-      throw new Error(`${label} requires string cwd and input.`);
-    }
-    if (args[0] !== "exec") throw new Error(`${label} requires a Codex exec argument list.`);
     const appServer = codexAppServerProcessOptionsFromEnv(label);
     return runAgentProcess({
-      scanSource: options.scanSource,
+      scanSource: review?.scanSource ?? { kind: "prompt" },
       label,
-      prompt: options.input,
+      prompt,
       model,
       reasoningEffort: codexReasoningEffort,
-      codexExtraArgs: args.slice(1),
-      cwd: options.cwd,
-      env: options.env ?? process.env,
-      timeoutMs: options.timeout ?? currentCodexTimeoutMs(),
-      ...(options.stdoutPath ? { stdoutPath: options.stdoutPath } : {}),
-      ...(options.stderrPath ? { stderrPath: options.stderrPath } : {}),
+      codexExtraArgs,
+      cwd: targetDir,
+      env,
+      timeoutMs,
+      stdoutPath: path.join(workRoot, `${logPrefix}.jsonl`),
+      stderrPath: path.join(workRoot, `${logPrefix}.stderr.log`),
       ...(appServer ? { appServer } : {}),
     });
   } finally {
-    stopCodexHeartbeat(heartbeat);
+    if (!heartbeat.killed) heartbeat.kill("SIGTERM");
   }
 }
 
@@ -411,10 +428,6 @@ setInterval(() => {
   });
   child.on("error", () => {});
   return child;
-}
-
-function stopCodexHeartbeat(child: ChildProcess) {
-  if (!child.killed) child.kill("SIGTERM");
 }
 
 function remainingFixStepBudgetMs() {
@@ -773,9 +786,9 @@ function shouldFallbackToReplacementAfterRepairError(error: JsonValue) {
 
 function isExecutableFixAction(action: LooseRecord, promotedReplacement: JsonValue) {
   if (!FIX_ACTIONS.has(String(action.action ?? ""))) return false;
-  if (action.status === "planned") return true;
-  if (!promotedReplacement || action.status !== "blocked") return false;
-  return ["fix_needed", "build_fix_artifact", "open_fix_pr"].includes(String(action.action ?? ""));
+  return (
+    action.status === "planned" || (Boolean(promotedReplacement) && action.status === "blocked")
+  );
 }
 
 function executableReplacementFixArtifact(fixArtifact: LooseRecord, workerResult: JsonValue) {
@@ -1075,7 +1088,6 @@ function pushRepairBranchAndUpdateStatus({
       targetDir,
       pull,
       sourceRef: prep.commit,
-      rewritten: branchUpdate.rewritten,
     });
   }
   const settleSeconds = repairPushSettleSeconds();
@@ -1111,7 +1123,6 @@ function pushRepairBranchAndUpdateStatus({
   assertTargetCheckoutBinding(targetDir, checkoutBinding, targetValidationTimeoutMs);
   const pushArgs = repairBranchPushArgs({
     pull,
-    rewritten: branchUpdate.rewritten,
     sourceRef: checkoutBinding.headSha,
   });
   try {
@@ -1287,7 +1298,6 @@ function openReplacementPrFromPreparedRepairCheckout({
     checkpointCommits: prep.checkpoint_commits,
   });
   prep.commit = historyCompaction.commit;
-  prep.history_compaction = historyCompaction;
   prep.checkout_binding = captureFinalTargetCheckoutBinding(
     targetDir,
     prep.checkout_binding,
@@ -2272,33 +2282,14 @@ function editValidatePrepareMerge({
         details: reconcileWithBase ? "reconciling latest base" : "repairing branch",
         headSha: headBeforeAttempt,
       });
-      const codexResult = spawnCodexSyncWithHeartbeat(
-        `Codex fix worker ${mode} attempt ${attempt}`,
-        [
-          "exec",
-          "--cd",
-          targetDir,
-          ...executionModelArgs,
-          "--sandbox",
-          codexWriteSandbox,
-          ...codexWriteSandboxConfigArgs(),
-          ...codexConfigArgs(),
-          "--output-last-message",
-          summaryPath,
-          "--json",
-          "-",
-        ],
-        {
-          cwd: targetDir,
-          input: prompt,
-          encoding: "utf8",
-          env: codexEnv(),
-          timeout: workerTimeoutMs,
-          scanSource: { kind: "prompt" },
-          stdoutPath: path.join(workRoot, `${mode}-codex-${attempt}.jsonl`),
-          stderrPath: path.join(workRoot, `${mode}-codex-${attempt}.stderr.log`),
-        },
-      );
+      const codexResult = runCodexWithHeartbeat({
+        label: `Codex fix worker ${mode} attempt ${attempt}`,
+        targetDir,
+        prompt,
+        timeoutMs: workerTimeoutMs,
+        outputPath: summaryPath,
+        logPrefix: `${mode}-codex-${attempt}`,
+      });
       const timedOut = (codexResult.error as JsonValue)?.code === "ETIMEDOUT";
       const errorDetail = timedOut
         ? `Codex fix worker timed out after ${workerTimeoutMs}ms`
@@ -2543,7 +2534,6 @@ function editValidatePrepareMerge({
     commit: expectedCommit,
     checkout_binding: checkoutBinding,
     checkpoint_commits: checkpointCommits,
-    history_compaction: historyCompaction,
     merge_preflight: buildMergePreflight({ fixArtifact, codexReview }),
     target_base_sha: acceptedBaseSha,
   };
@@ -2709,39 +2699,14 @@ function runCodexBaseReconcile({
       `${mode}-final-base-reconcile-summary-${attempt}-${codexAttempt}.md`,
     );
     const reconcileTimeoutMs = currentCodexTimeoutMs(true);
-    const codexResult = spawnCodexSyncWithHeartbeat(
-      `Codex final rebase worker ${mode} attempt ${attempt}.${codexAttempt}`,
-      [
-        "exec",
-        "--cd",
-        targetDir,
-        ...executionModelArgs,
-        "--sandbox",
-        codexWriteSandbox,
-        ...codexWriteSandboxConfigArgs(),
-        ...codexConfigArgs(),
-        "--output-last-message",
-        summaryPath,
-        "--json",
-        "-",
-      ],
-      {
-        cwd: targetDir,
-        input: prompt,
-        encoding: "utf8",
-        env: codexEnv(),
-        timeout: reconcileTimeoutMs,
-        scanSource: { kind: "prompt" },
-        stdoutPath: path.join(
-          workRoot,
-          `${mode}-final-base-reconcile-${attempt}-${codexAttempt}.jsonl`,
-        ),
-        stderrPath: path.join(
-          workRoot,
-          `${mode}-final-base-reconcile-${attempt}-${codexAttempt}.stderr.log`,
-        ),
-      },
-    );
+    const codexResult = runCodexWithHeartbeat({
+      label: `Codex final rebase worker ${mode} attempt ${attempt}.${codexAttempt}`,
+      targetDir,
+      prompt,
+      timeoutMs: reconcileTimeoutMs,
+      outputPath: summaryPath,
+      logPrefix: `${mode}-final-base-reconcile-${attempt}-${codexAttempt}`,
+    });
     if ((codexResult.error as JsonValue)?.code === "ETIMEDOUT") {
       throw new Error(`Codex final rebase worker timed out after ${reconcileTimeoutMs}ms`);
     }
@@ -2754,13 +2719,12 @@ function runCodexBaseReconcile({
       );
     }
     try {
-      const completed = completeTargetRebaseWithIsolation({
+      return completeTargetRebaseWithIsolation({
         cwd: targetDir,
         expectedBaseRef: baseSha,
         requireInProgress: true,
         timeoutMs: targetValidationTimeoutMs,
       });
-      return completed;
     } catch (error) {
       if (codexAttempt === maxEditAttempts) throw error;
       previousSummary = readTextIfExists(summaryPath).trim();
@@ -2812,11 +2776,11 @@ function readTextIfExists(filePath: string) {
   return fs.existsSync(filePath) ? fs.readFileSync(filePath, "utf8") : "";
 }
 
-function codexFailureDetail(child: LooseRecord, fallback: string) {
+function codexFailureDetail(child: CodexProcessResult, fallback: string) {
   const detail =
-    codexJsonlFailureDetail(String(child.stdout ?? "")) ||
-    codexJsonlFailureDetail(String(child.stderr ?? "")) ||
-    stripAnsi(String(child.stderr ?? child.stdout ?? "")).trim();
+    codexJsonlFailureDetail(child.stdout) ||
+    codexJsonlFailureDetail(child.stderr) ||
+    stripAnsi(child.stderr).trim();
   return detail || fallback;
 }
 
@@ -2824,8 +2788,7 @@ function codexFailureMessage(label: string, detail: string) {
   return `${label}: ${compactText(stripAnsi(detail || "no Codex output"), 900)}`;
 }
 
-function stripAnsi(value: string) {
-  const text = String(value ?? "");
+function stripAnsi(text: string) {
   let out = "";
   for (let index = 0; index < text.length; index += 1) {
     if (text.charCodeAt(index) !== 27) {
@@ -2843,14 +2806,6 @@ function stripAnsi(value: string) {
   return out;
 }
 
-function codexWriteSandboxConfigArgs() {
-  return codexWorkspaceSandboxConfigArgs(codexWriteSandbox, codexWriteNetworkAccess);
-}
-
-function codexReviewSandboxConfigArgs() {
-  return codexWorkspaceSandboxConfigArgs(codexReviewSandbox, codexReviewNetworkAccess);
-}
-
 function codexConfigArgs() {
   const configs = [
     'approval_policy="never"',
@@ -2861,12 +2816,12 @@ function codexConfigArgs() {
   return configs.flatMap((config: JsonValue) => ["-c", config]);
 }
 
-function codexWorkspaceSandboxConfigArgs(sandbox: string, networkAccess: string) {
+function codexWorkspaceSandboxConfigArgs(sandbox: string, networkAccess: boolean) {
   if (sandbox !== "workspace-write") return [];
   return ["-c", `sandbox_workspace_write.network_access=${networkAccess ? "true" : "false"}`];
 }
 
-function parseBooleanEnv(value: JsonValue, fallback: JsonValue) {
+function parseBooleanEnv(value: string | undefined, fallback: boolean): boolean {
   if (value == null || value === "") return fallback;
   if (/^(1|true|yes|on)$/i.test(String(value))) return true;
   if (/^(0|false|no|off)$/i.test(String(value))) return false;
@@ -3211,35 +3166,15 @@ function runCodexReview({
       timeoutMs: reviewTimeoutMs,
     },
     (scanSource, timeoutMs) =>
-      spawnCodexSyncWithHeartbeat(
-        `Codex /review ${mode} attempt ${attempt}`,
-        [
-          "exec",
-          "--cd",
-          targetDir,
-          ...executionModelArgs,
-          "--sandbox",
-          codexReviewSandbox,
-          ...codexReviewSandboxConfigArgs(),
-          ...codexConfigArgs(),
-          "--output-schema",
-          schemaPath,
-          "--output-last-message",
-          outputPath,
-          "--json",
-          "-",
-        ],
-        {
-          cwd: targetDir,
-          input: prompt,
-          encoding: "utf8",
-          env: codexEnv(),
-          timeout: timeoutMs,
-          scanSource,
-          stdoutPath: path.join(workRoot, `${mode}-codex-review-${attempt}.jsonl`),
-          stderrPath: path.join(workRoot, `${mode}-codex-review-${attempt}.stderr.log`),
-        },
-      ),
+      runCodexWithHeartbeat({
+        label: `Codex /review ${mode} attempt ${attempt}`,
+        targetDir,
+        prompt,
+        timeoutMs,
+        outputPath,
+        logPrefix: `${mode}-codex-review-${attempt}`,
+        review: { schemaPath, scanSource },
+      }),
   );
   if ((child.error as JsonValue)?.code === "ETIMEDOUT")
     throw new Error(`Codex /review timed out after ${reviewTimeoutMs}ms`);
@@ -3268,7 +3203,7 @@ function runCodexReview({
 }
 
 function extractCodexReviewFromJsonl(stdout: JsonValue) {
-  const candidates: LooseRecord[] = [];
+  const candidates: string[] = [];
   for (const line of String(stdout ?? "").split(/\r?\n/)) {
     if (!line.trim()) continue;
     let event;
@@ -3336,33 +3271,14 @@ function runCodexReviewFix({
     "```",
   ].join("\n");
   const reviewFixTimeoutMs = currentCodexTimeoutMs();
-  const child = spawnCodexSyncWithHeartbeat(
-    `Codex review-fix worker ${mode} attempt ${attempt}`,
-    [
-      "exec",
-      "--cd",
-      targetDir,
-      ...executionModelArgs,
-      "--sandbox",
-      codexWriteSandbox,
-      ...codexWriteSandboxConfigArgs(),
-      ...codexConfigArgs(),
-      "--output-last-message",
-      path.join(workRoot, `${mode}-codex-review-fix-${attempt}.md`),
-      "--json",
-      "-",
-    ],
-    {
-      cwd: targetDir,
-      input: prompt,
-      encoding: "utf8",
-      env: codexEnv(),
-      timeout: reviewFixTimeoutMs,
-      scanSource: { kind: "prompt" },
-      stdoutPath: path.join(workRoot, `${mode}-codex-review-fix-${attempt}.jsonl`),
-      stderrPath: path.join(workRoot, `${mode}-codex-review-fix-${attempt}.stderr.log`),
-    },
-  );
+  const child = runCodexWithHeartbeat({
+    label: `Codex review-fix worker ${mode} attempt ${attempt}`,
+    targetDir,
+    prompt,
+    timeoutMs: reviewFixTimeoutMs,
+    outputPath: path.join(workRoot, `${mode}-codex-review-fix-${attempt}.md`),
+    logPrefix: `${mode}-codex-review-fix-${attempt}`,
+  });
   if ((child.error as JsonValue)?.code === "ETIMEDOUT")
     throw new Error(`Codex review-fix worker timed out after ${reviewFixTimeoutMs}ms`);
   if (child.error) throw new Error(child.error.message || String(child.error));
@@ -3417,33 +3333,14 @@ function runCodexValidationFix({
     "```",
   ].join("\n");
   const validationFixTimeoutMs = currentCodexTimeoutMs();
-  const child = spawnCodexSyncWithHeartbeat(
-    `Codex validation-fix worker ${mode} attempt ${attempt}`,
-    [
-      "exec",
-      "--cd",
-      targetDir,
-      ...executionModelArgs,
-      "--sandbox",
-      codexWriteSandbox,
-      ...codexWriteSandboxConfigArgs(),
-      ...codexConfigArgs(),
-      "--output-last-message",
-      path.join(workRoot, `${mode}-codex-validation-fix-${attempt}.md`),
-      "--json",
-      "-",
-    ],
-    {
-      cwd: targetDir,
-      input: prompt,
-      encoding: "utf8",
-      env: codexEnv(),
-      timeout: validationFixTimeoutMs,
-      scanSource: { kind: "prompt" },
-      stdoutPath: path.join(workRoot, `${mode}-codex-validation-fix-${attempt}.jsonl`),
-      stderrPath: path.join(workRoot, `${mode}-codex-validation-fix-${attempt}.stderr.log`),
-    },
-  );
+  const child = runCodexWithHeartbeat({
+    label: `Codex validation-fix worker ${mode} attempt ${attempt}`,
+    targetDir,
+    prompt,
+    timeoutMs: validationFixTimeoutMs,
+    outputPath: path.join(workRoot, `${mode}-codex-validation-fix-${attempt}.md`),
+    logPrefix: `${mode}-codex-validation-fix-${attempt}`,
+  });
   if ((child.error as JsonValue)?.code === "ETIMEDOUT")
     throw new Error(`Codex validation-fix worker timed out after ${validationFixTimeoutMs}ms`);
   if (child.error) throw new Error(child.error.message || String(child.error));
@@ -3678,7 +3575,7 @@ function checkoutRecoverableReplacementBranch({
         const pull = fetchPullRequest(result.repo, sourcePr.number);
         if (pull.state !== "open")
           throw new Error(`source PR #${sourcePr.number} is ${pull.state}`);
-        const checkout = checkoutSourcePullRequestHead({
+        checkoutSourcePullRequestHead({
           targetDir,
           repo: result.repo,
           branch,
@@ -3687,20 +3584,16 @@ function checkoutRecoverableReplacementBranch({
         });
         return {
           resumed: false,
-          replaced_stale_branch: true,
-          branch,
-          source_pr: checkout.sourcePr.url,
-          source_head_sha: checkout.sourceHeadSha,
           remote_lease_sha: remoteLeaseSha,
         };
       }
     }
-    return { resumed: true, branch, remote_lease_sha: remoteLeaseSha };
+    return { resumed: true, remote_lease_sha: remoteLeaseSha };
   }
   if (sourcePr) {
     const pull = fetchPullRequest(result.repo, sourcePr.number);
     if (pull.state !== "open") throw new Error(`source PR #${sourcePr.number} is ${pull.state}`);
-    const checkout = checkoutSourcePullRequestHead({
+    checkoutSourcePullRequestHead({
       targetDir,
       repo: result.repo,
       branch,
@@ -3709,9 +3602,6 @@ function checkoutRecoverableReplacementBranch({
     });
     return {
       resumed: false,
-      branch,
-      source_pr: checkout.sourcePr.url,
-      source_head_sha: checkout.sourceHeadSha,
       remote_lease_sha: remoteLeaseSha,
     };
   }
@@ -3721,7 +3611,7 @@ function checkoutRecoverableReplacementBranch({
     expectedHeadSha: run("git", ["rev-parse", `origin/${baseBranch}`], { cwd: targetDir }).trim(),
     timeoutMs: targetValidationTimeoutMs,
   });
-  return { resumed: false, branch, remote_lease_sha: remoteLeaseSha };
+  return { resumed: false, remote_lease_sha: remoteLeaseSha };
 }
 
 function commitCheckpointIfNeeded({ targetDir, message, trailers = [] }: LooseRecord) {
@@ -3904,13 +3794,13 @@ function safeBranchName(value: JsonValue) {
 function findLatestResultPath() {
   const runsRoot = path.join(repoRoot(), ".clawsweeper-repair", "runs");
   if (!fs.existsSync(runsRoot)) throw new Error("no run directory exists");
-  const candidates: LooseRecord[] = [];
+  const candidates: { path: string; mtimeMs: number }[] = [];
   for (const runName of fs.readdirSync(runsRoot)) {
     const candidate = path.join(runsRoot, runName, "result.json");
     if (fs.existsSync(candidate))
       candidates.push({ path: candidate, mtimeMs: fs.statSync(candidate).mtimeMs });
   }
-  candidates.sort((left: JsonValue, right: JsonValue) => right.mtimeMs - left.mtimeMs);
+  candidates.sort((left, right) => right.mtimeMs - left.mtimeMs);
   if (!candidates[0]) throw new Error("no result.json files found");
   return candidates[0].path;
 }

--- a/test/repair/execute-fix-artifact-source.test.ts
+++ b/test/repair/execute-fix-artifact-source.test.ts
@@ -209,6 +209,24 @@ test("terminal Codex and persistent setup failures do not request repair requeue
   assert.match(source, /sandbox \(\?:wrapper\|startup\)/);
 });
 
+// Source guard: every Codex launch must go through the bounded agent runner with file-backed capture.
+test("repair Codex heartbeat wrapper uses bounded process capture", () => {
+  const source = readText(path.join(process.cwd(), "src/repair/execute-fix-artifact.ts"));
+  const helperStart = source.indexOf("function runCodexWithHeartbeat(");
+  const helperEnd = source.indexOf("function startCodexHeartbeat(", helperStart);
+
+  assert.notEqual(helperStart, -1);
+  assert.notEqual(helperEnd, -1);
+  const helper = source.slice(helperStart, helperEnd);
+  assert.match(helper, /return runAgentProcess\(\{/);
+  assert.match(helper, /reasoningEffort: codexReasoningEffort/);
+  assert.match(helper, /stdoutPath: path\.join\(workRoot/);
+  assert.match(helper, /stderrPath: path\.join\(workRoot/);
+  assert.doesNotMatch(source, /spawnSync\("codex"/);
+  assert.doesNotMatch(source, /CLAWSWEEPER_CODEX_STDIO_MAX_BUFFER_MB/);
+  assert.doesNotMatch(source, /writeFileSync\([^)]*codexResult\.stdout/);
+});
+
 test("issue implementation rechecks opt-out labels immediately before branch pushes", () => {
   const source = readText(path.join(process.cwd(), "src/repair/execute-fix-artifact.ts"));
   const pushStart = source.indexOf("function pushRecoverableBranch(");

--- a/test/repair/execute-fix-artifact-source.test.ts
+++ b/test/repair/execute-fix-artifact-source.test.ts
@@ -35,7 +35,6 @@ test("repair review preserves the checkout accepted by changed-surface validatio
   const review = source.slice(reviewStart, reviewEnd);
 
   assert.match(source, /const defaultCodexReviewSandbox = "read-only";/);
-  assert.match(review, /"--sandbox",\s*codexReviewSandbox/);
   assert.match(review, /validation commands listed below have already passed/);
   assert.match(review, /do not rerun them or start nested autoreview helpers/);
   assert.match(
@@ -208,27 +207,6 @@ test("terminal Codex and persistent setup failures do not request repair requeue
     "terminal and persistent setup failures must be rejected before the broad Codex failure fallback",
   );
   assert.match(source, /sandbox \(\?:wrapper\|startup\)/);
-});
-
-test("repair Codex heartbeat wrapper uses bounded process capture", () => {
-  const sourcePath = path.join(process.cwd(), "src/repair/execute-fix-artifact.ts");
-  const source = readText(sourcePath);
-  const helperStart = source.indexOf("function spawnCodexSyncWithHeartbeat(");
-  const helperEnd = source.indexOf("function startCodexHeartbeat(", helperStart);
-
-  assert.notEqual(helperStart, -1);
-  assert.notEqual(helperEnd, -1);
-  const helper = source.slice(helperStart, helperEnd);
-  assert.match(helper, /return runAgentProcess\(\{/);
-  assert.match(helper, /prompt: options\.input/);
-  assert.match(helper, /model,/);
-  assert.match(helper, /reasoningEffort: codexReasoningEffort/);
-  assert.match(helper, /codexExtraArgs: args\.slice\(1\)/);
-  assert.match(helper, /\{ stdoutPath: options\.stdoutPath \}/);
-  assert.match(helper, /\{ stderrPath: options\.stderrPath \}/);
-  assert.doesNotMatch(helper, /spawnSync\("codex"/);
-  assert.doesNotMatch(source, /CLAWSWEEPER_CODEX_STDIO_MAX_BUFFER_MB/);
-  assert.doesNotMatch(source, /writeFileSync\([^)]*codexResult\.stdout/);
 });
 
 test("issue implementation rechecks opt-out labels immediately before branch pushes", () => {


### PR DESCRIPTION
## What Problem This Solves

The fix executor repeats Codex argument, sandbox, capture-file, and heartbeat setup in five execution paths. The apply-result owner repeats revision checks and carries comment-window branches its caller cannot reach. These copies make behavior-preserving maintenance harder to review.

## Why This Change Was Made

Centralize Codex launch setup behind a typed input that keeps review schema and scan context together. Keep each caller's timeout, failure classification, retries, and finalization in place. Reuse the existing revision-block shape before close/merge and after coverage proof, specialize comment compaction to its fixed caller contract, and remove unread preparation fields and obsolete source-shape assertions.

The local hash helper is intentionally retained for https://github.com/openclaw/clawsweeper/pull/1391. Replacement publication and target-validation ownership remain outside this focused cut.

## User Impact

Behavior-neutral; no runtime contract, config, or workflow change. Operator report fields, command arguments, log messages, exit codes, and publication deferral remain unchanged.

## Evidence

### pr-behavior-proof

**Claim:** preserve executor and apply-result behavior while deleting duplicated setup and unreachable internal branches. **Exercised surface:** repair CLI paths, artifact validation, publication deferral, post-flight outcomes, coverage-proof context, and the complete repository check gate. **Scenario/fixture:** existing repair and repository suites, including synthetic GitHub/model fixtures and temporary Git repositories.

**Command and environment:** macOS arm64, Node v26.8.1, pnpm 11.10.0. For this behavior-neutral refactor, proof is the full `pnpm run check` run plus the targeted repair suite, explicitly as specified by the work order. The source tree was unchanged between these checks and the commit.

```text
pnpm run build:all
node scripts/run-node-tests.mjs repair
ℹ tests 1402
ℹ pass 1395
ℹ fail 0
ℹ cancelled 0
ℹ skipped 7

pnpm run check
ℹ tests 4768
ℹ pass 4756
ℹ fail 0
ℹ cancelled 0
ℹ skipped 12
ℹ all files | 83.80 | 76.38 | 88.72 |

Changed-surface coverage (included in check):
ℹ tests 13
ℹ pass 13
ℹ fail 0
ℹ fix-prompt-builder.js | 100.00 | 88.61 | 100.00 |
```

**Observable result:** all required gates passed with exit code 0. `pnpm run format` and `git diff --check` passed. Supplemental baseline comparison matched all 80 Codex invocation traces across the five callers and sandbox/network/app-server settings; 13 comment-window boundary fixtures produced byte-identical JSON.

**Artifact or trace:** task-local logs `/tmp/deslop-execute-build.log`, `/tmp/deslop-execute-targeted.log`, `/tmp/deslop-execute-check.log`, and `/tmp/deslop-execute-equivalence.log`; the pass summaries are reproduced above. **Limits:** synthetic/local proof, no live repair model calls, production GitHub mutations, or Linux containment proof. Platform skips are retained; no thresholds or baselines changed.

Independent Codex review: scoped-clean at P1; no accepted/actionable findings. A further 96 action/status/promotion cases matched the baseline, including exclusion of contributor-branch actions.

Validated commit: `3ad49729d2d85934edee7e8d3202c914c122b69f`.

OpenClaw Bay not affected: no dashboard changes.

LOC delta from `git diff --numstat origin/main...HEAD`:

| Scope | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Production | 158 | 312 | -154 |
| Tests | 0 | 22 | -22 |
| Docs | 0 | 0 | 0 |


### Update after ClawSweeper review (head 917a7bf7c)

The reviewed head adds one commit over the validated transcript: it restores the `repair Codex heartbeat wrapper uses bounded process capture` source guard, adapted to the shared `runCodexWithHeartbeat` launcher (asserts the launcher returns through `runAgentProcess`, passes `reasoningEffort`, writes file-backed stdout/stderr capture under `workRoot`, and that no raw `spawnSync("codex")` or unbounded stdio buffer exists). `node --test test/repair/execute-fix-artifact-source.test.ts` on this head: 21 pass, 0 fail.

**Real behavior proof (production command-chain harness, current head):** the documented automerge e2e harness (`docs/repair/automerge-e2e.md`, `--scenario all --fixture all`) ran on this exact head in CI: https://github.com/openclaw/clawsweeper/actions/runs/33829734390 (job `production automerge flow`, success). It executes the compiled `execute-fix-artifact` and `apply-result` CLIs end to end on both fixtures: the fix worker launches through the shared launcher in write mode (`04-execute` step logs, `run/fix-execution/repair-codex-1.jsonl` and `.stderr.log` capture files), the exact-head review launches through the same launcher in read-only review mode with the output schema (`run/fix-execution/repair-codex-review-final-sync.json`/`.jsonl`, `codex-review.schema.json`), and `apply-result` runs the guarded close/merge applicator (`06-apply-before`, `11-apply-after`, `run/apply-report.json`). Codex and GitHub are the harness's simulators; the launcher argument construction, sandbox/config flags, schema wiring, scan source, file-backed capture, and applicator decisions are the real compiled code on this head. Per-step artifacts are in the run's `automerge-e2e-*` artifact.
