### PR TITLE
fix(dashboard): report fresh publication failures with retained Bay data

### DIFF
--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -7556,7 +7556,6 @@ async function attachExactReviewQueueStatus(snapshot, env) {
   ]
     .map((item) => String(objectValue(item).item_key || ""))
     .filter(Boolean);
-  let exactReviewQueue = null;
   let recentDurablePublicationEvents = null;
   const exactReviewQueueRequest = withTimeout(
     exactReviewQueueStatusSnapshot(env, {
@@ -7576,7 +7575,8 @@ async function attachExactReviewQueueStatus(snapshot, env) {
     exactReviewQueueRequest,
     recentDurablePublicationEventsRequest,
   ]);
-  if (queueResult.status === "fulfilled") exactReviewQueue = queueResult.value;
+  const freshExactReviewQueue = queueResult.status === "fulfilled" ? queueResult.value : null;
+  let exactReviewQueue = freshExactReviewQueue;
   if (eventsResult.status === "fulfilled") recentDurablePublicationEvents = eventsResult.value;
   const allowedRepositories = verifiedPublicBayRepositories(env);
   const staleStatusSnapshot =
@@ -7646,7 +7646,8 @@ async function attachExactReviewQueueStatus(snapshot, env) {
       recent_durable_publication_events_error: eventsResult.status === "rejected",
     },
   };
-  return { ...attached, dashboard_health: summarizeDashboardHealth(attached) };
+  const healthSnapshot = { ...attached, exact_review_queue: freshExactReviewQueue };
+  return { ...attached, dashboard_health: summarizeDashboardHealth(healthSnapshot) };
 }
 
 async function triageSnapshot(env) {

--- a/test/dashboard-worker-observability.test.ts
+++ b/test/dashboard-worker-observability.test.ts
@@ -2822,6 +2822,140 @@ test("optional queue status failure retains the last complete public Bay queue s
   }
 });
 
