### PR TITLE
refactor(sweep): simplify apply and review owners

### DIFF
--- a/src/clawsweeper-apply-decision-workflow.ts
+++ b/src/clawsweeper-apply-decision-workflow.ts
@@ -330,7 +330,6 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
               left.applyCheckedAt - right.applyCheckedAt ||
               left.number - right.number,
     );
-    const files = fileEntries.map((entry) => entry.name);
     const boundedExactSelection = exactEventPublication && requestedItemNumberSet.size > 0;
     const openReportEntry = createOpenReportLookup(fileEntries, boundedExactSelection);
     const pairedIssueCloseoutReportKeys = new Set<string>();
@@ -492,7 +491,7 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
       return;
     }
     logProgress(
-      `starting apply: files=${files.length} dry_run=${dryRun} apply_kind=${applyKind} min_age=${minAgeDescription} apply_close_reasons=${closeReasonFilterText(applyCloseReasons)} stale_min_age_days=${staleMinAgeDays} close_delay_ms=${closeDelayMs} sync_comments_only=${syncCommentsOnly} suppress_automation_markers=${suppressAutomationMarkers} comment_sync_min_age_days=${commentSyncMinAgeDays} comment_sync_cursor=${commentSyncCursor ?? "none"} max_runtime_ms=${maxRuntimeMs} item_numbers=${requestedItemNumbers.join(",") || "all"} reconciliation_deferred=${[...reconciliationDeferredItemNumbers].join(",") || "none"}`,
+      `starting apply: files=${fileEntries.length} dry_run=${dryRun} apply_kind=${applyKind} min_age=${minAgeDescription} apply_close_reasons=${closeReasonFilterText(applyCloseReasons)} stale_min_age_days=${staleMinAgeDays} close_delay_ms=${closeDelayMs} sync_comments_only=${syncCommentsOnly} suppress_automation_markers=${suppressAutomationMarkers} comment_sync_min_age_days=${commentSyncMinAgeDays} comment_sync_cursor=${commentSyncCursor ?? "none"} max_runtime_ms=${maxRuntimeMs} item_numbers=${requestedItemNumbers.join(",") || "all"} reconciliation_deferred=${[...reconciliationDeferredItemNumbers].join(",") || "none"}`,
     );
     // oxfmt-ignore
     for (const entry of fileEntries) {
@@ -623,25 +622,16 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
         liveReadGeneration.invalidate();
         resetGenerationBoundReads();
         if (!preserveGuardReadCacheAfterMutation) resetMutationGuardBoundary();
-        if (mutationEntry === entry) {
-          activeApplyItem = { repo, number, mutationOccurred: true };
-          mutationByItem.set(`${repo}#${number}`, true);
-        } else {
-          activeApplyItem = {
-            repo: mutationEntry.repo,
-            number: mutationEntry.number,
-            mutationOccurred: true,
-          };
-          mutationByItem.set(`${mutationEntry.repo}#${mutationEntry.number}`, true);
-        }
+        activeApplyItem = {
+          repo: mutationEntry.repo,
+          number: mutationEntry.number,
+          mutationOccurred: true,
+        };
+        mutationByItem.set(`${mutationEntry.repo}#${mutationEntry.number}`, true);
       };
       const recordMutation = (parentEventId?: string | null): void => {
         markMutationObserved();
-        if (mutationLedgerEntry === entry) {
-          recordApplyMutationBoundary(applyLedger, entry, parentEventId);
-        } else {
-          recordApplyMutationBoundary(applyLedger, mutationLedgerEntry, parentEventId);
-        }
+        recordApplyMutationBoundary(applyLedger, mutationLedgerEntry, parentEventId);
       };
       dependencies.activeApplyMutationRunner = <T>(options: {
         identity: string;
@@ -1938,45 +1928,59 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
           continue;
         }
       }
-      let reviewCommentHash = reviewCommentBodyDigest(markedReviewComment);
       const allowApplyCloseActionUpgrade = isUpgradedCloseCandidate && !syncCommentsOnly;
-      let existingReviewCommentMatches = commentBodyMatches(
-        existingReviewComment,
-        markedReviewComment,
-        { allowApplyCloseActionUpgrade },
-      );
-      let needsReviewCommentBodySync = !existingReviewComment || !existingReviewCommentMatches;
-      let needsReviewCommentHashSync = !reviewCommentHashMatches(
-        existingReviewComment,
-        markedReviewComment,
-        frontMatterValue(markdown, "review_comment_sha256"),
-        reviewCommentHash,
-        { allowApplyCloseActionUpgrade },
-      );
-      let needsReviewCommentReferenceSync =
-        /^(?:none|unknown)?$/.test(frontMatterValue(markdown, "review_comment_id") ?? "") ||
-        /^(?:none|unknown)?$/.test(frontMatterValue(markdown, "review_comment_url") ?? "");
       const guarded =
         guardedReviewAction &&
         reviewedSourceFresh() &&
         !stalePrReviewHead;
