### PR TITLE
fix(codex): preserve full metadata in private Actions configuration

### DIFF
--- a/.github/actions/setup-codex/configure-clawrouter.mjs
+++ b/.github/actions/setup-codex/configure-clawrouter.mjs
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { gunzipSync } from "node:zlib";
 
 const alias = "internal";
 
@@ -8,7 +9,16 @@ try {
   const home = process.env.CODEX_HOME;
   const raw = process.env.CLAWSWEEPER_CLAWROUTER_CONFIG ?? "";
   if (Buffer.byteLength(raw) > 256 * 1024) throw new Error("Private configuration is too large.");
-  const settings = JSON.parse(raw);
+  let payload = raw;
+  if (raw.startsWith("gzip:")) {
+    const encoded = raw.slice(5);
+    const compressed = Buffer.from(encoded, "base64");
+    if (compressed.toString("base64") !== encoded) throw new Error("Invalid private encoding.");
+    payload = new TextDecoder("utf-8", { fatal: true }).decode(
+      gunzipSync(compressed, { maxOutputLength: 256 * 1024 }),
+    );
+  }
+  const settings = JSON.parse(payload);
   if (
     !settings ||
     typeof settings !== "object" ||
@@ -52,6 +62,7 @@ try {
   ) {
     throw new Error("Full alias-only native model metadata is required.");
   }
+  if (process.env.GITHUB_ACTIONS === "true") console.log(`::add-mask::${credential}`);
   mkdirSync(home, { recursive: true, mode: 0o700 });
   chmodSync(home, 0o700);
   const catalog = join(home, "clawrouter-models.json");

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,14 @@ on:
       - "results/**"
   pull_request:
   workflow_dispatch:
+    inputs:
+      codex_auth_mode:
+        description: "Inference route for the hosted canary; configured uses the repository setting"
+        type: choice
+        default: configured
+        options:
+          - configured
+          - clawrouter
 
 permissions:
   contents: read
@@ -35,11 +43,11 @@ jobs:
           build-script: build
       - uses: ./.github/actions/setup-codex
         env:
-          OPENAI_API_KEY: ${{ vars.CLAWSWEEPER_CODEX_AUTH_MODE != 'clawrouter' && secrets.OPENAI_API_KEY || '' }}
-          CLAWSWEEPER_INTERNAL_MODEL: ${{ vars.CLAWSWEEPER_CODEX_AUTH_MODE != 'clawrouter' && secrets.CLAWSWEEPER_MODEL || '' }}
+          OPENAI_API_KEY: ${{ inputs.codex_auth_mode != 'clawrouter' && vars.CLAWSWEEPER_CODEX_AUTH_MODE != 'clawrouter' && secrets.OPENAI_API_KEY || '' }}
+          CLAWSWEEPER_INTERNAL_MODEL: ${{ inputs.codex_auth_mode != 'clawrouter' && vars.CLAWSWEEPER_CODEX_AUTH_MODE != 'clawrouter' && secrets.CLAWSWEEPER_MODEL || '' }}
           CLAWSWEEPER_CLAWROUTER_CONFIG: ${{ secrets.CLAWSWEEPER_CLAWROUTER_CONFIG }}
         with:
-          auth-mode: ${{ vars.CLAWSWEEPER_CODEX_AUTH_MODE || 'proxy' }}
+          auth-mode: ${{ inputs.codex_auth_mode == 'clawrouter' && 'clawrouter' || vars.CLAWSWEEPER_CODEX_AUTH_MODE || 'proxy' }}
       - name: Prove refusal then clean structured review
         run: node scripts/hosted-review-scan-smoke.mjs "$RUNNER_TEMP/hosted-review-scan-proof.json"
       - uses: actions/upload-artifact@v7

--- a/docs/private-inference.md
+++ b/docs/private-inference.md
@@ -2,7 +2,7 @@
 
 Set the repository variable `CLAWSWEEPER_CODEX_AUTH_MODE=clawrouter` to route
 Codex lanes through ClawRouter's isolated `/private/v1` endpoint. Provision and
-prove that private deployment before enabling the variable. This selects the
+prove that private deployment before enabling the variable. This configures the
 Codex runner; deployments using the separate OpenClaw runner must first choose
 `CLAWSWEEPER_RUNNER=codex`.
 
@@ -13,7 +13,14 @@ ModelInfo object, with `slug: "internal"` and `display_name: "Codex"`). Supply
 verified, alias-only metadata for the entitled upstream; discovery's reduced
 model row is insufficient. Preserve genuine reasoning, context, Lite, tool,
 review, and safety requirements. Never put real upstream model identifiers or
-subscription credentials in this secret, workflow inputs, source, or reports.
+upstream credentials in this secret, workflow inputs, source, or reports.
+
+When full metadata exceeds GitHub's 48 KiB secret limit, gzip the complete JSON
+document, base64-encode it, and prefix the result with `gzip:`. Setup accepts both
+plain JSON and this packed format, with a 256 KiB decompression limit. Do not
+remove native instructions or safety capabilities to make the secret smaller.
+Setup registers the decoded workload credential with GitHub's log masker before
+invoking the native client.
 
 Setup uses the built-in OpenAI provider and native API-key credential storage
 with the opaque workload credential. Missing or invalid private configuration
@@ -24,11 +31,25 @@ identifiers when switching to private inference.
 
 ClawRouter owns upstream authentication, routing, response identity containment,
 and any configured availability fallback. It must run under a separate private
-administrative boundary, with an owner-managed subscription token lifecycle.
+administrative boundary, with owner-managed upstream credentials. Its explicit
+API transport uses an API key held only by the broker; subscription transport
+requires a token refresh lifecycle.
 ClawSweeper continues to report only `internal`. Its existing review scanner,
 sandbox checks, proof requirements, and deterministic publication gates remain
 in force. Validate the deployed route with the pinned native Codex client,
 including tools and failure paths, before enabling live jobs.
+
+After storing the Actions secret, run the hosted canary before changing the
+repository routing variable:
+
+```bash
+gh workflow run ci.yml --ref main -f codex_auth_mode=clawrouter
+```
+
+This override affects only the dispatch-only native review smoke job. It proves
+scanner refusals, native sandbox execution, and a structured review against a
+synthetic repository without GitHub mutation. The default `configured` choice
+uses the repository's current authentication mode.
 
 The default `proxy` mode and explicit legacy `login` mode retain their existing
 API-key configuration. Changing the authentication-mode variable affects new

--- a/scripts/hosted-review-scan-smoke.mjs
+++ b/scripts/hosted-review-scan-smoke.mjs
@@ -20,6 +20,7 @@ import { AgentInputScanError } from "../dist/agent-input-scan.js";
 // Dispatch-only proof: no GitHub credentials, publications, or target repository.
 assert.equal(process.platform, "linux");
 const originalPath = process.env.PATH;
+const originalScannerCache = process.env.CLAWSWEEPER_REVIEW_TOOLS_DIR;
 const artifact = process.argv[2];
 assert.ok(artifact, "pass a proof JSON destination");
 const sourceHead = execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim();
@@ -116,6 +117,9 @@ ${live ? `const child = require('node:child_process').spawnSync(${JSON.stringify
     assert.equal(readFileSync(join(cwd, "value.txt"), "utf8"), `two ${marker}\n`);
     assert.deepEqual(scratch(), initialScratch);
   };
+  // A missing PATH scanner can now bootstrap automatically. Make that second
+  // source unavailable only for the synthetic refusal cases, before any download.
+  process.env.CLAWSWEEPER_REVIEW_TOOLS_DIR = "relative-unavailable-scanner-cache";
   for (const scenario of ["missing", "failure", "findings", "unexpected-output"]) {
     process.env.PATH = bin;
     if (scenario !== "missing")
@@ -149,6 +153,8 @@ ${live ? `const child = require('node:child_process').spawnSync(${JSON.stringify
     assertCheckout();
   }
   process.env.PATH = originalPath;
+  if (originalScannerCache === undefined) delete process.env.CLAWSWEEPER_REVIEW_TOOLS_DIR;
+  else process.env.CLAWSWEEPER_REVIEW_TOOLS_DIR = originalScannerCache;
   writeProvider(true);
   const result = run();
   // Raw model output/diagnostics and configured model identity never enter proof artifacts.
@@ -203,5 +209,7 @@ ${live ? `const child = require('node:child_process').spawnSync(${JSON.stringify
   );
 } finally {
   process.env.PATH = originalPath;
+  if (originalScannerCache === undefined) delete process.env.CLAWSWEEPER_REVIEW_TOOLS_DIR;
+  else process.env.CLAWSWEEPER_REVIEW_TOOLS_DIR = originalScannerCache;
   rmSync(root, { recursive: true, force: true });
 }

--- a/test/setup-clawrouter-action.test.ts
+++ b/test/setup-clawrouter-action.test.ts
@@ -12,6 +12,7 @@ import {
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import test from "node:test";
+import { gzipSync } from "node:zlib";
 
 const script = resolve(".github/actions/setup-codex/configure-clawrouter.mjs");
 const token = "private-workload-SYNTHETIC_PRIVATE_CREDENTIAL_123456789";
@@ -24,6 +25,10 @@ const modelInfo = {
   use_responses_lite: true,
   auto_review_model_override: null,
 };
+
+function publicOutput(result: { stdout: string; stderr: string }) {
+  return result.stdout.replace(/^::add-mask::[^\r\n]*\n/gm, "") + result.stderr;
+}
 
 function fixture() {
   const root = mkdtempSync(join(tmpdir(), "clawsweeper-private-setup-"));
@@ -69,6 +74,7 @@ test(
     try {
       const result = f.run(f.settings);
       assert.equal(result.status, 0, result.stderr);
+      assert.ok(result.stdout.startsWith(`::add-mask::${token}\n`));
       const receipt = JSON.parse(readFileSync(f.receipt, "utf8"));
       assert.deepEqual(receipt.args, ["login", "--with-api-key"]);
       assert.equal(receipt.input, token);
@@ -86,10 +92,7 @@ test(
         models: [modelInfo],
       });
       assert.equal(statSync(join(f.home, "config.toml")).mode & 0o777, 0o600);
-      assert.doesNotMatch(
-        result.stdout + result.stderr + config,
-        /SYNTHETIC_PRIVATE|SYNTHETIC_UNRELATED/,
-      );
+      assert.doesNotMatch(publicOutput(result) + config, /SYNTHETIC_PRIVATE|SYNTHETIC_UNRELATED/);
     } finally {
       rmSync(f.root, { recursive: true, force: true });
     }
@@ -105,6 +108,9 @@ test("private setup rejects malformed config, non-private endpoints, and non-ali
     for (const settings of [
       "",
       "invalid",
+      "gzip:invalid-base64",
+      `gzip:${Buffer.from("invalid compressed data").toString("base64")}`,
+      `gzip:${gzipSync(Buffer.alloc(256 * 1024 + 1)).toString("base64")}`,
       { ...f.settings, token: "SYNTHETIC_API_CREDENTIAL" },
       ...[
         "http://127.0.0.1/private/v1",
@@ -139,7 +145,34 @@ test(
       const result = f.run(f.settings, { CODEX_TEST_EXIT: "23" });
       assert.equal(result.status, 1);
       assert.match(result.stderr, /Private ClawRouter setup failed/);
-      assert.doesNotMatch(result.stdout + result.stderr, /SYNTHETIC/);
+      assert.doesNotMatch(publicOutput(result), /SYNTHETIC/);
+    } finally {
+      rmSync(f.root, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "packed private configuration preserves a full catalog larger than an Actions secret",
+  { skip: process.platform === "win32" },
+  () => {
+    const f = fixture();
+    try {
+      const largeModel = {
+        ...modelInfo,
+        model_messages: { base_instructions: "Synthetic native instruction.\n".repeat(3000) },
+      };
+      const raw = JSON.stringify({ ...f.settings, modelInfo: largeModel });
+      const packed = `gzip:${gzipSync(raw).toString("base64")}`;
+      assert.ok(Buffer.byteLength(raw) > 48 * 1024);
+      assert.ok(Buffer.byteLength(packed) < 48 * 1024);
+      const result = f.run(packed);
+      assert.equal(result.status, 0, result.stderr);
+      assert.deepEqual(JSON.parse(readFileSync(join(f.home, "clawrouter-models.json"), "utf8")), {
+        models: [largeModel],
+      });
+      assert.ok(result.stdout.startsWith(`::add-mask::${token}\n`));
+      assert.doesNotMatch(publicOutput(result), /SYNTHETIC/);
     } finally {
       rmSync(f.root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

Full native model metadata can exceed GitHub's 48 KiB Actions secret limit, preventing private inference setup. Accept a bounded `gzip:` plus base64 configuration without trimming native instructions, capabilities, or safety requirements, and register the decoded workload credential with Actions masking before invoking Codex.

Add a dispatch-only CI input that exercises ClawRouter before the repository-wide routing variable changes. The hosted canary uses a synthetic repository, proves scanner refusals, and requests a native sandboxed structured review without publishing or mutating GitHub targets. Document the packed format and cutover sequence. Repair the canary’s missing-scanner fixture to exclude managed bootstrap only during synthetic refusal cases, restoring the original environment before real inference.

## Validation

- Four setup regressions passed, including metadata larger than an Actions secret, malformed compression, decompression bounds, and credential masking.
- Formatting, documentation checks, and workflow actionlint passed.
- Independent Codex reviews found no actionable issues; all seven scanner-refusal regressions pass.
- The pinned native client used the packed configuration against the deployed private Worker, completed a shell command, and returned the expected answer; configured upstream identities and credentials were absent from client output.
- The first hosted canary exposed a stale fixture assumption: removing the PATH scanner now legitimately activates managed bootstrap. The corrected fixture is included here.
- [Hosted Cloudflare/native canary](https://github.com/openclaw/clawsweeper/actions/runs/33845518770) passed on commit `0e8309d4c66cf20f1a1a3d953a1681da175e8cb4`: zero provider starts on scanner refusals, one successful structured review with the pinned native CLI, and private prompt diagnostics at mode 0600. Logs and the proof artifact were checked for configured private values.
- [Full PR CI](https://github.com/openclaw/clawsweeper/actions/runs/33845505318) and the full canary workflow passed on the final PR head before landing.
- The private route was enabled after merge. The [configured-mode canary on merged main](https://github.com/openclaw/clawsweeper/actions/runs/33846322764) also passed its native review job; its logs and proof contain no configured private values.
- An additional local parallel full-suite run hit an unrelated ledger timing failure; the failing test passed in isolation on Node 24. The redundant local run was stopped after both complete exact-head CI suites passed.