+test("dashboard health grades fresh queue telemetry while retaining prior public Bay activity", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalCaches = globalThis.caches;
+  Object.defineProperty(globalThis, "caches", {
+    configurable: true,
+    value: { default: new MemoryCache() },
+  });
+  globalThis.fetch = async () => {
+    throw new Error("shared snapshot should avoid GitHub requests");
+  };
+
+  const queue = new ExactReviewQueue({ storage: new MemoryDurableStorage() }, {});
+  const enqueue = await queue.fetch(
+    buildExactReviewQueueRequest(
+      "bay-status-fresh-health",
+      125_205,
+      "opened",
+      "issue",
+      "openclaw/openclaw",
+    ),
+  );
+  assert.equal(enqueue.status, 202);
+  const publicQueueResponse = await worker.fetch(
+    new Request("https://clawsweeper.openclaw.ai/api/exact-review-queue"),
+    {
+      EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+      PUBLIC_BAY_REPOS: "openclaw/openclaw",
+    },
+  );
+  assert.equal(publicQueueResponse.status, 200);
+  const priorExactReviewQueue = await publicQueueResponse.json();
+  const emptyActivityStages = Object.fromEntries(
+    Object.keys(priorExactReviewQueue.bay_projection.stages).map((stage) => [stage, 0]),
+  );
+  priorExactReviewQueue.bay_projection.activity = {
+    complete: true,
+    queue_stages: { ...emptyActivityStages, arriving: 1 },
+    live_stages: { ...emptyActivityStages, reviewing: 1 },
+    total: 2,
+    items: [
+      {
+        repository: "openclaw/openclaw",
+        item_number: 125_205,
+        stage: "reviewing",
+        source: "worker",
+      },
+    ],
+  };
+  const priorActivity = structuredClone(priorExactReviewQueue.bay_projection.activity);
+  assert.equal(priorActivity.complete, true);
+
+  const statusStore = new MemoryKv();
+  await statusStore.put(
+    "snapshot:bay-scope:v1:openclaw%2Fopenclaw",
+    JSON.stringify({
+      schema_version: 1,
+      generated_at: new Date().toISOString(),
+      public_projection_complete: true,
+      health: {},
+      workers: [],
+      automatic_work: [],
+      bay: {
+        active_census_complete: false,
+        timings: {
+          sample_kind: "completed_review_journeys",
+          source: "durable_exact_review_lifecycles",
+          completion_source: "verified_final_review_receipts",
+          including_legacy_batch: {
+            overall: { average_ms: null, median_ms: null, samples: 0 },
+            history: { bucket_minutes: 5, points: [] },
+          },
+        },
+      },
+      pipeline: [],
+      recent: {},
+      fleet: { active_workflow_runs: 0 },
+      diagnostics: { errors: [], error_count: 0 },
+      exact_review_queue: priorExactReviewQueue,
+    }),
+  );
+  const queueWithCriticalPublicationHealth = {
+    fetch: async (request: Request) => {
+      const response = await queue.fetch(request);
+      if (new URL(request.url).pathname !== "/stats") return response;
+      const body = await response.json();
+      body.lanes.publication.health = {
+        ...body.lanes.publication.health,
+        status: "critical",
+      };
+      body.lanes.publication.dead_letters = {
+        ...body.lanes.publication.dead_letters,
+        open: 2,
+      };
+      return jsonResponse(body);
+    },
+  };
+
+  try {
+    const response = await worker.fetch(
+      new Request("https://clawsweeper.openclaw.ai/api/status"),
+      {
+        CACHE_TTL_SECONDS: "60",
+        STATUS_STORE: statusStore,
+        EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queueWithCriticalPublicationHealth),
+        PUBLIC_BAY_REPOS: "openclaw/openclaw",
+      },
+      { waitUntil: () => undefined },
+    );
+    const status = await response.json();
+    assert.deepEqual(
+      status.exact_review_queue.bay_projection.items,
+      priorExactReviewQueue.bay_projection.items,
+    );
+    assert.equal(status.exact_review_queue.bay_projection.activity.complete, true);
+    assert.deepEqual(
+      status.exact_review_queue.bay_projection.activity.queue_stages,
+      priorActivity.queue_stages,
+    );
+    assert.deepEqual(
+      status.exact_review_queue.bay_projection.activity.live_stages,
+      priorActivity.live_stages,
+    );
+    assert.equal(status.exact_review_queue.bay_projection.activity.total, priorActivity.total);
+    assert.equal(status.exact_review_queue.lanes.publication.health, undefined);
+    assert.equal(status.exact_review_queue.lanes.publication.dead_letters, undefined);
+    assert.equal(status.dashboard_health.reasons.includes("publication_critical"), true);
+    assert.equal(status.dashboard_health.reasons.includes("publication_dlq_open"), true);
+    assert.equal(status.dashboard_health.reasons.includes("publication_health_unavailable"), false);
+  } finally {
+    globalThis.fetch = originalFetch;
+    Object.defineProperty(globalThis, "caches", { configurable: true, value: originalCaches });
+  }
+});
+
 test("durable lifecycle Bay stale polls share one background refresh and respect maximum age", async (t) => {
   t.mock.timers.enable({ apis: ["Date"], now: new Date("2026-09-04T00:00:00Z") });
   const originalCaches = globalThis.caches;


### PR DESCRIPTION
Related: https://github.com/openclaw/clawsweeper/issues/1372

## What Problem This Solves

Fixes an issue where operators viewing `/api/status` could see `publication_health_unavailable` even though the current queue probe reported critical publication health and open dead letters. This happened when the Bay correctly retained a prior complete public activity projection during an incomplete worker census.

## Why This Change Was Made

Dashboard health now grades the fresh fulfilled queue sample from the current request. The existing Bay fallback and replacement logic remains unchanged, and rejected or unbound queue probes still summarize as unavailable.

The dashboard attachment path remains the architectural owner. No queue schema, public projection, dashboard health policy, docs, or Bay output changed.

## User Impact

Operators now see current publication-critical and DLQ signals in dashboard health even when the public Bay activity projection must remain on its prior complete sample.

## OpenClaw Bay Impact

OpenClaw Bay is unaffected. The controlled `/api/status` proof retains the prior Bay item set and activity counts exactly, while the public response continues to omit raw publication health and dead-letter internals.

## Documentation Impact

No documentation update is needed. The existing observer-only Bay and status contracts are unchanged; this repair only corrects which already-collected queue sample feeds the existing health summary.

## Evidence

- Frozen base: `0bf6bf603a1237017e269387109ee0156201b89f`
- Current head: `83d7053f0c8978ecb61a0cc2a85c52a8a48d8f03`
- `node --test test/dashboard-health.test.ts test/dashboard-worker-observability.test.ts test/dashboard-worker-status-privacy.test.ts`: 65 passed
- `node scripts/check-dashboard-queue-boundary.ts`: passed
- `node scripts/check-dashboard-strict.mjs`: passed
- `./node_modules/.bin/tsc -p tsconfig.dashboard.json`: passed
- `git diff --check`: passed
- Independent uncommitted and committed-head Codex reviews: no actionable findings
- Production delta: `dashboard/worker.ts` `+4/-3`
- Test delta: `test/dashboard-worker-observability.test.ts` `+134/-0`

`pnpm run check` was not run locally because this Codex worktree uses the required shared `node_modules` symlink and pnpm attempted to reconcile the shared install against the frozen head. The focused commands above used the existing binaries directly without mutating that shared dependency tree; hosted CI remains the full gate.

## Real Behavior Proof

**Claim:** `/api/status` reports current publication-critical and open-DLQ health while preserving a prior complete public Bay projection during an incomplete active-worker census.

**Exercised surface:** a disposable archive of exact head `83d7053f0c8978ecb61a0cc2a85c52a8a48d8f03` ran under real `wrangler 4.107.0 dev --local`, Miniflare `4.20260701.0`, and `workerd 2026-07-01`. The run used the production signed `/internal/exact-review/enqueue`, public `/api/exact-review-queue`, and production `/api/status` routes with real `StatusStore` and `ExactReviewQueue` SQLite Durable Objects.

**Scenario:** a signed synthetic protocol-v2 publication was accepted with HTTP 202. With the Worker stopped, the unambiguous queue SQLite database was edited transactionally to contain one pending publication aged 25,201 seconds, with its retry still scheduled in the future, and one open dead letter. The prior stored public snapshot had `bay.active_census_complete = false` and a complete prior Bay activity projection.

**Observed result:**

- Raw queue telemetry reported one pending publication, `health = critical`, `reason = oldest_pending_over_6h`, and `dead_letters.open = 1`.
- Production `/api/status` retained the prior Bay activity and prior Bay item set exactly.
- `dashboard_health.reasons` included `publication_critical` and `publication_dlq_open`, and excluded `publication_health_unavailable`.
- The public response omitted raw publication health, raw dead-letter data, and all synthetic identifiers.
- The harness hard-failed and counted outbound Worker fetches; the final outbound GitHub request count was `0`.
- Both Wrangler process groups stopped, the loopback port closed, temporary runtime/state was removed, and the source head/tree remained unchanged.

**Scrubbed artifacts:**

```text
74b919b320a71ad331f759c53ff4765cb5fc24061adbb84feee75d79c2f3f27f  proof.json
ff3c20515b1967885818e4a98a2ceb6b44ce8627b61b50b93f604fefbc80f236  transcript.txt
cf41858dfb17d261095f2b6f4baf3dd7245330591ccf35f08aa4c53cdf2e8b8d  wrangler.log
```

Source archive SHA-256: `c2cd79aecb617985b4276cc999759779ad3898e7c17a5c8d093cd758d8be9f31`. Temporary harness entry SHA-256: `241bb37817d623549728262eeb0266fcb6dc6082762c2743a590b8a5f746d5fd`.

**Limits:** controlled local workerd and SQLite Durable Objects with synthetic signed input and loopback-only token-gated proof hooks for status seeding and raw aggregate inspection. This does not claim deployed Cloudflare edge behavior.