-      let needsReviewCommentSync = shouldSyncReviewComment({
-        syncCommentsOnly,
-        isCloseProposal,
-        commentSyncMinAgeDays,
-        reviewCommentSyncedAt: frontMatterValue(markdown, "review_comment_synced_at"),
-        reviewCommentVerifiedAt: frontMatterValue(markdown, "review_comment_checked_at"),
-        reviewedAt: frontMatterValue(markdown, "reviewed_at"),
-        lastFullReviewAt: frontMatterValue(markdown, "last_full_review_at"),
-        guardedReviewedAt: guarded ? frontMatterValue(markdown, "apply_checked_at") : undefined,
-        hasExistingReviewComment: Boolean(existingReviewComment),
-        needsReviewCommentBodySync,
-        needsReviewCommentHashSync,
-        needsReviewCommentReferenceSync,
-        forceReviewCommentBodySync:
-          clawSweeperLabelsChanged || Boolean(closeBlockedForCommentSync) || guarded ||
+      const reviewCommentSyncState = (mode: "current" | "rewritten", forceBodySync = true) => {
+        const reviewCommentHash = reviewCommentBodyDigest(markedReviewComment);
+        const matchOptions = mode === "current" ? { allowApplyCloseActionUpgrade } : undefined;
+        const existingReviewCommentMatches = commentBodyMatches(
+          existingReviewComment,
+          markedReviewComment,
+          matchOptions,
+        );
+        const needsReviewCommentBodySync = !existingReviewComment || !existingReviewCommentMatches;
+        const needsReviewCommentHashSync = mode === "current"
+          ? !reviewCommentHashMatches(
+              existingReviewComment,
+              markedReviewComment,
+              frontMatterValue(markdown, "review_comment_sha256"),
+              reviewCommentHash,
+              matchOptions,
+            )
+          : frontMatterValue(markdown, "review_comment_sha256") !== reviewCommentHash;
+        const needsReviewCommentReferenceSync =
+          /^(?:none|unknown)?$/.test(frontMatterValue(markdown, "review_comment_id") ?? "") ||
+          /^(?:none|unknown)?$/.test(frontMatterValue(markdown, "review_comment_url") ?? "");
+        return {
+          needsReviewCommentBodySync,
+          needsReviewCommentSync: shouldSyncReviewComment({
+            syncCommentsOnly,
+            isCloseProposal,
+            commentSyncMinAgeDays,
+            reviewCommentSyncedAt: frontMatterValue(markdown, "review_comment_synced_at"),
+            reviewedAt: frontMatterValue(markdown, "reviewed_at"),
+            lastFullReviewAt: frontMatterValue(markdown, "last_full_review_at"),
+            // Rewritten reports cannot reuse the prior verification or guarded-review receipt.
+            ...(mode === "current" ? {
+              reviewCommentVerifiedAt: frontMatterValue(markdown, "review_comment_checked_at"),
+              guardedReviewedAt: guarded ? frontMatterValue(markdown, "apply_checked_at") : undefined,
+            } : {}),
+            hasExistingReviewComment: Boolean(existingReviewComment),
+            needsReviewCommentBodySync,
+            needsReviewCommentHashSync,
+            needsReviewCommentReferenceSync,
+            forceReviewCommentBodySync: forceBodySync,
+          }),
+        };
+      };
+      let { needsReviewCommentBodySync, needsReviewCommentSync } = reviewCommentSyncState(
+        "current",
+        clawSweeperLabelsChanged || Boolean(closeBlockedForCommentSync) || guarded ||
           Boolean(stalePrReviewHead),
-      });
+      );
       if (
         isCloseProposal &&
         closeReason === "duplicate_or_superseded" &&
@@ -2034,30 +2038,7 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
             isCloseProposal = false;
             reviewComment = renderReviewCommentFromReport(markdown, closeReason, renderOptions);
             markedReviewComment = markedReviewCommentForApply(reviewComment);
-            reviewCommentHash = reviewCommentBodyDigest(markedReviewComment);
-            existingReviewCommentMatches = commentBodyMatches(
-              existingReviewComment,
-              markedReviewComment,
-            );
-            needsReviewCommentBodySync = !existingReviewComment || !existingReviewCommentMatches;
-            needsReviewCommentHashSync =
-              frontMatterValue(markdown, "review_comment_sha256") !== reviewCommentHash;
-            needsReviewCommentReferenceSync =
-              /^(?:none|unknown)?$/.test(frontMatterValue(markdown, "review_comment_id") ?? "") ||
-              /^(?:none|unknown)?$/.test(frontMatterValue(markdown, "review_comment_url") ?? "");
-            needsReviewCommentSync = shouldSyncReviewComment({
-              syncCommentsOnly,
-              isCloseProposal,
-              commentSyncMinAgeDays,
-              reviewCommentSyncedAt: frontMatterValue(markdown, "review_comment_synced_at"),
-              reviewedAt: frontMatterValue(markdown, "reviewed_at"),
-              lastFullReviewAt: frontMatterValue(markdown, "last_full_review_at"),
-              hasExistingReviewComment: Boolean(existingReviewComment),
-              needsReviewCommentBodySync,
-              needsReviewCommentHashSync,
-              needsReviewCommentReferenceSync,
-              forceReviewCommentBodySync: true,
-            });
+            ({ needsReviewCommentBodySync, needsReviewCommentSync } = reviewCommentSyncState("rewritten"));
           }
           const coveringFreshnessBlock = postProofCoveringPrFreshnessBlock();
           if (coveringFreshnessBlock) {
@@ -2111,30 +2092,7 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
         if (!wasStaleCanonicalCommentSyncPending && staleCanonicalCommentSyncPending) {
           reviewComment = renderCurrentReviewComment();
           markedReviewComment = markedReviewCommentForApply(reviewComment);
-          reviewCommentHash = reviewCommentBodyDigest(markedReviewComment);
-          existingReviewCommentMatches = commentBodyMatches(
-            existingReviewComment,
-            markedReviewComment,
-          );
-          needsReviewCommentBodySync = !existingReviewComment || !existingReviewCommentMatches;
-          needsReviewCommentHashSync =
-            frontMatterValue(markdown, "review_comment_sha256") !== reviewCommentHash;
-          needsReviewCommentReferenceSync =
-            /^(?:none|unknown)?$/.test(frontMatterValue(markdown, "review_comment_id") ?? "") ||
-            /^(?:none|unknown)?$/.test(frontMatterValue(markdown, "review_comment_url") ?? "");
-          needsReviewCommentSync = shouldSyncReviewComment({
-            syncCommentsOnly,
-            isCloseProposal,
-            commentSyncMinAgeDays,
-            reviewCommentSyncedAt: frontMatterValue(markdown, "review_comment_synced_at"),
-            reviewedAt: frontMatterValue(markdown, "reviewed_at"),
-            lastFullReviewAt: frontMatterValue(markdown, "last_full_review_at"),
-            hasExistingReviewComment: Boolean(existingReviewComment),
-            needsReviewCommentBodySync,
-            needsReviewCommentHashSync,
-            needsReviewCommentReferenceSync,
-            forceReviewCommentBodySync: true,
-          });
+          ({ needsReviewCommentBodySync, needsReviewCommentSync } = reviewCommentSyncState("rewritten"));
         }
       }
       if (
@@ -2145,63 +2103,10 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
         const markedReviewCommentBeforeLabelFlush = markedReviewComment;
         flushIssueLabelBatch();
         if (markedReviewComment !== markedReviewCommentBeforeLabelFlush) {
-          reviewCommentHash = reviewCommentBodyDigest(markedReviewComment);
-          existingReviewCommentMatches = commentBodyMatches(
-            existingReviewComment,
-            markedReviewComment,
-            { allowApplyCloseActionUpgrade },
-          );
-          needsReviewCommentBodySync = !existingReviewComment || !existingReviewCommentMatches;
-          needsReviewCommentHashSync = !reviewCommentHashMatches(
-            existingReviewComment,
-            markedReviewComment,
-            frontMatterValue(markdown, "review_comment_sha256"),
-            reviewCommentHash,
-            { allowApplyCloseActionUpgrade },
-          );
-          needsReviewCommentReferenceSync =
-            /^(?:none|unknown)?$/.test(frontMatterValue(markdown, "review_comment_id") ?? "") ||
-            /^(?:none|unknown)?$/.test(frontMatterValue(markdown, "review_comment_url") ?? "");
-          needsReviewCommentSync = shouldSyncReviewComment({
-            syncCommentsOnly,
-            isCloseProposal,
-            commentSyncMinAgeDays,
-            reviewCommentSyncedAt: frontMatterValue(markdown, "review_comment_synced_at"),
-            reviewCommentVerifiedAt: frontMatterValue(markdown, "review_comment_checked_at"),
-            reviewedAt: frontMatterValue(markdown, "reviewed_at"),
-            lastFullReviewAt: frontMatterValue(markdown, "last_full_review_at"),
-            guardedReviewedAt: guarded ? frontMatterValue(markdown, "apply_checked_at") : undefined,
-            hasExistingReviewComment: Boolean(existingReviewComment),
-            needsReviewCommentBodySync,
-            needsReviewCommentHashSync,
-            needsReviewCommentReferenceSync,
-            forceReviewCommentBodySync: true,
-          });
+          ({ needsReviewCommentBodySync, needsReviewCommentSync } = reviewCommentSyncState("current"));
         }
       }
       if (needsReviewCommentSync) {
-        const staleSyncReason = needsReviewCommentBodySync ? staleReviewCommentReason : null;
-        if (staleSyncReason) {
-          markdown = replaceFrontMatterValue(
-            markdown,
-            "apply_checked_at",
-            new Date().toISOString(),
-          );
-          if (!dryRun) writeReportAfterDiscardingIssueLabelBatch(path, markdown);
-          results.push({
-            number,
-            action: "skipped_stale_review_comment_sync",
-            reason: staleSyncReason,
-            ...(emitEventApplyProof &&
-            verifiedNewerReviewTuple(markdown, existingReviewComment, staleSyncReason)
-              ? { newerReviewTupleVerified: true }
-              : {}),
-          });
-          processedCount += 1;
-          maybeLogProgress(`skipped stale review comment sync #${number}`);
-          if (processedCount >= processedLimit) break;
-          continue;
-        }
         const lockedCommentSkip = skipLockedConversation(
           needsReviewCommentBodySync ? lockedConversationApplyReason(item) : null,
         );

--- a/src/clawsweeper-review-command-workflow.ts
+++ b/src/clawsweeper-review-command-workflow.ts
@@ -208,8 +208,9 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
       reviewPolicy,
       explicitDispatch,
       maintainerRequest,
+      additionalPrompt,
     } = preparation;
