### PR TITLE
fix(repair): preserve contributor credits in replacement links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Preserve explicit contributor credits in source-PR link comments for both direct replacements and fallback publication after a blocked fork push.
+
 - Reject parent-directory validation symlinks, preserve porcelain paths when selecting repair checks, retain the fast-rebase base SHA for replacement publication, and mark omitted PR comments in close-coverage proof.
 - Run dashboard smoke checks through symlinks and continue dead-letter recovery after a repository without an App installation.
 

--- a/src/repair/execute-fix-artifact.ts
+++ b/src/repair/execute-fix-artifact.ts
@@ -1351,9 +1351,6 @@ function openReplacementPrFromPreparedRepairCheckout({
   });
   const body = replacementPrBody({
     fixArtifact,
-    fallbackReason,
-    clusterId: result.cluster_id,
-    provenance,
     contributorCredits,
     maintainerAttribution: jobMaintainerAttribution(),
     sourceClosingReferences: sourceClosingReferences({
@@ -1419,6 +1416,7 @@ function openReplacementPrFromPreparedRepairCheckout({
             parsed,
             replacementPrUrl: prUrl,
             targetDir,
+            contributorCredits,
             provenance,
           }),
     );
@@ -1754,9 +1752,6 @@ function executeReplacementBranch({
   });
   const body = replacementPrBody({
     fixArtifact,
-    fallbackReason,
-    clusterId: result.cluster_id,
-    provenance,
     contributorCredits,
     maintainerAttribution: jobMaintainerAttribution(),
     sourceClosingReferences: sourceClosingReferences({
@@ -1876,6 +1871,7 @@ function executeReplacementBranch({
               parsed,
               replacementPrUrl: prUrl,
               targetDir,
+              contributorCredits,
               provenance,
             }),
       );

--- a/test/repair/execute-fix-fast-rebase.test.ts
+++ b/test/repair/execute-fix-fast-rebase.test.ts
@@ -4,51 +4,69 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { writeFakeScanner } from "../agent-input-scan-helpers.ts";
 
-test(
-  "fast rebase publishes a compacted replacement when the fork push is blocked",
-  { skip: process.platform === "win32" },
-  () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-fast-rebase-"));
-    try {
-      const target = path.join(root, "target");
-      const remote = path.join(root, "remote.git");
-      const bin = path.join(root, "bin");
-      fs.mkdirSync(target);
-      fs.mkdirSync(bin);
-      const realGit = execFileSync("which", ["git"], { encoding: "utf8" }).trim();
-      const git = (...args: string[]) =>
-        execFileSync(realGit, args, { cwd: target, encoding: "utf8" }).trim();
-      git("init", "-b", "main");
-      git("config", "user.name", "Fixture Author");
-      git("config", "user.email", "fixture@example.invalid");
-      fs.writeFileSync(path.join(target, "README.md"), "Base.\n");
-      git("add", ".");
-      git("commit", "-m", "base");
-      git("checkout", "-b", "contributor");
-      fs.writeFileSync(path.join(target, "CONTRIBUTING.md"), "Contribution.\n");
-      git("add", ".");
-      git("commit", "-m", "contributor change");
-      fs.appendFileSync(path.join(target, "CONTRIBUTING.md"), "Follow-up.\n");
-      git("commit", "-am", "contributor follow-up");
-      const sourceHead = git("rev-parse", "HEAD");
-      git("checkout", "main");
-      fs.appendFileSync(path.join(target, "README.md"), "New base.\n");
-      git("commit", "-am", "advance base");
-      const baseSha = git("rev-parse", "HEAD");
-      git("clone", "--bare", target, remote);
-      git("--git-dir", remote, "update-ref", "refs/pull/1/head", sourceHead);
-      git("remote", "add", "origin", remote);
-      git("fetch", "origin");
-      const trace = path.join(root, "commands.jsonl");
-      fs.writeFileSync(
-        path.join(bin, "git"),
-        `#!/bin/sh\nexec '${process.execPath}' '${path.join(bin, "git.cjs")}' "$@"\n`,
-        { mode: 0o755 },
-      );
-      fs.writeFileSync(
-        path.join(bin, "git.cjs"),
-        `
+for (const strategy of ["repair_contributor_branch", "replace_uneditable_branch"]) {
+  test(
+    `replacement publication preserves contributor credit via ${strategy}`,
+    { skip: process.platform === "win32" },
+    () => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-fast-rebase-"));
+      try {
+        const target = path.join(root, "target");
+        const remote = path.join(root, "remote.git");
+        const bin = path.join(root, "bin");
+        fs.mkdirSync(target);
+        fs.mkdirSync(bin);
+        writeFakeScanner(bin);
+        const codex = path.join(bin, "codex");
+        fs.writeFileSync(
+          codex,
+          `#!${process.execPath}
+const fs = require("node:fs");
+const assert = require("node:assert/strict");
+const args = process.argv.slice(2);
+assert.ok(args.includes("--output-schema"), "only a review is expected");
+fs.readFileSync(0, "utf8");
+fs.writeFileSync(args[args.indexOf("--output-last-message") + 1], JSON.stringify({
+  status: "clean", summary: "Fixture review", findings: [], findings_addressed: true, evidence: []
+}));
+`,
+          { mode: 0o755 },
+        );
+        const realGit = execFileSync("which", ["git"], { encoding: "utf8" }).trim();
+        const git = (...args: string[]) =>
+          execFileSync(realGit, args, { cwd: target, encoding: "utf8" }).trim();
+        git("init", "-b", "main");
+        git("config", "user.name", "Fixture Author");
+        git("config", "user.email", "fixture@example.invalid");
+        fs.writeFileSync(path.join(target, "README.md"), "Base.\n");
+        git("add", ".");
+        git("commit", "-m", "base");
+        git("checkout", "-b", "contributor");
+        fs.writeFileSync(path.join(target, "CONTRIBUTING.md"), "Contribution.\n");
+        git("add", ".");
+        git("commit", "-m", "contributor change");
+        fs.appendFileSync(path.join(target, "CONTRIBUTING.md"), "Follow-up.\n");
+        git("commit", "-am", "contributor follow-up");
+        const sourceHead = git("rev-parse", "HEAD");
+        git("checkout", "main");
+        fs.appendFileSync(path.join(target, "README.md"), "New base.\n");
+        git("commit", "-am", "advance base");
+        const baseSha = git("rev-parse", "HEAD");
+        git("clone", "--bare", target, remote);
+        git("--git-dir", remote, "update-ref", "refs/pull/1/head", sourceHead);
+        git("remote", "add", "origin", remote);
+        git("fetch", "origin");
+        const trace = path.join(root, "commands.jsonl");
+        fs.writeFileSync(
+          path.join(bin, "git"),
+          `#!/bin/sh\nexec '${process.execPath}' '${path.join(bin, "git.cjs")}' "$@"\n`,
+          { mode: 0o755 },
+        );
+        fs.writeFileSync(
+          path.join(bin, "git.cjs"),
+          `
 const { spawnSync } = require("node:child_process");
 const { appendFileSync } = require("node:fs");
 const args = process.argv.slice(2);
@@ -63,14 +81,16 @@ if (localArgs.some(arg => /^https?:/.test(arg))) throw new Error("unexpected net
 const child = spawnSync(${JSON.stringify(realGit)}, localArgs, { stdio: "inherit", env: process.env });
 process.exit(child.status ?? 1);
 `,
-      );
-      const sourceUrl = "https://github.com/openclaw/fixture/pull/1";
-      const replacementUrl = "https://github.com/openclaw/fixture/pull/2";
-      const gh = path.join(bin, "gh.cjs");
-      fs.writeFileSync(
-        gh,
-        `
+        );
+        const sourceUrl = "https://github.com/openclaw/fixture/pull/1";
+        const replacementUrl = "https://github.com/openclaw/fixture/pull/2";
+        const gh = path.join(bin, "gh.cjs");
+        const publicationTrace = path.join(root, "publication.jsonl");
+        fs.writeFileSync(
+          gh,
+          `
 const args = process.argv.slice(2);
+const fs = require("node:fs");
 const endpoint = args[1] || "";
 if (args[0] === "api" && endpoint === "repos/openclaw/fixture/pulls/1") {
   console.log(JSON.stringify({ state: "open", maintainer_can_modify: true, labels: [], head: { sha: ${JSON.stringify(sourceHead)}, ref: "contributor", repo: { full_name: "contributor/fixture" } }, base: { ref: "main", sha: ${JSON.stringify(baseSha)} } }));
@@ -80,98 +100,129 @@ if (args[0] === "api" && endpoint === "repos/openclaw/fixture/pulls/1") {
   console.log(JSON.stringify({ data: { repository: { pullRequest: { reviewThreads: { nodes: [], pageInfo: { hasNextPage: false } } } } } }));
 } else if (args[0] === "api" && endpoint.includes("/comments")) {
   console.log("[]");
+} else if (args[0] === "api" && endpoint === "users/octocat") {
+  console.log(JSON.stringify({ id: 1, login: "octocat", name: "Mona Octocat" }));
 } else if (args[0] === "pr" && args[1] === "view") {
-  console.log(JSON.stringify({ state: "OPEN", mergedAt: null, author: { login: "fixture[bot]", is_bot: true }, title: "Contribution", url: args[2] === "1" ? ${JSON.stringify(sourceUrl)} : ${JSON.stringify(replacementUrl)}, body: "", headRefOid: ${JSON.stringify(sourceHead)}, statusCheckRollup: [] }));
+  console.log(JSON.stringify({ state: "OPEN", mergedAt: null, author: { login: "octocat", is_bot: false }, title: "Contribution", url: args[2] === "1" ? ${JSON.stringify(sourceUrl)} : ${JSON.stringify(replacementUrl)}, body: "", headRefOid: ${JSON.stringify(sourceHead)}, statusCheckRollup: [] }));
 } else if (args[0] === "pr" && args[1] === "list") {
   console.log(args.includes("--jq") ? "" : "[]");
 } else if (args[0] === "pr" && args[1] === "create") {
+  fs.appendFileSync(${JSON.stringify(publicationTrace)}, JSON.stringify({ kind: "pr", body: fs.readFileSync(args[args.indexOf("--body-file") + 1], "utf8") }) + "\\n");
   console.log(${JSON.stringify(replacementUrl)});
-} else if (args[0] === "label" || (args[0] === "issue" && args[1] === "edit") || (args[0] === "pr" && ["edit", "comment"].includes(args[1]))) {
+} else if (args[0] === "pr" && args[1] === "comment") {
+  fs.appendFileSync(${JSON.stringify(publicationTrace)}, JSON.stringify({ kind: "comment", number: args[2], body: args[args.indexOf("--body") + 1] }) + "\\n");
+} else if (args[0] === "label" || (args[0] === "issue" && args[1] === "edit") || (args[0] === "pr" && args[1] === "edit")) {
   console.log("");
 } else {
   console.error("unexpected gh command", JSON.stringify(args)); process.exit(1);
 }
 `,
-      );
-      const job = path.join(root, "job.md");
-      const result = path.join(root, "result.json");
-      fs.writeFileSync(
-        job,
-        "---\nrepo: openclaw/fixture\ncluster_id: automerge-fixture-1\nmode: autonomous\nsource: pr_automerge\nallowed_actions: [fix, raise_pr]\nallow_fix_pr: true\ncandidates: ['#1']\ncanonical: ['#1']\n---\nFixture\n",
-      );
-      fs.writeFileSync(
-        result,
-        JSON.stringify({
-          repo: "openclaw/fixture",
-          cluster_id: "automerge-fixture-1",
-          mode: "autonomous",
-          canonical_pr: sourceUrl,
-          reviewed_sha: sourceHead,
-          actions: [{ action: "fix_needed", target: sourceUrl, status: "planned" }],
-          fix_artifact: {
-            summary: "Rebase contribution",
-            pr_title: "fix: preserve contribution",
-            pr_body: "Preserve the contribution on current main.",
-            affected_surfaces: ["docs"],
-            likely_files: ["CONTRIBUTING.md"],
-            linked_refs: [sourceUrl],
-            validation_commands: ["git diff --check"],
-            credit_notes: ["Fixture contribution"],
-            changelog_required: false,
-            repair_strategy: "repair_contributor_branch",
-            source_prs: [sourceUrl],
-            deterministic_rebase_only: true,
-          },
-        }),
-      );
-      const child = spawnSync(
-        process.execPath,
-        [
-          path.resolve("dist/repair/execute-fix-artifact.js"),
+        );
+        const job = path.join(root, "job.md");
+        const result = path.join(root, "result.json");
+        fs.writeFileSync(
           job,
+          "---\nrepo: openclaw/fixture\ncluster_id: automerge-fixture-1\nmode: autonomous\nsource: pr_automerge\nallowed_actions: [fix, raise_pr]\nallow_fix_pr: true\ncandidates: ['#1']\ncanonical: ['#1']\n---\nFixture\n",
+        );
+        fs.writeFileSync(
           result,
-          "--target-dir",
-          target,
-          "--defer-publication",
-        ],
-        {
-          encoding: "utf8",
-          timeout: 120_000,
-          env: {
-            ...process.env,
-            PATH: `${bin}${path.delimiter}${process.env.PATH}`,
-            GH_BIN: process.execPath,
-            GH_BIN_ARGS: JSON.stringify([gh]),
-            CODEX_BIN: path.join(bin, "unexpected-codex"),
-            GH_TOKEN: "fixture-token",
-            GITHUB_TOKEN: "",
-            CLAWSWEEPER_ALLOW_EXECUTE: "1",
-            CLAWSWEEPER_ALLOW_FIX_PR: "1",
-            CLAWSWEEPER_ALLOWED_OWNER: "openclaw",
-            CLAWSWEEPER_MODEL: "fixture-model",
-            CLAWSWEEPER_INSTALL_TARGET_DEPS: "0",
-            CLAWSWEEPER_BRANCH_PUSH_SETTLE_SECONDS: "0",
-            CLAWSWEEPER_CLOSE_SUPERSEDED_SOURCE_PRS: "0",
+          JSON.stringify({
+            repo: "openclaw/fixture",
+            cluster_id: "automerge-fixture-1",
+            mode: "autonomous",
+            canonical_pr: sourceUrl,
+            reviewed_sha: sourceHead,
+            actions: [{ action: "fix_needed", target: sourceUrl, status: "planned" }],
+            fix_artifact: {
+              summary: "Rebase contribution",
+              pr_title: "fix: preserve contribution",
+              pr_body: "Preserve the contribution on current main.",
+              affected_surfaces: ["docs"],
+              likely_files: ["CONTRIBUTING.md"],
+              linked_refs: [sourceUrl],
+              validation_commands: ["git diff --check"],
+              credit_notes: ["Fixture contribution"],
+              changelog_required: false,
+              repair_strategy: strategy,
+              source_prs: [sourceUrl],
+              deterministic_rebase_only: true,
+            },
+          }),
+        );
+        const child = spawnSync(
+          process.execPath,
+          [
+            path.resolve("dist/repair/execute-fix-artifact.js"),
+            job,
+            result,
+            "--target-dir",
+            target,
+            "--defer-publication",
+          ],
+          {
+            encoding: "utf8",
+            timeout: 120_000,
+            env: {
+              ...process.env,
+              PATH: `${bin}${path.delimiter}${process.env.PATH}`,
+              GH_BIN: process.execPath,
+              GH_BIN_ARGS: JSON.stringify([gh]),
+              CODEX_BIN:
+                strategy === "repair_contributor_branch"
+                  ? path.join(bin, "unexpected-codex")
+                  : codex,
+              GH_TOKEN: "fixture-token",
+              GITHUB_TOKEN: "",
+              CLAWSWEEPER_ALLOW_EXECUTE: "1",
+              CLAWSWEEPER_ALLOW_FIX_PR: "1",
+              CLAWSWEEPER_ALLOWED_OWNER: "openclaw",
+              CLAWSWEEPER_MODEL: "fixture-model",
+              CLAWSWEEPER_INSTALL_TARGET_DEPS: "0",
+              CLAWSWEEPER_BRANCH_PUSH_SETTLE_SECONDS: "0",
+              CLAWSWEEPER_CLOSE_SUPERSEDED_SOURCE_PRS: "0",
+            },
           },
-        },
-      );
-      assert.equal(child.status, 0, child.stdout + child.stderr);
-      assert.match(child.stdout, /automerge deterministic rebase validated/);
-      assert.match(child.stdout, /repair branch push blocked; publishing prepared repair/);
-      const report = JSON.parse(
-        fs.readFileSync(path.join(root, "fix-execution-report.json"), "utf8"),
-      );
-      assert.equal(report.status, "opened", JSON.stringify(report));
-      const published = report.actions.find((action) => action.action === "open_fix_pr");
-      assert.equal(published.pr_url, replacementUrl);
-      assert.equal(git("rev-parse", `${published.commit}^`), baseSha);
-      assert.equal(
-        git("--git-dir", remote, "rev-parse", "refs/heads/clawsweeper/automerge-fixture-1"),
-        published.commit,
-      );
-      assert.equal(git("show", `${published.commit}:CONTRIBUTING.md`), "Contribution.\nFollow-up.");
-    } finally {
-      fs.rmSync(root, { recursive: true, force: true });
-    }
-  },
-);
+        );
+        assert.equal(child.status, 0, child.stdout + child.stderr);
+        if (strategy === "repair_contributor_branch") {
+          assert.match(child.stdout, /automerge deterministic rebase validated/);
+          assert.match(child.stdout, /repair branch push blocked; publishing prepared repair/);
+        }
+        const report = JSON.parse(
+          fs.readFileSync(path.join(root, "fix-execution-report.json"), "utf8"),
+        );
+        assert.equal(report.status, "opened", JSON.stringify(report));
+        const published = report.actions.find((action) => action.action === "open_fix_pr");
+        assert.equal(published.pr_url, replacementUrl);
+        assert.equal(git("rev-parse", `${published.commit}^`), baseSha);
+        assert.equal(
+          git("--git-dir", remote, "rev-parse", "refs/heads/clawsweeper/automerge-fixture-1"),
+          published.commit,
+        );
+        assert.equal(
+          git("show", `${published.commit}:CONTRIBUTING.md`),
+          "Contribution.\nFollow-up.",
+        );
+        const publications = fs
+          .readFileSync(publicationTrace, "utf8")
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line));
+        assert.match(
+          publications.find((entry) => entry.kind === "pr").body,
+          /Original contributor: @octocat\./,
+        );
+        const comments = publications.filter((entry) => entry.kind === "comment");
+        assert.equal(comments.length, 1);
+        assert.equal(comments[0].number, "1");
+        assert.match(comments[0].body, /Source PR status: left open/);
+        assert.match(
+          comments[0].body,
+          /@octocat: Co-authored-by: Mona Octocat <1\+octocat@users\.noreply\.github\.com>/,
+        );
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    },
+  );
+}


### PR DESCRIPTION
## What Problem This Solves

When replacement publication leaves the source PR open, its link comment loses the explicit contributor list even though the replacement PR body has it. This affects both direct replacement publication and fallback publication after a prepared contributor-branch push is blocked.

## Why This Change Was Made

Pass the already-computed `contributorCredits` to both `linkReplacementSourcePr` calls. Remove six unused arguments from the neighboring PR-body renderer calls. Extend the existing execute-fix harness to exercise both publication paths with a human contributor, a real local Git remote, and captured GitHub command bodies. Add the fix under the current Unreleased changelog section.

## User Impact

Source-PR link comments now name the same contributor as the replacement PR body and include the co-author trailer. Apart from this requested attribution correction, behavior is unchanged: no runtime control-flow contract, config, or workflow change. Source PRs remain open when source closing is disabled.

## Evidence

OpenClaw Bay not affected: no dashboard changes.

### pr-behavior-proof

**Claim:** direct replacement and blocked-fork-push fallback preserve the original contributor in both the replacement PR body and the source link comment.

**Exercised surface:** the compiled `execute-fix-artifact` CLI, source-author credit collection, local Git rebase/compaction/push, replacement PR creation, and source-comment rendering/publication.

**Scenario/fixture:** the existing fast-rebase harness now runs both `repair_contributor_branch` and `replace_uneditable_branch`, with synthetic contributor `octocat`. It verifies the published branch and tree, the PR body's contributor login, exactly one source link comment, the left-open status, and the explicit `Co-authored-by` line. Before the source fix, both scenarios failed specifically on the missing comment credit after successfully publishing the replacement to the fixture remote.

**Command and environment:** local macOS arm64, Node 26.8.1, pnpm 11.10.0; full-gate retry on AWS Linux via Crabbox, Node 24.18.1, pnpm 11.10.0. Validated content is committed as `931f6dceb0a61fa1509e82cb6a99ff6f5ea96677`.

```sh
corepack enable >/dev/null 2>&1; pnpm install --prefer-offline
pnpm run build:all
node scripts/run-node-tests.mjs repair -- --test-name-pattern='replacement publication preserves contributor credit'
pnpm run format
pnpm run build:all
node scripts/run-node-tests.mjs repair -- --test-name-pattern='replacement publication preserves contributor credit|replacement comments|replacement PR body|replacement co-author'
pnpm run check
node --test --test-name-pattern='pinned-base reproduction bounds checkout and possible promisor fetches' test/repair/target-validation.test.ts
crabbox run --no-hydrate --idle-timeout 90m --ttl 240m --timing-json --capture-stdout /tmp/deslop-bugs2-crabbox.stdout.log --capture-stderr /tmp/deslop-bugs2-crabbox.stderr.log --shell -- 'corepack enable && pnpm install --prefer-offline && node --version && pnpm run check'
```

**Observable result:** the two regression scenarios failed before the fix and passed afterward. The selected repair runner passed, as did the unchanged full gate on AWS. No thresholds, baselines, or coverage floors were changed.

```text
Focused repair runner: tests 133; pass 133; fail 0; cancelled 0; skipped 0
Mac full gate: tests 4818; pass 4804; fail 1; cancelled 0; skipped 13
Unchanged timing-test rerun: tests 1; pass 1; fail 0
AWS focused coverage gate: tests 13; pass 13; fail 0
AWS full pnpm run check: tests 4818; pass 4800; fail 0; cancelled 0; skipped 18
AWS coverage: lines 85.66%; branches 76.12%; functions 89.69%
```

The macOS failure was the existing two-second elapsed-time assertion in `test/repair/target-validation.test.ts:2382`. It passed unchanged in isolation and in the full AWS gate (58 ms). Both credit regressions also passed in the macOS full run and the AWS full run.

**Artifact/trace:** `/tmp/deslop-bugs2-red.log`, `/tmp/deslop-bugs2-targeted.log`, `/tmp/deslop-bugs2-check.log`, `/tmp/deslop-bugs2-timing-rerun.log`, and the captured Crabbox logs above. Summaries are copied here so review does not depend on local files. Crabbox provider `aws`, lease `cbx_1bea634ad331`, run `run_69611ad8a58f`, image `ami-0461d919be7deb53c` in `eu-west-1`, instance `c7a.8xlarge`; full command exit 0.

**Limits:** GitHub, Codex, and the scanner are fixture substitutes; the executor, renderers, Git repository, and published fixture branch are real. No live repair target, production deployment, or production model call was exercised.

**Independent review:** Codex autoreview `--mode local --base origin/main --max-priority P1`: **scoped-clean**, no accepted/actionable findings. The committed patch is identical to the reviewed patch. Report: `/tmp/autoreview-deslop-bugs2-credit.md`.

| Category | Added | Removed | Net LOC |
| --- | ---: | ---: | ---: |
| Production (`src`, `scripts`) | 2 | 6 | -4 |
| Tests | 184 | 133 | +51 |
| Docs/changelog | 2 | 0 | +2 |


### Update after ClawSweeper review (head 931f6dceb, unchanged)

**Scoped proof decision (maintainer):** the production change is two call-site lines that pass the already-computed `contributorCredits` into `linkReplacementSourcePr`; the comment renderer (`replacementSourceLinkComment`) and the transport (`gh pr comment --body`) are untouched and run in production on every replacement publication. The observable after-fix behavior is the rendered body handed to that transport, which the new fixture captures for both strategies (`Co-authored-by: Mona Octocat <1+octocat@users.noreply.github.com>` present; absent on pre-fix code, where the same test fails). Posting a live credited comment would require opening a real replacement PR against a real target repository with a real contributor, which is disproportionate for an argument-plumbing fix and outside the narrowest meaningful proof.

Current-head production command-chain evidence: the documented automerge e2e harness ran on this exact head in CI (https://github.com/openclaw/clawsweeper/actions/runs/33841225876, job `production automerge flow`, success), executing the compiled executor through replacement publication on both fixtures; GitHub is its documented simulator. Full gate on this head: 4,800 passed / 18 skipped (Crabbox, Linux), plus macOS targeted suites.
