### PR TITLE
refactor(ledger): deduplicate shard packing and runtime helpers

### DIFF
--- a/src/action-ledger-files.ts
+++ b/src/action-ledger-files.ts
@@ -156,17 +156,8 @@ export function readDirectoryEntriesNoFollow(
 }
 
 export function writeUtf8FileExclusiveNoFollow(target: SafeWriteTarget, content: string): void {
-  writeUtf8FileExclusiveNoFollowWithIdentity(target, content, false);
-}
-
-function writeUtf8FileExclusiveNoFollowWithIdentity(
-  target: SafeWriteTarget,
-  content: string,
-  cleanupOnFailure: boolean,
-): FileIdentity {
   const parentChain = captureSafeParentChain(target, true);
   let descriptor: number | undefined;
-  let createdIdentity: FileIdentity | undefined;
   try {
     assertStableParentChain(target, parentChain);
     descriptor = fs.openSync(
@@ -174,43 +165,16 @@ function writeUtf8FileExclusiveNoFollowWithIdentity(
       fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | NO_FOLLOW,
       0o600,
     );
-    createdIdentity = descriptorIdentity(descriptor, target.label);
+    const createdIdentity = descriptorIdentity(descriptor, target.label);
     assertStableParentChain(target, parentChain);
     assertPathMatchesIdentity(target.path, createdIdentity, target.label);
     fs.writeFileSync(descriptor, content, "utf8");
     fs.fsyncSync(descriptor);
     assertStableParentChain(target, parentChain);
     assertPathMatchesIdentity(target.path, createdIdentity, target.label);
-  } catch (error) {
-    if (descriptor !== undefined) {
-      if (createdIdentity === undefined) {
-        try {
-          createdIdentity = descriptorIdentity(descriptor, target.label);
-        } catch {
-          // Preserve the original failure; cleanup below remains best effort.
-        }
-      }
-      fs.closeSync(descriptor);
-      descriptor = undefined;
-    }
-    if (cleanupOnFailure && createdIdentity !== undefined) {
-      try {
-        removeFileNoFollow(target, createdIdentity);
-      } catch (cleanupError) {
-        if (!isNotFoundError(cleanupError)) {
-          // oxlint-disable-next-line preserve-caught-error -- AggregateError retains both failures.
-          throw new AggregateError(
-            [error, cleanupError],
-            `failed to clean up ${target.label} after lock creation failure`,
-          );
-        }
-      }
-    }
-    throw error;
   } finally {
     if (descriptor !== undefined) fs.closeSync(descriptor);
   }
-  return createdIdentity!;
 }
 
 export function tryAcquireUtf8FileLockNoFollow(
@@ -311,7 +275,6 @@ function claimAndRemoveUtf8FileNoFollow(
     `${path.basename(target.path)}.${process.pid}.${randomUUID()}.reclaim`,
   );
   let descriptor: number | undefined;
-  let removed = false;
   try {
     assertStableParentChain(target, parentChain);
     const pathIdentity = fileIdentity(target.path, `${target.label} stale lock`);
@@ -343,11 +306,11 @@ function claimAndRemoveUtf8FileNoFollow(
     assertStableParentChain(target, parentChain);
     const claimedIdentity = fileIdentity(claimed.path, `${target.label} stale lock claim`);
     if (!fileIdentitiesEqual(claimedIdentity, openedIdentity)) {
-      restoreClaimedFileNoFollow(claimed, target, claimedIdentity);
+      linkFileExclusiveNoFollow(claimed, target);
+      removeFileNoFollow(claimed, claimedIdentity);
       return "replaced";
     }
     removeFileNoFollow(claimed, openedIdentity);
-    removed = true;
   } catch (error) {
     if (isNotFoundError(error)) return "missing";
     if (error instanceof FileIdentityMismatchError) return "replaced";
@@ -355,7 +318,6 @@ function claimAndRemoveUtf8FileNoFollow(
   } finally {
     if (descriptor !== undefined) fs.closeSync(descriptor);
   }
-  if (!removed) return "replaced";
   try {
     fileIdentity(target.path, `${target.label} successor lock`);
     return "replaced";
@@ -363,15 +325,6 @@ function claimAndRemoveUtf8FileNoFollow(
     if (isNotFoundError(error)) return "removed";
     throw error;
   }
-}
-
-function restoreClaimedFileNoFollow(
-  claimed: SafeWriteTarget,
-  target: SafeWriteTarget,
-  identity: FileIdentity,
-): void {
-  linkFileExclusiveNoFollow(claimed, target);
-  removeFileNoFollow(claimed, identity);
 }
 
 export function processIncarnationIdentitySha256(

--- a/src/action-ledger-runtime.ts
+++ b/src/action-ledger-runtime.ts
@@ -1,5 +1,6 @@
-import { createHash, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 import path from "node:path";
+import { sha256 } from "./content-hash.js";
 
 import {
   prepareSafeReadRoot,
@@ -38,6 +39,7 @@ import {
   parseActionEventShardContent,
   readAllSpooledActionEvents,
   sortActionEventsCausally,
+  splitActionEventShardEvents,
   validateActionEvent,
   writeActionEvent,
   writeActionEventShards,
@@ -327,14 +329,13 @@ export function recordWorkflowActionEvent(
   const writeOptions = { now: () => recordedAt };
   const candidate = createActionEvent(eventInput, writeOptions);
   const partitionDate = workflowPartitionDate(env);
-  const event = withWorkflowProducerLock(root, candidate.producer, () => {
+  return withWorkflowProducerLock(root, candidate.producer, () => {
     assertWorkflowProducerAcceptsEvent(root, candidate);
     ensureWorkflowPartitionDateValue(root, persistedWorkflowProducer(producer), partitionDate);
     const persisted = writeActionEvent(root, eventInput, writeOptions).event;
     queueCrabFleetEvent(root, persisted, env, options.fetchImpl ?? fetch);
     return persisted;
   });
-  return event;
 }
 
 export function recordWorkflowPhaseEvent(
@@ -456,14 +457,19 @@ function workflowActionEventIsMutationOutcome(event: ActionEvent): boolean {
 
 function workflowActionRecoveryPriority(event: ActionEvent): number {
   if (workflowActionEventIsUncertainMutationStart(event)) return 0;
-  if (
+  return workflowActionAggregatesChildMutations(event) ? 2 : 1;
+}
+
+function workflowActionAggregatesChildMutations(event: ActionEvent): boolean {
+  return (
     event.event_type === ACTION_EVENT_TYPES.reviewBatch ||
     event.event_type === ACTION_EVENT_TYPES.applyBatch ||
     (event.event_type === ACTION_EVENT_TYPES.reviewRetry && event.subject.kind === "workflow")
-  ) {
-    return 2;
-  }
-  return 1;
+  );
+}
+
+function compareWorkflowActionPhases(left: ActionEvent, right: ActionEvent): number {
+  return left.phase_seq - right.phase_seq || left.event_id.localeCompare(right.event_id);
 }
 
 function workflowActionEventClosesLifecycle(start: ActionEvent, event: ActionEvent): boolean {
@@ -496,12 +502,7 @@ function interruptedWorkflowPhaseSeq(
   parentEventId: string,
 ): number {
   const parent = current.find((event) => event.event_id === parentEventId);
-  const reservedTerminalPhase =
-    start.event_type === ACTION_EVENT_TYPES.reviewBatch ||
-    start.event_type === ACTION_EVENT_TYPES.applyBatch ||
-    (start.event_type === ACTION_EVENT_TYPES.reviewRetry && start.subject.kind === "workflow")
-      ? 1_000_000
-      : 0;
+  const reservedTerminalPhase = workflowActionAggregatesChildMutations(start) ? 1_000_000 : 0;
   let phaseSeq = Math.max(
     reservedTerminalPhase,
     start.phase_seq + 1,
@@ -563,8 +564,7 @@ export function interruptOpenWorkflowActionEvents(
         .sort(
           (left, right) =>
             workflowActionRecoveryPriority(left) - workflowActionRecoveryPriority(right) ||
-            left.phase_seq - right.phase_seq ||
-            left.event_id.localeCompare(right.event_id),
+            compareWorkflowActionPhases(left, right),
         );
       let written = 0;
       for (const start of starts) {
@@ -581,18 +581,12 @@ export function interruptOpenWorkflowActionEvents(
             (event) =>
               event.operation_id === start.operation_id &&
               event.attempt_id === start.attempt_id &&
-              (start.event_type === ACTION_EVENT_TYPES.reviewBatch ||
-                start.event_type === ACTION_EVENT_TYPES.applyBatch ||
-                (start.event_type === ACTION_EVENT_TYPES.reviewRetry &&
-                  start.subject.kind === "workflow") ||
+              (workflowActionAggregatesChildMutations(start) ||
                 actionLedgerJson(workflowActionSubjectIdentity(event)) ===
                   actionLedgerJson(workflowActionSubjectIdentity(start))) &&
               workflowActionEventIsUncertainMutationStart(event),
           )
-          .sort(
-            (left, right) =>
-              left.phase_seq - right.phase_seq || left.event_id.localeCompare(right.event_id),
-          );
+          .sort(compareWorkflowActionPhases);
         const mutationEvents = current
           .filter(
             (event) =>
@@ -600,23 +594,14 @@ export function interruptOpenWorkflowActionEvents(
               event.attempt_id === start.attempt_id &&
               event.action.mutation,
           )
-          .sort(
-            (left, right) =>
-              left.phase_seq - right.phase_seq || left.event_id.localeCompare(right.event_id),
-          );
+          .sort(compareWorkflowActionPhases);
         const lifecycleMutations = lifecycleEvents
           .filter((event) => event.action.mutation)
-          .sort(
-            (left, right) =>
-              left.phase_seq - right.phase_seq || left.event_id.localeCompare(right.event_id),
-          );
+          .sort(compareWorkflowActionPhases);
         const lifecycleMutation = lifecycleMutations.at(-1);
         const lifecycleOutcome = lifecycleEvents
           .filter(workflowActionEventIsMutationOutcome)
-          .sort(
-            (left, right) =>
-              left.phase_seq - right.phase_seq || left.event_id.localeCompare(right.event_id),
-          )
+          .sort(compareWorkflowActionPhases)
           .at(-1);
         const openUncertainMutationStarts = uncertainMutationStarts.filter((event) => {
           const eventLifecycleKey = workflowActionLifecycleKey(event);
@@ -630,11 +615,7 @@ export function interruptOpenWorkflowActionEvents(
         const openUncertainMutation =
           workflowActionEventIsUncertainMutationStart(start) ||
           openUncertainMutationStarts.length > 0;
-        const aggregatesChildMutations =
-          start.event_type === ACTION_EVENT_TYPES.reviewBatch ||
-          start.event_type === ACTION_EVENT_TYPES.applyBatch ||
-          (start.event_type === ACTION_EVENT_TYPES.reviewRetry &&
-            start.subject.kind === "workflow");
+        const aggregatesChildMutations = workflowActionAggregatesChildMutations(start);
         const relevantMutationEvents = aggregatesChildMutations
           ? mutationEvents
           : lifecycleMutations;
@@ -892,7 +873,9 @@ export async function postActionEventToCrabFleet(
 ): Promise<void> {
   const config = crabFleetProjectionConfig(env);
   if (!config) return;
-  await enqueueCrabFleetProjection(event, config, fetchImpl);
+  const request = createCrabFleetProjectionRequest(event, config, fetchImpl);
+  admitCrabFleetProjection(request);
+  await request.promise;
 }
 
 function startActionEventCrabFleetPost(
@@ -1180,7 +1163,7 @@ function actionEventShardImportBindings(
   for (const shard of shards) {
     const { partitionDate, ...producerIdentity } = shard.identity;
     const producerKey = actionLedgerJson(producerIdentity);
-    const producerDigest = createHash("sha256").update(producerKey).digest("hex");
+    const producerDigest = sha256(producerKey);
     const producerContent = `${actionLedgerJson({
       schema: "clawsweeper.action-ledger-import-producer-run",
       schema_version: 1,
@@ -1236,9 +1219,9 @@ function actionEventShardImportBindings(
       producer: ordered[0]!.identity,
       shards: ordered.map((shard) => ({
         path: shard.relativePath,
-        replay_sha256: createHash("sha256")
-          .update(`${shard.events.map((event) => actionEventReplayJson(event)).join("\n")}\n`)
-          .digest("hex"),
+        replay_sha256: sha256(
+          `${shard.events.map((event) => actionEventReplayJson(event)).join("\n")}\n`,
+        ),
       })),
     };
     const reservationContent = `${actionLedgerJson(reservation)}\n`;
@@ -1254,7 +1237,7 @@ function actionEventShardImportBindings(
         schema: "clawsweeper.action-ledger-import-shard-set-completion",
         schema_version: 1,
         producer: ordered[0]!.identity,
-        reservation_sha256: createHash("sha256").update(reservationContent).digest("hex"),
+        reservation_sha256: sha256(reservationContent),
       })}\n`,
       label: "action event shard import producer shard-set completion binding",
       kind: "completion",
@@ -1317,15 +1300,13 @@ function validateImportedActionEventHistory(
 
   const resolved = new Set<string>();
   for (const eventId of incoming.keys()) {
-    const pathPositions = new Map<string, number>();
-    const traversed: string[] = [];
+    const traversed = new Set<string>();
     let current: string | null = eventId;
     while (current !== null && !resolved.has(current)) {
-      if (pathPositions.has(current)) {
+      if (traversed.has(current)) {
         throw new Error(`action event shard import contains a causal cycle: ${current}`);
       }
-      pathPositions.set(current, traversed.length);
-      traversed.push(current);
+      traversed.add(current);
       current = (incoming.get(current) ?? readBinding(current))?.parent_event_id ?? null;
     }
     for (const traversedEventId of traversed) resolved.add(traversedEventId);
@@ -1515,7 +1496,7 @@ function validateCanonicalImportedShard(
       relativePath,
     );
   const first = events[0];
-  if (!match || !first || events.length === 0) {
+  if (!match || !first) {
     throw new Error(`action event shard is empty or has an invalid path: ${relativePath}`);
   }
   const seen = new Set<string>();
@@ -1614,7 +1595,7 @@ function validateCanonicalImportedShardGroup(group: readonly ImportedActionEvent
     }
   }
   const events = sortActionEventsCausally(ordered.flatMap((shard) => shard.events));
-  const packed = packImportedActionEventShards(events);
+  const packed = splitActionEventShardEvents(events);
   if (packed.length !== ordered.length) {
     throw new Error("action event shard batch is not deterministically packed");
   }
@@ -1633,33 +1614,6 @@ function validateCanonicalImportedShardGroup(group: readonly ImportedActionEvent
       throw new Error("action event shard batch is not deterministically packed");
     }
   }
-}
-
-function packImportedActionEventShards(events: readonly ActionEvent[]): ActionEvent[][] {
-  const shards: ActionEvent[][] = [];
-  let current: ActionEvent[] = [];
-  let currentBytes = 0;
-  for (const event of events) {
-    const eventBytes = Buffer.byteLength(`${actionLedgerJson(event)}\n`, "utf8");
-    if (eventBytes > ACTION_EVENT_SHARD_FILE_LIMITS.maxBytes) {
-      throw new Error(
-        `action event ${event.event_id} exceeds ${ACTION_EVENT_SHARD_FILE_LIMITS.maxBytes} shard byte limit`,
-      );
-    }
-    if (
-      current.length > 0 &&
-      (current.length >= ACTION_EVENT_SHARD_FILE_LIMITS.maxEvents ||
-        currentBytes + eventBytes > ACTION_EVENT_SHARD_FILE_LIMITS.maxBytes)
-    ) {
-      shards.push(current);
-      current = [];
-      currentBytes = 0;
-    }
-    current.push(event);
-    currentBytes += eventBytes;
-  }
-  if (current.length > 0) shards.push(current);
-  return shards;
 }
 
 function importedShardPart(relativePath: string): {
@@ -1707,16 +1661,6 @@ function queueCrabFleetEvent(
   pendingWorkflowCrabFleetPosts.set(rootKey, rootPosts);
   pendingCrabFleetPosts.add(post);
   admitCrabFleetProjection(request);
-}
-
-function enqueueCrabFleetProjection(
-  event: ActionEvent,
-  config: CrabFleetProjectionConfig,
-  fetchImpl: typeof fetch,
-): Promise<void> {
-  const request = createCrabFleetProjectionRequest(event, config, fetchImpl);
-  admitCrabFleetProjection(request);
-  return request.promise;
 }
 
 function createCrabFleetProjectionRequest(
@@ -1926,7 +1870,10 @@ function failCrabFleetProjection(root: string, event: ActionEvent, reason: strin
 
 function recordCrabFleetProjectionFailure(root: string, event: ActionEvent): void {
   try {
-    const producer = crabFleetProjectionFailureProducer(event);
+    const producer = {
+      ...event.producer,
+      component: machineIdentifier(`${event.producer.component}.crabfleet_projection`, 256),
+    };
     const partitionDate = readWorkflowPartitionDate(
       prepareSafeReadRoot(root, "action event spool"),
       event.producer,
@@ -1946,28 +1893,8 @@ function recordCrabFleetProjectionFailure(root: string, event: ActionEvent): voi
         destination: "crabfleet",
       }),
       type: ACTION_EVENT_TYPES.projectionFailed,
-      producer: {
-        repository: producer.repository,
-        sha: producer.sha,
-        workflow: producer.workflow,
-        job: producer.job,
-        runId: producer.run_id,
-        runAttempt: producer.run_attempt,
-        component: producer.component,
-      },
-      subject: {
-        repository: event.subject.repository,
-        kind: event.subject.kind,
-        ...(event.subject.subject_id === undefined ? {} : { subjectId: event.subject.subject_id }),
-        ...(event.subject.number === undefined ? {} : { number: event.subject.number }),
-        ...(event.subject.cluster_id === undefined ? {} : { clusterId: event.subject.cluster_id }),
-        ...(event.subject.source_revision === undefined
-          ? {}
-          : { sourceRevision: event.subject.source_revision }),
-        ...(event.subject.record_path === undefined
-          ? {}
-          : { recordPath: event.subject.record_path }),
-      },
+      producer: workflowActionProducerInput(producer),
+      subject: workflowActionSubjectInput(event.subject),
       action: {
         name: "crabfleet_projection",
         status: "failed",
@@ -2004,13 +1931,6 @@ function recordCrabFleetProjectionFailure(root: string, event: ActionEvent): voi
       }`,
     );
   }
-}
-
-function crabFleetProjectionFailureProducer(event: ActionEvent): ActionEvent["producer"] {
-  return {
-    ...event.producer,
-    component: machineIdentifier(`${event.producer.component}.crabfleet_projection`, 256),
-  };
 }
 
 function workflowPartitionDate(env: NodeJS.ProcessEnv): string {
@@ -2211,9 +2131,7 @@ function reserveWorkflowProducerFinalization(
     producer,
     partition_date: partitionDate,
     event_count: events.length,
-    replay_sha256: createHash("sha256")
-      .update(`${events.map((event) => actionEventReplayJson(event)).join("\n")}\n`)
-      .digest("hex"),
+    replay_sha256: sha256(`${events.map((event) => actionEventReplayJson(event)).join("\n")}\n`),
   };
   const content = `${actionLedgerJson(value)}\n`;
   const target = prepareSafeWriteTarget(
@@ -2293,17 +2211,17 @@ function readWorkflowPartitionDate(root: SafeReadRoot, producer: ActionEvent["pr
 }
 
 function workflowPartitionRelativePath(producer: ActionEvent["producer"]): string {
-  const identity = createHash("sha256").update(actionLedgerJson(producer)).digest("hex");
+  const identity = sha256(actionLedgerJson(producer));
   return path.join(".clawsweeper-repair", "action-events", "_partitions", `${identity}.txt`);
 }
 
 function workflowFinalizationRelativePath(producer: ActionEvent["producer"]): string {
-  const identity = createHash("sha256").update(actionLedgerJson(producer)).digest("hex");
+  const identity = sha256(actionLedgerJson(producer));
   return path.join(".clawsweeper-repair", "action-events", "_finalizations", `${identity}.json`);
 }
 
 function workflowProducerLockRelativePath(producer: ActionEvent["producer"]): string {
-  const identity = createHash("sha256").update(actionLedgerJson(producer)).digest("hex");
+  const identity = sha256(actionLedgerJson(producer));
   return path.join(".clawsweeper-repair", "action-events", "_locks", `${identity}.lock`);
 }
 
@@ -2400,7 +2318,7 @@ function machineIdentifier(value: string, maxLength: number): string {
   const readable = source.replace(/[^A-Za-z0-9_.:/@+-]+/g, "-").replace(/^-+|-+$/g, "");
   if (!readable) throw new Error("workflow action identifier is required");
   if (readable === source && readable.length <= maxLength) return readable;
-  const digest = createHash("sha256").update(source).digest("hex").slice(0, 12);
+  const digest = sha256(source).slice(0, 12);
   const prefixLength = maxLength - digest.length - 1;
   if (prefixLength < 1) throw new Error("workflow action identifier limit is too small");
   const prefix = readable.slice(0, prefixLength).replace(/-+$/g, "") || "id";

--- a/src/action-ledger.ts
+++ b/src/action-ledger.ts
@@ -1216,7 +1216,7 @@ export function readAllSpooledActionEvents(root: string | SafeReadRoot): ActionE
     if (isNotFoundError(error)) return [];
     throw error;
   }
-  const budget = createActionEventSpoolReadBudget();
+  const budget: ActionEventSpoolReadBudget = { events: [], producerKeys: new Set(), totalBytes: 0 };
   let repositoryCount = 0;
   for (const repositoryEntry of repositoryEntries) {
     if (
@@ -1269,10 +1269,6 @@ type ActionEventSpoolReadBudget = {
   totalBytes: number;
 };
 
-function createActionEventSpoolReadBudget(): ActionEventSpoolReadBudget {
-  return { events: [], producerKeys: new Set(), totalBytes: 0 };
-}
-
 function retainSpooledActionEvent(budget: ActionEventSpoolReadBudget, event: ActionEvent): void {
   if (budget.events.length >= ACTION_EVENT_SPOOL_READ_LIMITS.maxEvents) {
     throw new Error(
@@ -1299,16 +1295,7 @@ function retainSpooledActionEvent(budget: ActionEventSpoolReadBudget, event: Act
   budget.events.push(event);
 }
 
-function assertCanonicalSpooledEventPath(
-  event: ActionEvent,
-  relativePath: string,
-  expectedRepository?: string,
-): void {
-  if (expectedRepository && event.subject.repository !== expectedRepository) {
-    throw new Error(
-      `action event spool repository mismatch: ${event.subject.repository} != ${expectedRepository}`,
-    );
-  }
+function assertCanonicalSpooledEventPath(event: ActionEvent, relativePath: string): void {
   const canonicalPath = actionEventSpoolRelativePath(event.subject.repository, event.event_id);
   if (path.normalize(relativePath) !== path.normalize(canonicalPath)) {
     throw new Error(`action event spool path is not canonical: ${relativePath}`);
@@ -1522,11 +1509,7 @@ function normalizeAttributeScalar(
     if (typeof value !== "string") {
       throw new Error(`action event attribute ${key} must be machine-readable text`);
     }
-    const normalized = machineText(value, `action event attribute ${key}`);
-    if (containsConfidentialIdentifier(normalized)) {
-      throw new Error(`action event attribute ${key} contains a confidential identifier`);
-    }
-    return normalized;
+    return machineText(value, `action event attribute ${key}`);
   }
   throw new Error(`action event attribute has no value contract: ${key}`);
 }
@@ -1584,7 +1567,7 @@ function assertRawActionEventShardInput(events: readonly ActionEvent[], maxEvent
   }
 }
 
-function splitActionEventShardEvents(events: readonly ActionEvent[]): ActionEvent[][] {
+export function splitActionEventShardEvents(events: readonly ActionEvent[]): ActionEvent[][] {
   const shards: ActionEvent[][] = [];
   let current: ActionEvent[] = [];
   let currentBytes = 0;
@@ -2482,7 +2465,7 @@ function canonicalizeJsonValue(
       }
     }
     const normalized: Record<string, unknown> = {};
-    for (const key of (ownKeys as string[]).sort(compareCanonicalKeys)) {
+    for (const key of (ownKeys as string[]).sort(compareLedgerText)) {
       if (rejectCredentialFields && highRiskCredentialField(key)) {
         throw new Error(
           `action event identity contains a high-risk credential field at ${location}`,
@@ -2621,10 +2604,6 @@ function validateCanonicalJsonComplexity(root: unknown): void {
   }
 }
 
-function compareCanonicalKeys(left: string, right: string): number {
-  return compareLedgerText(left, right);
-}
-
 function compareLedgerText(left: string, right: string): number {
   return Buffer.compare(Buffer.from(left, "utf8"), Buffer.from(right, "utf8"));
 }
@@ -2645,7 +2624,7 @@ function serializeCanonicalJson(value: unknown): string {
     throw new Error("action event data contains a non-JSON value");
   }
   const entries = Object.keys(value)
-    .sort(compareCanonicalKeys)
+    .sort(compareLedgerText)
     .map(
       (key) =>
         `${JSON.stringify(key)}:${serializeCanonicalJson((value as Record<string, unknown>)[key])}`,

--- a/test/action-ledger.test.ts
+++ b/test/action-ledger.test.ts
@@ -331,9 +331,6 @@ test("canonical identity hashing rejects excessive depth, nodes, and input size 
 });
 
 test("ledger and shared JSON ordering are both binary and locale independent", () => {
-  // The shared serializer used to order keys by locale collation, and this test
-  // pinned that difference. It now uses the same code-unit comparator as the
-  // ledger, so "z" (0x7A) precedes "\u00e4" (0xE4) in both.
   assert.equal(stableJson({ "\u00e4": 1, z: 2 }), '{"z":2,"\u00e4":1}');
   assert.equal(
     actionLedgerJson({ "2": "two", "10": "ten", "\u00e4": 1, z: 2 }),
@@ -1996,16 +1993,6 @@ test("generated occurrence clocks cannot reverse deterministic shard ordering", 
   assert.deepEqual(
     readActionEventShard(first.path).map((event) => event.event_id),
     firstEvents.map((event) => event.event_id).sort(),
-  );
-});
-
-test("replaying an event with a changed explicit occurrence time still conflicts", () => {
-  const root = tempRoot();
-  writeActionEvent(root, reviewInput({ occurredAt: "2026-07-12T10:00:00.000Z" }));
-
-  assert.throws(
-    () => writeActionEvent(root, reviewInput({ occurredAt: "2026-07-12T10:00:01.000Z" })),
-    /action event conflict/,
   );
 });
 


### PR DESCRIPTION
## What Problem This Solves

The action-ledger writer and importer separately implemented identical shard packing. Runtime recovery and projection failure recording also repeated existing comparisons and field conversions, while the exclusive file writer carried an unused cleanup mode and identity result.

## Why This Change Was Made

Use one shard-packing implementation, the existing SHA-256 helper, and the existing producer/subject conversions. Share repeated recovery predicates and phase comparisons; remove forwarding wrappers, unreachable bookkeeping, a duplicate confidential-identifier check, and one exactly duplicated replay-conflict test. The stronger replay-conflict test remains.

The file writer still leaves cleanup to its existing publication/lock owners. Serialization, filenames, lock records and protocols, timeouts, redaction patterns, and write ordering are unchanged. The runtime test file is unchanged, including the load-tolerant lock-wait assertions and release handshake from https://github.com/openclaw/clawsweeper/pull/1412.

## User Impact

Behavior-neutral; no runtime contract, config, or workflow change.

## Evidence

For this behavior-neutral refactor, the behavior proof is the full `pnpm run check` run plus the targeted suites, supplemented by a pre/post comparison through the real local ledger writer, recovery, finalization, and importer.

**pr-behavior-proof contract**

- **Claim:** the refactor preserves ledger behavior, durable bytes, and publication ordering.
- **Exercised surface:** event persistence, interruption recovery, projection-failure recording, producer finalization, deterministic shard packing, and import bindings, plus the existing invariant tests below.
- **Scenario/fixture:** deterministic synthetic review/mutation recovery, a rejected synthetic projection, and 1,025 events crossing the shard limit; import all five resulting shards into a fresh trusted root.
- **Command and environment:** macOS arm64, Node 26.8.1, pnpm 11.10.0. `pnpm run build:all`; `node scripts/run-node-tests.mjs all -- --test-name-pattern='ledger|shard|projection|producer|lock'`; `pnpm run check`. Before and after the source edits: `node /tmp/deslop-ledger-bytes.mjs`, followed by `cmp /tmp/deslop-ledger-before.json /tmp/deslop-ledger-after.json`.
- **Observable result:** all 1,061 captured durable paths and file contents, and all 1,061 publication-link targets in sequence, compare byte-for-byte identical. Five shards imported successfully. Both captures have SHA-256 `45e96337e5d85fb4cda0234fb2efd04054722a4e5e5ed50e62c13a6e7d5868a4`.
- **Artifact or trace:** local `/tmp/deslop-ledger-bytes.mjs`, `/tmp/deslop-ledger-before.json`, `/tmp/deslop-ledger-after.json`, `/tmp/deslop-ledger-targeted.log`, and `/tmp/deslop-ledger-check.log`; summaries below.
- **Limits:** synthetic local filesystem proof, with a fixed clock and mocked projection response. No live GitHub mutation or CrabFleet request. Random transient lock filenames are excluded from the byte capture; lock semantics are covered by the existing tests. Linux-only process tests are platform-skipped on macOS.

| Preserved invariant | Existing test proving it |
| --- | --- |
| Shard filenames, packing, immutability | `action-ledger.test.ts`: “durable shards batch sorted events once per producer job”; “durable shard writers split deterministically within importer event and byte limits”; “a shard identity cannot be reused for a different event set”; “shard paths use the stable run partition instead of event ordering” |
| Causal ordering and `phaseSeq` | `action-ledger.test.ts`: “durable shards preserve causal order ahead of source timestamps”; `action-ledger-runtime.test.ts`: “timeout recovery terminalizes the latest open mutation before its item summary” |
| Producer and import serialization | `action-ledger-runtime.test.ts`: “concurrent flushes converge on one immutable shard”; “destination import transactions prevent concurrent opposing parent edges” |
| macOS V1/V2 transition; PID and incarnation-based reclaim | `action-ledger-runtime.test.ts`: “producer locks reclaim fresh dead owners and never evict a live holder by age”; “macOS producer/import locks retain live V1 owners and recover dead V1 owners”; “producer/import locks reclaim current-version PID reuse and reject unknown versions”; “producer and import writers serialize the platform's lock identity version” |
| NoFollow symlink refusal | `action-ledger.test.ts`: “spool and shard writes reject symlinked parent directories”; `action-ledger-runtime.test.ts`: “partition markers and import destinations reject symlinked parents” |
| Confidential identifiers and high-risk credential fields rejected before persistence | `action-ledger.test.ts`: “identity hashing rejects values outside the canonical JSON domain”; “durable privacy guards reject raw text, local paths, secrets, and invalid digests”; `action-ledger-runtime.test.ts`: “workflow event scopes reject confidential identifiers before persistence or projection” |
| Mutation observation precedes finalization | `clawsweeper-action-ledger.test.ts`: “apply receipts start per item and persist mutation observation before finalization” |

OpenClaw Bay not affected: no dashboard changes.

| Scope | Added | Removed | Net LOC |
| --- | ---: | ---: | ---: |
| Production | 55 | 205 | -150 |
| Tests | 0 | 13 | -13 |
| Docs | 0 | 0 | 0 |

Validation summaries:

```text
Targeted runner:
ℹ tests 633
ℹ pass 629
ℹ fail 0
ℹ cancelled 0
ℹ skipped 4
ℹ duration_ms 385417.855667

pnpm run check (exit 0):
Changed-coverage suite: 13 passed, 0 failed.
ℹ tests 4843
ℹ pass 4830
ℹ fail 0
ℹ cancelled 0
ℹ skipped 13
ℹ duration_ms 907903.758125
ℹ all files | 85.71% lines | 76.17% branches | 89.59% functions
```

Independent Codex autoreview: `scoped-clean` at P0/P1, with no accepted/actionable findings, using `autoreview --mode local --base origin/main --max-priority P1`. Full output: local `/tmp/autoreview-deslop-ledger.md`.

Validated source committed as `b6c548305` without further source changes after proof or review.
