### PR TITLE
refactor(repair): remove unused Git and GitHub helpers

### DIFF
--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -7,14 +7,14 @@ import { clawsweeperGitUserEmail, clawsweeperGitUserName } from "./process-env.j
 import { mergeSweepStatusJson } from "./sweep-status-merge.js";
 import { acquireStateWriterCoordinator } from "./state-writer-coordinator.js";
 
-export type GitRunResult = {
+type GitRunResult = {
   status: number;
   stdout: string;
   stderr: string;
   timedOut: boolean;
 };
 
-export type GitRunOptions = {
+type GitRunOptions = {
   allowFailure?: boolean;
   env?: NodeJS.ProcessEnv;
   input?: string | Uint8Array;
@@ -41,14 +41,14 @@ export type PublishResult = "committed" | "unchanged";
 const GIT_TIMEOUT_MS = 60_000;
 const GIT_PUSH_TIMEOUT_MS = 300_000;
 
-export class GitCommandTimeoutError extends Error {
+class GitCommandTimeoutError extends Error {
   constructor(args: readonly string[], timeoutMs: number) {
     super(`git ${safeAction(args[0])} timed out after ${timeoutMs}ms`);
     this.name = "GitCommandTimeoutError";
   }
 }
 
-export function configureGitUser(): void {
+function configureGitUser(): void {
   runGit(["config", "user.name", clawsweeperGitUserName()]);
   runGit(["config", "user.email", clawsweeperGitUserEmail()]);
 }
@@ -64,7 +64,7 @@ export function runGit(args: readonly string[], options: GitRunOptions = {}): st
   return result.stdout;
 }
 
-export function spawnGit(args: readonly string[], options: GitRunOptions = {}): GitRunResult {
+function spawnGit(args: readonly string[], options: GitRunOptions = {}): GitRunResult {
   const child = spawnSync("git", [...args], {
     cwd: publishRoot() ?? process.cwd(),
     encoding: "utf8",
@@ -101,10 +101,10 @@ export function publishMainCommit(options: GitPublishOptions): PublishResult {
     stagePaths(options.paths);
     if (!hasStagedChanges()) {
       console.log("No publish changes");
-      refreshSourceAfterStatePublish(options.paths, null);
+      refreshSourceAfterStatePublish(options.paths);
       return "unchanged";
     }
-    runGit(["commit", "-m", commitMessageForPublishedPaths(options.message, options.paths)]);
+    runGit(["commit", "-m", options.message]);
     coordinator?.assertActive();
     const push = spawnGit(["push", remote, `HEAD:${branch}`], {
       quiet: true,
@@ -117,25 +117,25 @@ export function publishMainCommit(options: GitPublishOptions): PublishResult {
       throw new Error(push.stderr.trim() || `git push failed with status ${push.status}`);
     }
     restoreWorktree(options.restorePaths ?? []);
-    refreshSourceAfterStatePublish(options.paths, null);
+    refreshSourceAfterStatePublish(options.paths);
     return "committed";
   } finally {
     coordinator?.release();
   }
 }
 
-export function stagePaths(paths: readonly string[]): void {
+function stagePaths(paths: readonly string[]): void {
   const unique = uniqueNonEmpty(paths).map(normalizedPath);
   if (!unique.length) throw new Error("No paths were provided for publishing");
   runGit(["add", "-A", "--", ...unique]);
 }
 
-export function restoreWorktree(paths: readonly string[]): void {
+function restoreWorktree(paths: readonly string[]): void {
   const unique = uniqueNonEmpty(paths).map(normalizedPath);
   if (unique.length) runGit(["restore", "--worktree", "--", ...unique], { allowFailure: true });
 }
 
-export function hasStagedChanges(): boolean {
+function hasStagedChanges(): boolean {
   return spawnGit(["diff", "--cached", "--quiet"], { quiet: true }).status !== 0;
 }
 
@@ -144,7 +144,7 @@ export function publishRoot(): string | undefined {
   return configured ? resolve(configured) : undefined;
 }
 
-export function syncPublishPaths(paths: readonly string[]): void {
+function syncPublishPaths(paths: readonly string[]): void {
   const stateRoot = publishRoot();
   if (!stateRoot) return;
   const sourceRoot = resolve(process.cwd());
@@ -186,10 +186,7 @@ export function syncPublishPaths(paths: readonly string[]): void {
   }
 }
 
-export function refreshSourceAfterStatePublish(
-  paths: readonly string[],
-  _baselineCommit: string | null,
-): void {
+export function refreshSourceAfterStatePublish(paths: readonly string[]): void {
   const stateRoot = publishRoot();
   if (!stateRoot) return;
   const sourceRoot = resolve(process.cwd());
@@ -205,17 +202,8 @@ export function refreshSourceAfterStatePublish(
   }
 }
 
-export function hardResetToRemoteMain(remote = "origin", branch = publishDefaultBranch()): void {
-  runGit(["fetch", "--no-tags", "--depth=1", remote, branch], { timeout: GIT_PUSH_TIMEOUT_MS });
-  runGit(["checkout", "--detach", "FETCH_HEAD"]);
-}
-
-export function uniqueNonEmpty(values: readonly string[]): string[] {
+function uniqueNonEmpty(values: readonly string[]): string[] {
   return [...new Set(values.map((value) => value.trim()).filter(Boolean))];
-}
-
-export function commitMessageForPublishedPaths(message: string, _paths: readonly string[]): string {
-  return message;
 }
 
 function publishDefaultBranch(): string {

--- a/src/repair/git-repo-utils.ts
+++ b/src/repair/git-repo-utils.ts
@@ -18,10 +18,6 @@ type TargetDir = {
   targetDir: string;
 };
 
-type TargetBranch = TargetDir & {
-  branch: string;
-};
-
 type TargetBaseBranch = TargetDir & {
   baseBranch: string;
 };
@@ -30,13 +26,6 @@ export type RebaseOntoBaseResult = {
   status: "already-current" | "rebased" | "conflicts";
   base_ref: string;
   base_sha: string;
-  previous_head: string;
-  current_head: string;
-  detail?: string;
-};
-
-export type CompleteRebaseResult = {
-  status: "not-in-progress" | "continued";
   previous_head: string;
   current_head: string;
   detail?: string;
@@ -72,16 +61,6 @@ export function isAncestor({
   return child.status === 0;
 }
 
-export function remoteBranchSha({ targetDir, branch }: TargetBranch): string {
-  const child = runGitCommand(["ls-remote", "--heads", "origin", branch], {
-    targetDir,
-    timeoutMs: gitNetworkTimeoutMs,
-  });
-  if (child.status !== 0) return "";
-  const sha = child.stdout.trim().split(/\s+/)[0] ?? "";
-  return /^[0-9a-f]{40}$/.test(sha) ? sha : "";
-}
-
 export function branchHasBaseDiff({ targetDir, baseBranch }: TargetBaseBranch): boolean {
   const range = `origin/${baseBranch}...HEAD`;
   const first = runGitCommand(["diff", "--name-only", range], { targetDir });
@@ -109,106 +88,6 @@ export function ensureMergeBaseAvailable({ targetDir, baseBranch }: TargetBaseBr
 
   const detail = `${retry.stderr ?? ""}\n${retry.stdout ?? ""}`.trim();
   throw new Error(detail || `no merge base between ${baseRef} and HEAD`);
-}
-
-export function rebaseOntoBase({ targetDir, baseBranch }: TargetBaseBranch): RebaseOntoBaseResult {
-  ensureMergeBaseAvailable({ targetDir, baseBranch });
-  const baseRef = `origin/${baseBranch}`;
-  const baseSha = gitOutput(["rev-parse", baseRef], { targetDir }).trim();
-  const previousHead = currentHead(targetDir);
-  if (isAncestor({ targetDir, ancestor: baseRef, descendant: "HEAD" })) {
-    return {
-      status: "already-current",
-      base_ref: baseRef,
-      base_sha: baseSha,
-      previous_head: previousHead,
-      current_head: previousHead,
-    };
-  }
-
-  const child = runGitCommand(["rebase", baseRef], { targetDir });
-  const detail = `${child.stderr ?? ""}\n${child.stdout ?? ""}`.trim();
-  if (child.status === 0) {
-    return {
-      status: "rebased",
-      base_ref: baseRef,
-      base_sha: baseSha,
-      previous_head: previousHead,
-      current_head: currentHead(targetDir),
-      detail,
-    };
-  }
-  if (hasRebaseInProgress(targetDir) || unmergedPaths(targetDir).length > 0) {
-    return {
-      status: "conflicts",
-      base_ref: baseRef,
-      base_sha: baseSha,
-      previous_head: previousHead,
-      current_head: currentHead(targetDir),
-      detail,
-    };
-  }
-  throw new Error(detail || `git rebase ${baseRef} failed`);
-}
-
-export function completeRebaseIfResolved({ targetDir }: TargetDir): CompleteRebaseResult {
-  const previousHead = currentHead(targetDir);
-  if (!hasRebaseInProgress(targetDir)) {
-    return {
-      status: "not-in-progress",
-      previous_head: previousHead,
-      current_head: previousHead,
-    };
-  }
-
-  assertNoConflictMarkers({ targetDir, paths: unmergedPaths(targetDir) });
-  gitOutput(["add", "--all"], { targetDir });
-  const unresolved = unmergedPaths(targetDir);
-  if (unresolved.length > 0) {
-    throw new Error(`rebase conflicts remain unresolved: ${unresolved.join(", ")}`);
-  }
-  let detail = "";
-  while (hasRebaseInProgress(targetDir)) {
-    const child = runGitCommand(["-c", "core.editor=true", "rebase", "--continue"], {
-      targetDir,
-    });
-    detail = `${detail}\n${child.stderr ?? ""}\n${child.stdout ?? ""}`.trim();
-    if (child.status !== 0) {
-      const remaining = unmergedPaths(targetDir);
-      if (remaining.length > 0) {
-        throw new Error(`rebase produced additional conflicts: ${remaining.join(", ")}`);
-      }
-      throw new Error(detail || "git rebase --continue failed");
-    }
-  }
-
-  return {
-    status: "continued",
-    previous_head: previousHead,
-    current_head: currentHead(targetDir),
-    detail,
-  };
-}
-
-function assertNoConflictMarkers({ targetDir, paths }: TargetDir & { paths: string[] }): void {
-  const unresolved = paths.filter((filePath) => {
-    const absolute = path.join(targetDir, filePath);
-    if (!fs.existsSync(absolute) || !fs.statSync(absolute).isFile()) return false;
-    const text = fs.readFileSync(absolute, "utf8");
-    return /^<{7} |^={7}$|^>{7} /m.test(text);
-  });
-  if (unresolved.length > 0) {
-    throw new Error(`rebase conflicts remain unresolved: ${unresolved.join(", ")}`);
-  }
-}
-
-export function hasRebaseInProgress(targetDir: string): boolean {
-  const gitDir = gitOutput(["rev-parse", "--git-dir"], { targetDir }).trim();
-  const absoluteGitDir = path.isAbsolute(gitDir) ? gitDir : path.join(targetDir, gitDir);
-  return (
-    fs.existsSync(path.join(absoluteGitDir, "rebase-merge")) ||
-    fs.existsSync(path.join(absoluteGitDir, "rebase-apply"))
-  );
 }
 
 export function unmergedPaths(targetDir: string): string[] {

--- a/src/repair/github-cli.ts
+++ b/src/repair/github-cli.ts
@@ -2,7 +2,7 @@ import type { JsonValue } from "./json-types.js";
 import { execFile, execFileSync, spawnSync } from "node:child_process";
 import { promisify } from "node:util";
 import { stripAnsi } from "./comment-router-utils.js";
-import { ghCliEnv } from "./process-env.js";
+import { ghCliEnv as ghEnv } from "./process-env.js";
 import { repoRoot } from "./paths.js";
 import { GitHubRateLimitError, ghRetryKind, ghRetryWaitMs } from "../github-retry.js";
 import { parseGhJsonWithRetry, parseGhJsonWithRetryAsync } from "../github-json.js";
@@ -266,14 +266,6 @@ export async function ghTextAsync(ghArgs: string[], options: GhRunOptions = {}):
   return stripAnsi(String(stdout)).trim();
 }
 
-export function ghBestEffort(ghArgs: string[], options: GhRunOptions = {}): void {
-  try {
-    ghText(ghArgs, options);
-  } catch {
-    // Helpful metadata should not block the primary command path.
-  }
-}
-
 export function ghBestEffortWithRetry(
   ghArgs: string[],
   options: GhRetryOptions | number = {},
@@ -296,10 +288,6 @@ export function ghSpawn(ghArgs: string[], options: GhRunOptions = {}) {
     input: options.input,
     stdio: "pipe",
   });
-}
-
-export function ghEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
-  return ghCliEnv(overrides);
 }
 
 function ghCommandEnv(ghArgs: readonly string[], options: GhRunOptions): NodeJS.ProcessEnv {

--- a/test/repair/event-record-store.test.ts
+++ b/test/repair/event-record-store.test.ts
@@ -191,10 +191,12 @@ test("authoritative state refresh exposes a remote winner hidden by a stale loca
     const previousStateDir = process.env.CLAWSWEEPER_STATE_DIR;
     process.env.CLAWSWEEPER_STATE_DIR = stateRoot;
     try {
-      refreshSourceAfterStatePublish(
-        [paths.itemRecord, paths.closedRecord, paths.planRecord, paths.decisionPacket],
-        null,
-      );
+      refreshSourceAfterStatePublish([
+        paths.itemRecord,
+        paths.closedRecord,
+        paths.planRecord,
+        paths.decisionPacket,
+      ]);
     } finally {
       if (previousStateDir === undefined) delete process.env.CLAWSWEEPER_STATE_DIR;
       else process.env.CLAWSWEEPER_STATE_DIR = previousStateDir;

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -5,11 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import {
-  commitMessageForPublishedPaths,
-  publishMainCommit,
-  runGit,
-} from "../../dist/repair/git-publish.js";
+import { publishMainCommit, runGit } from "../../dist/repair/git-publish.js";
 
 test("remaining git publisher performs one ordinary push without lease refs or rebuild recovery", () => {
   const source = fs.readFileSync("src/repair/git-publish.ts", "utf8");
@@ -56,11 +52,4 @@ test("remaining git publisher commits an operational path to the requested branc
     else process.env.CLAWSWEEPER_STATE_DIR = previousStateDir;
     fs.rmSync(root, { recursive: true, force: true });
   }
-});
-
-test("git publish commit messages are no longer path-specialized", () => {
-  assert.equal(
-    commitMessageForPublishedPaths("chore: publish operational state", ["results/status.json"]),
-    "chore: publish operational state",
-  );
 });

--- a/test/repair/git-repo-utils.test.ts
+++ b/test/repair/git-repo-utils.test.ts
@@ -9,11 +9,8 @@ import { pathToFileURL } from "node:url";
 
 import {
   branchHasBaseDiff,
-  completeRebaseIfResolved,
   ensureMergeBaseAvailable,
-  rebaseOntoBase,
   runGitCommand,
-  unmergedPaths,
 } from "../../dist/repair/git-repo-utils.js";
 import { mockCommandBinEnv } from "../helpers.ts";
 
@@ -80,28 +77,6 @@ test(
   },
 );
 
-test("rebaseOntoBase rebases a repair branch onto latest origin main", () => {
-  const { work } = fixtureRepo();
-  run("git", ["checkout", "-b", "feature"], { cwd: work });
-  fs.writeFileSync(path.join(work, "feature.txt"), "feature\n");
-  run("git", ["add", "feature.txt"], { cwd: work });
-  run("git", ["commit", "-m", "feature"], { cwd: work });
-
-  run("git", ["checkout", "main"], { cwd: work });
-  fs.writeFileSync(path.join(work, "main.txt"), "main\n");
-  run("git", ["add", "main.txt"], { cwd: work });
-  run("git", ["commit", "-m", "main update"], { cwd: work });
-  run("git", ["push", "origin", "main"], { cwd: work });
-  run("git", ["checkout", "feature"], { cwd: work });
-
-  const result = rebaseOntoBase({ targetDir: work, baseBranch: "main" });
-
-  assert.equal(result.status, "rebased");
-  run("git", ["merge-base", "--is-ancestor", "origin/main", "HEAD"], { cwd: work });
-  assert.equal(fs.readFileSync(path.join(work, "feature.txt"), "utf8"), "feature\n");
-  assert.equal(fs.readFileSync(path.join(work, "main.txt"), "utf8"), "main\n");
-});
-
 for (const pruneConfig of ["fetch.prune", "remote.origin.prune"]) {
   test(`base fetch updates its requested ref with ${pruneConfig}=true`, () => {
     const { root, remote, work } = fixtureRepo();
@@ -151,52 +126,6 @@ for (const pruneConfig of ["fetch.prune", "remote.origin.prune"]) {
     }
   });
 }
-
-test("rebaseOntoBase leaves conflicts for Codex repair instead of aborting", () => {
-  const { work } = fixtureRepo();
-  run("git", ["checkout", "-b", "feature"], { cwd: work });
-  fs.writeFileSync(path.join(work, "shared.txt"), "feature\n");
-  run("git", ["add", "shared.txt"], { cwd: work });
-  run("git", ["commit", "-m", "feature conflict"], { cwd: work });
-
-  run("git", ["checkout", "main"], { cwd: work });
-  fs.writeFileSync(path.join(work, "shared.txt"), "main\n");
-  run("git", ["add", "shared.txt"], { cwd: work });
-  run("git", ["commit", "-m", "main conflict"], { cwd: work });
-  run("git", ["push", "origin", "main"], { cwd: work });
-  run("git", ["checkout", "feature"], { cwd: work });
-
-  const result = rebaseOntoBase({ targetDir: work, baseBranch: "main" });
-
-  assert.equal(result.status, "conflicts");
-  assert.deepEqual(unmergedPaths(work), ["shared.txt"]);
-  assert.match(fs.readFileSync(path.join(work, "shared.txt"), "utf8"), /<<<<<<< HEAD/);
-});
-
-test("completeRebaseIfResolved continues a resolved conflicting rebase", () => {
-  const { work } = fixtureRepo();
-  run("git", ["checkout", "-b", "feature"], { cwd: work });
-  fs.writeFileSync(path.join(work, "shared.txt"), "feature\n");
-  run("git", ["add", "shared.txt"], { cwd: work });
-  run("git", ["commit", "-m", "feature conflict"], { cwd: work });
-
-  run("git", ["checkout", "main"], { cwd: work });
-  fs.writeFileSync(path.join(work, "shared.txt"), "main\n");
-  run("git", ["add", "shared.txt"], { cwd: work });
-  run("git", ["commit", "-m", "main conflict"], { cwd: work });
-  run("git", ["push", "origin", "main"], { cwd: work });
-  run("git", ["checkout", "feature"], { cwd: work });
-
-  const result = rebaseOntoBase({ targetDir: work, baseBranch: "main" });
-  assert.equal(result.status, "conflicts");
-
-  fs.writeFileSync(path.join(work, "shared.txt"), "main\nfeature\n");
-  const continued = completeRebaseIfResolved({ targetDir: work });
-
-  assert.equal(continued.status, "continued");
-  run("git", ["merge-base", "--is-ancestor", "origin/main", "HEAD"], { cwd: work });
-  assert.equal(fs.readFileSync(path.join(work, "shared.txt"), "utf8"), "main\nfeature\n");
-});
 
 test("ensureMergeBaseAvailable deepens shallow history without pruning the base ref", (t) => {
   const { root, remote, work } = fixtureRepo();


### PR DESCRIPTION
## What Problem This Solves

The repair utilities still contain unused Git rebase and recovery helpers, a best-effort GitHub wrapper without callers, and exports used only inside their own module. These paths add code and tests without participating in the active repair flow.

## Why This Change Was Made

Use the reference audit as a candidate list and confirm every removal with exact symbol searches across source, scripts, tests, dashboard, workflows/actions, package metadata, docs, and the repair TypeScript allowlist. Remove the old in-place rebase implementation and its tests; active repairs use the isolated rebase implementation. Delete unused remote-branch lookup and checkout helpers, inline the identity commit-message helper, drop the unused refresh parameter, and replace the GitHub environment forwarding wrapper with the existing implementation. Make ten publisher implementation exports private.

The remaining references to removed rebase names are negative source assertions and archived test transcripts, not entrypoints or consumers. CLI entrypoints, workflow-facing publisher options, and the repair allowlist remain unchanged. This is a bounded repair-utility cut from the larger audit.

## User Impact

Behavior-neutral; no runtime contract, config, or workflow change.

## Evidence

OpenClaw Bay not affected: no dashboard changes.

### pr-behavior-proof

**Claim:** deleting unreachable helpers and narrowing internal exports preserves the active Git and GitHub repair/publishing paths.

**Exercised surface:** Git process execution and timeouts, base-ref fetch and shallow-history recovery, operational-state publication/refresh, GitHub credential selection and deadline behavior, and the execute-fix blocked-fork replacement path.

**Scenario/fixture:** the surviving suites use local Git repositories and bare remotes to publish and verify real commits, exercise shallow histories and prune settings, and run the compiled execute-fix CLI. GitHub command fixtures test environment and deadline behavior without live mutations. Obsolete tests for the deleted rebase and identity helpers are removed.

**Command and environment:** macOS arm64, Node 26.8.1, pnpm 11.10.0 for build/format and the targeted run; the configured AWS Linux Crabbox provider for the full gate. For this behavior-neutral refactor, the proof is the full `pnpm run check` run plus the targeted suites.

```sh
corepack enable >/dev/null 2>&1; pnpm install --prefer-offline
pnpm run format
pnpm run build:all
node scripts/run-node-tests.mjs repair -- --test-name-pattern='git helper|base fetch|ensureMergeBaseAvailable|remaining git publisher|authoritative state refresh|GitHub CLI|public target reads|public read throttles|githubPaginatedPath|githubLimitedPagePath|fast rebase publishes'
crabbox run --no-hydrate --idle-timeout 90m --ttl 240m --timing-json --capture-stdout /tmp/deslop-dead-exports2-crabbox.stdout.log --capture-stderr /tmp/deslop-dead-exports2-crabbox.stderr.log --shell -- 'corepack enable && pnpm install --prefer-offline && node --version && pnpm run check'
```

**Observable result:** the selected repair runner passed, and the unchanged full gate passed on AWS. The real-Git fixtures preserve the expected commit, tree, branch, fetch, and publication behavior. No threshold, baseline, or coverage floor was changed.

```text
Focused repair runner: tests 142; pass 142; fail 0; cancelled 0; skipped 0
AWS focused coverage gate: tests 13; pass 13; fail 0; skipped 0
AWS full pnpm run check: tests 4813; pass 4795; fail 0; cancelled 0; skipped 18
AWS coverage: lines 85.03%; branches 76.29%; functions 89.42%
```

**Artifact/trace:** `/tmp/deslop-dead-exports2-targeted.log`, `/tmp/deslop-dead-exports2-crabbox.stdout.log`, `/tmp/deslop-dead-exports2-crabbox.stderr.log`, and `/tmp/deslop-dead-exports2-crabbox.log`. Summaries are copied here so review does not depend on local files. Crabbox provider `aws`, lease `cbx_c50bc15aa27b`, run `run_e9da8d2dda95`, image `ami-0461d919be7deb53c` in `eu-west-1`, instance `c7a.8xlarge`, Node 24.18.1, pnpm 11.10.0; full command exit 0. The original 2,515-line audit and exact before/after reference searches are retained in ignored worktree scratch space.

**Limits:** the Git repositories, subprocesses, executor, and fixture branch publication are real; external GitHub operations and model responses are fixture substitutes. No live repair target or production deployment was exercised. The name-filtered repair runner also reports test files with no matching cases; its count is a runner total. The full suite has no name filter.

| Category | Added | Removed | Net LOC |
| --- | ---: | ---: | ---: |
| Production (`src`, `scripts`) | 15 | 160 | -145 |
| Tests | 7 | 87 | -80 |
| Docs/changelog | 0 | 0 | 0 |

**Validated head:** `0314635a714214300edbf3410490852d965772b4`. The committed patch is identical to the validated and reviewed patch.

**Independent review:** Codex autoreview `--mode local --base origin/main --max-priority P1`: **scoped-clean**, no accepted/actionable findings. Report: `/tmp/autoreview-deslop-bugs2-dead-exports.md`.
