### PR TITLE
fix(review): recover scheduled enqueue from transient queue failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
-- Retry transient scheduled review enqueue failures with the same signed delivery identity, while failing closed on ambiguous dedupes and preserving single-attempt publication post-effects.
+- Replay durable scheduled enqueue dispositions after transient response loss while preserving signed delivery identity, rejecting mismatched bytes, failing closed on legacy ambiguous receipts, and leaving publication post-effects single-attempt.
 - Preserve canonical repository slugs when reading persisted apply records, including dots, underscores, and repeated or trailing hyphens.
 - Make timeout tests tolerate loaded macOS hosts by isolating checkout timing, synchronizing lock contention, and budgeting snapshot admission fixtures separately from deadline tests.
 - Preserve explicit contributor credits in source-PR link comments for both direct replacements and fallback publication after a blocked fork push.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Retry transient scheduled review enqueue failures with the same signed delivery identity, while failing closed on ambiguous dedupes and preserving single-attempt publication post-effects.
 - Preserve canonical repository slugs when reading persisted apply records, including dots, underscores, and repeated or trailing hyphens.
 - Make timeout tests tolerate loaded macOS hosts by isolating checkout timing, synchronizing lock contention, and budgeting snapshot admission fixtures separately from deadline tests.
 - Preserve explicit contributor credits in source-PR link comments for both direct replacements and fallback publication after a blocked fork push.

