### PR TITLE
fix(review): prevent test-merge ancestry from being attributed to original commits

### DIFF
--- a/docs/pr-review-comments.md
+++ b/docs/pr-review-comments.md
@@ -247,10 +247,19 @@ This changes evidence rendering only, not the observer API or OpenClaw Bay.
 ## PR Introduction Evidence
 
 Before model execution, the host assembles bounded local Git evidence for the
-pinned PR base and head. The reviewer receives the actual checkout SHA separately
-from fetched main, the unique merge base, introduced files and patch from
-merge-base to head, base-branch changes, and a separately labeled base-to-head
-endpoint comparison. A file that differs only because main advanced is not
+pinned PR base and head. `originalHead` records the exact pinned head and its raw
+parents; `checkout` separately records the actual local commit and its raw parents.
+Both carry explicit roles and inspection status. Reads disable replacement refs
+and grafts, require an exact commit object, and bound these parent lists to eight
+entries. Failed, malformed, missing, or oversized inspection yields unavailable
+with `parents: null`; only an inspected root yields `parents: []`. Shallow history
+does not erase recorded parents or prove their objects are available. Neither
+workspace/test-merge ancestry nor fetched main or the merge base may substitute
+for original parentage; raw parents do not establish causality or authorship.
+
+The reviewer also receives fetched main, the unique merge base, introduced files
+and patch from merge-base to head, base-branch changes, and a separately labeled
+base-to-head endpoint comparison. A file that differs only because main advanced is not
 automatically a PR edit. Findings in untouched files remain valid when an
 introduced hunk elsewhere causes the failure; risks, labels, scores, and fixups
 must use that same ownership boundary.

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -90,13 +90,24 @@ Review deeply before closing. High confidence means you read enough current code
 For PR ownership, start with the host-computed `PR Introduction Evidence`.
 `introduced` is the pinned merge-base..head delta; `endpointDrift` is base..head
 and is not introduction evidence. `baseChanges` and `baseOnlyFiles` identify
-base-branch work, not edits by this PR. `checkoutSha` records the actual local
+base-branch work, not edits by this PR. `checkout.sha` records the actual local
 revision; `fetchedMainSha` is behavioral context and may differ from both the
 checkout and the pinned PR base. GitHub `pullFiles` supplies bounded PR patches,
 not an endpoint comparison; check truncation and pinned identities before use.
 When host evidence is unavailable, ambiguous, or incomplete, say what is missing
 and use only independently verified introduced hunks. Never guess ownership from
 an older head's contents or a current-main comparison.
+
+For immutable PR parentage, use `originalHead.sha` and `originalHead.parents`
+only when `originalHead.status` is `verified`: these are raw parent records of
+the exact pinned original PR head, read with replacements and grafts disabled.
+`checkout` describes the actual local commit; `testMerge` separately describes
+the GitHub test-merge candidate and its validation. Never attribute a synthetic
+test merge, rebased workspace, merge-base, or fetched main's ancestry to the
+original PR head. Unavailable inspection (`parents: null`) is unknown, not a
+root; only a verified empty parent list establishes no recorded parents. Raw
+parent records do not establish that parent objects are available, causal
+introduction, or authorship. Keep these roles separate in every public claim.
 
 Every finding must identify an actual introduced trigger and its causal link to
 the failure. An untouched affected file is a valid finding location when another
@@ -151,8 +162,9 @@ otherwise use a display name without the `<email>` part.
 Blame identifies last modification, not feature introduction. `^SHA`, porcelain
 `boundary`, revision limits, or missing parent objects leave introduction unknown.
 `--root`/`blame.showRoot` can hide those markers; `git show --root` and graph-based
-`%P` can misrepresent a shallow commit as a root. Inspect `git cat-file commit
-<sha>` and compare the exact source line against the raw recorded parents. An
+`%P` can misrepresent a shallow commit as a root. Inspect `git --no-replace-objects
+cat-file commit <sha>` at the exact source commit SHA and compare the exact source
+line against the raw recorded parents; do not substitute workspace ancestry. An
 unchanged line is carried forward, not introduced. Keep code author, committer,
 PR author, reviewer, and merger separate; one role never proves another.
 

