### PR TITLE
feat(codex): route private inference through ClawRouter

### DIFF
--- a/.github/actions/setup-codex/action.yml
+++ b/.github/actions/setup-codex/action.yml
@@ -3,12 +3,12 @@ description: Cache, install, and authenticate the OpenAI Codex CLI.
 inputs:
   codex-version:
     description: Exact Codex CLI npm package version.
-    default: "0.146.0"
+    default: "0.151.0"
   proxy-version:
     description: Exact Codex Responses proxy npm package version.
     default: "0.139.0"
   auth-mode:
-    description: Authentication mode. Use proxy to keep OPENAI_API_KEY out of Codex subprocesses, or login for legacy codex login.
+    description: Authentication mode. Use clawrouter for private alias inference, proxy for an isolated API-key proxy, or login for legacy codex login.
     default: "proxy"
   codex-home:
     description: CODEX_HOME directory. Defaults to an isolated per-run ClawSweeper directory.
@@ -47,7 +47,7 @@ runs:
         echo "$HOME/.clawsweeper-repair/codex/bin" >> "$GITHUB_PATH"
         export PATH="$HOME/.clawsweeper-repair/codex/bin:$PATH"
 
-        install_env=(env -u OPENAI_API_KEY -u CODEX_API_KEY -u PROXY_API_KEY -u CLAWSWEEPER_INTERNAL_MODEL)
+        install_env=(env -u OPENAI_API_KEY -u CODEX_API_KEY -u PROXY_API_KEY -u CLAWSWEEPER_INTERNAL_MODEL -u CLAWSWEEPER_CLAWROUTER_CONFIG)
         "${install_env[@]}" npm install -g "@openai/codex@${{ inputs['codex-version'] }}" \
           --prefer-online --no-audit --no-fund --ignore-scripts
         if [[ "${{ inputs['auth-mode'] }}" == "proxy" ]]; then
@@ -94,6 +94,7 @@ runs:
         echo "Using isolated CODEX_HOME=$CODEX_HOME"
 
     - name: Configure internal Codex model
+      if: ${{ inputs['auth-mode'] != 'clawrouter' }}
       shell: bash
       run: |
         set -euo pipefail
@@ -102,6 +103,11 @@ runs:
         model_json="$(node -e 'process.stdout.write(JSON.stringify(process.argv[1]))' "$CLAWSWEEPER_INTERNAL_MODEL")"
         printf 'model = %s\n' "$model_json" > "$CODEX_HOME/config.toml"
         chmod 600 "$CODEX_HOME/config.toml"
+
+    - name: Configure private ClawRouter inference
+      if: ${{ inputs['auth-mode'] == 'clawrouter' }}
+      shell: bash
+      run: node "${{ github.action_path }}/configure-clawrouter.mjs"
 
     - name: Authenticate Codex through Responses proxy
       if: ${{ inputs['auth-mode'] == 'proxy' }}
@@ -151,7 +157,7 @@ runs:
         fi
 
     - name: Reject unknown Codex auth mode
-      if: ${{ inputs['auth-mode'] != 'proxy' && inputs['auth-mode'] != 'login' }}
+      if: ${{ inputs['auth-mode'] != 'proxy' && inputs['auth-mode'] != 'login' && inputs['auth-mode'] != 'clawrouter' }}
       shell: bash
       run: |
         echo "Unsupported setup-codex auth-mode: ${{ inputs['auth-mode'] }}" >&2

