### PR TITLE
fix: align persisted-record slugs and stabilize timeout tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Preserve canonical repository slugs when reading persisted apply records, including dots, underscores, and repeated or trailing hyphens.
+- Make timeout tests tolerate loaded macOS hosts by isolating checkout timing, synchronizing lock contention, and budgeting snapshot admission fixtures separately from deadline tests.
 - Preserve explicit contributor credits in source-PR link comments for both direct replacements and fallback publication after a blocked fork push.
 
 - Reject parent-directory validation symlinks, preserve porcelain paths when selecting repair checks, retain the fast-rebase base SHA for replacement publication, and mark omitted PR comments in close-coverage proof.

--- a/docs/state-storage.md
+++ b/docs/state-storage.md
@@ -5,6 +5,12 @@ for review records, R2 is canonical for immutable action ledgers and published
 assets, and the `state` branch of `openclaw/clawsweeper-state` retains only the
 operational paths that have not migrated yet.
 
+Record paths use the repository profile's lowercase slug: the owner/repository
+separator becomes a hyphen, while dots, underscores, and existing hyphens remain
+literal. For example, `OpenClaw/Some.Repo_Debug` uses
+`records/openclaw-some.repo_debug/`. Apply selection and cursor reads use the same
+slug as record publication and hydration; existing records need no migration.
+
 Report readers share one anchored leading-front-matter parser. A unique header
 value remains authoritative when report prose or a valid fenced example quotes
 the same key. Duplicate header keys and competing unfenced metadata blocks

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -18,7 +18,7 @@ import {
   isLiveRecheckCloseGuardAction,
   isSelectableApplyCloseAction,
 } from "../apply-close-actions.js";