-    let { additionalPrompt, git } = preparation;
+    let { git } = preparation;
     const readonlyModeSnapshots = readonlyOpenclaw ? makeTreeReadOnly(openclawDir) : [];
     const acquiredReviewLeases: Array<{ itemNumber: number; lease: AcquiredReviewStartLease }> = [];
     const releaseOwnedReviewLease = (
@@ -543,6 +544,39 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
           ? previousClawSweeperReviewDigestFromReport(priorReview.markdown)
           : null;
         let acquiredReviewLease: AcquiredReviewStartLease | null = null;
+        const acquireReviewStartLease = (headSha: () => string): AcquiredReviewStartLease | null => {
+          try {
+            const startComment = postReviewStartStatusComment({
+              item,
+              headSha: headSha(),
+              reviewTimeoutMs: timeoutMs,
+              position: completed + 1,
+              total: candidates.length,
+              shardIndex,
+              shardCount,
+            });
+            console.error(
+              `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} start-comment=${startComment.status} #${item.number}`,
+            );
+            if (startComment.status === "held") {
+              coordinationHeldRetryAt = startComment.retryAt;
+              return null;
+            }
+            acquiredReviewLeases.push({ itemNumber: item.number, lease: startComment.lease });
+            return startComment.lease;
+          } catch (error) {
+            leaseAcquisitionFailures += 1;
+            leaseAcquisitionFailureDetails.push(
+              `#${item.number}: ${error instanceof Error ? error.message : String(error)}`,
+            );
+            console.error(
+              `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} start-comment=failed #${item.number}: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+            );
+            return null;
+          }
+        };
         let structuralRecord: ReviewStructuralRecord | null = null;
         let preHydrationStructuralRecord: ReviewStructuralRecord | null = null;
         let hydratedStructuralAnchor: ReviewStructuralRecord | null = null;
@@ -672,11 +706,6 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
                     continue;
                   }
                   acquiredReviewLease = startComment.lease;
-                  if (!acquiredReviewLease) {
-                    throw new Error(
-                      `structural cache lease acquisition returned no identity for #${item.number}`,
-                    );
-                  }
                   acquiredReviewLeases.push({ itemNumber: item.number, lease: acquiredReviewLease });
                 }
               } catch (error) {
@@ -846,42 +875,10 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
           }
         }
         if (!skipStartComment && !acquiredReviewLease && item.kind === "pull_request") {
-          try {
-            const startComment = postReviewStartStatusComment({
-              item,
-              headSha: structuralRecord?.pullHeadSha ?? pullRequestHeadSha(item.number),
-              reviewTimeoutMs: timeoutMs,
-              position: completed + 1,
-              total: candidates.length,
-              shardIndex,
-              shardCount,
-            });
-            console.error(
-              `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} start-comment=${startComment.status} #${item.number}`,
-            );
-            if (startComment.status === "held") {
-              coordinationHeldRetryAt = startComment.retryAt;
-              continue;
-            }
-            acquiredReviewLease = startComment.lease;
-            if (!acquiredReviewLease) {
-              throw new Error(
-                `review lease acquisition returned no identity for PR #${item.number}`,
-              );
-            }
-            acquiredReviewLeases.push({ itemNumber: item.number, lease: acquiredReviewLease });
-          } catch (error) {
-            leaseAcquisitionFailures += 1;
-            leaseAcquisitionFailureDetails.push(
-              `#${item.number}: ${error instanceof Error ? error.message : String(error)}`,
-            );
-            console.error(
-              `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} start-comment=failed #${item.number}: ${
-              error instanceof Error ? error.message : String(error)
-            }`,
-            );
-            continue;
-          }
+          acquiredReviewLease = acquireReviewStartLease(
+            () => structuralRecord?.pullHeadSha ?? pullRequestHeadSha(item.number),
+          );
+          if (!acquiredReviewLease) continue;
         }
         const contextStartedAt = Date.now();
         if (!localRangeData) hydrationRuns += 1;
