### PR TITLE
fix(review): use valid run evidence for failed-review retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ checkpoint, and status-only commits are intentionally omitted.
 ### Fixed
 
 - Replay durable scheduled enqueue dispositions after transient response loss while preserving signed delivery identity, rejecting mismatched bytes, failing closed on legacy ambiguous receipts, and leaving publication post-effects single-attempt.
+- Use the producer Actions run URL in failed-review retry receipts so ledger validation no longer prevents dispatch and fails the retry command.
 - Preserve canonical repository slugs when reading persisted apply records, including dots, underscores, and repeated or trailing hyphens.
 - Make timeout tests tolerate loaded macOS hosts by isolating checkout timing, synchronizing lock contention, and budgeting snapshot admission fixtures separately from deadline tests.
 - Preserve a valid stale Bay lifecycle snapshot when a background refresh is unavailable or malformed, without extending its original 60-second expiry.

--- a/docs/action-ledger.md
+++ b/docs/action-ledger.md
@@ -126,6 +126,8 @@ confidential-identifier checks as every other durable machine-text field.
   so a changed failed-review record cannot reuse an earlier dispatch receipt.
   Operators must reconcile the workflow run before another launch; automatic
   retry never duplicates an outcome-unknown dispatch.
+  Retry receipts link to the producing Actions run; the dispatch workflow page
+  remains in the retry report and sidecar, not in ledger run-URL evidence.
 - Repository, producer SHA, workflow, job, run, attempt, and component all bind
   shard identity. They do not define the logical operation.
 - Workflow, step, invocation, and component identifiers keep a readable prefix