-import { repositoryProfileFor } from "../repository-profiles.js";
+import { repositoryProfileFor, slugForRepo } from "../repository-profiles.js";
 
 type ApplyAction = {
   action: string;
@@ -1353,7 +1353,7 @@ function selectedProposedItemCandidates(
   candidateSnapshot?: readonly ProposedItemCandidate[],
   nowMs = Date.now(),
 ): ProposedItemCandidate[] {
-  const itemsDir = path.join("records", targetSlug(options.targetRepo), "items");
+  const itemsDir = path.join("records", slugForRepo(options.targetRepo.toLowerCase()), "items");
   if (!candidateSnapshot && !fs.existsSync(itemsDir)) return [];
 
   const allowedCloseReasons =
@@ -1540,7 +1540,7 @@ function inconsistentOrStaleProposedItemCount(
   options: ProposedItemOptions,
   candidateNumbers: ReadonlySet<number>,
 ): number {
-  const itemsDir = path.join("records", targetSlug(options.targetRepo), "items");
+  const itemsDir = path.join("records", slugForRepo(options.targetRepo.toLowerCase()), "items");
   if (!fs.existsSync(itemsDir)) return 0;
   const allowedCloseReasons =
     options.applyCloseReasons === "all"
@@ -1930,7 +1930,7 @@ function closePromotionSignalTexts(markdown: string): string[] {
 
 export function commentSyncBatchOutput(options: CommentSyncBatchOptions): Record<string, string> {
   const urgentCandidates = new Map<number, number>();
-  const targetSlug = commentSyncTargetSlug(options.targetRepo);
+  const targetSlug = slugForRepo(options.targetRepo.toLowerCase());
   const automaticAllItemCursor =
     options.applyKind === "all" && path.basename(options.cursorPath) === `${targetSlug}.json`;
   const candidates = commentSyncCandidates(
@@ -2174,7 +2174,7 @@ function readApplyCursorTrace(tracePath: string): number[] {
 }
 
 function applyCheckedAtForItem(targetRepo: string, itemNumber: number): string {
-  const baseDir = path.join("records", targetSlug(targetRepo));
+  const baseDir = path.join("records", slugForRepo(targetRepo.toLowerCase()));
   for (const stateDir of ["items", "closed"]) {
     const dir = path.join(baseDir, stateDir);
     if (!fs.existsSync(dir)) continue;
@@ -2264,8 +2264,7 @@ function commentSyncCandidates(
   urgentCandidates = new Map<number, number>(),
   automaticAllItemCursor = false,
 ): number[] {
-  const targetSlug = commentSyncTargetSlug(targetRepo);
-  const itemsDir = path.join("records", targetSlug, "items");
+  const itemsDir = path.join("records", slugForRepo(targetRepo.toLowerCase()), "items");
   if (!fs.existsSync(itemsDir)) return [];
 
   return fs
@@ -2404,10 +2403,6 @@ function commentSyncCandidates(
       return [number];
     })
     .sort((left, right) => left - right);
-}
-
-function commentSyncTargetSlug(targetRepo: string): string {
-  return targetRepo.toLowerCase().replace(/[^a-z0-9_.-]+/g, "-");
 }
 
 function readCommentSyncCursor(cursorPath: string): number {
@@ -2612,13 +2607,6 @@ function repoFor(markdown: string, name: string): string {
   return (
     frontMatterValue(markdown, "repository") || (/^\d+\.md$/.test(name) ? "openclaw/openclaw" : "")
   );
-}
-
-function targetSlug(targetRepo: string): string {
-  return targetRepo
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-|-$/g, "");
 }
 
 function numberFor(name: string): number {

--- a/test/action-ledger-runtime.test.ts
+++ b/test/action-ledger-runtime.test.ts
@@ -2322,7 +2322,7 @@ test("concurrent flushes converge on one immutable shard", async () => {
   );
 });
 
-test("producer locks reclaim fresh dead owners and never evict a live holder by age", async () => {
+test("producer locks reclaim fresh dead owners and never evict a live holder by age", async (t) => {
   const deadRoot = tempRoot();
   const deadEvent = recordReviewNumber(deadRoot, 41);
   assert.ok(deadEvent);
@@ -2341,9 +2341,10 @@ test("producer locks reclaim fresh dead owners and never evict a live holder by 
   })}\n`;
   const releaseDead = tryAcquireUtf8FileLockNoFollow(deadTarget, deadContent);
   assert.ok(releaseDead);
-  const deadStartedAt = Date.now();
+  const deadWait = t.mock.method(Atomics, "wait");
   assert.ok(recordReviewNumber(deadRoot, 42));
-  assert.ok(Date.now() - deadStartedAt < 5_000);
+  assert.equal(deadWait.mock.callCount(), 0);
+  deadWait.mock.restore();
   assert.doesNotThrow(releaseDead);
 
   const liveRoot = tempRoot();
@@ -2351,6 +2352,7 @@ test("producer locks reclaim fresh dead owners and never evict a live holder by 
   const liveEvent = recordReviewNumber(liveRoot, 51);
   assert.ok(liveEvent);
   const readyPath = path.join(liveRoot, "holder-ready");
+  const releasePath = path.join(liveRoot, "holder-release");
   const filesModuleUrl = pathToFileURL(
     path.join(process.cwd(), "dist", "action-ledger-files.js"),
   ).href;
@@ -2371,36 +2373,52 @@ const content = actionLedgerJson({
   schema_version: process.platform === "darwin" ? 2 : 1,
   pid: process.pid,
   process_incarnation_sha256: processIncarnation,
-  acquired_at_ms: Date.now() - 5 * 60_000 + 75,
+  acquired_at_ms: Date.now() - 5 * 60_000 - 1,
   nonce: "00000000-0000-4000-8000-000000000001"
 }) + "\\n";
 const release = tryAcquireUtf8FileLockNoFollow(target, content);
 if (!release) process.exit(3);
 fs.writeFileSync(process.argv[3], "ready\\n");
-await new Promise((resolve) => setTimeout(resolve, 150));
+const deadline = performance.now() + 60_000;
+while (!fs.existsSync(process.argv[4])) {
+  if (performance.now() >= deadline) process.exit(5);
+  await new Promise((resolve) => setTimeout(resolve, 5));
+}
 if (!fs.existsSync(target.path) || fs.readFileSync(target.path, "utf8") !== content) process.exit(4);
 release();
 `;
-  const holder = spawn(
-    process.execPath,
-    [
-      "--input-type=module",
-      "-e",
-      holderScript,
-      liveRoot,
-      producerLockRelativePath(liveEvent),
-      readyPath,
-    ],
-    { stdio: ["ignore", "pipe", "pipe"] },
-  );
-  const holderDone = childResult(holder);
-  await waitForPath(readyPath);
-
-  const startedAt = Date.now();
-  assert.ok(recordReviewNumber(liveRoot, 52));
-  assert.ok(Date.now() - startedAt >= 100);
-  const result = await holderDone;
-  assert.equal(result.code, 0, result.stderr || result.stdout);
+  await withImportRaceChildren(async (own) => {
+    const holderDone = own(
+      spawn(
+        process.execPath,
+        [
+          "--input-type=module",
+          "-e",
+          holderScript,
+          liveRoot,
+          producerLockRelativePath(liveEvent),
+          readyPath,
+          releasePath,
+        ],
+        { stdio: ["ignore", "pipe", "pipe"] },
+      ),
+    );
+    await waitForPath(readyPath, 60_000);
+    const originalWait = Atomics.wait;
+    const liveWait = t.mock.method(Atomics, "wait", (...args: Parameters<typeof Atomics.wait>) => {
+      // The holder releases only after the contender has observed the occupied lock.
+      fs.writeFileSync(releasePath, "release\n");
+      return originalWait(...args);
+    });
+    try {
+      assert.ok(recordReviewNumber(liveRoot, 52));
+      assert.ok(liveWait.mock.callCount() > 0);
+    } finally {
+      liveWait.mock.restore();
+    }
+    const result = await holderDone;
+    assert.equal(result.code, 0, result.stderr || result.stdout);
+  });
 
   const paths = await flushWorkflowActionEvents(liveRoot, {
     env: workflowEnv(),
@@ -2415,7 +2433,7 @@ for (const kind of ["producer", "import"] as const) {
   test(
     `macOS ${kind} locks retain live V1 owners and recover dead V1 owners`,
     { skip: process.platform === "darwin" ? false : "requires macOS lock identity transition" },
-    () => {
+    (t) => {
       const root = tempRoot();
       const source = tempRoot();
       const first = recordReviewNumber(root, 61);
@@ -2443,9 +2461,9 @@ for (const kind of ["producer", "import"] as const) {
       const releaseLive = tryAcquireUtf8FileLockNoFollow(target, liveContent);
       assert.ok(releaseLive);
       try {
-        const startedAt = Date.now();
+        const startedAt = performance.now();
         assert.throws(invoke, /lock timed out after 10000ms/);
-        assert.ok(Date.now() - startedAt >= 10_000);
+        assert.ok(performance.now() - startedAt >= 10_000);
         assert.equal(fs.readFileSync(target.path, "utf8"), liveContent);
       } finally {
         releaseLive();
@@ -2454,9 +2472,9 @@ for (const kind of ["producer", "import"] as const) {
       const deadContent = `${actionLedgerJson({ ...owner, pid: 2_147_483_647 })}\n`;
       const releaseDead = tryAcquireUtf8FileLockNoFollow(target, deadContent);
       assert.ok(releaseDead);
-      const deadStartedAt = Date.now();
+      const deadWait = t.mock.method(Atomics, "wait");
       assert.ok(invoke());
-      assert.ok(Date.now() - deadStartedAt < 5_000);
+      assert.equal(deadWait.mock.callCount(), 0);
       assert.doesNotThrow(releaseDead);
     },
   );

--- a/test/agent-input-scan.test.ts
+++ b/test/agent-input-scan.test.ts
@@ -91,7 +91,7 @@ function fixture(t: test.TestContext, prompt = "Review the change.") {
     `#!${process.execPath}\nrequire('node:fs').appendFileSync(${JSON.stringify(calls)}, 'called'); require('node:fs').readFileSync(0);`,
     { mode: 0o755 },
   );
-  const run = (source: Parameters<typeof scanAgentInput>[0]["source"]) =>
+  const run = (source: Parameters<typeof scanAgentInput>[0]["source"], timeoutMs = 30_000) =>
     runAgentProcess({
       label: "scan-fixture",
       prompt,
@@ -100,7 +100,7 @@ function fixture(t: test.TestContext, prompt = "Review the change.") {
       model: "internal",
       cwd,
       env: { ...process.env, CODEX_BIN: binary },
-      timeoutMs: 30_000,
+      timeoutMs,
     });
   return { root, cwd, git, commit, calls, diagnosticPromptPath, run };
 }
@@ -1070,7 +1070,8 @@ process.exit(scenario === 'unexpected successful output' ? 0 : 183);
       if (scenario.includes("snapshot")) {
         const expected = captureTargetCheckoutBinding(f.cwd);
         return withTargetReviewSnapshot(
-          { cwd: f.cwd, baseSha, expected, timeoutMs: 30_000 },
+          // Admission fixtures include repeated Git fences; deadline failures have separate tests.
+          { cwd: f.cwd, baseSha, expected, timeoutMs: 120_000 },
           f.run,
         );
       }

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -2363,23 +2363,52 @@ test("pinned-base reproduction preserves the source SHA-256 object format", () =
   assert.match(String(baseError), /src\/base\.ts:1: lint failed/);
 });
 
-test("pinned-base reproduction bounds checkout and possible promisor fetches", () => {
+test("pinned-base reproduction bounds checkout and possible promisor fetches", (t) => {
   const cwd = gitPackageFixture({ "check:changed": "node check.js" });
   fs.writeFileSync(path.join(cwd, "check.js"), "process.exit(1);\n");
   git(cwd, "add", ".");
   git(cwd, "commit", "-m", "base");
   const pinnedBaseRef = git(cwd, "rev-parse", "HEAD");
-  const startedAt = Date.now();
-
-  assert.equal(
-    reproduceValidationFailureAtPinnedBase({
-      commands: ["pnpm check:changed"],
-      targetDir: cwd,
-      options: validationOptions("openclaw/openclaw", { pinnedBaseRef, setupTimeoutMs: 1 }),
-    }),
-    null,
+  const originalSpawnSync = childProcess.spawnSync;
+  let checkoutTimeout: number | undefined;
+  let checkoutElapsed = Infinity;
+  let checkoutError: Error | undefined;
+  const spawn = t.mock.method(
+    childProcess,
+    "spawnSync",
+    (command: string, args: readonly string[], options?: childProcess.SpawnSyncOptions) => {
+      if (path.basename(command).replace(/\.exe$/, "") !== "git" || !args.includes("checkout")) {
+        return originalSpawnSync(command, args, options);
+      }
+      checkoutTimeout = options?.timeout;
+      // Time only the bounded subprocess, not the preceding repository setup.
+      const startedAt = performance.now();
+      const result = originalSpawnSync(process.execPath, ["-e", "setInterval(() => {}, 1_000)"], {
+        ...options,
+        timeout: checkoutTimeout ?? 2_000,
+      });
+      checkoutElapsed = performance.now() - startedAt;
+      checkoutError = result.error;
+      return result;
+    },
   );
-  assert.ok(Date.now() - startedAt < 2_000);
+  syncBuiltinESMExports();
+  try {
+    assert.equal(
+      reproduceValidationFailureAtPinnedBase({
+        commands: ["pnpm check:changed"],
+        targetDir: cwd,
+        options: validationOptions("openclaw/openclaw", { pinnedBaseRef, setupTimeoutMs: 1 }),
+      }),
+      null,
+    );
+    assert.equal(checkoutTimeout, 1);
+    assert.match(checkoutError?.message ?? "", /ETIMEDOUT/);
+    assert.ok(checkoutElapsed < 2_000);
+  } finally {
+    spawn.mock.restore();
+    syncBuiltinESMExports();
+  }
 });
 
 test("pinned-base reproduction does not inherit target-controlled checkout hooks", () => {

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -28,6 +28,7 @@ import {
   writeApplyCursor,
   writeCommentSyncCursor,
 } from "../../dist/repair/workflow-utils.js";
+import { repositoryProfileFor } from "../../dist/repository-profiles.js";
 import {
   AUTOMATION_LIMITS,
   WORKER_CONFIG,
@@ -3264,36 +3265,82 @@ test("manual all-item cursors still include recently synchronized issues", () =>
   }
 });
 
-test("comment synchronization preserves canonical dotted and underscored repository slugs", () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
-  const targetRepo = "steipete/tool.v2_debug";
-  const targetSlug = "steipete-tool.v2_debug";
-  const cursorPath = path.join(root, `results/comment-sync-cursors/${targetSlug}.json`);
-  const reportPath = path.join(root, `records/${targetSlug}/items/${targetSlug}-41.md`);
-  try {
+for (const [input, expectedSlug] of [
+  ["openclaw/some.repo", "openclaw-some.repo"],
+  ["openclaw/some_repo", "openclaw-some_repo"],
+  ["OpenClaw/Some.Repo_Debug", "openclaw-some.repo_debug"],
+  ["openclaw/some-repo", "openclaw-some-repo"],
+  ["openclaw/some--repo", "openclaw-some--repo"],
+  ["openclaw/-some-", "openclaw--some-"],
+] as const) {
+  test(`workflow record lookup preserves the writer slug for ${input}`, (t) => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-slug-"));
+    t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+    const profile = repositoryProfileFor(input);
+    assert.equal(profile.slug, expectedSlug);
+    const checkedAt = "2026-01-02T00:00:00Z";
+    const record = [
+      "---",
+      `repository: ${profile.targetRepo}`,
+      "type: issue",
+      "review_status: complete",
+      "item_snapshot_hash: abc123",
+      "decision: close",
+      "confidence: high",
+      "action_taken: proposed_close",
+      "close_reason: implemented_on_main",
+      "item_created_at: 2024-01-01T00:00:00Z",
+      `apply_checked_at: ${checkedAt}`,
+      "---",
+      "",
+    ].join("\n");
+    const repoRoot = path.join(root, "records", profile.slug);
+    const item = path.join(repoRoot, "items", "41.md");
+    write(item, record);
     write(
-      reportPath,
-      [
-        "---",
-        `repository: ${targetRepo}`,
-        "type: issue",
-        "review_status: complete",
-        "item_snapshot_hash: abc123",
-        "action_taken: kept_open",
-        "---",
-        "",
-      ].join("\n"),
+      path.join(repoRoot, "items", "42.md"),
+      record.replace("confidence: high", "confidence: low"),
     );
-    const result = withCwd(root, () =>
-      commentSyncBatchOutput({ targetRepo, applyKind: "all", batchSize: 40, cursorPath }),
-    );
-
-    assert.equal(result.item_numbers, "41");
-    assert.equal(result.next_cursor, "41");
-  } finally {
-    fs.rmSync(root, { recursive: true, force: true });
-  }
-});
+    const options = {
+      targetRepo: profile.targetRepo,
+      applyKind: "all",
+      applyCloseReasons: "all",
+      staleMinAgeDays: 60,
+      minAgeDays: 0,
+      minAgeMinutes: null,
+    };
+    withCwd(root, () => {
+      assert.deepEqual(proposedItemNumbers(options), [41]);
+      const inventory = proposedItemInventory(options);
+      assert.equal(inventory.eligible_total, 1);
+      assert.equal(inventory.inconsistent_or_stale, 1);
+      assert.equal(
+        commentSyncBatchOutput({
+          targetRepo: profile.targetRepo,
+          applyKind: "all",
+          batchSize: 40,
+          cursorPath: path.join(root, "comment-cursor.json"),
+        }).item_numbers,
+        "41,42",
+      );
+      const report = path.join(root, "apply-report.json");
+      const cursor = path.join(root, "apply-cursor.json");
+      write(report, JSON.stringify([{ number: 41, action: "kept_open" }]));
+      for (const section of ["items", "closed"]) {
+        if (section === "closed") {
+          fs.mkdirSync(path.join(repoRoot, section));
+          fs.renameSync(item, path.join(repoRoot, section, "41.md"));
+        }
+        writeApplyCursor(cursor, report, input);
+        assert.equal(
+          JSON.parse(fs.readFileSync(cursor, "utf8")).next_after_apply_checked_at,
+          checkedAt,
+          section,
+        );
+      }
+    });
+  });
+}
 
 test("fresh review priority crosses an existing maintenance cursor", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));


### PR DESCRIPTION
## What Problem This Solves

Persisted apply-record readers used a different repository-slug normalizer from the writer. A record for `openclaw/some.repo` or `openclaw/some_repo` was stored under its literal name but looked up under `openclaw-some-repo`. Repeated hyphens and trailing hyphens were also collapsed or trimmed, potentially selecting another repository's cursor timestamp.

Loaded macOS hosts also made timing tests fail despite correct runtime behavior: the checkout assertion included repository preparation, the dead-owner assertion included the entire record write, and snapshot admission shared an unnecessarily short fixture budget.

## Why This Change Was Made

Use the existing writer's `slugForRepo` helper for all workflow-record lookups and delete both local slug helpers. The regression table exercises dotted, underscored, mixed-case, hyphenated, repeated-hyphen, and trailing-hyphen names through proposal selection, inventory, comment synchronization, and open/closed cursor reads.

Measure the checkout subprocess with a monotonic clock, retaining the two-second bound and exercising a hung child with the supplied one-millisecond timeout. Assert that dead-owner recovery does not enter the lock wait, and release the live holder only after its contender observes the occupied lock. Give snapshot admission fixtures a bounded two-minute budget and pass the remaining budget into the agent runner; deadline-specific tests retain their existing limits.

## User Impact

The timeout-test changes are behavior-neutral; no runtime timeout, config, or workflow change. The intentional bug fix makes persisted-record lookup honor the existing writer contract. No new runtime contract or storage migration is introduced.

Resolution changes only for repository names whose literal dots, underscores, repeated hyphens, or trailing hyphens were previously replaced, collapsed, or trimmed. Mixed case still resolves to lowercase. Ordinary hyphenated names are unchanged.

The current configured targets are `openclaw/openclaw`, `openclaw/clawhub`, `openclaw/clawsweeper`, `openclaw/openclaw-facetime`, `openclaw/fs-safe`, `openclaw/crabbox`, and `steipete/camsnap`. Worker `TARGET_REPOS` lists the first three plus `openclaw/fs-safe`; apply targets are `openclaw/openclaw` and optional `openclaw/clawhub`. None changes resolution. The hosted registry uses the same configuration, with generic fallback owners `openclaw` and `steipete`; this audit checks configured targets, not an enumeration of every dynamically admitted repository.

Current `main` was checked through the GitHub contents API. `git log -S 'target_repo' -- config/target-repositories.json` and `git log -S 'TARGET_REPOS =' -- dashboard/wrangler.toml`, plus inspection of every historical target-config revision, found no configured dotted or underscored name. The additional historical explicit target was `openclaw/openclaw-windows-node`.

## Evidence

`pr-behavior-proof` contract:

- **Claim:** persisted workflow reads resolve the canonical writer namespace, and the timing fixtures tolerate scheduling delays without changing production deadlines or retries.
- **Exercised surface:** built workflow utilities reading/writing real temporary records and cursor files; actual subprocess timeout, live/dead process locks, scanner snapshot admission, and terminal cleanup.
- **Scenario/fixture:** six repository-name cases, one eligible and one inconsistent record, open-to-closed movement, a hung checkout substitute, a held lock released after observed contention, and the repeated regular-snapshot OID fixture.
- **Command/environment:** macOS arm64, Node v26.8.1, pnpm 11.10.0. For the behavior-neutral test refactor, proof is the full `pnpm run check` run plus the targeted suites, explicitly supplemented by before/after artificial load and injected scheduling gaps.
- **Observable result:** the pre-fix slug regression passed only the ordinary-hyphen control (1 pass, 5 failures); all six now find item 41 and its cursor timestamp. The pre-fix load run reproduced the dead-owner elapsed assertion. A 2.2-second setup delay and a simulated 31-second snapshot scheduling gap failed the old tests; both now pass while their intended bounds remain enforced.
- **Artifact/trace:** local logs under `/tmp/deslop-bugs3-*`, including `slug-regression-before.log`, `slug-after.log`, `before-targeted.log`, `after-targeted.log`, `jitter-after.log`, and `check.log` (the full gate). Pass summaries are below.
- **Limits:** local macOS proof; no live apply, remote record mutation, Linux/Windows execution, or production deployment. The requested terminal watchdog scenario passed before and after and was left unchanged. The baseline also exposed intermittent `ENOTEMPTY` cleanup failures at `test/live-proof-review-environment.test.ts:1262` and `:1296`; both passed focused reruns and the later load run. Each failed cleanup left a `cleanup.result.tmp.scan.*` file, consistent with a cleanup scanner writing after removal began. Their separate cleanup race is not claimed fixed here.

The load harness ran these four commands concurrently, unchanged before and after:

```sh
pnpm run check:static
pnpm run check:static
node --test test/clawsweeper.test.ts
node --test test/repair/target-validation.test.ts test/action-ledger-runtime.test.ts test/agent-input-scan.test.ts test/live-proof-review-environment.test.ts
```

Validation commands and summaries:

```text
corepack enable >/dev/null 2>&1; pnpm install --prefer-offline — PASS
pnpm run format — PASS
pnpm run build:all — PASS
node scripts/run-node-tests.mjs repair -- --test-name-pattern='workflow record lookup preserves the writer slug|pinned-base reproduction bounds' — PASS (135 reported tests)
node scripts/run-node-tests.mjs unit -- --test-name-pattern='producer locks reclaim fresh dead|locks retain live V1|reviewed synthetic fixture admission: repeated regular snapshot OID' — PASS (172 reported tests)
node --test test/repair/workflow-utils.test.ts
ℹ tests 77
ℹ pass 77
ℹ fail 0

node --import /tmp/deslop-bugs3-jitter.mjs --test --test-name-pattern='pinned-base reproduction bounds|producer locks reclaim fresh dead|reviewed synthetic fixture admission: repeated regular snapshot OID' test/repair/target-validation.test.ts test/action-ledger-runtime.test.ts test/agent-input-scan.test.ts
ℹ tests 3
ℹ pass 3
ℹ fail 0

python3 /tmp/deslop-bugs3-load.py after
static-a: exit=0
static-b: exit=0
large: exit=0 (76 passed)
ℹ tests 514
ℹ pass 509
ℹ fail 0
ℹ skipped 5

pnpm run check
Changed-file coverage:
ℹ tests 13
ℹ pass 13
ℹ fail 0
ℹ all files | 100.00 | 88.61 | 100.00 |
Full coverage:
ℹ tests 4822
ℹ pass 4809
ℹ fail 0
ℹ cancelled 0
ℹ skipped 13
ℹ all files | 85.73 | 76.18 | 89.70 |
```

Independent review: Codex autoreview scoped-clean, no accepted/actionable findings at P0/P1 (`--mode local --base origin/main --max-priority P1`, with context explaining the unrelated upstream-only differences). Validated head: 3bbb1957b8aa28a5f89651a1d181e06d0d2db44c.

OpenClaw Bay not affected: no dashboard changes.

| Scope | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Production | 6 | 18 | -12 |
| Tests | 167 | 72 | +95 |
| Docs/changelog | 8 | 0 | +8 |