@@ -1087,42 +1084,8 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
             );
           }
         } else if (item.kind !== "pull_request") {
-          try {
-            const startComment = postReviewStartStatusComment({
-              item,
-              headSha: context.sourceRevision ?? "",
-              reviewTimeoutMs: timeoutMs,
-              position: completed + 1,
-              total: candidates.length,
-              shardIndex,
-              shardCount,
-            });
-            console.error(
-              `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} start-comment=${startComment.status} #${item.number}`,
-            );
-            if (startComment.status === "held") {
-              coordinationHeldRetryAt = startComment.retryAt;
-              continue;
-            }
-            acquiredReviewLease = startComment.lease;
-            if (!acquiredReviewLease) {
-              throw new Error(
-                `review lease acquisition returned no identity for issue #${item.number}`,
-              );
-            }
-            acquiredReviewLeases.push({ itemNumber: item.number, lease: acquiredReviewLease });
-          } catch (error) {
-            leaseAcquisitionFailures += 1;
-            leaseAcquisitionFailureDetails.push(
-              `#${item.number}: ${error instanceof Error ? error.message : String(error)}`,
-            );
-            console.error(
-              `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} start-comment=failed #${item.number}: ${
-              error instanceof Error ? error.message : String(error)
-            }`,
-            );
-            continue;
-          }
+          acquiredReviewLease = acquireReviewStartLease(() => context.sourceRevision ?? "");
+          if (!acquiredReviewLease) continue;
         }
         if (!localRangeData && item.kind === "issue" && acquiredReviewLease) {
           try {

--- a/src/clawsweeper-runtime.ts
+++ b/src/clawsweeper-runtime.ts
@@ -402,19 +402,12 @@ function reviewPolicyHash(options: {
     stableJson({
       version: REVIEW_POLICY_VERSION,
       freshDays: FRESH_DAYS,
-      // Maintainer decision 2026-07-17: the model is deliberately NOT part of
-      // review-policy identity. Baking it in made every model change invalidate
-      // all stored reviews (a fleet-wide re-review wave), which makes model
-      // swaps untestable in production. Model changes now roll through the
-      // normal review cadence instead; bump REVIEW_POLICY_VERSION explicitly
-      // when a full re-review is actually wanted. The sentinel migrates all
-      // hashes once, riding the 2026-07 prompt-change wave already in flight.
+      // Model changes roll through normal review cadence. Keep this sentinel
+      // stable; bump REVIEW_POLICY_VERSION to invalidate stored reviews.
       model: "model-excluded-2026-07",
       reasoningEffort: options.reasoningEffort ?? DEFAULT_REASONING_EFFORT,
       sandboxMode: options.sandboxMode ?? "read-only",
-      // Service tier changes latency, never decisions. Pinned to the historical
-      // hash value so tier changes cannot mark every stored review policy-stale
-      // and trigger a fleet-wide re-review wave.
+      // Keep the historical hash value so service tier changes do not invalidate reviews.
       serviceTier: "",
       targetRepo: policyTargetRepo,
       ...(policyTargetRepo.toLowerCase() === "openclaw/openclaw"
@@ -849,12 +842,12 @@ const regressionProvenanceVerifier = createRegressionProvenanceVerifier({
 });
 
 function verifyRegressionProvenance(
-  decision: import("./clawsweeper-types.js").Decision,
-  item: import("./clawsweeper-types.js").Item,
-  context: import("./clawsweeper-types.js").ItemContext,
+  decision: Decision,
+  item: Item,
+  context: ItemContext,
   checkoutDir: string,
-  git: import("./clawsweeper-types.js").GitInfo,
-): import("./clawsweeper-types.js").Decision {
+  git: GitInfo,
+): Decision {
   const regressionProvenance = regressionProvenanceVerifier.verify({
     candidate: decision.regressionProvenance,
     item,
@@ -1079,27 +1072,6 @@ const {
   sectionList,
 } = reportHelpers;
 
-// A routine phrase inside a larger actionable or negated sentence ("Do not merge
-// after required checks are green; rotate the token first") must not suppress the
-// step, so require the routine phrase, reject negation, and re-check actionability.
-
-// Checklist entries are list items, not table cells; only flatten newlines so
-// downstream consumers of the checklist see command/path text unaltered.
-
-// Labels are wrapped in renderer-owned bold markers, so Markdown delimiters inside
-// report-provided titles must be escaped or they would break the bold span and the
-// downstream label-stripping parsers.
-
-// Model-generated text is rendered above renderer-owned sections such as
-// "## Before merge", and downstream routing extracts those sections from the first
-// matching Markdown heading. Escape heading-shaped lines in model text so injected
-// content can never spoof a renderer-owned section boundary.
-
-// The review prompt and schema require Mermaid flowchart source with no code fences,
-// click directives, URLs, HTML, or initialization/styling directives. The diagram is
-// model output that crosses into a trusted bot comment, so enforce that allowlist
-// here and drop the diagram entirely when it does not comply.
-
 const closeDecisionWorkflow = createCloseDecisionWorkflow({
   targetRepo,
   isMaintainerAuthorAssociation,
@@ -1184,12 +1156,6 @@ const planCommand = createPlanCommand({
   targetProfile,
 });
 
-// Offline local-range review: synthesize the Item + ItemContext from the local
-// git range (merge-base(base, HEAD)..HEAD) so the FULL review (real-behavior
-// proof + mantis decision) can run BEFORE a PR exists — the "advisory review
-// before submission" #357 describes but gates behind an already-open PR. No
-// GitHub fetch: the diff comes from `git diff`, the body from the commit message
-// (or --body-file), so it works offline on a fork checkout.
 const buildLocalRangeReview = createLocalRangeReviewer({
   run,
   pullCommitContentRevision,

--- a/test/clawsweeper-action-ledger.test.ts
+++ b/test/clawsweeper-action-ledger.test.ts
@@ -576,11 +576,6 @@ test("apply receipts start per item and persist mutation observation before fina
   );
 
   assert.match(applyLoop, /startApplyActionLedgerItem\(applyLedger, entry\)/);
-  assert.match(applyLoop, /mutationByItem\.set\(`\$\{repo\}#\$\{number\}`, true\)/);
-  assert.match(
-    applyLoop,
-    /const recordMutation = \(parentEventId\?: string \| null\): void => \{[\s\S]*recordApplyMutationBoundary\(applyLedger, entry, parentEventId\)/,
-  );
   assert.match(source, /completion_reason: "mutation_attempted"/);
   assert.match(source, /parentEventId: state\.lastEventId \?\? state\.startEventId/);
   assert.match(source, /const phaseSeq = nextApplyPhaseSeq\(ledger\)/);


### PR DESCRIPTION
## What Problem This Solves

The apply owner repeated its durable-comment synchronization calculation four times, and the review owner duplicated normal PR/issue lease acquisition and error handling. Those copies obscure the freshness distinctions and make behavior-preserving maintenance harder.

## Why This Change Was Made

The shared calculations stay in their existing owners and preserve evaluation order. Current reports retain their comment-hash upgrade matching and verification receipts; rewritten reports retain strict hash matching without those receipts. The removed stale-comment check was unreachable after the earlier stale/open-state exits. Fresh reads before mutation remain in place.

Normal review lease acquisition now shares one path, with revision lookup still inside its error boundary and the existing posted/held result union enforcing lease identity. Identical mutation bookkeeping is collapsed, and orphan comments and historical narration are removed from the runtime. All close-safety and marker tests, including the full provenance/paired-closeout matrix, remain intact. Two source-text assertions that required the removed duplicate bookkeeping branches are deleted from the direct apply-owner test; its other receipt checks remain.

## User Impact

Behavior-neutral; no runtime contract, config, or workflow change. No new dependency or exported API. No changelog entry is needed because this introduces no user-visible behavior change.

## Evidence

The pr-behavior-proof contract for this behavior-neutral refactor is the full `pnpm run check` run plus the targeted suites, as specified in the work order.

- **Claim:** preserve durable review bodies and markers, apply-report entries, close reasons, label sets, status strings, lease cleanup, and close-safety outcomes.
- **Exercised surface:** compiled review/apply owners and runtime, through the existing command fixtures, comment identity/rendering tests, live-state guards, and workflow contract tests.
- **Scenario/fixture:** normal and rewritten comment sync; metadata-only synchronization; stale heads and newer durable reviews; protected labels and maintainer ownership; snapshot/timestamp drift and self-mutation receipts; locked conversations and terminal locked-comment 403s; the complete provenance/paired-closeout scenario matrix; scheduled review/cache/lease behavior.
- **Command and environment:** Node 26.8.1 on macOS arm64 for targeted proof; Node 24.18.1 and pnpm 11.10.0 on isolated AWS Linux for the full gate, `pnpm run build:all`; the eight targeted suites below; `pnpm run format`; `pnpm run check`.
- **Observable result:** retained body/marker, result-object, close-reason, label, status, and mutation-order assertions pass. Full-gate results are recorded below.
- **Artifact/trace:** local logs `/tmp/deslop-owners-targeted.log`, `/tmp/deslop-owners-targeted-retry.log`, `/tmp/deslop-owners-crabbox-stdout.log`, `/tmp/deslop-owners-crabbox-stderr.log`, and `/tmp/autoreview-deslop-owners.md`. Crabbox provider `aws`, lease `cbx_e4bd31a0e523`, type `c7a.8xlarge`, image `ami-0461d919be7deb53c`, region `eu-west-1`. All four changed-file SHA-256 hashes matched before remote execution and match commit `002ce5db42f4ba8d5c08902a7b48a43c109976a5`.
- **Limits:** controlled local fixtures and the complete repository gate; no live GitHub close/apply operation or production deployment was exercised.

Operator-visible surfaces verified unchanged:

| Surface | Verification |
| --- | --- |
| Durable comment bodies and markers | Existing rendering, marker, public-identity, stale-review, and apply publication assertions |
| Apply-report entries and close reasons | Exact result assertions in apply live-state and provenance/paired-closeout fixtures |
| Label sets and status strings | Apply label synchronization and workflow suites |
| Close-safety gate order and lease cleanup | Existing protected/maintainer, drift, locked-conversation, mutation-boundary, and paired-closeout assertions |
| Runtime policy identity | Existing review-policy hash assertions; hash inputs and sentinels unchanged |

Targeted command:

```sh
node --test test/clawsweeper.test.ts test/apply-label-sync.test.ts test/review-command-workflow.test.ts test/sweep-workflow.test.ts test/apply-live-state.test.ts test/review-comment-markers.test.ts test/review-comment-rendering.test.ts test/review-comment-noop.test.ts
```

The first full gate reported the obsolete branch-spelling assertions and an existing macOS lock timing failure at `test/action-ledger-runtime.test.ts:2459` (`Date.now() - deadStartedAt < 5_000`). Its coverage floors passed (85.04% lines, 76.23% branches, 89.37% functions). After removing only the obsolete owner assertions, both affected cases passed under coverage with:

```sh
node scripts/run-node-tests.mjs unit -- --test-name-pattern='apply receipts start per item|macOS import locks retain live V1 owners and recover dead V1 owners' --experimental-test-coverage
```

The lock test passed unchanged in 12.07 seconds total, including its required ten-second live-lock wait. No ledger implementation or timing threshold changed.

The Mac full rerun passed both earlier cases but hit two other existing fixture-admission/process-cleanup failures. The complete gate passed in an isolated AWS environment through the configured Crabbox provider. The Mac failures were a snapshot deadline in `test/agent-input-scan.test.ts:1120` and a terminal cleanup watchdog in `test/live-proof-review-environment.test.ts:790`; those owners and thresholds remain unchanged. Crabbox's hydration interpreter could not handle the pinned pnpm setup action, so the successful setup path uses `--no-hydrate` and `pnpm install --frozen-lockfile`; no repository workflow was edited.

Pass summaries (verbatim):

```text
Targeted owner / safety / marker suites:
ℹ tests 388
ℹ pass 388
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0

Full pnpm run check on AWS (all gates passed, exit 0):
ℹ tests 4817
ℹ pass 4799
ℹ fail 0
ℹ cancelled 0
ℹ skipped 18
ℹ all files                                     |  85.02 |    76.26 |   89.37 | 
```

The full gate also passed the separate fix-prompt-builder coverage check: 13/13 tests, 100% lines, 88.61% branches, and 100% functions. OS/tool-dependent skips are the suite's existing conditions; no tests or thresholds were disabled. The AWS command completed in 3m49s; source hashes were identical to this candidate.

Independent Codex autoreview (`--mode local --base origin/main --max-priority P1`) is **scoped-clean**: no accepted/actionable findings in the selected Git scope and priority. Both AWS leases used for validation are confirmed released.

OpenClaw Bay not affected: no dashboard changes.

| Scope | Added | Removed | Net LOC |
| --- | ---: | ---: | ---: |
| Production | 107 | 273 | -166 |
| Tests | 0 | 5 | -5 |
| Docs | 0 | 0 | 0 |


### Update after ClawSweeper review (head 002ce5db4, unchanged): real after-fix workflow runs

Both changed production owners were executed on this exact head against live GitHub state, read-only (no mutations), from a build of this branch (`pnpm run build` at `002ce5db4`), on macOS with the operator's Codex login (`pnpm run codex:local:check` passed, smoke 16.7s).

**1. Review owner (`src/clawsweeper-review-command-workflow.ts`, `src/clawsweeper-runtime.ts`)** via the documented local review lane:
```text
$ node dist/clawsweeper.js review -- --local-only --target-repo openclaw/clawsweeper --item-number 1407
Local ClawSweeper review for openclaw/clawsweeper#1407
Preparing target checkout   mode: managed PR checkout   path: artifacts/local-review-1407/target   base: main
Loading review item         item: PR #1407   state: open
Collecting GitHub context
Running Codex review        timeout: 20m 0s
Review complete             elapsed: 5m 5s   decision: keep_open   confidence: high   action: kept_open
                            report: artifacts/local-review-1407/1407.md
```
Real GitHub reads (item, context hydration; the webhook read model was degraded at the time and the workflow fell back to live polling as designed), real target checkout, real Codex review, report and cache artifacts written.

**2. Apply owner (`src/clawsweeper-apply-decision-workflow.ts`)** via the AGENTS.md-sanctioned copied-report procedure (temp `items/`, `--dry-run`, `--skip-dashboard`, `--item-numbers`, temp `--closed-dir`), feeding the report produced in step 1:
```text
[apply] starting apply: files=1 dry_run=true apply_kind=issue ... item_numbers=1407 ...
[apply] finished apply closed=0/20 processed=1/50 counts={"skipped_stale_review_comment_sync":1}
[{ "number": 1407, "action": "skipped_stale_review_comment_sync",
   "reason": "live durable review tuple has lease comment 5536553273, but the local report has no durable lease identity" }]
```
The apply owner read the live durable review tuple on GitHub (the current ClawSweeper lease comment on this PR), evaluated the refactored durable-comment sync decision (`reviewCommentSyncState` in "current" mode plus the canonical-bound stale-review guard), and correctly refused to overwrite the newer live comment. That is the close-safety behavior `AGENTS.md` requires ("snapshot or `updated_at` drift blocks apply unless the only change is the existing ClawSweeper review comment") observed against real GitHub state after the fix.

Limits: no live close, label mutation, or comment write was performed (dry-run and local-only by design); the merged-state paths are covered by the fixture suites listed above.


### Coverage correction and maintainer proof override (head 002ce5db4)

Correction to the previous section: the local-only review run does **not** exercise the extracted `acquireReviewStartLease` closure (local mode skips start comments by design), and the apply dry-run exited at the pre-existing canonical-bound stale guard, before the extracted `reviewCommentSyncState` closure. Those runs prove the surrounding review and apply owners execute end to end on this head against real GitHub reads; they do not reach the two refactored closures.

Maintainer disposition (`proof: override`): reaching those closures for real requires either posting a ClawSweeper review-start lease comment with the App credentials (a mutation on a live item) or an authenticated Worker record export to feed apply with a lease-bearing record; both are disproportionate for two behavior-preserving extractions. Each extraction was verified line by line against `main` during maintainer review:
- `acquireReviewStartLease`: PR and issue sites had identical bodies except the head-SHA source, now a parameter; the removed "returned no identity" throws were unreachable because `ReviewStartStatusCommentResult` types `lease` as non-null for every non-`held` status; held/failed handling (`coordinationHeldRetryAt`, failure counters, `continue`) is unchanged.
- `reviewCommentSyncState`: the four inline recomputation sites map to `"current"` (with `allowApplyCloseActionUpgrade`, `reviewCommentHashMatches`, `reviewCommentVerifiedAt`, `guardedReviewedAt`, force flag as before) and `"rewritten"` (no match options, direct sha256 comparison, no verified/guarded receipts, force true), matching the originals field for field; `isCloseProposal` is read at call time as before.
- The removed late `skipped_stale_review_comment_sync` block was unreachable: open items exit at the canonical-bound guard earlier in the loop and closed items exit in the archive branch (`continue`/`break`) before it.
Fixture coverage: 388 targeted tests across the close-safety, marker, provenance, and paired-closeout suites plus the full gate (4,799 passed on Linux). Post-merge watch: the sweep executes both closures on every review start and every apply cycle; the maintainer is monitoring sweep, comment-router, and apply outcomes for the first hour after landing and will revert on any regression.
