### PR TITLE
fix(bay): preserve stale success when refresh fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 - Preserve canonical repository slugs when reading persisted apply records, including dots, underscores, and repeated or trailing hyphens.
 - Make timeout tests tolerate loaded macOS hosts by isolating checkout timing, synchronizing lock contention, and budgeting snapshot admission fixtures separately from deadline tests.
+- Preserve a valid stale Bay lifecycle snapshot when a background refresh is unavailable or malformed, without extending its original 60-second expiry.
 - Preserve explicit contributor credits in source-PR link comments for both direct replacements and fallback publication after a blocked fork push.
 
 - Reject parent-directory validation symlinks, preserve porcelain paths when selecting repair checks, retain the fast-rebase base SHA for replacement publication, and mark omitted PR comments in close-coverage proof.

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -5615,7 +5615,11 @@ async function publicExactReviewQueueJson(env) {
 }
 
 const DURABLE_LIFECYCLE_BAY_CACHE_SECONDS = 30;
-const durableLifecycleBayRefreshes = new Map<string, Promise<Record<string, unknown>>>();
+type DurableLifecycleBayRefresh = {
+  promise: Promise<Record<string, unknown>>;
+  state: { preserveStaleSuccess: boolean };
+};
+const durableLifecycleBayRefreshes = new Map<string, DurableLifecycleBayRefresh>();
 
 function durableLifecycleBayCacheKey(request: Request, env, bucket: "fresh" | "stale") {
   const scope = publicBayRepositoryScope(verifiedPublicBayRepositories(env));
@@ -5658,30 +5662,54 @@ async function durableLifecycleBayJson(request: Request, env, ctx?: DashboardCon
   const staleKey = durableLifecycleBayCacheKey(request, env, "stale");
   const stale = await cachedDurableLifecycleBay(staleKey);
   if (stale && ctx?.waitUntil) {
-    ctx.waitUntil(refreshDurableLifecycleBay(env, freshKey, staleKey).catch(() => undefined));
+    const preserveStaleSuccess =
+      objectValue(objectValue(stale.durable_lifecycle_bay).collection).state === "complete";
+    ctx.waitUntil(
+      refreshDurableLifecycleBay(env, freshKey, staleKey, preserveStaleSuccess).catch(
+        () => undefined,
+      ),
+    );
     return json(stale);
   }
   return json(await refreshDurableLifecycleBay(env, freshKey, staleKey));
 }
 
-function refreshDurableLifecycleBay(env, freshKey: Request, staleKey: Request) {
+function refreshDurableLifecycleBay(
+  env,
+  freshKey: Request,
+  staleKey: Request,
+  preserveStaleSuccess = false,
+) {
   const key = freshKey.url;
   const pending = durableLifecycleBayRefreshes.get(key);
-  if (pending) return pending;
-  const promise = refreshDurableLifecycleBayCaches(env, freshKey, staleKey);
-  durableLifecycleBayRefreshes.set(key, promise);
+  if (pending) {
+    if (preserveStaleSuccess) pending.state.preserveStaleSuccess = true;
+    return pending.promise;
+  }
+  const state = { preserveStaleSuccess };
+  const promise = refreshDurableLifecycleBayCaches(env, freshKey, staleKey, state);
+  const refresh = { promise, state };
+  durableLifecycleBayRefreshes.set(key, refresh);
   promise
     .finally(() => {
-      if (durableLifecycleBayRefreshes.get(key) === promise)
+      if (durableLifecycleBayRefreshes.get(key) === refresh)
         durableLifecycleBayRefreshes.delete(key);
     })
     .catch(() => undefined);
   return promise;
 }
 
-async function refreshDurableLifecycleBayCaches(env, freshKey: Request, staleKey: Request) {
+async function refreshDurableLifecycleBayCaches(
+  env,
+  freshKey: Request,
+  staleKey: Request,
+  state: { preserveStaleSuccess: boolean },
+) {
   const snapshot = await durableLifecycleBaySnapshot(env);
   const body = { durable_lifecycle_bay: snapshot };
+  if (state.preserveStaleSuccess && objectValue(snapshot.collection).state !== "complete") {
+    return body;
+  }
   const remainingSeconds = Math.floor(
     (Date.parse(snapshot.generated_at) + 60_000 - Date.now()) / 1000,
   );

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -479,10 +479,13 @@ The outer `/api/durable-lifecycle-bay` route caches the sanitized response for
 After expiry it serves a stale copy while coalescing one background refresh per
 scope per isolate, as the status route does. Both cache buckets are capped by
 the original snapshot's 60-second maximum age; neither layer renews
-`generated_at`. Without a background execution context, an expired fresh entry
-is refreshed synchronously. Edge caches are local to each colo, so cross-colo
-misses can still reach the object; its TTL memo absorbs those reads. Bay's
-public field set, freshness contract, and observer-only boundary are unchanged.
+`generated_at`. An unavailable or malformed background refresh leaves an
+existing complete stale snapshot untouched until that original age expires,
+then the route fails closed until a complete refresh replaces both buckets.
+Without a background execution context, an expired fresh entry is refreshed
+synchronously. Edge caches are local to each colo, so cross-colo misses can
+still reach the object; its TTL memo absorbs those reads. Bay's public field
+set, freshness contract, and observer-only boundary are unchanged.
 
 An uncached Bay build still scans every retained projection in the requested
 repositories (all repositories for an unscoped internal request). It has no

--- a/test/dashboard-worker-observability.test.ts
+++ b/test/dashboard-worker-observability.test.ts
@@ -1,3 +1,5 @@
+import type { TestContext } from "node:test";
+
 import {
   assert,
   createHmac,
@@ -3021,3 +3023,128 @@ test("durable lifecycle Bay stale polls share one background refresh and respect
   assert.notEqual(await (await read()).text(), fresh);
   assert.equal(reads, 3, "expired source data cannot be served as stale success");
 });
+
+async function assertFailedBayRefreshPreservesStaleSuccess(
+  t: TestContext,
+  failure: "unavailable" | "malformed",
+) {
+  const startedAt = Date.parse("2026-09-04T00:00:00Z");
+  t.mock.timers.enable({ apis: ["Date"], now: new Date(startedAt) });
+  const originalCaches = globalThis.caches;
+  const values = new MemoryCache();
+  const expires = new Map<string, number>();
+  let writes = 0;
+  Object.defineProperty(globalThis, "caches", {
+    configurable: true,
+    value: {
+      default: {
+        async match(request: Request) {
+          if ((expires.get(request.url) || 0) <= Date.now()) return undefined;
+          return values.match(request);
+        },
+        async put(request: Request, response: Response) {
+          const ttl = Number(
+            /max-age=(\d+)/.exec(response.headers.get("cache-control") || "")?.[1],
+          );
+          expires.set(request.url, Date.now() + ttl * 1000);
+          writes += 1;
+          await values.put(request, response);
+        },
+      },
+    },
+  });
+  t.after(() => Object.defineProperty(globalThis, "caches", { value: originalCaches }));
+
+  const queue = new ExactReviewQueue({ storage: new MemoryDurableStorage() }, {});
+  let reads = 0;
+  let mode: "success" | "unavailable" | "malformed" = "success";
+  let releaseFailedRefresh!: () => void;
+  const failedRefreshGate = new Promise<void>((resolve) => {
+    releaseFailedRefresh = resolve;
+  });
+  const namespace = new MemoryDurableNamespace({
+    async fetch(request: Request) {
+      reads += 1;
+      if (reads === 2) await failedRefreshGate;
+      if (mode === "unavailable") return new Response(null, { status: 503 });
+      if (mode === "malformed") return jsonResponse({ durable_lifecycle_bay: {} });
+      return queue.fetch(request);
+    },
+  });
+  const env = {
+    PUBLIC_BAY_REPOS: "openclaw/openclaw",
+    EXACT_REVIEW_QUEUE: namespace,
+  };
+  const url = "https://failed-refresh.example/api/durable-lifecycle-bay";
+  const background: Promise<unknown>[] = [];
+  const ctx = {
+    waitUntil(promise: Promise<unknown>) {
+      background.push(promise);
+    },
+  };
+  const read = async (context?: typeof ctx) => {
+    const response = await worker.fetch(new Request(url), env, context);
+    return { text: await response.text(), response };
+  };
+
+  const initial = await read();
+  const initialBody = JSON.parse(initial.text);
+  const initialGeneratedAt = initialBody.durable_lifecycle_bay.generated_at;
+  assert.equal(initialBody.durable_lifecycle_bay.collection.state, "complete");
+  assert.equal(reads, 1);
+  assert.equal(writes, 2);
+  const freshKey = [...expires.keys()].find((key) => key.endsWith("/fresh"))!;
+  const staleKey = [...expires.keys()].find((key) => key.endsWith("/stale"))!;
+  const originalFreshExpiry = expires.get(freshKey);
+  const originalStaleExpiry = expires.get(staleKey);
+  assert.equal(originalFreshExpiry, startedAt + 30_000);
+  assert.equal(originalStaleExpiry, startedAt + 60_000);
+
+  t.mock.timers.tick(30_000);
+  mode = failure;
+  const staleBatch = await Promise.all(Array.from({ length: 8 }, () => read(ctx)));
+  assert.ok(staleBatch.every((entry) => entry.text === initial.text));
+  assert.equal(reads, 2, "concurrent stale polls share one failed owner refresh");
+  releaseFailedRefresh();
+  await Promise.all(background.splice(0));
+  assert.equal(writes, 2, "a failed refresh must not replace either cache bucket");
+  assert.equal(expires.get(freshKey), originalFreshExpiry);
+  assert.equal(expires.get(staleKey), originalStaleExpiry);
+
+  t.mock.timers.tick(29_999);
+  const beforeExpiry = await read(ctx);
+  assert.equal(beforeExpiry.text, initial.text);
+  await Promise.all(background.splice(0));
+  assert.equal(expires.get(staleKey), originalStaleExpiry);
+
+  t.mock.timers.tick(2);
+  const afterExpiry = await read();
+  const failedBody = JSON.parse(afterExpiry.text);
+  assert.deepEqual(failedBody.durable_lifecycle_bay.collection, {
+    state: "unknown",
+    reason: failure,
+  });
+  assert.notEqual(failedBody.durable_lifecycle_bay.generated_at, initialGeneratedAt);
+
+  t.mock.timers.tick(30_001);
+  mode = "success";
+  const recovered = await read();
+  const recoveredBody = JSON.parse(recovered.text);
+  const recoveredGeneratedAt = recoveredBody.durable_lifecycle_bay.generated_at;
+  assert.equal(recoveredBody.durable_lifecycle_bay.collection.state, "complete");
+  assert.notEqual(recoveredGeneratedAt, initialGeneratedAt);
+  assert.equal(writes, 6, "failed-close and later success each replace both buckets");
+  for (const key of [freshKey, staleKey]) {
+    const cached = await values.match(new Request(key));
+    assert.ok(cached);
+    assert.equal((await cached.json()).durable_lifecycle_bay.generated_at, recoveredGeneratedAt);
+  }
+  assert.equal(expires.get(freshKey), Date.now() + 30_000);
+  assert.equal(expires.get(staleKey), Date.now() + 60_000);
+}
+
+test("durable lifecycle Bay preserves stale success across unavailable background refresh", (t) =>
+  assertFailedBayRefreshPreservesStaleSuccess(t, "unavailable"));
+
+test("durable lifecycle Bay preserves stale success across malformed background refresh", (t) =>
+  assertFailedBayRefreshPreservesStaleSuccess(t, "malformed"));


### PR DESCRIPTION
Related: https://github.com/openclaw/clawsweeper/pull/1388

## What Problem This Solves

Fixes an issue where OpenClaw Bay could replace a still-valid stale lifecycle success with an unavailable or malformed background refresh. Operators could then receive an early fail-closed response even though the original successful snapshot had not reached its 60-second source-age expiry.

## Why This Change Was Made

The worker now carries the already-validated stale-success fact into the coalesced refresh owner. Any joining request can upgrade preservation, and later callers cannot downgrade it. While preservation is active, incomplete refresh results skip both Cache API writes; a later complete refresh replaces both buckets using its own original `generated_at`.

The change does not add a second stale-cache read or extend the lifetime of the old snapshot.

## User Impact

Bay lifecycle data remains available through its original stale window when a background refresh is unavailable or malformed. It still fails closed at the original 60-second source-age boundary, and a later successful refresh restores normal fresh and stale cache entries.

## OpenClaw Bay Impact

This changes the lifecycle Bay JSON cache path. The exact-head proof exercised the outer Worker through the Durable Object binding and the real Cache API, including fresh reuse, eight-way stale coalescing, unavailable and malformed refreshes, original source-age expiry, fail-closed behavior, later-success recovery, both cache replacements, scope isolation, and Durable Object memo behavior.

Regression provenance: PR #1388 exposed the failed-refresh overwrite behavior during exact-head Worker/DO/Cache qualification.

## Documentation Impact

`docs/live-dashboard.md` is active operator documentation. It now states that failed or malformed background refreshes preserve a valid stale success only until that snapshot's original maximum age, then fail closed. Source of truth: the dashboard worker lifecycle cache implementation; update trigger: changes to lifecycle cache freshness, stale serving, or refresh failure policy.

## Evidence

- Exact head: `08568d120c450d185c86f37c613b76ac467a0998`
- Exact tree: `5c3d383accf449e57758794b0def31b8f7ee33c6`
- Focused lifecycle Bay regression tests: 9/9 passed.
- Targeted formatting, lint, diff check, privacy scan, and committed-head autoreview passed.
- Full static checks, documentation checks, dashboard boundary/strict checks, build-all, lint lanes, and changed coverage passed. Changed coverage: 13/13 tests, 100% lines/functions and 88.61% branches.
- The all-coverage tail of `pnpm run check` emitted two unrelated macOS process-identity failures and later stalled. The isolated failed surface was rerun once and passed 2/2 in 13.8 seconds. Hosted exact-head CI remains the authoritative full-suite gate.
- Diff: production `+36/-8`, tests `+127`, documentation `+7/-4`, changelog `+1`.

## Real Behavior Proof

**Claim:** A valid stale complete success survives unavailable and malformed coalesced refreshes without either cache bucket being overwritten, expires at its original source age, fails closed afterward, and is replaced in both buckets by a later complete refresh.

**Surface:** outer Worker -> Durable Object binding -> `ExactReviewQueue` -> real Cache API.

**Environment:**

- Crabbox provider: `local-container`
- Image/architecture: `ubuntu:26.04`, arm64
- Resources: 4 CPUs, 8 GiB memory
- Lease/run: `cbx_8a268585925f` / `run_49cf5b51888d`
- Wrangler: `4.107.0`
- Lease policy: 20-minute TTL, `stop-after=always`, no hydration
- Read-only source archive SHA-256: `734d1b9cce498913f8ec37237a24f25512ee88c74a654105af16ac03412c5896`
- Pre/post workspace identity: 1,386 entries, manifest SHA-256 `65e7ce7329b4cd41c5af7d2fe15e171650f7da10a3a0f5599ebf94984510271d`

**Observed result:**

- Fresh reads reused byte-identical cached responses without another Durable Object read.
- Each eight-request stale burst coalesced to exactly one Durable Object refresh read.
- Unavailable and malformed refreshes left the stale bytes and `generated_at` unchanged and wrote no fresh replacement.
- Pre-expiry verification completed with 26,547 ms and 25,960 ms remaining, respectively.
- Both original entries expired by at least five seconds before the fail-closed assertions.
- Recovery completed within bounded idempotent attempts; recovery read counts stayed within the number of attempts capable of server work.
- Both fresh and stale buckets matched the recovered bytes. A final outer read matched those bytes without another Durable Object read.
- The Durable Object memo survived 25 sustained writes and performed one projection scan per TTL.
- Proof result: `PASS`; lease teardown confirmed.

**Artifacts:**

- Proof report SHA-256: `7c18693b9e72b0486fb0429bd2d6fb4eb641816b78fb8d50547b7d900d45e8fb`
- Artifact bundle SHA-256: `55a58efc05e0ff649106150c07aeb78484d10c8d713b30e10b89ac201bd94877`

**Limits:**

- Local workerd proof; it does not claim production deployment or cross-colo cache eviction.
- Empty lifecycle datasets validate routing, cache behavior, failure preservation, coalescing, source-age expiry, and recovery.
- Proof-only instrumentation injects unavailable/malformed responses and counts Durable Object reads/scans without changing product tables.
- Two loopback origins select isolated public repository scopes. No credentials, private services, or private data were used.
- Recovery uses idempotent GET attempts with 12-second per-attempt bounds and a 90-second absolute deadline; transport timeouts never count as success.