--- a/dashboard/dashboard-pages.ts
+++ b/dashboard/dashboard-pages.ts
@@ -1956,7 +1956,7 @@ const STATUS_BOOLEAN_FIELDS = new Set([
   "workflow_run_census_complete", "durable_server_observed"
 ]);
 const STATUS_TEXT_FIELDS = new Set([
-  "conclusion", "mode", "outcome", "reason", "sample_kind", "severity", "source", "stage", "state",
+  "conclusion", "enqueue_replay", "mode", "outcome", "reason", "sample_kind", "severity", "source", "stage", "state",
   "status", "terminal_outcome", "work_kind", "errors", "reasons", "cache_state"
 ]);
 const STATUS_TEXT_VALUES = new Set([
@@ -1973,6 +1973,7 @@ const STATUS_TEXT_VALUES = new Set([
   "observed", "queue_empty", "claim_stalled", "dispatcher_blocked", "dispatcher_paused",
   "claim_delayed", "handoff_current", "handoff_unknown", "capacity_unavailable", "capacity_available",
   "no_ready_backlog", "no_admissible_backlog", "dispatcher_inactive", "capacity_full_with_backlog",
+  "scheduled_disposition_v1",
   "fresh", "miss", "repeated_failure_identity", "terminal_review_failure",
   "retryable_review_failure", "queue_telemetry_unavailable", "queue_handoff_stalled",
   "queue_handoff_degraded", "queue_handoff_unavailable", "publication_critical",

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -646,6 +646,25 @@ const DEFAULT_EXACT_REVIEW_TARGET_BURST = 50;
 const EXACT_REVIEW_GITHUB_THROTTLE_ADMISSION_COOLDOWN_MS = 15 * 60 * 1000;
 const EXACT_REVIEW_SCHEDULED_FEED_KEY_PREFIX = "exact-review-scheduled-feed:v1";
 type ExactReviewScheduledBucket = ExactReviewScheduledLane | "global";
+type ExactReviewScheduledDisposition =
+  | {
+      ok: true;
+      queued: true;
+      item_key: string;
+      superseded_publications: number;
+    }
+  | {
+      ok: true;
+      deduped: true;
+      item_key: string;
+      dedupe_scope: "scheduled_queue_item";
+      dedupe_reason: "item_already_pending_or_active";
+    }
+  | {
+      ok: true;
+      shed: true;
+      reason: "backpressure" | "scheduled_rate";
+    };
 const EXACT_REVIEW_COMPLETION_RETRY_MAX_MS = 2 * 60 * 60 * 1000;
 const EXACT_REVIEW_ARTIFACT_RETRY_MAX_MS = 80 * 24 * 60 * 60 * 1000;
 const EXACT_REVIEW_PUBLICATION_ARTIFACT_RETRY_LIMIT = 3;
@@ -696,6 +715,8 @@ const EXACT_REVIEW_SOURCE_AUTHORITY_RETRY_MAX_MS = 15 * 60_000;
 const EXACT_REVIEW_QUEUE_META_TABLE = "exact_review_queue_meta";
 const EXACT_REVIEW_QUEUE_ITEM_TABLE = "exact_review_queue_items";
 const EXACT_REVIEW_QUEUE_DELIVERY_TABLE = "exact_review_queue_deliveries";
+export const EXACT_REVIEW_AUTHENTICATED_BODY_FINGERPRINT_HEADER =
+  "x-clawsweeper-exact-review-body-sha256";
 const EXACT_REVIEW_QUEUE_INGRESS_TABLE = "exact_review_queue_ingress";
 const EXACT_REVIEW_QUEUE_EDIT_SEMANTIC_TABLE = "exact_review_queue_edit_semantic";
 const EXACT_REVIEW_QUEUE_METRICS_TABLE = "exact_review_queue_metrics";
@@ -1351,6 +1372,15 @@ export class ExactReviewQueue {
         return json({ error: "reserved_delivery_id" }, 400);
       }
       if (!decision) return json({ error: "invalid_exact_review_item" }, 400);
+      const scheduledLane = exactReviewScheduledLane(decision);
+      const bodyFingerprintHeader = request.headers.get(
+        EXACT_REVIEW_AUTHENTICATED_BODY_FINGERPRINT_HEADER,
+      );
+      if (scheduledLane && bodyFingerprintHeader && !/^[a-f0-9]{64}$/.test(bodyFingerprintHeader)) {
+        return json({ error: "invalid_authenticated_body_fingerprint" }, 400);
+      }
+      const authenticatedBodyFingerprint =
+        scheduledLane && bodyFingerprintHeader ? bodyFingerprintHeader : null;
       if (body.ingress !== undefined && !ingress) {
         return json({ error: "invalid_exact_review_ingress" }, 400);
       }
@@ -1391,19 +1421,44 @@ export class ExactReviewQueue {
           deliveryId,
           now - EXACT_REVIEW_QUEUE_DELIVERY_TTL_MS,
         );
-        const insertedReceipts = Array.from(
+        const existingReceipt = Array.from(
           this.storage.sql.exec(
-            `INSERT OR IGNORE INTO ${EXACT_REVIEW_QUEUE_DELIVERY_TABLE}
-             (delivery_id, received_at) VALUES (?, ?)
-           RETURNING delivery_id`,
+            `SELECT authenticated_body_fingerprint, scheduled_disposition_json
+               FROM ${EXACT_REVIEW_QUEUE_DELIVERY_TABLE}
+              WHERE delivery_id = ?`,
             deliveryId,
-            now,
           ),
-        );
-        if (insertedReceipts.length !== 1) {
+        )[0] as
+          | {
+              authenticated_body_fingerprint?: string | null;
+              scheduled_disposition_json?: string | null;
+            }
+          | undefined;
+        if (existingReceipt) {
           this.syncLegacyCompatibilitySync(this.readStateSync());
-          return { deduped: true as const };
+          const storedFingerprint = existingReceipt.authenticated_body_fingerprint;
+          const storedDispositionJson = existingReceipt.scheduled_disposition_json;
+          if (!storedFingerprint) return { deduped: true as const };
+          if (storedFingerprint !== authenticatedBodyFingerprint) {
+            return { conflict: true as const };
+          }
+          if (!storedDispositionJson) return { deduped: true as const };
+          const disposition = exactReviewScheduledDispositionFromJson(storedDispositionJson);
+          if (!disposition) return { deduped: true as const };
+          return {
+            replayed: true as const,
+            disposition,
+            dispositionJson: storedDispositionJson,
+          };
         }
+        this.storage.sql.exec(
+          `INSERT INTO ${EXACT_REVIEW_QUEUE_DELIVERY_TABLE}
+             (delivery_id, received_at, authenticated_body_fingerprint)
+           VALUES (?, ?, ?)`,
+          deliveryId,
+          now,
+          authenticatedBodyFingerprint,
+        );
         const counterpartIngress = ingress
           ? this.recordIngressSync(ingress, decision.targetBranch, now)
           : null;
@@ -1637,13 +1692,25 @@ export class ExactReviewQueue {
           }
         }
         const current = state.items[key];
-        if (current && exactReviewScheduledLane(decision)) {
+        if (current && scheduledLane) {
           this.writeStateSync(state);
+          const disposition: ExactReviewScheduledDisposition = {
+            ok: true,
+            deduped: true,
+            item_key: key,
+            dedupe_scope: "scheduled_queue_item",
+            dedupe_reason: "item_already_pending_or_active",
+          };
           return {
             deduped: true as const,
             scheduled: true as const,
             key,
             state,
+            scheduledDispositionJson: this.recordScheduledDispositionSync(
+              deliveryId,
+              authenticatedBodyFingerprint,
+              disposition,
+            ),
           };
         }
         let supersededRunId: string | null = null;
@@ -1871,7 +1938,7 @@ export class ExactReviewQueue {
         } else {
           if (
             !decision.publication &&
-            (isLowPriorityExactReviewDecision(decision) || exactReviewScheduledLane(decision)) &&
+            (isLowPriorityExactReviewDecision(decision) || scheduledLane) &&
             exactReviewQueuePendingReviewCount(state) >= exactReviewPendingSoftLimit(this.env)
           ) {
             state.shedSinceReset = exactReviewShedSinceReset(state) + 1;
@@ -1883,7 +1950,22 @@ export class ExactReviewQueue {
               pending_count: ordinaryLogCount(exactReviewQueuePendingReviewCount(state)),
               configured_limit: ordinaryLogCount(exactReviewPendingSoftLimit(this.env)),
             });
-            return { shed: true as const, reason: "backpressure" as const };
+            const disposition: ExactReviewScheduledDisposition = {
+              ok: true,
+              shed: true,
+              reason: "backpressure",
+            };
+            return {
+              shed: true as const,
+              reason: "backpressure" as const,
+              scheduledDispositionJson: scheduledLane
+                ? this.recordScheduledDispositionSync(
+                    deliveryId,
+                    authenticatedBodyFingerprint,
+                    disposition,
+                  )
+                : null,
+            };
           }
           if (!this.takeScheduledReviewTokenSync(decision, now)) {
             state.shedSinceReset = exactReviewShedSinceReset(state) + 1;
@@ -1894,9 +1976,22 @@ export class ExactReviewQueue {
               category: "scheduled_rate",
               lane: exactReviewScheduledLane(decision) || "background",
             });
-            return { shed: true as const, reason: "scheduled_rate" as const };
+            const disposition: ExactReviewScheduledDisposition = {
+              ok: true,
+              shed: true,
+              reason: "scheduled_rate",
+            };
+            return {
+              shed: true as const,
+              reason: "scheduled_rate" as const,
+              scheduledDispositionJson: this.recordScheduledDispositionSync(
+                deliveryId,
+                authenticatedBodyFingerprint,
+                disposition,
+              ),
+            };
           }
-          if (!decision.publication && !exactReviewScheduledLane(decision)) {
+          if (!decision.publication && !scheduledLane) {
             this.consumeScheduledReviewCapacitySync(now);
           }
           state.items[key] = {
@@ -1950,17 +2045,41 @@ export class ExactReviewQueue {
           this.insertSupersessionAuditSync(supersessionAudit);
           this.incrementQueueMetricsSync({ reviewSuperseded: 1 });
         }
+        const scheduledDispositionJson = scheduledLane
+          ? this.recordScheduledDispositionSync(deliveryId, authenticatedBodyFingerprint, {
+              ok: true,
+              queued: true,
+              item_key: key,
+              superseded_publications: supersededPublications,
+            })
+          : null;
         return {
           deduped: false as const,
           key,
           state,
           supersededPublications,
           supersededRunId,
+          scheduledDispositionJson,
         };
       });
       if (deferredBayLifecycle) this.syncBayLifecycle(deferredBayLifecycle);
+      if ("conflict" in accepted && accepted.conflict) {
+        return json({ error: "exact_review_delivery_conflict" }, 409);
+      }
+      if ("replayed" in accepted && accepted.replayed) {
+        if (accepted.disposition.queued || accepted.disposition.deduped) {
+          await this.scheduleNext(this.readStateSync(), now);
+        }
+        return jsonText(accepted.dispositionJson, 202);
+      }
       if (accepted.deduped) {
         if ("state" in accepted) await this.scheduleNext(accepted.state, now);
+        if (
+          "scheduledDispositionJson" in accepted &&
+          typeof accepted.scheduledDispositionJson === "string"
+        ) {
+          return jsonText(accepted.scheduledDispositionJson, 202);
+        }
         return json(
           {
             ok: true,
@@ -2006,9 +2125,15 @@ export class ExactReviewQueue {
         );
       }
       if (accepted.shed) {
+        if (typeof accepted.scheduledDispositionJson === "string") {
+          return jsonText(accepted.scheduledDispositionJson, 202);
+        }
         return json({ ok: true, shed: true, reason: accepted.reason }, 202);
       }
       await this.scheduleNext(accepted.state, now);
+      if (typeof accepted.scheduledDispositionJson === "string") {
+        return jsonText(accepted.scheduledDispositionJson, 202);
+      }
       return json(
         {
           ok: true,
@@ -9575,9 +9700,25 @@ export class ExactReviewQueue {
     this.storage.sql.exec(
       `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_QUEUE_DELIVERY_TABLE} (
          delivery_id TEXT PRIMARY KEY,
-         received_at INTEGER NOT NULL
+         received_at INTEGER NOT NULL,
+         authenticated_body_fingerprint TEXT,
+         scheduled_disposition_json TEXT
        ) STRICT`,
     );
+    const deliveryColumns = new Set(
+      Array.from(
+        this.storage.sql.exec(
+          `SELECT name FROM pragma_table_info('${EXACT_REVIEW_QUEUE_DELIVERY_TABLE}')`,
+        ) as Iterable<{ name: string }>,
+      ).map((row) => row.name),
+    );
+    for (const column of ["authenticated_body_fingerprint", "scheduled_disposition_json"]) {
+      if (!deliveryColumns.has(column)) {
+        this.storage.sql.exec(
+          `ALTER TABLE ${EXACT_REVIEW_QUEUE_DELIVERY_TABLE} ADD COLUMN ${column} TEXT`,
+        );
+      }
+    }
     // Store only the current SHA-256 tuple for a PR. That lets a later genuine
     // change back to an older tuple enqueue normally, while duplicate webhook
     // deliveries of the current edit stay idempotent even after queue handoff.
@@ -10479,6 +10620,7 @@ export class ExactReviewQueue {
     const normal = this.scheduledReviewBucketSync("normal_backfill", now);
     return {
       target_rate_per_hour: global.ratePerHour,
+      enqueue_replay: "scheduled_disposition_v1",
       burst: global.burst,
       token_balance: Math.floor(global.tokens),
       ...(global.throttleObservedAt
@@ -11764,6 +11906,32 @@ export class ExactReviewQueue {
       ),
     )[0] as { receipt_count?: number } | undefined;
     return Number(row?.receipt_count || 0);
+  }
+
+  private recordScheduledDispositionSync(
+    deliveryId: string,
+    authenticatedBodyFingerprint: string | null,
+    disposition: ExactReviewScheduledDisposition,
+  ) {
+    if (!authenticatedBodyFingerprint) return null;
+    // Persist the exact response with admission so response-loss retries replay
+    // it without consuming queue capacity or scheduled-feed tokens twice.
+    const dispositionJson = JSON.stringify(disposition, null, 2);
+    const updated = Array.from(
+      this.storage.sql.exec(
+        `UPDATE ${EXACT_REVIEW_QUEUE_DELIVERY_TABLE}
+            SET scheduled_disposition_json = ?
+          WHERE delivery_id = ? AND authenticated_body_fingerprint = ?
+        RETURNING delivery_id`,
+        dispositionJson,
+        deliveryId,
+        authenticatedBodyFingerprint,
+      ),
+    );
+    if (updated.length !== 1) {
+      throw new Error("scheduled exact-review disposition receipt is unavailable");
+    }
+    return dispositionJson;
   }
 
   private legacyReceiptTimestamp(receivedAt: number) {
@@ -15207,6 +15375,55 @@ function exactReviewPendingSoftLimit(env) {
   );
 }
 
+function exactReviewScheduledDispositionFromJson(
+  value: string,
+): ExactReviewScheduledDisposition | null {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    const body = objectValue(parsed);
+    let disposition: ExactReviewScheduledDisposition | null = null;
+    if (
+      body.ok === true &&
+      body.queued === true &&
+      typeof body.item_key === "string" &&
+      /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+#[1-9]\d*$/.test(body.item_key) &&
+      Number.isSafeInteger(body.superseded_publications) &&
+      Number(body.superseded_publications) >= 0
+    ) {
+      disposition = {
+        ok: true,
+        queued: true,
+        item_key: body.item_key,
+        superseded_publications: Number(body.superseded_publications),
+      };
+    } else if (
+      body.ok === true &&
+      body.deduped === true &&
+      typeof body.item_key === "string" &&
+      /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+#[1-9]\d*$/.test(body.item_key) &&
+      body.dedupe_scope === "scheduled_queue_item" &&
+      body.dedupe_reason === "item_already_pending_or_active"
+    ) {
+      disposition = {
+        ok: true,
+        deduped: true,
+        item_key: body.item_key,
+        dedupe_scope: "scheduled_queue_item",
+        dedupe_reason: "item_already_pending_or_active",
+      };
+    } else if (
+      body.ok === true &&
+      body.shed === true &&
+      (body.reason === "backpressure" || body.reason === "scheduled_rate")
+    ) {
+      disposition = { ok: true, shed: true, reason: body.reason };
+    }
+    return disposition && stableJson(parsed) === stableJson(disposition) ? disposition : null;
+  } catch {
+    return null;
+  }
+}
+
 function exactReviewScheduledFeedKey(lane: ExactReviewScheduledBucket) {
   return `${EXACT_REVIEW_SCHEDULED_FEED_KEY_PREFIX}:${lane}`;
 }
@@ -16759,9 +16976,9 @@ function snapshotErrorResponse(error: unknown) {
   return json({ error: "snapshot_request_failed", snapshotStoreAvailable: true }, 500);
 }
 
-function json(value, status = 200) {
+function jsonText(value: string, status = 200) {
   return cors(
-    new Response(JSON.stringify(value, null, 2), {
+    new Response(value, {
       status,
       headers: {
         "content-type": "application/json; charset=utf-8",
@@ -16769,6 +16986,10 @@ function json(value, status = 200) {
       },
     }),
   );
+}
+
+function json(value, status = 200) {
+  return jsonText(JSON.stringify(value, null, 2), status);
 }
 
 export function hostedTargetProbeResponse(admission: HostedTargetAdmission) {

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -7,6 +7,7 @@ import {
 import { legacyCommandCommentId } from "../src/repair/command-ack-convergence.ts";
 import { directReReviewIntake } from "../src/repair/direct-re-review-admission.ts";
 import { isExactReviewCloseGuardLabel } from "../src/repair/exact-review-guard-labels.ts";
+import { sha256Hex } from "./exact-review-direct-publication.ts";
 import { exactReviewSourceRevisionMaterial } from "./exact-review-source-revision.ts";
 import {
   GITHUB_ETAG_CACHE_MAX_BODY_BYTES,
@@ -46,6 +47,7 @@ import { TRIAGE_ROUTING_GROUPS, triageRoutingGroupsForLabels } from "./triage-ro
 import {
   EXACT_REVIEW_QUEUE_NAME,
   EXACT_REVIEW_RECONCILE_CONCURRENCY,
+  EXACT_REVIEW_AUTHENTICATED_BODY_FINGERPRINT_HEADER,
   HOSTED_TARGET_ELIGIBILITY_HEADER,
   exactReviewActionsReadToken,
   exactReviewClaimedRuns,
@@ -1786,6 +1788,7 @@ const PUBLIC_STATUS_TEXT_VALUES = new Set([
   "queue_handoff_stalled",
   "queue_handoff_degraded",
   "queue_handoff_unavailable",
+  "scheduled_disposition_v1",
   "publication_critical",
   "publication_degraded",
   "publication_health_unavailable",
@@ -1804,6 +1807,7 @@ const PUBLIC_STATUS_TEXT_VALUES = new Set([
 const PUBLIC_STATUS_TEXT_FIELDS = new Set([
   "conclusion",
   "completion_source",
+  "enqueue_replay",
   "mode",
   "outcome",
   "reason",
@@ -5109,11 +5113,17 @@ async function exactReviewQueueFetch(queue: DurableObjectStub, path: string, req
   const traceId = newExactReviewQueueTraceId();
   const endpoint = exactReviewQueueEndpointTemplate(path);
   const preparedHostedTarget = request?.headers.get(HOSTED_TARGET_ELIGIBILITY_HEADER);
+  const authenticatedBodyFingerprint = request?.headers.get(
+    EXACT_REVIEW_AUTHENTICATED_BODY_FINGERPRINT_HEADER,
+  );
   try {
     const headers = new Headers(body ? { "content-type": "application/json" } : undefined);
     headers.set(EXACT_REVIEW_QUEUE_TRACE_HEADER, traceId);
     if (preparedHostedTarget) {
       headers.set(HOSTED_TARGET_ELIGIBILITY_HEADER, preparedHostedTarget);
+    }
+    if (authenticatedBodyFingerprint) {
+      headers.set(EXACT_REVIEW_AUTHENTICATED_BODY_FINGERPRINT_HEADER, authenticatedBodyFingerprint);
     }
     const response = await queue.fetch(
       new Request(`https://clawsweeper-exact-review-queue${path}`, {
@@ -5486,10 +5496,13 @@ export function publicExactReviewQueueProjection(
   const sourcePressure = objectValue(source.pressure);
   const projectedPressure = publicExactReviewPressure(sourcePressure);
   const projectedReviewFailureHealth = publicExactReviewFailureHealth(source.review_failure_health);
+  const scheduledFeed = objectValue(source.scheduled_feed);
   const scheduledTargetRate = publicQueueCount(
-    objectValue(source.scheduled_feed).target_rate_per_hour,
+    scheduledFeed.target_rate_per_hour,
     PUBLIC_SCHEDULED_FEED_RATE_LIMIT,
   );
+  const scheduledEnqueueReplay =
+    scheduledFeed.enqueue_replay === "scheduled_disposition_v1" ? "scheduled_disposition_v1" : null;
   const requiredCounts = [
     source.pending,
     source.ready_pending,
@@ -5590,8 +5603,11 @@ export function publicExactReviewQueueProjection(
     pressure: projectedPressure,
     review_failure_health: projectedReviewFailureHealth.value,
     scheduled_feed:
-      scheduledTargetRate !== null && scheduledTargetRate > 0
-        ? { target_rate_per_hour: scheduledTargetRate }
+      scheduledTargetRate !== null && scheduledTargetRate > 0 && scheduledEnqueueReplay
+        ? {
+            target_rate_per_hour: scheduledTargetRate,
+            enqueue_replay: scheduledEnqueueReplay,
+          }
         : null,
     lanes: {
       review: projectedReviewLane.value,
@@ -6337,15 +6353,22 @@ async function authenticatedHostedTargetQueueRequest(request, env, path: string)
       });
     }
   }
+  const headers = new Headers({
+    "content-type": "application/json",
+    [HOSTED_TARGET_ELIGIBILITY_HEADER]: targetRepo,
+  });
+  if (path === "/enqueue") {
+    headers.set(
+      EXACT_REVIEW_AUTHENTICATED_BODY_FINGERPRINT_HEADER,
+      await sha256Hex(new TextEncoder().encode(body)),
+    );
+  }
   return exactReviewQueueRequest(
     env,
     path,
     new Request(`https://clawsweeper-exact-review-queue${path}`, {
       method: "POST",
-      headers: {
-        "content-type": "application/json",
-        [HOSTED_TARGET_ELIGIBILITY_HEADER]: targetRepo,
-      },
+      headers,
       body,
     }),
   );

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -576,6 +576,9 @@ observed planning average of 30 requests per completed review.
 The producer probes that field before its first enqueue and fails closed while
 an older Worker is still deployed, preventing a workflow-first rollout from
 bypassing the rate limiter.
+Scheduled review ingress retries transient transport and HTTP 5xx failures with
+the same signed delivery bytes, but fails closed when a retry cannot recover the
+original admission disposition; publication post-effects remain single-attempt.
 
 Normal fanout ordinarily divides one live queue-advertised candidate-capacity
 budget across the selected repositories; it does not grant 50 candidates to

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -576,9 +576,11 @@ observed planning average of 30 requests per completed review.
 The producer probes that field before its first enqueue and fails closed while
 an older Worker is still deployed, preventing a workflow-first rollout from
 bypassing the rate limiter.
-Scheduled review ingress retries transient transport and HTTP 5xx failures with
-the same signed delivery bytes, but fails closed when a retry cannot recover the
-original admission disposition; publication post-effects remain single-attempt.
+Scheduled review ingress requires
+`scheduled_feed.enqueue_replay: scheduled_disposition_v1` before retrying
+transient transport or HTTP 5xx failures with the same signed delivery bytes;
+legacy ambiguous receipts fail closed, and publication post-effects remain
+single-attempt.
 
 Normal fanout ordinarily divides one live queue-advertised candidate-capacity
 budget across the selected repositories; it does not grant 50 candidates to

--- a/src/repair/exact-review-batch-queue-client.ts
+++ b/src/repair/exact-review-batch-queue-client.ts
@@ -269,6 +269,10 @@ export class ExactReviewBatchQueueClient implements ExactReviewBatchQueue {
     return this.postUrl(POST_EFFECT_ROUTES[route], payload);
   }
 
+  async enqueueScheduledReview(payload: string) {
+    return this.postUrl(POST_EFFECT_ROUTES.enqueue, payload, Date.now() + RETRY_DEADLINE_MS, true);
+  }
+
   async reconcilePublications(input: { apply: boolean; maxItems: number }) {
     const response = await this.postUrl("/internal/exact-review/publications/reconcile", {
       apply: input.apply,
@@ -429,6 +433,7 @@ export class ExactReviewBatchQueueClient implements ExactReviewBatchQueue {
     path: string,
     payload: Record<string, unknown> | string,
     retryDeadline?: number,
+    rejectUnscopedRetriedDedupe = false,
   ): Promise<Record<string, unknown>> {
     // Serialize and sign once: receipt/delivery identity must survive ambiguous failures.
     const body = typeof payload === "string" ? payload : JSON.stringify(payload);
@@ -493,7 +498,16 @@ export class ExactReviewBatchQueueClient implements ExactReviewBatchQueue {
         } catch {
           throw new Error(`Batch queue ${path} returned invalid JSON (HTTP ${response!.status})`);
         }
-        return objectValue(parsed);
+        const result = objectValue(parsed);
+        if (
+          rejectUnscopedRetriedDedupe &&
+          attempt > 1 &&
+          result.deduped === true &&
+          result.dedupe_scope !== "scheduled_queue_item"
+        ) {
+          throw new Error(`Batch queue ${path} returned an ambiguous dedupe after retry`);
+        }
+        return result;
       }
       if (attempt === maxAttempts) throw failure;
       const backoff = Math.floor(1_000 * 2 ** (attempt - 1) * (0.5 + Math.random() * 0.5));

--- a/src/repair/scheduled-review-enqueue.ts
+++ b/src/repair/scheduled-review-enqueue.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-import { createHmac } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
+import { ExactReviewBatchQueueClient } from "./exact-review-batch-queue-client.js";
 import { parseArgs } from "./lib.js";
 
 type ScheduledReviewLane = "hot_intake" | "normal_backfill";
@@ -53,6 +53,11 @@ export async function enqueueScheduledReviewPlan(
   }
   for (const candidate of options.plan.candidates) validateCandidate(candidate, options.targetRepo);
   const queueUrl = options.queueUrl.replace(/\/$/, "");
+  const queueClient = new ExactReviewBatchQueueClient({
+    baseUrl: queueUrl,
+    webhookSecret: options.secret,
+    fetch: fetchImpl,
+  });
   const capabilityResponse = await fetchImpl(`${queueUrl}/api/exact-review-queue`, {
     signal: AbortSignal.timeout(20_000),
   });
@@ -110,22 +115,10 @@ export async function enqueueScheduledReviewPlan(
         sourceUpdatedAt: candidate.updatedAt,
       },
     });
-    const signature = `sha256=${createHmac("sha256", options.secret).update(payload).digest("hex")}`;
     summary.attempted += 1;
-    const response = await fetchImpl(`${queueUrl}/internal/exact-review/enqueue`, {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-clawsweeper-exact-review-signature": signature,
-      },
-      body: payload,
-      signal: AbortSignal.timeout(20_000),
-    });
-    const body = (await response.json().catch(() => null)) as Record<string, unknown> | null;
-    if (!response.ok || !body || body.ok !== true) {
-      throw new Error(
-        `scheduled review queue rejected ${candidate.repo}#${candidate.number}: HTTP ${response.status}`,
-      );
+    const body = await queueClient.enqueueScheduledReview(payload);
+    if (body.ok !== true) {
+      throw new Error(`scheduled review queue rejected ${candidate.repo}#${candidate.number}`);
     }
     if (body.queued === true) summary.queued += 1;
     else if (body.deduped === true) summary.deduped += 1;

--- a/src/repair/scheduled-review-enqueue.ts
+++ b/src/repair/scheduled-review-enqueue.ts
@@ -69,7 +69,8 @@ export async function enqueueScheduledReviewPlan(
   if (
     !capabilityResponse.ok ||
     !scheduledFeed ||
-    !Number.isFinite(Number(scheduledFeed.target_rate_per_hour))
+    !Number.isFinite(Number(scheduledFeed.target_rate_per_hour)) ||
+    scheduledFeed.enqueue_replay !== "scheduled_disposition_v1"
   ) {
     throw new Error("exact-review queue does not advertise scheduled feed admission");
   }

--- a/test/dashboard-worker-dashboard-status.test.ts
+++ b/test/dashboard-worker-dashboard-status.test.ts
@@ -814,7 +814,11 @@ test("dashboard sanitizes stored status immediately and never renders transport 
       maximum_age_ms: 60_000,
     },
     exact_review_queue: {
-      scheduled_feed: { target_rate_per_hour: 300, token_balance: marker },
+      scheduled_feed: {
+        target_rate_per_hour: 300,
+        enqueue_replay: "scheduled_disposition_v1",
+        token_balance: marker,
+      },
     },
   });
   const withCache = await run(cached);
@@ -824,6 +828,7 @@ test("dashboard sanitizes stored status immediately and never renders transport 
   assert.match(withCache.writes[0], /telemetry_unavailable/);
   assert.deepEqual(JSON.parse(withCache.writes[0]).exact_review_queue.scheduled_feed, {
     target_rate_per_hour: 300,
+    enqueue_replay: "scheduled_disposition_v1",
   });
   const persisted = JSON.parse(withCache.writes[0]);
   assert.equal(persisted.freshness.state, "stale");

--- a/test/dashboard-worker-queue-policy.test.ts
+++ b/test/dashboard-worker-queue-policy.test.ts
@@ -3539,6 +3539,7 @@ test("scheduled review feed is lane-paced and exposes its configured target", as
   assert.equal(stats.shed_since_reset, 2);
   assert.deepEqual(stats.scheduled_feed, {
     target_rate_per_hour: 2,
+    enqueue_replay: "scheduled_disposition_v1",
     burst: 2,
     token_balance: 0,
     lanes: {

--- a/test/dashboard-worker-status-privacy.test.ts
+++ b/test/dashboard-worker-status-privacy.test.ts
@@ -1324,6 +1324,7 @@ test("public queue projection retains only closed operational aggregates", () =>
     },
     scheduled_feed: {
       target_rate_per_hour: 300,
+      enqueue_replay: "scheduled_disposition_v1",
       burst: 50,
       token_balance: 42,
       throttle_source: sentinel,
@@ -1467,7 +1468,10 @@ test("public queue projection retains only closed operational aggregates", () =>
       workflow: 1,
     },
   });
-  assert.deepEqual(projected.scheduled_feed, { target_rate_per_hour: 300 });
+  assert.deepEqual(projected.scheduled_feed, {
+    target_rate_per_hour: 300,
+    enqueue_replay: "scheduled_disposition_v1",
+  });
   assert.deepEqual(projected.bay_projection.activity, {
     complete: false,
     queue_stages: null,
@@ -1519,6 +1523,7 @@ test("public queue projection retains only closed operational aggregates", () =>
   );
   assert.deepEqual(statusProjected.exact_review_queue.scheduled_feed, {
     target_rate_per_hour: 300,
+    enqueue_replay: "scheduled_disposition_v1",
   });
   assert.deepEqual(statusProjected.exact_review_queue.handoff_health.phases, {
     pending: { count: 7, oldest_at: null, oldest_age_seconds: null },
@@ -1552,6 +1557,8 @@ test("public queue projection retains only closed operational aggregates", () =>
     { target_rate_per_hour: 1.5 },
     { target_rate_per_hour: 2_001 },
     { target_rate_per_hour: "300" },
+    { target_rate_per_hour: 300 },
+    { target_rate_per_hour: 300, enqueue_replay: "future_contract" },
   ]) {
     assert.equal(
       publicExactReviewQueueProjection({ ...source, scheduled_feed }).scheduled_feed,

--- a/test/repair/scheduled-review-enqueue.test.ts
+++ b/test/repair/scheduled-review-enqueue.test.ts
@@ -1,9 +1,49 @@
 import assert from "node:assert/strict";
-import { createHmac } from "node:crypto";
+import { createHash, createHmac } from "node:crypto";
 import test from "node:test";
 
 import { enqueueScheduledReviewPlan } from "../../dist/repair/scheduled-review-enqueue.js";
 import { selectDueCandidates } from "../../dist/scheduler-policy.js";
+import {
+  buildExactReviewQueueRequest,
+  ExactReviewQueue,
+  MemoryDurableNamespace,
+  MemoryDurableStorage,
+  worker,
+} from "../dashboard-worker-harness.ts";
+
+function scheduledFeedCapability(targetRatePerHour: number) {
+  return {
+    scheduled_feed: {
+      target_rate_per_hour: targetRatePerHour,
+      enqueue_replay: "scheduled_disposition_v1",
+    },
+  };
+}
+
+const scheduledReplaySecret = "scheduled-replay-test-secret";
+
+function scheduledCandidate(number: number) {
+  return {
+    repo: "openclaw/gogcli",
+    number,
+    kind: "issue" as const,
+    updatedAt: "2026-09-04T00:00:00Z",
+  };
+}
+
+function signedScheduledWorkerRequest(body: string) {
+  return new Request("https://clawsweeper.openclaw.ai/internal/exact-review/enqueue", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-clawsweeper-exact-review-signature": `sha256=${createHmac("sha256", scheduledReplaySecret)
+        .update(body)
+        .digest("hex")}`,
+    },
+    body,
+  });
+}
 
 test("coverage-untracked plans reach queue admission before canonical refreshes", async () => {
   const repo = "openclaw/openclaw";
@@ -45,7 +85,7 @@ test("coverage-untracked plans reach queue admission before canonical refreshes"
     deliveryPrefix: "scheduled:coverage:1",
     fetchImpl: async (_input, init) => {
       if (!init?.method) {
-        return Response.json({ scheduled_feed: { target_rate_per_hour: 600 } });
+        return Response.json(scheduledFeedCapability(600));
       }
       const body = JSON.parse(String(init.body)) as { decision: { itemNumber: number } };
       queuedNumbers.push(body.decision.itemNumber);
@@ -86,7 +126,7 @@ test("scheduled review enqueue reports the full selection-to-queue funnel and st
     deliveryPrefix: "scheduled:100:1",
     fetchImpl: async (_input, init) => {
       if (!init?.method) {
-        return Response.json({ scheduled_feed: { target_rate_per_hour: 200 } });
+        return Response.json(scheduledFeedCapability(200));
       }
       const body = String(init?.body || "");
       const headers = (init?.headers ?? {}) as Record<string, string>;
@@ -148,7 +188,7 @@ for (const failure of ["HTTP 500", "TimeoutError"] as const) {
       deliveryPrefix: "scheduled:retry:1",
       fetchImpl: async (_input, init) => {
         if (!init?.method) {
-          return Response.json({ scheduled_feed: { target_rate_per_hour: 300 } });
+          return Response.json(scheduledFeedCapability(300));
         }
         const headers = init.headers as Record<string, string>;
         requests.push({
@@ -178,6 +218,130 @@ for (const failure of ["HTTP 500", "TimeoutError"] as const) {
   });
 }
 
+for (const scenario of [
+  {
+    name: "queued",
+    env: {},
+    prepare: async (_queue: ExactReviewQueue) => {},
+    expectedBody: {
+      ok: true,
+      queued: true,
+      item_key: "openclaw/gogcli#42",
+      superseded_publications: 0,
+    },
+    summaryField: "queued",
+  },
+  {
+    name: "scheduled item dedupe",
+    env: {},
+    prepare: async (queue: ExactReviewQueue) => {
+      await queue.fetch(
+        buildExactReviewQueueRequest(
+          "scheduled-replay-existing",
+          42,
+          "opened",
+          "issue",
+          "openclaw/gogcli",
+        ),
+      );
+    },
+    expectedBody: {
+      ok: true,
+      deduped: true,
+      item_key: "openclaw/gogcli#42",
+      dedupe_scope: "scheduled_queue_item",
+      dedupe_reason: "item_already_pending_or_active",
+    },
+    summaryField: "deduped",
+  },
+  {
+    name: "backpressure shed",
+    env: { EXACT_REVIEW_PENDING_SOFT_LIMIT: "1" },
+    prepare: async (queue: ExactReviewQueue) => {
+      await queue.fetch(
+        buildExactReviewQueueRequest(
+          "scheduled-replay-backpressure",
+          41,
+          "opened",
+          "issue",
+          "openclaw/gogcli",
+        ),
+      );
+    },
+    expectedBody: { ok: true, shed: true, reason: "backpressure" },
+    summaryField: "backpressured",
+  },
+  {
+    name: "scheduled rate shed",
+    env: {
+      EXACT_REVIEW_TARGET_RATE_PER_HOUR: "2",
+      EXACT_REVIEW_TARGET_BURST: "2",
+    },
+    prepare: async (queue: ExactReviewQueue) => {
+      await queue.fetch(
+        buildExactReviewQueueRequest(
+          "scheduled-replay-rate",
+          41,
+          "scheduled_normal_backfill",
+          "issue",
+          "openclaw/gogcli",
+        ),
+      );
+    },
+    expectedBody: { ok: true, shed: true, reason: "scheduled_rate" },
+    summaryField: "rateLimited",
+  },
+] as const) {
+  test(`scheduled review response-loss retry replays the exact ${scenario.name} disposition`, async () => {
+    const storage = new MemoryDurableStorage();
+    const queue = new ExactReviewQueue({ storage }, scenario.env);
+    await scenario.prepare(queue);
+    const env = {
+      CLAWSWEEPER_WEBHOOK_SECRET: scheduledReplaySecret,
+      EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+    };
+    const requests: Array<{ body: string; signature: string }> = [];
+    const responseBodies: string[] = [];
+    const fetchImpl: typeof fetch = async (input, init) => {
+      const request = new Request(input, init);
+      if (request.method === "POST") {
+        requests.push({
+          body: await request.clone().text(),
+          signature: request.headers.get("x-clawsweeper-exact-review-signature") || "",
+        });
+      }
+      const response = await worker.fetch(request, env);
+      if (request.method !== "POST") return response;
+      responseBodies.push(await response.clone().text());
+      if (responseBodies.length === 1) {
+        throw new DOMException("synthetic response loss", "TimeoutError");
+      }
+      return response;
+    };
+
+    const summary = await enqueueScheduledReviewPlan({
+      plan: { candidates: [scheduledCandidate(42)] },
+      lane: "normal_backfill",
+      targetRepo: "openclaw/gogcli",
+      targetBranch: "main",
+      queueUrl: "https://clawsweeper.openclaw.ai",
+      secret: scheduledReplaySecret,
+      deliveryPrefix: `scheduled:response-loss:${scenario.summaryField}`,
+      fetchImpl,
+    });
+
+    assert.equal(summary.attempted, 1);
+    assert.equal(summary[scenario.summaryField], 1);
+    assert.equal(requests.length, 2);
+    assert.equal(requests[0]!.body, requests[1]!.body);
+    assert.equal(requests[0]!.signature, requests[1]!.signature);
+    assert.equal(responseBodies[0], responseBodies[1]);
+    assert.deepEqual(JSON.parse(responseBodies[1]!), scenario.expectedBody);
+    const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+    assert.equal(stats.lanes.review.shed_since_reset, scenario.expectedBody.shed === true ? 1 : 0);
+  });
+}
+
 test("scheduled review enqueue fails closed when a retry loses the original disposition", async () => {
   const requests: Array<{ body: string; signature: string }> = [];
   await assert.rejects(
@@ -200,7 +364,7 @@ test("scheduled review enqueue fails closed when a retry loses the original disp
       deliveryPrefix: "scheduled:retry:1",
       fetchImpl: async (_input, init) => {
         if (!init?.method) {
-          return Response.json({ scheduled_feed: { target_rate_per_hour: 300 } });
+          return Response.json(scheduledFeedCapability(300));
         }
         const headers = init.headers as Record<string, string>;
         requests.push({
@@ -242,7 +406,7 @@ test("scheduled review enqueue accepts a scoped item dedupe after retry", async 
     deliveryPrefix: "scheduled:retry:1",
     fetchImpl: async (_input, init) => {
       if (!init?.method) {
-        return Response.json({ scheduled_feed: { target_rate_per_hour: 300 } });
+        return Response.json(scheduledFeedCapability(300));
       }
       const headers = init.headers as Record<string, string>;
       requests.push({
@@ -274,6 +438,225 @@ test("scheduled review enqueue accepts a scoped item dedupe after retry", async 
   );
 });
 
+test("scheduled review delivery IDs conflict when authenticated bytes differ", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  const env = {
+    CLAWSWEEPER_WEBHOOK_SECRET: scheduledReplaySecret,
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+  };
+  const body = JSON.stringify({
+    delivery_id: "scheduled:byte-conflict:42",
+    decision: {
+      targetRepo: "openclaw/gogcli",
+      targetBranch: "main",
+      itemNumber: 42,
+      itemKind: "issue",
+      sourceEvent: "issues",
+      sourceAction: "scheduled_normal_backfill",
+      supersedesInProgress: false,
+      sourceUpdatedAt: "2026-09-04T00:00:00Z",
+    },
+  });
+  const first = await worker.fetch(signedScheduledWorkerRequest(body), env);
+  assert.equal(first.status, 202);
+  assert.equal((await first.json()).queued, true);
+
+  const conflict = await worker.fetch(signedScheduledWorkerRequest(`${body} `), env);
+  assert.equal(conflict.status, 409);
+  assert.deepEqual(await conflict.json(), { error: "exact_review_delivery_conflict" });
+
+  const receipt = Array.from(
+    storage.sql.exec(
+      `SELECT authenticated_body_fingerprint, scheduled_disposition_json
+         FROM exact_review_queue_deliveries
+        WHERE delivery_id = ?`,
+      "scheduled:byte-conflict:42",
+    ),
+  )[0] as {
+    authenticated_body_fingerprint: string;
+    scheduled_disposition_json: string;
+  };
+  assert.equal(
+    receipt.authenticated_body_fingerprint,
+    createHash("sha256").update(body).digest("hex"),
+  );
+  assert.equal(receipt.scheduled_disposition_json.includes(scheduledReplaySecret), false);
+  assert.equal(receipt.scheduled_disposition_json.includes("sourceUpdatedAt"), false);
+});
+
+test("scheduled disposition persistence rolls back with queue admission", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  const env = {
+    CLAWSWEEPER_WEBHOOK_SECRET: scheduledReplaySecret,
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+  };
+  await queue.fetch(new Request("https://queue/stats"));
+  storage.failNextSql(/SET scheduled_disposition_json = \?/);
+  const body = JSON.stringify({
+    delivery_id: "scheduled:atomic:42",
+    decision: {
+      targetRepo: "openclaw/gogcli",
+      targetBranch: "main",
+      itemNumber: 42,
+      itemKind: "issue",
+      sourceEvent: "issues",
+      sourceAction: "scheduled_normal_backfill",
+      supersedesInProgress: false,
+      sourceUpdatedAt: "2026-09-04T00:00:00Z",
+    },
+  });
+
+  const failed = await worker.fetch(signedScheduledWorkerRequest(body), env);
+  assert.equal(failed.status, 500);
+  let stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(stats.pending, 0);
+  assert.equal(stats.delivery_receipts, 0);
+  assert.equal(stats.lanes.review.enqueued_total, 0);
+
+  const accepted = await worker.fetch(signedScheduledWorkerRequest(body), env);
+  assert.equal(accepted.status, 202);
+  assert.equal((await accepted.json()).queued, true);
+  stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(stats.pending, 1);
+  assert.equal(stats.delivery_receipts, 1);
+  assert.equal(stats.lanes.review.enqueued_total, 1);
+});
+
+test("delivery receipt upgrade leaves legacy rows ambiguous without a schema bump", async () => {
+  const storage = new MemoryDurableStorage();
+  storage.sql.exec(
+    `CREATE TABLE exact_review_queue_deliveries (
+       delivery_id TEXT PRIMARY KEY,
+       received_at INTEGER NOT NULL
+     ) STRICT`,
+  );
+  storage.sql.exec(
+    `INSERT INTO exact_review_queue_deliveries (delivery_id, received_at) VALUES (?, ?)`,
+    "scheduled:legacy-upgrade:0:42",
+    Date.now(),
+  );
+  const queue = new ExactReviewQueue({ storage }, {});
+  const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(stats.storage_schema_version, 1);
+  assert.deepEqual(
+    Array.from(
+      storage.sql.exec(
+        "SELECT name FROM pragma_table_info('exact_review_queue_deliveries') ORDER BY cid",
+      ),
+    ).map((row) => row.name),
+    ["delivery_id", "received_at", "authenticated_body_fingerprint", "scheduled_disposition_json"],
+  );
+  const body = JSON.stringify({
+    delivery_id: "scheduled:legacy-upgrade:0:42",
+    decision: {
+      targetRepo: "openclaw/gogcli",
+      targetBranch: "main",
+      itemNumber: 42,
+      itemKind: "issue",
+      sourceEvent: "issues",
+      sourceAction: "scheduled_normal_backfill",
+      supersedesInProgress: false,
+    },
+  });
+  const env = {
+    CLAWSWEEPER_WEBHOOK_SECRET: scheduledReplaySecret,
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+  };
+  const response = await worker.fetch(signedScheduledWorkerRequest(body), env);
+  assert.equal(response.status, 202);
+  assert.deepEqual(await response.json(), {
+    ok: true,
+    deduped: true,
+    item_key: "openclaw/gogcli#42",
+  });
+
+  let postAttempt = 0;
+  await assert.rejects(
+    enqueueScheduledReviewPlan({
+      plan: {
+        candidates: [scheduledCandidate(42)],
+      },
+      lane: "normal_backfill",
+      targetRepo: "openclaw/gogcli",
+      targetBranch: "main",
+      queueUrl: "https://queue.example",
+      secret: scheduledReplaySecret,
+      deliveryPrefix: "scheduled:legacy-upgrade",
+      fetchImpl: async (request, init) => {
+        const url = typeof request === "string" ? request : request.url;
+        if (url.endsWith("/api/exact-review-queue")) {
+          return Response.json(scheduledFeedCapability(300));
+        }
+        postAttempt += 1;
+        if (postAttempt === 1) throw new DOMException("request timed out", "TimeoutError");
+        return worker.fetch(new Request(request, init), env);
+      },
+    }),
+    /ambiguous dedupe after retry/,
+  );
+  assert.equal(postAttempt, 2);
+});
+
+test("rollback-era receipts stay ambiguous while prior scheduled receipts still replay", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  const env = {
+    CLAWSWEEPER_WEBHOOK_SECRET: scheduledReplaySecret,
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+  };
+  const originalBody = JSON.stringify({
+    delivery_id: "scheduled:before-rollback:42",
+    decision: {
+      targetRepo: "openclaw/gogcli",
+      targetBranch: "main",
+      itemNumber: 42,
+      itemKind: "issue",
+      sourceEvent: "issues",
+      sourceAction: "scheduled_normal_backfill",
+      supersedesInProgress: false,
+    },
+  });
+  const original = await worker.fetch(signedScheduledWorkerRequest(originalBody), env);
+  const originalResponseText = await original.text();
+  const shadow = structuredClone(
+    storage.rawGet("exact-review-queue") as {
+      deliveries: Record<string, number>;
+      items: Record<string, unknown>;
+    },
+  );
+  shadow.deliveries["scheduled:during-rollback:43"] = Date.now();
+  storage.rawPut("exact-review-queue", shadow);
+
+  const upgradedQueue = new ExactReviewQueue({ storage }, {});
+  const upgradedEnv = {
+    CLAWSWEEPER_WEBHOOK_SECRET: scheduledReplaySecret,
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(upgradedQueue),
+  };
+  const replay = await worker.fetch(signedScheduledWorkerRequest(originalBody), upgradedEnv);
+  assert.equal(await replay.text(), originalResponseText);
+
+  const rollbackBody = JSON.stringify({
+    delivery_id: "scheduled:during-rollback:43",
+    decision: {
+      targetRepo: "openclaw/gogcli",
+      targetBranch: "main",
+      itemNumber: 43,
+      itemKind: "issue",
+      sourceEvent: "issues",
+      sourceAction: "scheduled_normal_backfill",
+      supersedesInProgress: false,
+    },
+  });
+  const ambiguous = await worker.fetch(signedScheduledWorkerRequest(rollbackBody), upgradedEnv);
+  assert.deepEqual(await ambiguous.json(), {
+    ok: true,
+    deduped: true,
+    item_key: "openclaw/gogcli#43",
+  });
+});
+
 test("scheduled review enqueue does not retry HTTP 4xx and preserves request identity", async () => {
   const secret = "scheduled-review-retry-secret";
   const requests: Array<{ body: string; signature: string }> = [];
@@ -297,7 +680,7 @@ test("scheduled review enqueue does not retry HTTP 4xx and preserves request ide
       deliveryPrefix: "scheduled:retry:1",
       fetchImpl: async (_input, init) => {
         if (!init?.method) {
-          return Response.json({ scheduled_feed: { target_rate_per_hour: 300 } });
+          return Response.json(scheduledFeedCapability(300));
         }
         const headers = init.headers as Record<string, string>;
         requests.push({
@@ -339,21 +722,32 @@ test("scheduled review enqueue rejects numeric target branches before queue admi
   );
 });
 
-test("scheduled review enqueue fails closed until the queue advertises pacing", async () => {
-  await assert.rejects(
-    enqueueScheduledReviewPlan({
-      plan: { candidates: [] },
-      lane: "normal_backfill",
-      targetRepo: "openclaw/openclaw",
-      targetBranch: "main",
-      queueUrl: "https://queue.example",
-      secret: "secret",
-      deliveryPrefix: "scheduled:100:1",
-      fetchImpl: async () => Response.json({ lanes: {} }),
-    }),
-    /does not advertise scheduled feed admission/,
-  );
-});
+for (const capability of [
+  { lanes: {} },
+  { scheduled_feed: { target_rate_per_hour: 300 } },
+  {
+    scheduled_feed: {
+      target_rate_per_hour: 300,
+      enqueue_replay: "future_contract",
+    },
+  },
+]) {
+  test("scheduled review enqueue fails closed until the queue advertises replay-safe pacing", async () => {
+    await assert.rejects(
+      enqueueScheduledReviewPlan({
+        plan: { candidates: [] },
+        lane: "normal_backfill",
+        targetRepo: "openclaw/openclaw",
+        targetBranch: "main",
+        queueUrl: "https://queue.example",
+        secret: "secret",
+        deliveryPrefix: "scheduled:100:1",
+        fetchImpl: async () => Response.json(capability),
+      }),
+      /does not advertise scheduled feed admission/,
+    );
+  });
+}
 
 test("scheduled review enqueue rejects cross-repository plan candidates", async () => {
   await assert.rejects(

--- a/test/repair/scheduled-review-enqueue.test.ts
+++ b/test/repair/scheduled-review-enqueue.test.ts
@@ -125,6 +125,202 @@ test("scheduled review enqueue reports the full selection-to-queue funnel and st
   assert.equal(second.decision.supersedesInProgress, false);
 });
 
+for (const failure of ["HTTP 500", "TimeoutError"] as const) {
+  test(`scheduled review enqueue retries ${failure} with one logical attempt and stable identity`, async () => {
+    const secret = "scheduled-review-retry-secret";
+    const requests: Array<{ body: string; signature: string }> = [];
+    const summary = await enqueueScheduledReviewPlan({
+      plan: {
+        candidates: [
+          {
+            repo: "openclaw/openclaw",
+            number: 42,
+            kind: "issue",
+            updatedAt: "2026-09-04T00:00:00Z",
+          },
+        ],
+      },
+      lane: "normal_backfill",
+      targetRepo: "openclaw/openclaw",
+      targetBranch: "main",
+      queueUrl: "https://queue.example",
+      secret,
+      deliveryPrefix: "scheduled:retry:1",
+      fetchImpl: async (_input, init) => {
+        if (!init?.method) {
+          return Response.json({ scheduled_feed: { target_rate_per_hour: 300 } });
+        }
+        const headers = init.headers as Record<string, string>;
+        requests.push({
+          body: String(init.body),
+          signature: String(headers["x-clawsweeper-exact-review-signature"]),
+        });
+        if (requests.length === 1) {
+          if (failure === "HTTP 500") {
+            return Response.json({ error: "exact_review_queue_unavailable" }, { status: 500 });
+          }
+          throw new DOMException("synthetic timeout", "TimeoutError");
+        }
+        return Response.json({ ok: true, queued: true }, { status: 202 });
+      },
+    });
+
+    assert.equal(summary.attempted, 1);
+    assert.equal(summary.queued, 1);
+    assert.equal(requests.length, 2);
+    assert.equal(requests[0]!.body, requests[1]!.body);
+    assert.equal(requests[0]!.signature, requests[1]!.signature);
+    assert.equal(
+      requests[0]!.signature,
+      `sha256=${createHmac("sha256", secret).update(requests[0]!.body).digest("hex")}`,
+    );
+    assert.equal(JSON.parse(requests[0]!.body).delivery_id, "scheduled:retry:1:0:42");
+  });
+}
+
+test("scheduled review enqueue fails closed when a retry loses the original disposition", async () => {
+  const requests: Array<{ body: string; signature: string }> = [];
+  await assert.rejects(
+    enqueueScheduledReviewPlan({
+      plan: {
+        candidates: [
+          {
+            repo: "openclaw/openclaw",
+            number: 42,
+            kind: "issue",
+            updatedAt: "2026-09-04T00:00:00Z",
+          },
+        ],
+      },
+      lane: "normal_backfill",
+      targetRepo: "openclaw/openclaw",
+      targetBranch: "main",
+      queueUrl: "https://queue.example",
+      secret: "scheduled-review-retry-secret",
+      deliveryPrefix: "scheduled:retry:1",
+      fetchImpl: async (_input, init) => {
+        if (!init?.method) {
+          return Response.json({ scheduled_feed: { target_rate_per_hour: 300 } });
+        }
+        const headers = init.headers as Record<string, string>;
+        requests.push({
+          body: String(init.body),
+          signature: String(headers["x-clawsweeper-exact-review-signature"]),
+        });
+        return requests.length === 1
+          ? Response.json({ error: "exact_review_queue_unavailable" }, { status: 500 })
+          : Response.json({ ok: true, deduped: true }, { status: 202 });
+      },
+    }),
+    /ambiguous dedupe after retry/,
+  );
+
+  assert.equal(requests.length, 2);
+  assert.equal(requests[0]!.body, requests[1]!.body);
+  assert.equal(requests[0]!.signature, requests[1]!.signature);
+});
+
+test("scheduled review enqueue accepts a scoped item dedupe after retry", async () => {
+  const secret = "scheduled-review-retry-secret";
+  const requests: Array<{ body: string; signature: string }> = [];
+  const summary = await enqueueScheduledReviewPlan({
+    plan: {
+      candidates: [
+        {
+          repo: "openclaw/openclaw",
+          number: 42,
+          kind: "issue",
+          updatedAt: "2026-09-04T00:00:00Z",
+        },
+      ],
+    },
+    lane: "normal_backfill",
+    targetRepo: "openclaw/openclaw",
+    targetBranch: "main",
+    queueUrl: "https://queue.example",
+    secret,
+    deliveryPrefix: "scheduled:retry:1",
+    fetchImpl: async (_input, init) => {
+      if (!init?.method) {
+        return Response.json({ scheduled_feed: { target_rate_per_hour: 300 } });
+      }
+      const headers = init.headers as Record<string, string>;
+      requests.push({
+        body: String(init.body),
+        signature: String(headers["x-clawsweeper-exact-review-signature"]),
+      });
+      return requests.length === 1
+        ? Response.json({ error: "exact_review_queue_unavailable" }, { status: 500 })
+        : Response.json(
+            {
+              ok: true,
+              deduped: true,
+              dedupe_scope: "scheduled_queue_item",
+              dedupe_reason: "item_already_pending_or_active",
+            },
+            { status: 202 },
+          );
+    },
+  });
+
+  assert.equal(summary.attempted, 1);
+  assert.equal(summary.deduped, 1);
+  assert.equal(requests.length, 2);
+  assert.equal(requests[0]!.body, requests[1]!.body);
+  assert.equal(requests[0]!.signature, requests[1]!.signature);
+  assert.equal(
+    requests[0]!.signature,
+    `sha256=${createHmac("sha256", secret).update(requests[0]!.body).digest("hex")}`,
+  );
+});
+
+test("scheduled review enqueue does not retry HTTP 4xx and preserves request identity", async () => {
+  const secret = "scheduled-review-retry-secret";
+  const requests: Array<{ body: string; signature: string }> = [];
+  await assert.rejects(
+    enqueueScheduledReviewPlan({
+      plan: {
+        candidates: [
+          {
+            repo: "openclaw/openclaw",
+            number: 42,
+            kind: "issue",
+            updatedAt: "2026-09-04T00:00:00Z",
+          },
+        ],
+      },
+      lane: "normal_backfill",
+      targetRepo: "openclaw/openclaw",
+      targetBranch: "main",
+      queueUrl: "https://queue.example",
+      secret,
+      deliveryPrefix: "scheduled:retry:1",
+      fetchImpl: async (_input, init) => {
+        if (!init?.method) {
+          return Response.json({ scheduled_feed: { target_rate_per_hour: 300 } });
+        }
+        const headers = init.headers as Record<string, string>;
+        requests.push({
+          body: String(init.body),
+          signature: String(headers["x-clawsweeper-exact-review-signature"]),
+        });
+        return Response.json({ error: "exact_review_conflict" }, { status: 409 });
+      },
+    }),
+    {
+      message:
+        "Batch queue /internal/exact-review/enqueue failed (HTTP 409): exact_review_conflict",
+    },
+  );
+
+  assert.equal(requests.length, 1);
+  assert.equal(
+    requests[0]!.signature,
+    `sha256=${createHmac("sha256", secret).update(requests[0]!.body).digest("hex")}`,
+  );
+  assert.equal(JSON.parse(requests[0]!.body).delivery_id, "scheduled:retry:1:0:42");
+});
+
 test("scheduled review enqueue rejects numeric target branches before queue admission", async () => {
   await assert.rejects(
     enqueueScheduledReviewPlan({


### PR DESCRIPTION
Related: #1372

## What Problem This Solves

Fixes an issue where scheduled review enqueue could commit in the Worker but lose the HTTP response, causing the producer's retry to receive an ambiguous delivery receipt and abort the plan even though admission had already happened.

## Why This Change Was Made

The Worker now fingerprints the exact authenticated scheduled-enqueue bytes and atomically stores a closed queued, scheduled-item-deduped, backpressure-shed, or scheduled-rate-shed disposition with the delivery receipt. A matching delivery ID and fingerprint replays the exact stored response; different authenticated bytes return HTTP 409; legacy receipts without a fingerprint remain ambiguous and fail closed in the producer.

The public queue projection advertises `scheduled_feed.enqueue_replay: scheduled_disposition_v1`, which the scheduled producer requires before posting. Only scheduled enqueue uses the existing bounded three-attempt transport/5xx retry. Publication and other post-effects remain single-attempt.

No workflow, queue limit, dead-letter, concurrency, or generic delivery-receipt behavior changed. The additive nullable delivery columns do not bump the storage schema version.

## User Impact

Maintainers can expect scheduled review plans to recover from a lost response without duplicating queue admission, shed accounting, or logical attempted counts. Rollout fails closed until the Worker advertises the exact replay capability.

## OpenClaw Bay Impact

OpenClaw Bay is unaffected. The public queue status gains one bounded scheduler capability field, but Bay activity, lifecycle projections, references, and mutation boundaries are unchanged; the strict projector retains only the rate and capability.

## Documentation Impact

Updated `docs/scheduler.md` with the capability gate, byte-stable retry contract, legacy fail-closed behavior, and the explicit publication post-effect exclusion.

## Evidence

- Signed head: `843078fc9b5ad2cd6b68edb8429e1db92107d0a6`
- Base: `934d526e73e032ece6fcd23f374be9895dffd71b`
- Focused scheduled enqueue/Worker/DO tests: 20 passed, 0 failed.
- Focused queue/status/privacy/dashboard tests: 131 passed, 0 failed.
- Shared batch queue client tests: 25 passed, 0 failed.
- Repair and dashboard TypeScript checks, targeted `oxfmt`, `git diff --check`, and privacy scrub: passed.
- Required precommit and committed-range Codex reviews: no actionable regressions. The committed review independently reported 176 focused tests passing with both typechecks.
- Production TypeScript delta: +295/-42, net +253. This implements the durable replay ownership boundary, authenticated-byte conflict invariant, additive storage upgrade, and public rollout capability. Tests: +620/-17, net +603.
- Local `pnpm run check` could not start because pnpm attempted to purge the shared symlinked `node_modules` and aborted without a TTY. The shared install was not mutated; exact-head hosted CI is the canonical full `pnpm run check` gate.
- Exact-head hosted `pnpm check`, sparse repair build, Windows launcher, CodeQL, and hosted-target rejection checks: passed.
- Crabbox run `run_8ce36a7d9fcb`, lease `cbx_8bfc59824297`: passed on the pinned local-container image below. Redacted artifact member `.artifacts/pr1416-local-container-proof.json`; archive SHA-256 `cf8b96d5d9d625b313ac2416e4b5d4e77356df8911b24a7124eb5eb15c898418`.

Accepted review finding:

- **P1 exact delivery replay:** resolved by preserving the exact scheduled disposition with its authenticated-body fingerprint in the same transaction as admission. No generic `delivery_receipt` scope was added.

Rank-up moves:

- Added queue-backed response-loss regressions for queued, scheduled-item-deduped, backpressure-shed, and scheduled-rate-shed outcomes.
- Added the exact Worker replay contract, accepting only a matching authenticated fingerprint and closed persisted disposition.
- Published a redacted exact-head Crabbox local-container trace with the provider, pinned image, lease, limits, replay identity, logical accounting, and one-attempt conflict evidence.

## Real Behavior Proof

**Claim:** A scheduled enqueue whose response is lost after the Worker/DO commit retries with identical signed bytes and receives the exact original disposition; altered bytes conflict without retry.

**Exercised surface:** Built scheduled producer and shared queue client over a loopback HTTPS server, forwarding through the actual Worker fetch adapter into the in-memory Durable Object implementation.

**Scenario:** The fixture destroyed the first TLS connection only after the Worker/DO returned a committed queued response. The producer retried. It then sent one separately signed request with the same delivery ID but one extra byte.

**Command/environment:** Fresh PR checkout in Crabbox local-container run `run_8ce36a7d9fcb`, lease `cbx_8bfc59824297`, with 4 CPUs, 8 GiB memory, Node 24.20.0, and pinned image `node:24-bookworm@sha256:be23f54a88d34e8824c741b19b91064094f92c1c97b194144bfc8b50d67258e2`. The fixture used a generated one-day loopback certificate; TLS verification was disabled only inside the isolated fixture process.

**Observed result:**

```json
{
  "source_head": "843078fc9b5ad2cd6b68edb8429e1db92107d0a6",
  "provider": "local-container",
  "image": "node:24-bookworm@sha256:be23f54a88d34e8824c741b19b91064094f92c1c97b194144bfc8b50d67258e2",
  "limits": {
    "cpus": 4,
    "memory": "8g"
  },
  "node": "v24.20.0",
  "https_fixture": true,
  "committed_response_lost": true,
  "retry_attempts": 2,
  "request_body_sha256_count": 1,
  "unique_retry_signatures": 1,
  "replay_response_bytes_equal": true,
  "summary": {
    "lane": "normal_backfill",
    "offered": 1,
    "attempted": 1,
    "queued": 1,
    "deduped": 0,
    "shed": 0,
    "rateLimited": 0,
    "backpressured": 0,
    "rejected": 0,
    "deferred": 0,
    "ageHours": {
      "p50": null,
      "p90": null,
      "max": null
    }
  },
  "conflict_status": 409,
  "conflict_body": {
    "error": "exact_review_delivery_conflict"
  },
  "conflict_attempts": 1
}
```

**Limits:** This used the real Worker routing and Durable Object adapter with in-memory storage inside an isolated local-container lease, not the production Cloudflare deployment. It did not mutate GitHub, the production queue, or OpenClaw Bay.