--- a/src/pr-review-evidence.ts
+++ b/src/pr-review-evidence.ts
@@ -7,6 +7,7 @@ import type { ItemContext } from "./clawsweeper-types.js";
 const OBJECT_ID = /^[0-9a-f]{40}(?:[0-9a-f]{24})?$/;
 const MAX_FILES = 80;
 const MAX_PATCH_CHARS = 24_000;
+const MAX_COMMIT_PARENTS = 8;
 // Git for Windows accepts the DOS device spelling but rejects Node's `\\\\.\\nul`
 // spelling when it is supplied through GIT_CONFIG_GLOBAL.
 const gitNullDevice = process.platform === "win32" ? "NUL" : devNull;
@@ -31,17 +32,23 @@ type DiffEvidence = {
   patchComplete?: boolean;
 };
 
+type CommitEvidence<Role extends string> = { role: Role } & (
+  | { status: "verified"; sha: string; parents: string[] }
+  | { status: "unavailable"; sha: string | null; parents: null; reason: string }
+);
+
 export type PullRequestReviewEvidence = {
-  checkoutSha: string | null;
+  checkout: CommitEvidence<"actual_checkout">;
+  originalHead: CommitEvidence<"original_pr_head">;
   fetchedMainSha: string | null;
   baseSha: string | null;
-  headSha: string | null;
   mergeBase: MergeBase;
   introduced: DiffEvidence;
   endpointDrift: DiffEvidence;
   baseChanges: DiffEvidence;
   baseOnlyFiles: string[] | null;
   testMerge: {
+    role: "github_test_merge";
     status: "verified" | "unavailable" | "stale" | "not_test_merge";
     sha: string | null;
     parents?: string[];
@@ -165,6 +172,30 @@ function git(
   return readReviewGit(targetDir, args, options)?.toString("utf8") ?? null;
 }
 
+function commitEvidence<Role extends string>(
+  targetDir: string | undefined,
+  sha: string | null,
+  role: Role,
+): CommitEvidence<Role> {
+  const unavailable = (reason: string): CommitEvidence<Role> => ({
+    role,
+    status: "unavailable",
+    sha,
+    parents: null,
+    reason,
+  });
+  if (!sha) return unavailable("Missing commit identity.");
+  // cat-file commit can peel tags; require the exact pinned object to be a commit.
+  if (git(targetDir, ["cat-file", "-t", sha])?.trim() !== "commit")
+    return unavailable("Exact commit object unavailable in bounded local inspection.");
+  const raw = git(targetDir, ["cat-file", "commit", sha]);
+  if (raw === null) return unavailable("Raw commit read failed or exceeded its bounds.");
+  const parents = reviewCommitParents(raw);
+  if (parents === null || parents.length > MAX_COMMIT_PARENTS)
+    return unavailable("Invalid raw parent records or more than eight recorded parents.");
+  return { role, status: "verified", sha, parents };
+}
+
 export function reviewMergeBase(
   targetDir: string | undefined,
   baseSha: string | null,
@@ -267,6 +298,7 @@ export function buildPullRequestReviewEvidence(options: {
     "base_branch_changes_since_merge_base",
   );
   const testMerge: PullRequestReviewEvidence["testMerge"] = {
+    role: "github_test_merge",
     status: "unavailable",
     sha: objectId(pull.mergeCommitSha),
     reason:
@@ -296,10 +328,14 @@ export function buildPullRequestReviewEvidence(options: {
     }
   }
   return {
-    checkoutSha: objectId(git(targetDir, ["rev-parse", "HEAD"])?.trim()),
+    checkout: commitEvidence(
+      targetDir,
+      objectId(git(targetDir, ["rev-parse", "HEAD"])?.trim()),
+      "actual_checkout",
+    ),
+    originalHead: commitEvidence(targetDir, headSha, "original_pr_head"),
     fetchedMainSha: objectId(options.mainSha),
     baseSha,
-    headSha,
     mergeBase,
     introduced,
     endpointDrift: diff(targetDir, baseSha, headSha, "endpoint_drift_not_introduction"),

--- a/test/review-provenance.test.ts
+++ b/test/review-provenance.test.ts
@@ -109,10 +109,20 @@ test("real Git graph distinguishes introduced changes from main-only upgrades an
       );
     }
     const { evidence } = promptEvidence(f);
-    assert.equal(evidence.checkoutSha, f.H);
+    assert.deepEqual(evidence.checkout, {
+      role: "actual_checkout",
+      status: "verified",
+      sha: f.H,
+      parents: [f.B],
+    });
     assert.equal(evidence.fetchedMainSha, f.M);
     assert.equal(evidence.baseSha, f.M);
-    assert.equal(evidence.headSha, f.H);
+    assert.deepEqual(evidence.originalHead, {
+      role: "original_pr_head",
+      status: "verified",
+      sha: f.H,
+      parents: [f.B],
+    });
     assert.deepEqual(evidence.mergeBase, { status: "verified", sha: f.B });
     assert.equal(evidence.introduced.role, "pr_introduced");
     assert.deepEqual(evidence.introduced.files, ["docs/hooks.md"]);
@@ -123,6 +133,7 @@ test("real Git graph distinguishes introduced changes from main-only upgrades an
     assert.equal(evidence.endpointDrift.role, "endpoint_drift_not_introduction");
     assert.deepEqual(evidence.baseOnlyFiles, [...upgradeFiles].sort());
     assert.equal(evidence.testMerge.status, "verified");
+    assert.equal(evidence.testMerge.role, "github_test_merge");
     assert.deepEqual(evidence.testMerge.parents, [f.M, f.H]);
     assert.deepEqual(evidence.testMerge.result.files, ["docs/hooks.md"]);
     if (process.env.CLAWSWEEPER_PROVENANCE_PROOF_DIR) {
@@ -147,6 +158,164 @@ test("real Git graph distinguishes introduced changes from main-only upgrades an
         ) + "\n",
       );
     }
+  } finally {
+    rmSync(f.root, { recursive: true, force: true });
+  }
+});
+
+test("original head parents survive synthetic merge and rebased checkout identities", () => {
+  const f = fixture();
+  try {
+    git(f.root, "checkout", "-qb", "rebased-pr", f.H);
+    git(f.root, "rebase", f.M);
+    const rebased = git(f.root, "rev-parse", "HEAD");
+    assert.notEqual(rebased, f.H);
+    const original = promptEvidence(f).evidence.originalHead;
+    assert.deepEqual(original, {
+      role: "original_pr_head",
+      status: "verified",
+      sha: f.H,
+      parents: [f.B],
+    });
+    for (const [checkout, parents] of [
+      [f.T, [f.M, f.H]],
+      [rebased, [f.M]],
+      [f.M, [f.B]],
+      [f.H, [f.B]],
+    ] as const) {
+      git(f.root, "checkout", "-q", "--detach", checkout);
+      const { evidence } = promptEvidence(f);
+      assert.deepEqual(evidence.originalHead, original);
+      assert.deepEqual(evidence.checkout, {
+        role: "actual_checkout",
+        status: "verified",
+        sha: checkout,
+        parents,
+      });
+      assert.equal(evidence.testMerge.status, "verified");
+      assert.deepEqual(evidence.testMerge.parents, [f.M, f.H]);
+      assert.deepEqual(evidence.introduced.files, ["docs/hooks.md"]);
+    }
+  } finally {
+    rmSync(f.root, { recursive: true, force: true });
+  }
+});
+
+for (const overlay of ["replace", "graft", "shallow"] as const) {
+  test(`raw original head and checkout parents ignore ${overlay} ancestry`, () => {
+    const f = fixture();
+    try {
+      if (overlay === "replace") {
+        git(f.root, "replace", f.H, f.T);
+        assert.notEqual(
+          git(f.root, "cat-file", "commit", f.H),
+          git(f.root, "--no-replace-objects", "cat-file", "commit", f.H),
+        );
+      } else {
+        writeFileSync(
+          join(f.root, ".git", overlay === "graft" ? "info/grafts" : "shallow"),
+          overlay === "graft" ? `${f.H} ${f.M}\n` : `${f.H}\n`,
+        );
+        assert.equal(git(f.root, "show", "-s", "--format=%P", f.H), overlay === "graft" ? f.M : "");
+      }
+      const { evidence } = promptEvidence(f);
+      assert.deepEqual(evidence.originalHead, {
+        role: "original_pr_head",
+        status: "verified",
+        sha: f.H,
+        parents: [f.B],
+      });
+      assert.deepEqual(evidence.checkout.parents, [f.B]);
+      assert.equal(evidence.testMerge.status, "verified");
+      assert.deepEqual(evidence.testMerge.parents, [f.M, f.H]);
+      assert.equal(evidence.mergeBase.status, overlay === "shallow" ? "unavailable" : "verified");
+    } finally {
+      rmSync(f.root, { recursive: true, force: true });
+    }
+  });
+}
+
+test("unavailable raw commits stay unknown while inspected roots have empty parents", () => {
+  const f = fixture();
+  try {
+    const tree = git(f.root, "rev-parse", `${f.H}^{tree}`);
+    git(f.root, "-c", "tag.gpgsign=false", "tag", "-a", "fixture-tag", "-m", "fixture", f.H);
+    const tag = git(f.root, "rev-parse", "refs/tags/fixture-tag");
+    for (const sha of [undefined, "not-an-object-id", "f".repeat(40), tree, tag]) {
+      const { evidence } = promptEvidence(f, { head: { sha } });
+      assert.equal(evidence.originalHead.status, "unavailable");
+      assert.equal(evidence.originalHead.parents, null);
+      assert.equal(
+        evidence.originalHead.sha,
+        sha === undefined || sha === "not-an-object-id" ? null : sha,
+      );
+      assert.ok(evidence.originalHead.reason);
+      assert.deepEqual(evidence.checkout.parents, [f.B]);
+    }
+    const root = promptEvidence(f, { head: { sha: f.B } }).evidence.originalHead;
+    assert.deepEqual(root, {
+      role: "original_pr_head",
+      status: "verified",
+      sha: f.B,
+      parents: [],
+    });
+    // HEAD identity can resolve even when its object cannot be inspected.
+    writeFileSync(join(f.root, ".git", "HEAD"), "f".repeat(40) + "\n");
+    const { evidence } = promptEvidence(f);
+    assert.equal(evidence.checkout.sha, "f".repeat(40));
+    assert.equal(evidence.checkout.status, "unavailable");
+    assert.equal(evidence.checkout.parents, null);
+    assert.ok(evidence.checkout.reason);
+    assert.deepEqual(evidence.originalHead.parents, [f.B]);
+  } finally {
+    rmSync(f.root, { recursive: true, force: true });
+  }
+});
+
+test("original head records immediate parents, not the merge base or commit message", () => {
+  const f = fixture();
+  try {
+    f.put("docs/hooks.md", "Clarified guide again\n");
+    const H = f.commit(`follow-up\n\nparent ${f.M}`);
+    const { evidence } = promptEvidence({ ...f, H });
+    assert.equal(evidence.mergeBase.sha, f.B);
+    assert.deepEqual(evidence.originalHead.parents, [f.H]);
+    assert.deepEqual(evidence.checkout.parents, [f.H]);
+    assert.deepEqual(promptEvidence(f, { head: { sha: f.T } }).evidence.originalHead.parents, [
+      f.M,
+      f.H,
+    ]);
+  } finally {
+    rmSync(f.root, { recursive: true, force: true });
+  }
+});
+
+test("invalid or oversized raw parent evidence is unavailable, never a truncated root", () => {
+  const f = fixture();
+  try {
+    const tree = git(f.root, "rev-parse", `${f.H}^{tree}`);
+    const ident = "Fixture <fixture@example.invalid> 1700000000 +0000";
+    for (const raw of [
+      `tree ${tree}\nparent invalid\nauthor ${ident}\ncommitter ${ident}\n\nfixture\n`,
+      `tree ${tree}\n${`parent ${f.B}\n`.repeat(9)}author ${ident}\ncommitter ${ident}\n\nfixture\n`,
+      `tree ${tree}\nparent ${f.B}\nauthor ${ident}\ncommitter ${ident}\n\n${"x".repeat(1024 * 1024)}`,
+    ]) {
+      const rawFile = join(f.root, ".git", "fixture-commit");
+      writeFileSync(rawFile, raw);
+      const H = git(f.root, "hash-object", "--literally", "-t", "commit", "-w", rawFile);
+      const { evidence } = promptEvidence({ ...f, H });
+      assert.equal(evidence.originalHead.sha, H);
+      assert.equal(evidence.originalHead.status, "unavailable");
+      assert.equal(evidence.originalHead.parents, null);
+      assert.ok(evidence.originalHead.reason);
+    }
+    const { evidence } = promptEvidence({ ...f, root: join(f.root, "missing-checkout") });
+    assert.equal(evidence.originalHead.sha, f.H);
+    assert.equal(evidence.originalHead.status, "unavailable");
+    assert.equal(evidence.originalHead.parents, null);
+    assert.equal(evidence.checkout.sha, null);
+    assert.equal(evidence.checkout.status, "unavailable");
+    assert.equal(evidence.checkout.parents, null);
   } finally {
     rmSync(f.root, { recursive: true, force: true });
   }
@@ -279,7 +448,7 @@ test("production source preparation recovers a shallow PR tip and fetches the pi
     const { evidence } = promptEvidence({ ...f, root: clone });
     assert.equal(evidence.mergeBase.sha, f.B);
     assert.equal(evidence.testMerge.status, "verified");
-    assert.equal(evidence.checkoutSha, f.H);
+    assert.equal(evidence.checkout.sha, f.H);
     assert.equal(git(clone, "rev-parse", "--is-shallow-repository"), "false");
     assert.equal(git(clone, "status", "--porcelain"), "");
   } finally {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a problem where a ClawSweeper review could attribute a GitHub test merge's main parent to the original PR commit. The [historical review of the Gateway PR](https://github.com/openclaw/openclaw/pull/136998#issuecomment-5520605493), reviewed at `2026-09-04T01:20:32.984Z`, claimed that original head `15ca0925f5d164df5283783aea5f4a01ffe3924e` had current main as its recorded parent. The original raw commit proves otherwise.

The [producer run](https://github.com/openclaw/clawsweeper/actions/runs/33825006229) ran code `8440386ebd92f39c5d6812d74cda3793a67530a3`. Its archived report (`exact-review-33825006229-1`, artifact ID `9919776836`, report SHA-256 `3db6dce3fe4050873ad4131159604ecd62b11432eed98a73fd962cba873772bb`) preserves the incorrect claim; the linked durable comment is mutable and now contains later reviews. The raw report is deliberately not reproduced here.

| Object role | Exact commit | Raw recorded parents, in order |
| --- | --- | --- |
| Original PR head | `15ca0925f5d164df5283783aea5f4a01ffe3924e` | `cd8c74889d21ddcc9f3a2d47fe868224a0e44acb` |
| Historical GitHub test merge | `782c712e2dad405a2e9010354b5291fb94d42fe6` | `3c0eb9fd822f8101dc3117ce40dbd2b0f5e01930`, `15ca0925f5d164df5283783aea5f4a01ffe3924e` |

## Why This Change Was Made

The evidence generator supplied identities and test-merge parents but omitted the original head's raw parents, and the model's prose conflated those distinct identities. Reuse the hardened Git reader and canonical parent parser to provide typed, role-labeled `originalHead` and `checkout` records, and explicitly label `testMerge`. The prompt requires public ancestry claims to keep these roles separate.

Exact object-type checks prevent tag peeling. Reads retain the existing five-second/1 MiB bounds and cap parent lists at eight; unavailable, malformed, or oversized reads return `parents: null`, while only an inspected root returns `[]`. The old scalar head/checkout aliases are removed. This is reviewer input, with no decision schema, dependency, configuration, routing, persistent-data, or publication-authority change and no prose scrubber.

Source preparation materializes the pinned original head. There is no evidence that a historical rebase caused the bad claim, and an integration checkout cannot rewrite an existing original SHA's parent.

## User Impact

Maintainers and contributors receive explicit original-commit ancestry in review evidence, reducing false provenance and ownership claims when the actual checkout, fetched main, merge base, or test merge differs. Unknown inspection remains visibly unknown. Raw parent records alone do not establish causal introduction, authorship, or parent-object availability.

## OpenClaw Bay Impact

Bay is unaffected: the change only adds reviewer-input provenance. No observer data contract, lifecycle/publication authority, queue state, telemetry, routes, or controls change.

## Documentation Impact

Updated the active implementation documentation in `docs/pr-review-comments.md`, section “PR Introduction Evidence,” and the owning reviewer prompt in `prompts/review-item.md`. ClawSweeper review maintainers own this contract; `src/pr-review-evidence.ts` is the source of truth. Verified against this PR's four-file patch; changes to record roles, raw-object bounds, unknown/root semantics, or source acquisition trigger a documentation update. Reviewed `CONTRIBUTING.md`, `docs/README.md`, `README.md`, and `VISION.md`; no other documentation changes are needed. Release-note context is preserved here without editing the changelog.

## Evidence

- Before the production change, the new regressions failed: initial focused run 89 passed / 7 failed; additional boundary cases 2 failed; exact-object-type case 1 failed. With the patch, all four focused files passed, 98/98, under Node 24.20.0 and pnpm 11.10.0 with standard Git configuration.
- Real Git fixtures cover synthetic merges, rebased checkouts, original heads with multiple commits, merge heads, replacement refs, legacy grafts, shallow history, missing objects, trees/tags, malformed raw parents, oversized objects, and genuine roots. Production prompt serialization is exercised, including preservation of introduced versus main-only changes.
- Static checks, all builds, lint, and the existing changed-surface coverage gate passed (13/13). The original full local `pnpm run check` was interrupted under severe host load and did not pass. A representative agent-runner failure was reproduced: that command set `TMPDIR` inside the checkout, which the scanner correctly rejects as `unsafe_path`. The unchanged test passes with the default external temp directory. This diagnoses that local failure only. The full gate subsequently passed in [exact-head Linux CI](https://github.com/openclaw/clawsweeper/actions/runs/33845765111/job/100937182439) on `f1a20200c0b22ccd309d38939879b8ec66fb7a85`; the same run also passed Windows launcher and sparse repair build checks, with no retry. [CodeQL](https://github.com/openclaw/clawsweeper/actions/runs/33845765036) passed at the same head. The hosted scan smoke is dispatch-only and was correctly skipped.
- Fresh isolated Codex reviews before commit and after rebase both passed with no actionable P0–P3 findings. On head `f1a20200c0b22ccd309d38939879b8ec66fb7a85` against base `b4f7d36406ed1e375dc8eac17abc00ff63a93f02`, the production build, exact historical-object probe, and selected rebase/unknown/type/size regression cases passed (3/3). The rebased four-file patch is byte-identical to the original 98/98-tested patch (SHA-256 `e0c149f62c70876b121df9dfb497ec23a6e72fb5cdaf9c8b8cbbfb7387188128`); upstream did not change its evidence or prompt-serialization owners.
- The [initial ClawSweeper review](https://github.com/openclaw/clawsweeper/pull/1409#issuecomment-5536859279) found no actionable issues or rank-up requests and judged the proof sufficient. No code changes were needed in response; this body now includes the completed CI result.
- Scope: four files, production TypeScript +40/-4 (net +36), prompt +15/-3 (net +12), tests +172/-3 (net +169), documentation +13/-4 (net +9). No other owner's files changed. The related [owner simplification PR](https://github.com/openclaw/clawsweeper/pull/1407) changes different files.

## Real Behavior Proof

**Claim:** compiled production evidence generation preserves the exact original PR head's raw parents independently of the actual integration/rebased checkout and GitHub test merge, and production prompt assembly carries those roles to the reviewer.

**Surface and scenarios:** `buildPullRequestReviewEvidence` and production `buildReviewPrompt` against real disposable Git histories; additionally, compiled evidence generation against the exact historical original and test-merge objects in a task-owned bare object store. Historical source objects and active PR checkouts were not modified.

**Commands/environment:** local macOS, Node 24.20.0, pinned pnpm 11.10.0, standard Git configuration. Build and focused proof:

```sh
pnpm run build
TMPDIR="$PWD/.artifacts/original-commit-provenance/tmp" CLAWSWEEPER_PROVENANCE_PROOF_DIR="$PWD/.artifacts/original-commit-provenance" node --test test/pr-review-evidence.test.ts test/review-prompt-context.test.ts test/review-prompt-policy.test.ts test/review-provenance.test.ts
```

The post-rebase boundary rerun used the default external temp directory and passed all three selected cases:

```sh
node --test --test-name-pattern='original head parents survive synthetic|unavailable raw commits|invalid or oversized raw parent' test/review-provenance.test.ts
```

The historical probe calls the compiled `buildPullRequestReviewEvidence` with `head.sha=15ca0925f5d164df5283783aea5f4a01ffe3924e`, `base.sha=3c0eb9fd822f8101dc3117ce40dbd2b0f5e01930`, `mergeCommitSha=782c712e2dad405a2e9010354b5291fb94d42fe6`, `mainSha` equal to that base, and the bare fixture's `HEAD` at the test merge. It first verifies both objects with `git --no-replace-objects cat-file -p <exact-sha>` and asserts the following production output:

```text
originalHead: verified, role=original_pr_head
  sha=15ca0925f5d164df5283783aea5f4a01ffe3924e
  parents=[cd8c74889d21ddcc9f3a2d47fe868224a0e44acb]
checkout: verified, role=actual_checkout
  sha=782c712e2dad405a2e9010354b5291fb94d42fe6
  parents=[3c0eb9fd822f8101dc3117ce40dbd2b0f5e01930,15ca0925f5d164df5283783aea5f4a01ffe3924e]
testMerge: verified, role=github_test_merge
  sha=782c712e2dad405a2e9010354b5291fb94d42fe6
  parents=[3c0eb9fd822f8101dc3117ce40dbd2b0f5e01930,15ca0925f5d164df5283783aea5f4a01ffe3924e]
mergeBase: verified, sha=cd8c74889d21ddcc9f3a2d47fe868224a0e44acb
PASS: immutable original-head parentage is separate from integration ancestry.
```

**Artifact/trace:** bounded historical output above, the original producer/artifact identities above, and reproducible real-Git regression assertions in `test/review-provenance.test.ts`. Red/green logs, fixture JSON, and historical production JSON are retained locally; raw reports and agent transcripts are not published on this branch.

**Limits:** this proves evidence generation and prompt assembly, not model compliance, a replay of the historical model session, or GitHub review publication. It does not guarantee that model prose never makes another provenance mistake. No Gateway PR or lifecycle session was changed.