--- a/.github/actions/setup-codex/configure-clawrouter.mjs
+++ b/.github/actions/setup-codex/configure-clawrouter.mjs
@@ -1,0 +1,96 @@
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const alias = "internal";
+
+try {
+  const home = process.env.CODEX_HOME;
+  const raw = process.env.CLAWSWEEPER_CLAWROUTER_CONFIG ?? "";
+  if (Buffer.byteLength(raw) > 256 * 1024) throw new Error("Private configuration is too large.");
+  const settings = JSON.parse(raw);
+  if (
+    !settings ||
+    typeof settings !== "object" ||
+    Array.isArray(settings) ||
+    Object.keys(settings).sort().join(",") !== "baseUrl,modelInfo,token"
+  )
+    throw new Error("Invalid private configuration.");
+  const base = new URL(settings.baseUrl);
+  const local = ["127.0.0.1", "[::1]"].includes(base.hostname);
+  if (
+    !home ||
+    base.username ||
+    base.password ||
+    base.search ||
+    base.hash ||
+    base.pathname.replace(/\/$/, "") !== "/private/v1" ||
+    (base.protocol !== "https:" &&
+      !(local && base.protocol === "http:" && process.env.GITHUB_ACTIONS !== "true"))
+  ) {
+    throw new Error("Invalid private endpoint configuration.");
+  }
+  const credential = settings.token;
+  if (
+    typeof credential !== "string" ||
+    !/^private-workload-[A-Za-z0-9_-]{32,128}$/.test(credential)
+  ) {
+    throw new Error("Invalid private workload credential.");
+  }
+  const model = settings.modelInfo;
+  if (
+    !model ||
+    typeof model !== "object" ||
+    Array.isArray(model) ||
+    model.slug !== alias ||
+    model.display_name !== "Codex" ||
+    !Array.isArray(model.supported_reasoning_levels) ||
+    typeof model.shell_type !== "string" ||
+    typeof model.supported_in_api !== "boolean" ||
+    (model.upgrade != null && model.upgrade.model !== alias) ||
+    (model.auto_review_model_override != null && model.auto_review_model_override !== alias)
+  ) {
+    throw new Error("Full alias-only native model metadata is required.");
+  }
+  mkdirSync(home, { recursive: true, mode: 0o700 });
+  chmodSync(home, 0o700);
+  const catalog = join(home, "clawrouter-models.json");
+  writeFileSync(catalog, JSON.stringify({ models: [model] }), { mode: 0o600 });
+  chmodSync(catalog, 0o600);
+  const config = [
+    `model = ${JSON.stringify(alias)}`,
+    'model_provider = "openai"',
+    `openai_base_url = ${JSON.stringify(base.href.replace(/\/$/, ""))}`,
+    `model_catalog_json = ${JSON.stringify(catalog)}`,
+    'forced_login_method = "api"',
+    'cli_auth_credentials_store = "file"',
+    "",
+  ].join("\n");
+  writeFileSync(join(home, "config.toml"), config, { mode: 0o600 });
+  chmodSync(join(home, "config.toml"), 0o600);
+  const env = { ...process.env };
+  for (const key of [
+    "OPENAI_API_KEY",
+    "CODEX_API_KEY",
+    "CODEX_ACCESS_TOKEN",
+    "PROXY_API_KEY",
+    "CLAWSWEEPER_INTERNAL_MODEL",
+    "CLAWSWEEPER_CLAWROUTER_CONFIG",
+  ])
+    delete env[key];
+  const login = spawnSync("codex", ["login", "--with-api-key"], {
+    env,
+    input: credential,
+    encoding: "utf8",
+    timeout: 30_000,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  if (login.error || login.status !== 0) throw new Error("Private workload authentication failed.");
+  console.log("Configured private ClawRouter inference with alias-only metadata.");
+} catch {
+  // Configuration and native errors may contain credentials, URLs, or model metadata.
+  console.error(
+    "Private ClawRouter setup failed; check its endpoint, workload credential, and native model metadata.",
+  );
+  process.exitCode = 1;
+}

--- a/.github/workflows/assist.yml
+++ b/.github/workflows/assist.yml
@@ -215,8 +215,11 @@ jobs:
       - uses: ./.github/actions/setup-codex
         if: ${{ env.CLAWSWEEPER_RUNNER != 'openclaw' }}
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          CLAWSWEEPER_INTERNAL_MODEL: ${{ secrets.CLAWSWEEPER_MODEL }}
+          OPENAI_API_KEY: ${{ vars.CLAWSWEEPER_CODEX_AUTH_MODE != 'clawrouter' && secrets.OPENAI_API_KEY || '' }}
+          CLAWSWEEPER_INTERNAL_MODEL: ${{ vars.CLAWSWEEPER_CODEX_AUTH_MODE != 'clawrouter' && secrets.CLAWSWEEPER_MODEL || '' }}
+          CLAWSWEEPER_CLAWROUTER_CONFIG: ${{ secrets.CLAWSWEEPER_CLAWROUTER_CONFIG }}
+        with:
+          auth-mode: ${{ vars.CLAWSWEEPER_CODEX_AUTH_MODE || 'proxy' }}
 
       - uses: ./.github/actions/setup-openclaw
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,11 @@ jobs:
           build-script: build
       - uses: ./.github/actions/setup-codex
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          CLAWSWEEPER_INTERNAL_MODEL: ${{ secrets.CLAWSWEEPER_MODEL }}
+          OPENAI_API_KEY: ${{ vars.CLAWSWEEPER_CODEX_AUTH_MODE != 'clawrouter' && secrets.OPENAI_API_KEY || '' }}
+          CLAWSWEEPER_INTERNAL_MODEL: ${{ vars.CLAWSWEEPER_CODEX_AUTH_MODE != 'clawrouter' && secrets.CLAWSWEEPER_MODEL || '' }}
+          CLAWSWEEPER_CLAWROUTER_CONFIG: ${{ secrets.CLAWSWEEPER_CLAWROUTER_CONFIG }}
+        with:
+          auth-mode: ${{ vars.CLAWSWEEPER_CODEX_AUTH_MODE || 'proxy' }}
       - name: Prove refusal then clean structured review
         run: node scripts/hosted-review-scan-smoke.mjs "$RUNNER_TEMP/hosted-review-scan-proof.json"
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/maintainer-activity-report.yml
+++ b/.github/workflows/maintainer-activity-report.yml
@@ -106,8 +106,11 @@ jobs:
 
       - uses: ./clawsweeper/.github/actions/setup-codex
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          CLAWSWEEPER_INTERNAL_MODEL: ${{ secrets.CLAWSWEEPER_MODEL }}
+          OPENAI_API_KEY: ${{ vars.CLAWSWEEPER_CODEX_AUTH_MODE != 'clawrouter' && secrets.OPENAI_API_KEY || '' }}
+          CLAWSWEEPER_INTERNAL_MODEL: ${{ vars.CLAWSWEEPER_CODEX_AUTH_MODE != 'clawrouter' && secrets.CLAWSWEEPER_MODEL || '' }}
+          CLAWSWEEPER_CLAWROUTER_CONFIG: ${{ secrets.CLAWSWEEPER_CLAWROUTER_CONFIG }}
+        with:
+          auth-mode: ${{ vars.CLAWSWEEPER_CODEX_AUTH_MODE || 'proxy' }}
 
       - name: Generate reports
         working-directory: maintainers

--- a/.github/workflows/repair-cluster-worker.yml
+++ b/.github/workflows/repair-cluster-worker.yml
@@ -277,9 +277,10 @@ jobs:
         if: ${{ env.CLAWSWEEPER_RUNNER != 'openclaw' && steps.check_job.outputs.job_exists == '1' && env.CLAWSWEEPER_STEERABLE_CODEX == '1' }}
         env:
           JOB_PATH: ${{ inputs.job }}
+          CODEX_AUTH_MODE: ${{ vars.CLAWSWEEPER_CODEX_AUTH_MODE || 'proxy' }}
         run: |
           set -euo pipefail
-          key="$(printf '%s' "$JOB_PATH" | sha256sum | cut -d' ' -f1)"
+          key="$(printf '%s\n' "$CODEX_AUTH_MODE" "$JOB_PATH" | sha256sum | cut -d' ' -f1)"
           codex_home="$HOME/.clawsweeper-repair/codex-home/work-$key"
           echo "key=$key" >> "$GITHUB_OUTPUT"
           echo "codex_home=$codex_home" >> "$GITHUB_OUTPUT"
@@ -288,9 +289,11 @@ jobs:
       - uses: ./.github/actions/setup-codex
         if: ${{ env.CLAWSWEEPER_RUNNER != 'openclaw' && steps.check_job.outputs.job_exists == '1' }}
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          CLAWSWEEPER_INTERNAL_MODEL: ${{ secrets.CLAWSWEEPER_MODEL }}
+          OPENAI_API_KEY: ${{ vars.CLAWSWEEPER_CODEX_AUTH_MODE != 'clawrouter' && secrets.OPENAI_API_KEY || '' }}
+          CLAWSWEEPER_INTERNAL_MODEL: ${{ vars.CLAWSWEEPER_CODEX_AUTH_MODE != 'clawrouter' && secrets.CLAWSWEEPER_MODEL || '' }}
+          CLAWSWEEPER_CLAWROUTER_CONFIG: ${{ secrets.CLAWSWEEPER_CLAWROUTER_CONFIG }}
         with:
+          auth-mode: ${{ vars.CLAWSWEEPER_CODEX_AUTH_MODE || 'proxy' }}
           codex-home: ${{ steps.codex_session.outputs.codex_home }}
 
       - uses: ./.github/actions/setup-openclaw
@@ -572,9 +575,10 @@ jobs:
         if: ${{ env.CLAWSWEEPER_RUNNER != 'openclaw' && steps.check_job.outputs.job_exists == '1' && env.CLAWSWEEPER_STEERABLE_CODEX == '1' }}
         env:
           JOB_PATH: ${{ inputs.job }}
+          CODEX_AUTH_MODE: ${{ vars.CLAWSWEEPER_CODEX_AUTH_MODE || 'proxy' }}
         run: |
           set -euo pipefail
-          key="$(printf '%s' "$JOB_PATH" | sha256sum | cut -d' ' -f1)"
+          key="$(printf '%s\n' "$CODEX_AUTH_MODE" "$JOB_PATH" | sha256sum | cut -d' ' -f1)"
           codex_home="$HOME/.clawsweeper-repair/codex-home/work-$key"
           echo "key=$key" >> "$GITHUB_OUTPUT"
           echo "codex_home=$codex_home" >> "$GITHUB_OUTPUT"
@@ -583,9 +587,11 @@ jobs:
       - uses: ./.github/actions/setup-codex
         if: ${{ env.CLAWSWEEPER_RUNNER != 'openclaw' && steps.check_job.outputs.job_exists == '1' }}
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          CLAWSWEEPER_INTERNAL_MODEL: ${{ contains(inputs.job, '/inbox/issue-') && (vars.CLAWSWEEPER_FIX_PR_MODEL || 'gpt-5.6-sol') || secrets.CLAWSWEEPER_MODEL }}
+          OPENAI_API_KEY: ${{ vars.CLAWSWEEPER_CODEX_AUTH_MODE != 'clawrouter' && secrets.OPENAI_API_KEY || '' }}
+          CLAWSWEEPER_INTERNAL_MODEL: ${{ vars.CLAWSWEEPER_CODEX_AUTH_MODE != 'clawrouter' && (contains(inputs.job, '/inbox/issue-') && (vars.CLAWSWEEPER_FIX_PR_MODEL || 'gpt-5.6-sol') || secrets.CLAWSWEEPER_MODEL) || '' }}
+          CLAWSWEEPER_CLAWROUTER_CONFIG: ${{ secrets.CLAWSWEEPER_CLAWROUTER_CONFIG }}
         with:
+          auth-mode: ${{ vars.CLAWSWEEPER_CODEX_AUTH_MODE || 'proxy' }}
           cache-suffix: target-pnpm
           codex-home: ${{ steps.codex_session.outputs.codex_home }}
 

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1030,9 +1030,11 @@ jobs:
       - uses: ./.github/actions/setup-codex
         if: ${{ env.CLAWSWEEPER_RUNNER != 'openclaw' && steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.live-item.outputs.proceed == 'true' }}
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          CLAWSWEEPER_INTERNAL_MODEL: ${{ secrets.CLAWSWEEPER_MODEL }}
+          OPENAI_API_KEY: ${{ vars.CLAWSWEEPER_CODEX_AUTH_MODE != 'clawrouter' && secrets.OPENAI_API_KEY || '' }}
+          CLAWSWEEPER_INTERNAL_MODEL: ${{ vars.CLAWSWEEPER_CODEX_AUTH_MODE != 'clawrouter' && secrets.CLAWSWEEPER_MODEL || '' }}
+          CLAWSWEEPER_CLAWROUTER_CONFIG: ${{ secrets.CLAWSWEEPER_CLAWROUTER_CONFIG }}
         with:
+          auth-mode: ${{ vars.CLAWSWEEPER_CODEX_AUTH_MODE || 'proxy' }}
           login-status: "true"
 
       - uses: ./.github/actions/setup-openclaw
@@ -4411,9 +4413,11 @@ jobs:
       - uses: ./clawsweeper/.github/actions/setup-codex
         if: ${{ env.CLAWSWEEPER_RUNNER != 'openclaw' }}
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          CLAWSWEEPER_INTERNAL_MODEL: ${{ secrets.CLAWSWEEPER_MODEL }}
+          OPENAI_API_KEY: ${{ vars.CLAWSWEEPER_CODEX_AUTH_MODE != 'clawrouter' && secrets.OPENAI_API_KEY || '' }}
+          CLAWSWEEPER_INTERNAL_MODEL: ${{ vars.CLAWSWEEPER_CODEX_AUTH_MODE != 'clawrouter' && secrets.CLAWSWEEPER_MODEL || '' }}
+          CLAWSWEEPER_CLAWROUTER_CONFIG: ${{ secrets.CLAWSWEEPER_CLAWROUTER_CONFIG }}
         with:
+          auth-mode: ${{ vars.CLAWSWEEPER_CODEX_AUTH_MODE || 'proxy' }}
           login-status: "true"
 
       - uses: ./clawsweeper/.github/actions/setup-openclaw
@@ -5819,8 +5823,11 @@ jobs:
       - uses: ./.github/actions/setup-codex
         if: ${{ env.CLAWSWEEPER_RUNNER != 'openclaw' && steps.proof-select.outputs.item_numbers != '' }}
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          CLAWSWEEPER_INTERNAL_MODEL: ${{ secrets.CLAWSWEEPER_MODEL }}
+          OPENAI_API_KEY: ${{ vars.CLAWSWEEPER_CODEX_AUTH_MODE != 'clawrouter' && secrets.OPENAI_API_KEY || '' }}
+          CLAWSWEEPER_INTERNAL_MODEL: ${{ vars.CLAWSWEEPER_CODEX_AUTH_MODE != 'clawrouter' && secrets.CLAWSWEEPER_MODEL || '' }}
+          CLAWSWEEPER_CLAWROUTER_CONFIG: ${{ secrets.CLAWSWEEPER_CLAWROUTER_CONFIG }}
+        with:
+          auth-mode: ${{ vars.CLAWSWEEPER_CODEX_AUTH_MODE || 'proxy' }}
 
       - uses: ./.github/actions/setup-openclaw
         if: ${{ steps.proof-select.outputs.item_numbers != '' }}

--- a/config/documentation-site.json
+++ b/config/documentation-site.json
@@ -29,6 +29,7 @@
         "github-egress-telemetry.md",
         "github-webhook-read-model.md",
         "operator-configuration.md",
+        "private-inference.md",
         "live-dashboard.md",
         "openclaw-bay-demo.md",
         "openclaw-event-hooks.md",

--- a/docs/private-inference.md
+++ b/docs/private-inference.md
@@ -1,0 +1,35 @@
+# Private inference through ClawRouter
+
+Set the repository variable `CLAWSWEEPER_CODEX_AUTH_MODE=clawrouter` to route
+Codex lanes through ClawRouter's isolated `/private/v1` endpoint. Provision and
+prove that private deployment before enabling the variable. This selects the
+Codex runner; deployments using the separate OpenClaw runner must first choose
+`CLAWSWEEPER_RUNNER=codex`.
+
+The `CLAWSWEEPER_CLAWROUTER_CONFIG` Actions secret contains exactly three fields:
+`baseUrl` (an HTTPS URL ending in `/private/v1`), `token` (the dedicated
+`private-workload-` credential), and `modelInfo` (the complete native Codex
+ModelInfo object, with `slug: "internal"` and `display_name: "Codex"`). Supply
+verified, alias-only metadata for the entitled upstream; discovery's reduced
+model row is insufficient. Preserve genuine reasoning, context, Lite, tool,
+review, and safety requirements. Never put real upstream model identifiers or
+subscription credentials in this secret, workflow inputs, source, or reports.
+
+Setup uses the built-in OpenAI provider and native API-key credential storage
+with the opaque workload credential. Missing or invalid private configuration
+fails the job; it does not fall back to a direct provider. Upstream API keys and
+model secrets are withheld from Codex setup in this mode. Session cache keys
+include the authentication mode so legacy sessions cannot reintroduce upstream
+identifiers when switching to private inference.
+
+ClawRouter owns upstream authentication, routing, response identity containment,
+and any configured availability fallback. It must run under a separate private
+administrative boundary, with an owner-managed subscription token lifecycle.
+ClawSweeper continues to report only `internal`. Its existing review scanner,
+sandbox checks, proof requirements, and deterministic publication gates remain
+in force. Validate the deployed route with the pinned native Codex client,
+including tools and failure paths, before enabling live jobs.
+
+The default `proxy` mode and explicit legacy `login` mode retain their existing
+API-key configuration. Changing the authentication-mode variable affects new
+jobs; it does not stop or reconfigure jobs already running.

--- a/docs/repair/README.md
+++ b/docs/repair/README.md
@@ -376,7 +376,10 @@ The workflow needs:
   materialization or dispatch; publication recovery retains the exact selected
   job and selector decision.
 - merge is separately gated by `CLAWSWEEPER_ALLOW_MERGE`, which defaults to `0`; merge-ready PRs are labeled `clawsweeper:human-review` and `clawsweeper:merge-ready` for a maintainer to merge manually when the global gate is closed
-- required `CLAWSWEEPER_MODEL` GitHub Actions secret containing the actual
+- optional private alias routing through ClawRouter; see
+  [`../private-inference.md`](../private-inference.md) for the isolated deployment,
+  workload credential, and native metadata contract
+- required `CLAWSWEEPER_MODEL` GitHub Actions secret for direct Codex modes, containing the actual
   internal model name; workflows, dispatch payloads, comments, and reports use
   only the public `internal` alias
 - Codex CLI and its responses API proxy install from their latest npm tags on

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2284,7 +2284,7 @@ test("agent workflows install pinned CLI releases and keep runner models secret"
     ".github/workflows/sweep.yml",
   ].map((file) => readText(file));
 
-  assert.match(action, /codex-version:[\s\S]*default: "0\.146\.0"/);
+  assert.match(action, /codex-version:[\s\S]*default: "0\.151\.0"/);
   assert.match(action, /proxy-version:[\s\S]*default: "0\.139\.0"/);
   assert.match(action, /@openai\/codex@\$\{\{ inputs\['codex-version'\] \}\}/);
   assert.match(action, /@openai\/codex-responses-api-proxy@\$\{\{ inputs\['proxy-version'\] \}\}/);
@@ -2304,7 +2304,10 @@ test("agent workflows install pinned CLI releases and keep runner models secret"
   );
   for (const workflow of workflows) {
     assert.match(workflow, /CLAWSWEEPER_MODEL: internal/);
-    assert.match(workflow, /CLAWSWEEPER_INTERNAL_MODEL: \$\{\{ secrets\.CLAWSWEEPER_MODEL \}\}/);
+    assert.match(
+      workflow,
+      /CLAWSWEEPER_INTERNAL_MODEL: \$\{\{ vars\.CLAWSWEEPER_CODEX_AUTH_MODE != 'clawrouter' && secrets\.CLAWSWEEPER_MODEL \|\| '' \}\}/,
+    );
     assert.doesNotMatch(workflow, /CLAWSWEEPER_CODEX_CLI_VERSION/);
     for (const line of workflow
       .split("\n")

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -3999,7 +3999,10 @@ test("assist workflow preserves flat field fallbacks after nested dispatch field
     /LENS: \$\{\{ github\.event\.client_payload\.assist\.lens \|\| github\.event\.client_payload\.lens \|\| inputs\.lens \|\| 'auto' \}\}/,
   );
   assert.match(workflow, /MODEL: internal/);
-  assert.match(workflow, /CLAWSWEEPER_INTERNAL_MODEL: \$\{\{ secrets\.CLAWSWEEPER_MODEL \}\}/);
+  assert.match(
+    workflow,
+    /CLAWSWEEPER_INTERNAL_MODEL: \$\{\{ vars\.CLAWSWEEPER_CODEX_AUTH_MODE != 'clawrouter' && secrets\.CLAWSWEEPER_MODEL \|\| '' \}\}/,
+  );
   assert.match(workflow, /REASONING_EFFORT: high/);
   assert.doesNotMatch(workflow, /client_payload\.(?:assist\.)?reasoning_effort/);
   assert.match(

--- a/test/repair/repair-cluster-worker-containment.test.ts
+++ b/test/repair/repair-cluster-worker-containment.test.ts
@@ -106,14 +106,17 @@ test("issue PR execution is pinned to sol xhigh without changing planning", () =
   const executeJob = workflow.slice(executeJobIndex);
 
   assert.ok(executeJobIndex >= 0);
-  assert.match(planningJob, /CLAWSWEEPER_INTERNAL_MODEL: \$\{\{ secrets\.CLAWSWEEPER_MODEL \}\}/);
+  assert.match(
+    planningJob,
+    /CLAWSWEEPER_INTERNAL_MODEL: \$\{\{ vars\.CLAWSWEEPER_CODEX_AUTH_MODE != 'clawrouter' && secrets\.CLAWSWEEPER_MODEL \|\| '' \}\}/,
+  );
   assert.match(
     executeJob,
     /CLAWSWEEPER_CODEX_REASONING_EFFORT: \$\{\{ contains\(inputs\.job, '\/inbox\/issue-'\) && \(vars\.CLAWSWEEPER_FIX_PR_REASONING_EFFORT \|\| 'xhigh'\)/,
   );
   assert.match(
     executeJob,
-    /CLAWSWEEPER_INTERNAL_MODEL: \$\{\{ contains\(inputs\.job, '\/inbox\/issue-'\) && \(vars\.CLAWSWEEPER_FIX_PR_MODEL \|\| 'gpt-5\.6-sol'\) \|\| secrets\.CLAWSWEEPER_MODEL \}\}/,
+    /CLAWSWEEPER_INTERNAL_MODEL: \$\{\{ vars\.CLAWSWEEPER_CODEX_AUTH_MODE != 'clawrouter' && \(contains\(inputs\.job, '\/inbox\/issue-'\) && \(vars\.CLAWSWEEPER_FIX_PR_MODEL \|\| 'gpt-5\.6-sol'\) \|\| secrets\.CLAWSWEEPER_MODEL\) \|\| '' \}\}/,
   );
   assert.match(
     executeJob,

--- a/test/setup-clawrouter-action.test.ts
+++ b/test/setup-clawrouter-action.test.ts
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import test from "node:test";
+
+const script = resolve(".github/actions/setup-codex/configure-clawrouter.mjs");
+const token = "private-workload-SYNTHETIC_PRIVATE_CREDENTIAL_123456789";
+const modelInfo = {
+  slug: "internal",
+  display_name: "Codex",
+  supported_reasoning_levels: [{ effort: "high", description: "High" }],
+  shell_type: "shell_command",
+  supported_in_api: true,
+  use_responses_lite: true,
+  auto_review_model_override: null,
+};
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-private-setup-"));
+  const home = join(root, "home");
+  const bin = join(root, "bin");
+  mkdirSync(bin);
+  writeFileSync(
+    join(bin, "codex"),
+    `#!${process.execPath}\n
+const fs = require('node:fs');
+const input = fs.readFileSync(0, 'utf8');
+fs.writeFileSync(process.env.CODEX_TEST_RECEIPT, JSON.stringify({ args: process.argv.slice(2), input, env: process.env }));
+process.stderr.write('SYNTHETIC_PRIVATE_UPSTREAM_NAME ' + input);
+process.exit(Number(process.env.CODEX_TEST_EXIT || 0));
+`,
+    { mode: 0o755 },
+  );
+  const receipt = join(root, "receipt.json");
+  const run = (settings: unknown, extra: NodeJS.ProcessEnv = {}) =>
+    spawnSync(process.execPath, [script], {
+      encoding: "utf8",
+      env: {
+        PATH: `${bin}:/usr/bin:/bin`,
+        CODEX_HOME: home,
+        CODEX_TEST_RECEIPT: receipt,
+        GITHUB_ACTIONS: "true",
+        OPENAI_API_KEY: "SYNTHETIC_UNRELATED_API_KEY",
+        CLAWSWEEPER_INTERNAL_MODEL: "SYNTHETIC_PRIVATE_UPSTREAM_NAME",
+        CLAWSWEEPER_CLAWROUTER_CONFIG:
+          typeof settings === "string" ? settings : JSON.stringify(settings),
+        ...extra,
+      },
+    });
+  const settings = { baseUrl: "https://private.example.invalid/private/v1", token, modelInfo };
+  return { root, home, receipt, settings, run };
+}
+
+test(
+  "private setup preserves native metadata and authenticates only the isolated workload",
+  { skip: process.platform === "win32" },
+  () => {
+    const f = fixture();
+    try {
+      const result = f.run(f.settings);
+      assert.equal(result.status, 0, result.stderr);
+      const receipt = JSON.parse(readFileSync(f.receipt, "utf8"));
+      assert.deepEqual(receipt.args, ["login", "--with-api-key"]);
+      assert.equal(receipt.input, token);
+      for (const key of [
+        "OPENAI_API_KEY",
+        "CLAWSWEEPER_INTERNAL_MODEL",
+        "CLAWSWEEPER_CLAWROUTER_CONFIG",
+      ])
+        assert.equal(receipt.env[key], undefined);
+      const config = readFileSync(join(f.home, "config.toml"), "utf8");
+      assert.match(config, /model = "internal"/);
+      assert.match(config, /model_provider = "openai"/);
+      assert.match(config, /openai_base_url = "https:\/\/private.example.invalid\/private\/v1"/);
+      assert.deepEqual(JSON.parse(readFileSync(join(f.home, "clawrouter-models.json"), "utf8")), {
+        models: [modelInfo],
+      });
+      assert.equal(statSync(join(f.home, "config.toml")).mode & 0o777, 0o600);
+      assert.doesNotMatch(
+        result.stdout + result.stderr + config,
+        /SYNTHETIC_PRIVATE|SYNTHETIC_UNRELATED/,
+      );
+    } finally {
+      rmSync(f.root, { recursive: true, force: true });
+    }
+  },
+);
+
+test("private setup rejects malformed config, non-private endpoints, and non-alias metadata before login", () => {
+  const f = fixture();
+  const userInfoUrl = new URL(f.settings.baseUrl);
+  userInfoUrl.username = "synthetic-user";
+  userInfoUrl.password = "synthetic-password";
+  try {
+    for (const settings of [
+      "",
+      "invalid",
+      { ...f.settings, token: "SYNTHETIC_API_CREDENTIAL" },
+      ...[
+        "http://127.0.0.1/private/v1",
+        "https://private.example.invalid/v1",
+        userInfoUrl.href,
+        "https://private.example.invalid/private/v1?model=SYNTHETIC_PRIVATE_UPSTREAM_NAME",
+      ].map((baseUrl) => ({ ...f.settings, baseUrl })),
+      { ...f.settings, modelInfo: { ...modelInfo, slug: "SYNTHETIC_PRIVATE_UPSTREAM_NAME" } },
+      {
+        ...f.settings,
+        modelInfo: { ...modelInfo, auto_review_model_override: "SYNTHETIC_PRIVATE_REVIEW_NAME" },
+      },
+      { ...f.settings, modelInfo: { slug: "internal", display_name: "Codex" } },
+    ]) {
+      const result = f.run(settings);
+      assert.equal(result.status, 1);
+      assert.equal(existsSync(f.receipt), false);
+      assert.equal(existsSync(join(f.home, "config.toml")), false);
+      assert.doesNotMatch(result.stdout + result.stderr, /SYNTHETIC|private.example|user:pass/);
+    }
+  } finally {
+    rmSync(f.root, { recursive: true, force: true });
+  }
+});
+
+test(
+  "native login failures fail closed without echoing private subprocess output",
+  { skip: process.platform === "win32" },
+  () => {
+    const f = fixture();
+    try {
+      const result = f.run(f.settings, { CODEX_TEST_EXIT: "23" });
+      assert.equal(result.status, 1);
+      assert.match(result.stderr, /Private ClawRouter setup failed/);
+      assert.doesNotMatch(result.stdout + result.stderr, /SYNTHETIC/);
+    } finally {
+      rmSync(f.root, { recursive: true, force: true });
+    }
+  },
+);


### PR DESCRIPTION
ClawSweeper can now use an isolated ClawRouter private inference endpoint through the new `clawrouter` authentication mode. Setup accepts an alias-only native model catalog and a dedicated workload credential, while keeping upstream credentials and target selection inside the broker. All Codex workflow entry points share the switch, and repair session caches are separated by authentication mode.

The native CLI pin moves to 0.151.0 because the previous version cannot load the current native model metadata. Full model capabilities and safety requirements are preserved. Invalid setup fails closed, and native login output cannot expose configuration details.

Validation: focused setup tests pass, independent autoreview is clean, and the pinned native client completed a real upstream shell-tool exchange through the private broker. A separate injected-availability-failure run completed the tool exchange on the alternate route and preserved continuation affinity; client output contained no configured upstream identities or credentials. Full local checks and this PR's CI provide the repository-wide gates.

Deployment: opt-in only. The isolated deployment and owner-managed upstream credential lifecycle must be provisioned and verified before enabling the repository variable. No production switch has been made. The private facade uses HTTPS streaming; the native client may first attempt WebSockets before falling back to HTTPS.