--- a/src/clawsweeper-failed-review-retry.ts
+++ b/src/clawsweeper-failed-review-retry.ts
@@ -545,7 +545,6 @@ export function createFailedReviewRetryWorkflow({
     revision: FailedReviewRetryRevision;
     reportPath: string;
     attempts: number;
-    dispatchUrl: string;
   }): void {
     const repository = targetRepo();
     const key = reviewRetryDispatchAttemptKey({
@@ -596,7 +595,7 @@ export function createFailedReviewRetryWorkflow({
         sourceRevision: options.revision.value,
         ...(recordPath.startsWith("../") ? {} : { recordPath }),
       },
-      evidence: [...workflowRunEvidence(), { kind: "retry_dispatch", runUrl: options.dispatchUrl }],
+      evidence: workflowRunEvidence(),
       attributes: {
         attempt: options.attempts + 1,
         retry_count: options.attempts,
@@ -783,7 +782,6 @@ export function createFailedReviewRetryWorkflow({
                 revision: retryRevision,
                 reportPath: path,
                 attempts: attemptsBeforeDispatch,
-                dispatchUrl: nextDispatchUrl,
               });
               markdown = checkpointFailedReviewRetry({
                 markdown,
@@ -1166,9 +1164,6 @@ export function createFailedReviewRetryWorkflow({
           ? [actionLedgerFileEvidence("review_record", result.reportPath)].filter(
               (entry): entry is ActionEventEvidence => entry !== null,
             )
-          : []),
-        ...(result.dispatchUrl?.startsWith("https://github.com/")
-          ? [{ kind: "retry_dispatch", runUrl: result.dispatchUrl }]
           : []),
       ];
       const retrySlot = reviewRetryIdempotencySlot(result.action);

--- a/test/failed-review-retry.test.ts
+++ b/test/failed-review-retry.test.ts
@@ -1,8 +1,18 @@
 import assert from "node:assert/strict";
-import childProcess, { execFileSync, type SpawnSyncReturns } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import childProcess, { execFileSync, spawnSync, type SpawnSyncReturns } from "node:child_process";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { syncBuiltinESMExports } from "node:module";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import test, { type TestContext } from "node:test";
 
 import {
@@ -15,6 +25,7 @@ import {
   reviewRetryActionNeedsItemEventForTest,
 } from "../dist/clawsweeper.js";
 import { tmpPrefix, withMockGh, workPlanCandidateReport } from "./helpers.ts";
+import { readAllSpooledActionEvents } from "../dist/action-ledger.js";
 
 function failedReviewReport(overrides = {}) {
   return `${workPlanCandidateReport({
@@ -136,6 +147,71 @@ function runFailedIssueRetry(
     ...failedIssueRetryArgs(fixture, extraArgs),
   ]);
 }
+
+test("failed review retry records the producer run URL before and after dispatch", () => {
+  const root = realpathSync(mkdtempSync(tmpPrefix));
+  const fixture = failedIssueRetryFixture(join(root, "records", "openclaw-openclaw"), 4350);
+  const dispatchPath = join(root, "dispatched");
+  const outputRoot = join(root, "ledger-output");
+  try {
+    for (const entry of ["dist", "config", "package.json"]) {
+      cpSync(entry, join(root, entry), { recursive: true });
+    }
+    symlinkSync(resolve("node_modules"), join(root, "node_modules"), "dir");
+    mkdirSync(outputRoot);
+    withMockGh(
+      root,
+      issueRetryGhMock(
+        fixture.issue,
+        `const fs = await import("node:fs"); fs.writeFileSync(${JSON.stringify(dispatchPath)}, "dispatched"); process.exit(0);`,
+      ),
+      () => {
+        const result = spawnSync(
+          process.execPath,
+          [join(root, "dist", "clawsweeper.js"), ...failedIssueRetryArgs(fixture)],
+          {
+            encoding: "utf8",
+            env: {
+              ...process.env,
+              CLAWSWEEPER_ACTION_LEDGER_FORCE: "1",
+              CLAWSWEEPER_ACTION_LEDGER_DISABLED: "0",
+              CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT: outputRoot,
+              CLAWSWEEPER_ACTION_LEDGER_PARTITION_DATE: "2026-09-04",
+              CLAWSWEEPER_ACTION_LEDGER_INVOCATION: "retry-fixture",
+              CLAWSWEEPER_CRABFLEET_AGENT_TOKEN: "",
+              GITHUB_REPOSITORY: "openclaw/clawsweeper",
+              GITHUB_RUN_ID: "123456",
+              GITHUB_RUN_ATTEMPT: "1",
+              GITHUB_WORKFLOW: "fixture",
+              GITHUB_WORKFLOW_REF: "",
+              GITHUB_JOB: "retry",
+              GITHUB_SHA: "abc123",
+            },
+          },
+        );
+        assert.equal(result.status, 0, result.stderr);
+      },
+    );
+    assert.equal(readFileSync(dispatchPath, "utf8"), "dispatched");
+    assert.equal(
+      JSON.parse(readFileSync(fixture.reportPath, "utf8"))[0].action,
+      "dispatched_failed_review_retry",
+    );
+    const events = readAllSpooledActionEvents(root).filter(
+      (event) => event.subject.number === fixture.number,
+    );
+    assert.deepEqual(events.map((event) => event.action.status).sort(), ["dispatched", "started"]);
+    for (const event of events) {
+      assert.ok(event.evidence);
+      assert.deepEqual(
+        event.evidence.filter((entry) => entry.run_url).map((entry) => entry.run_url),
+        ["https://github.com/openclaw/clawsweeper/actions/runs/123456"],
+      );
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
 
 async function runFailedIssueRetryAtDispatchDeadline(
   t: TestContext,


### PR DESCRIPTION
## What Problem This Solves

With action-ledger recording enabled, an otherwise eligible failed-review retry cannot dispatch: its pre-dispatch receipt puts an Actions workflow-page URL into a field that accepts only Actions run URLs. The checkpoint exception is caught as `definitely_not_dispatched`, leaving a `skipped_dispatch_failed` report with no consumed attempt and no GitHub dispatch. Recording that result repeats the invalid URL outside the dispatch catch, so the CLI exits 1. The CLI initially spools only the batch-start event. The workflow permits cleanup to continue, finalizes/interruption-recovers the ledger, then its “Restore failed-review retry outcome” step restores exit 1. The scheduled retry job therefore fails; the error is not silently swallowed.

## Why This Change Was Made

Both receipts already include `workflowRunEvidence()`, which derives the producing Actions run from `GITHUB_REPOSITORY` and `GITHUB_RUN_ID`. Remove the redundant invalid workflow-page evidence and its unused argument. Keep the dispatch workflow link in the report and retry sidecar, where it remains useful without pretending to identify a run. The action-ledger validator is unchanged.

The fourth bug-pass work order also requested investigation of intermittent `ENOTEMPTY` in terminal-proof cleanup. No current failure reproduced under concurrent load or five repeated runs of the implicated cases. The watchdog scan-file ordering was already fixed by https://github.com/openclaw/clawsweeper/pull/1344 (commit `7b6451305`): private scan removal precedes the completion receipt. Restoring the old ordering in a temporary built-driver copy makes the existing detached-child regression fail (`present` instead of `absent` at receipt publication). There is no additional terminal cleanup patch or deletion retry in this PR. These results do not rule out a different, still-unobserved late writer.

## User Impact

Retry eligibility, attempt accounting, and dispatch payloads remain behavior-neutral; no runtime contract, config, or workflow change. This fixes the malformed receipt that prevented the intended retry path when ledger recording was enabled.

## Evidence

**pr-behavior-proof contract**

- **Claim / exercised surface:** the real `retry-failed-reviews` CLI writes valid local ledger receipts before and after dispatch, exits successfully, and records the producer run URL in each item event.
- **Scenario / fixture:** a copied built runtime, synthetic failed issue record at its matching source revision, enabled ledger, and a mock GitHub subprocess. The ledger validator, filesystem persistence, retry checkpoint, and CLI error handling execute normally. The subprocess leaves a dispatch marker.
- **Command / environment:** `node scripts/run-node-tests.mjs unit -- --test-name-pattern='failed.*retry|failed review'`; macOS arm64, Node 26.8.1, pnpm 11.10.0. The complete gate uses `PATH="/opt/homebrew/opt/bash/bin:$PATH" pnpm run check` (Bash 5.3.15).
- **Observable result:** the final regression fails against pre-fix production code with CLI exit 1 and `action event evidence run URL must identify a public github.com Actions run`; after the fix it passes, the dispatch marker exists, the report is `dispatched_failed_review_retry`, and both item receipts contain `https://github.com/openclaw/clawsweeper/actions/runs/123456`.
- **Artifact / trace:** `test/failed-review-retry.test.ts`, test “failed review retry records the producer run URL before and after dispatch”; local logs `/tmp/deslop-bugs4-final-regression-before.json`, `/tmp/deslop-bugs4-retry-targeted.log`, and `/tmp/deslop-bugs4-check.log`. Pass summaries below are retained here for review.
- **Limits:** GitHub is a synthetic subprocess fixture; no live dispatch, apply, Worker, R2, or other production service was contacted. This is a bug fix, so the controlled CLI behavior proof above supplements the full check and targeted suites rather than claiming tests alone prove a behavior-neutral refactor.

Focused retry runner:

```text
ℹ tests 194
ℹ pass 194
ℹ fail 0
ℹ skipped 0
```

Terminal load proof: `node --test --test-concurrency=2 test/live-proof-review-environment.test.ts test/action-ledger-runtime.test.ts`:

```text
ℹ tests 118
ℹ pass 116
ℹ fail 0
ℹ skipped 2
```

The skips require Linux procfs. Five consecutive runs of `node --test --test-name-pattern='consecutive commands|hard newlines|detached Node child' test/live-proof-review-environment.test.ts` alongside the broader focused suites each passed all 3 tests (15/15 total). Restoring the old watchdog ordering failed the existing regression 0/1 as expected.

Full `pnpm run check` passed (including static checks, build, lint, both coverage gates):

```text
Focused coverage gate: 13 passed, 0 failed
ℹ tests 4845
ℹ pass 4832
ℹ fail 0
ℹ cancelled 0
ℹ skipped 13
ℹ all files | 85.73% lines | 76.18% branches | 89.60% functions
```

Independent Codex autoreview against `origin/main`: **scoped-clean**, no accepted/actionable P0/P1 findings; verdict “patch is correct”.

OpenClaw Bay not affected: no dashboard changes.

| Area | Added | Removed | Net LOC |
| --- | ---: | ---: | ---: |
| Production | 1 | 6 | -5 |
| Tests | 79 | 3 | +76 |
| Docs / changelog | 3 | 0 | +3 |


### Update after ClawSweeper review (head 5f08f974d, unchanged): transport-level proof with the real `gh` client

Ran the real retry CLI built from this head from a copied runtime root, with the operator's real `gh` transport (no mock), the action ledger enabled, and `--dry-run` so the only mutation (the workflow dispatch) is planned rather than executed. Target: a live open PR in `openclaw/openclaw` with a synthesized failed-review record pinned to its live head SHA.

```text
$ node dist/clawsweeper.js retry-failed-reviews --target-repo openclaw/openclaw \
    --items-dir records/openclaw-openclaw/items --item-number 138406 --workflow-ref main \
    --report-path records/openclaw-openclaw/failed-review-retry-report.json --dry-run
{"event":"github_read_model_degraded","consumer":"review_planning_item",...,"fallback":"live_poll"}
{ "results": [ { "repo": "openclaw/openclaw", "number": 138406, "action": "planned_failed_review_retry",
    "reason": "timeout", "headSha": "ffc2ed1d...", "revisionKind": "pull_head_sha", "revision": "ffc2ed1d...",
    "attempts": 0 } ], "dryRun": true, "attempted": 1, "dispatched": 1 }
[action-ledger] finalized 1 immutable workflow shard
```
Ledger events spooled for #138406 on this head (read back with `readAllSpooledActionEvents`):
```text
{"type":"review.retry","status":"planned","reason":"dry_run",
 "evidence":[{"kind":"review_record"},{"kind":"workflow_run","run_url":"https://github.com/openclaw/clawsweeper/actions/runs/424242"}]}
```
The live PR state and head were read through the real `gh` client (the webhook read model was degraded at the time and the lane fell back to live polling, as designed); the record's head matched the live head; the lane planned the dispatch and persisted its ledger receipt with only the producer Actions run URL as `run_url` evidence, which is exactly the after-fix contract. A control run against a PR that had closed between selection and execution recorded `skipped_not_open` with the same evidence shape. Before this fix the same receipt carried the workflow-page URL and failed ledger validation. Limits: the dispatch itself was dry-run (a real dispatch is a production mutation); `GITHUB_RUN_ID` was supplied by the shell as it would be by Actions.


### Rebase and maintainer disposition (head 269727664)

Rebased onto current `main` to resolve the `CHANGELOG.md` conflict (both Unreleased entries kept); code unchanged. `node --test test/failed-review-retry.test.ts`: 23 pass, 0 fail on this head.

Maintainer disposition on the remaining ask (`proof: override`): the only way to exercise the pre-dispatch and dispatched-outcome receipts through a non-dry-run real transport is to dispatch a real ClawSweeper retry workflow run against a live target item from an operator laptop, which is a production mutation and not a controlled proof. The receipts' *content* is what this PR changes (it removes the workflow-page `retry_dispatch` evidence and keeps the producer run evidence); the ledger validator that rejected the old content and accepts the new one is unchanged code that runs identically regardless of transport, and the end-to-end test in this PR drives the compiled CLI through the real dispatch code path (`dispatchFailedReviewRetry`, pre-dispatch receipt, dispatched-outcome receipt) with only the `gh` subprocess substituted, asserting both receipts persist with the run URL; that test fails on pre-fix code. The real-client dry-run trace above additionally shows the real transport path (live item read, head match, planning receipt) accepting the new evidence shape. The first scheduled retry lane run on `main` after landing exercises the full path for real; the retry lane is scheduled and its runs are visible in Actions, and the maintainer will watch its next run and revert on a validation failure.
