### PR TITLE
refactor(dashboard): share durable storage types

### DIFF
--- a/dashboard/durable-storage.ts
+++ b/dashboard/durable-storage.ts
@@ -1,0 +1,7 @@
+export type SqlStorage = {
+  exec: (query: string, ...bindings: unknown[]) => Iterable<Record<string, unknown>>;
+};
+export type DurableStorage = {
+  sql: SqlStorage;
+  transactionSync: <T>(callback: () => T) => T;
+};

--- a/dashboard/exact-review-direct-publication.ts
+++ b/dashboard/exact-review-direct-publication.ts
@@ -1,4 +1,5 @@
 import { EXACT_REVIEW_DIRECT_PUBLICATION_MAX_FILE_BYTES } from "../src/exact-review-publication-limits.ts";
+import type { DurableStorage } from "./durable-storage.ts";
 
 export { EXACT_REVIEW_DIRECT_PUBLICATION_MAX_FILE_BYTES };
 
@@ -30,15 +31,6 @@ const RECORD_SECTIONS = new Set<RecordSection>([
   "decision-packets",
   "commits",
 ]);
-
-type SqlStorage = {
-  exec: (query: string, ...bindings: unknown[]) => Iterable<Record<string, unknown>>;
-};
-
-type DurableStorage = {
-  sql: SqlStorage;
-  transactionSync: <T>(callback: () => T) => T;
-};
 
 export type RecordSection = "items" | "closed" | "plans" | "decision-packets" | "commits";
 export type ExactReviewTupleRecordSection = Exclude<RecordSection, "commits">;

--- a/dashboard/exact-review-lifecycle-telemetry.ts
+++ b/dashboard/exact-review-lifecycle-telemetry.ts
@@ -5,6 +5,7 @@ import {
   type ExactReviewLifecycleProjection,
   type LifecycleTerminalDisposition,
 } from "./exact-review-lifecycle.ts";
+import type { DurableStorage } from "./durable-storage.ts";
 
 export const EXACT_REVIEW_LIFECYCLE_TELEMETRY_DIRECT_TABLE =
   "exact_review_lifecycle_telemetry_direct_v1";
@@ -41,15 +42,6 @@ export const EXACT_REVIEW_LIFECYCLE_BAY_RECOVERY_BATCH_LIMIT = 256;
 // allowlist. Keep the unfiltered aggregate in a distinct tide-buffer partition
 // so changing to or from that empty public scope cannot corrupt either view.
 const BAY_GLOBAL_TIDE_SCOPE = "__all_repositories__";
-
-type SqlStorage = {
-  exec: (query: string, ...bindings: unknown[]) => Iterable<Record<string, unknown>>;
-};
-
-type DurableStorage = {
-  sql: SqlStorage;
-  transactionSync: <T>(callback: () => T) => T;
-};
 
 export type DirectPublicationTelemetryOutcome = "accepted" | "deduped" | "superseded" | "fallback";
 

--- a/dashboard/exact-review-lifecycle.ts
+++ b/dashboard/exact-review-lifecycle.ts
@@ -1,3 +1,5 @@
+import type { DurableStorage } from "./durable-storage.ts";
+
 export const EXACT_REVIEW_LIFECYCLE_PROJECTION_TABLE = "exact_review_lifecycle_projection_v1";
 export const EXACT_REVIEW_ACKNOWLEDGEMENT_ATTEMPT_LEASE_MS = 5 * 60 * 1000;
 export const EXACT_REVIEW_LIFECYCLE_BAY_SAMPLE_LIMIT = 24;
@@ -9,15 +11,6 @@ export const EXACT_REVIEW_LIFECYCLE_AUDIT_SNAPSHOT_MAX_ACTIVE = 4;
 const EXACT_REVIEW_LIFECYCLE_AUDIT_SNAPSHOT_TABLE = "exact_review_lifecycle_audit_snapshots_v1";
 const EXACT_REVIEW_LIFECYCLE_AUDIT_SNAPSHOT_ROW_TABLE =
   "exact_review_lifecycle_audit_snapshot_rows_v1";
-
-type SqlStorage = {
-  exec: (query: string, ...bindings: unknown[]) => Iterable<Record<string, unknown>>;
-};
-
-type DurableStorage = {
-  sql: SqlStorage;
-  transactionSync: <T>(callback: () => T) => T;
-};
 
 export type LifecycleTerminalDisposition =
   | "review_completed_routed"

--- a/dashboard/exact-review-publication-batches.ts
+++ b/dashboard/exact-review-publication-batches.ts
@@ -1,3 +1,5 @@
+import type { DurableStorage } from "./durable-storage.ts";
+
 export const EXACT_REVIEW_PUBLICATION_BATCH_TABLE = "exact_review_publication_batches";
 export const EXACT_REVIEW_PUBLICATION_BATCH_ITEM_TABLE = "exact_review_publication_batch_items";
 const EXACT_REVIEW_PUBLICATION_BATCH_GENERATION_TABLE =
@@ -5,15 +7,6 @@ const EXACT_REVIEW_PUBLICATION_BATCH_GENERATION_TABLE =
 
 const DEFAULT_COMPLETED_BATCH_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const DEFAULT_CLEANUP_LIMIT = 100;
-
-type SqlStorage = {
-  exec: (query: string, ...bindings: unknown[]) => Iterable<Record<string, unknown>>;
-};
-
-type DurableStorage = {
-  sql: SqlStorage;
-  transactionSync: <T>(callback: () => T) => T;
-};
 
 export type PublicationBatchCandidate = {
   itemKey: string;

--- a/dashboard/github-egress-telemetry.ts
+++ b/dashboard/github-egress-telemetry.ts
@@ -12,6 +12,7 @@ import {
   GITHUB_EGRESS_STATUS_BUCKETS,
   GITHUB_EGRESS_UNITS,
 } from "../src/github-egress-telemetry-contract.ts";
+import type { DurableStorage } from "./durable-storage.ts";
 
 const ROLLUP_TABLE = "exact_review_github_egress_rollups_v2";
 const RATE_LIMIT_TABLE = "exact_review_github_rate_limits_v2";
@@ -36,15 +37,6 @@ export type GithubEgressCredentialCircuitObservation = {
   retryAt: number;
   provenance: "retry_after" | "rate_limit_reset";
   authoritative: true;
-};
-
-type SqlStorage = {
-  exec: (query: string, ...bindings: unknown[]) => Iterable<Record<string, unknown>>;
-};
-
-type DurableStorage = {
-  sql: SqlStorage;
-  transactionSync: <T>(callback: () => T) => T;
 };
 
 function alignedBucketStart(bucketKind: "five_minute" | "hour", timestamp: number) {

--- a/dashboard/record-snapshots.ts
+++ b/dashboard/record-snapshots.ts
@@ -10,6 +10,7 @@ import type {
   ExactReviewDirectPublicationStore,
   RecordSnapshotIdentity,
 } from "./exact-review-direct-publication.ts";
+import type { DurableStorage } from "./durable-storage.ts";
 
 export const EXACT_REVIEW_RECORD_SNAPSHOT_TABLE = "exact_review_record_snapshots";
 export const RECORD_SNAPSHOT_KEEP = 2;
@@ -18,15 +19,6 @@ export const RECORD_SNAPSHOT_DOWNLOAD_MAX_BYTES = 32 * 1024 * 1024;
 const R2_MULTIPART_PART_BYTES = 8 * 1024 * 1024;
 const TAR_BLOCK_BYTES = 512;
 const encoder = new TextEncoder();
-
-type SqlStorage = {
-  exec: (query: string, ...bindings: unknown[]) => Iterable<Record<string, unknown>>;
-};
-
-type DurableStorage = {
-  sql: SqlStorage;
-  transactionSync: <T>(callback: () => T) => T;
-};
 
 type UploadedPart = { partNumber: number; etag: string };
 

--- a/dashboard/state-writer-coordinator.ts
+++ b/dashboard/state-writer-coordinator.ts
@@ -1,3 +1,5 @@
+import type { DurableStorage } from "./durable-storage.ts";
+
 const STATE_WRITER_TICKET_TABLE = "state_writer_tickets";
 const STATE_WRITER_META_TABLE = "state_writer_meta";
 const STATE_WRITER_TERMINAL_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
@@ -7,15 +9,6 @@ const MAX_CONSECUTIVE_INTAKE_TURNS = 1;
 const MAX_CONSECUTIVE_PRIORITY_TURNS = 2;
 
 export type StateWriterClass = "ordinary" | "publication_batch" | "cluster_intake";
-
-type SqlStorage = {
-  exec: (query: string, ...bindings: unknown[]) => Iterable<Record<string, unknown>>;
-};
-
-type DurableStorage = {
-  sql: SqlStorage;
-  transactionSync: <T>(callback: () => T) => T;
-};
 
 export type StateWriterTicketInput = {
   ticketId: string;


### PR DESCRIPTION
## What Problem This Solves

Seven dashboard storage modules independently declared the same structural Durable Object storage types, creating avoidable drift risk when that internal contract is maintained.

## Why This Change Was Made

This change moves the exact existing `SqlStorage` and `DurableStorage` structural declarations into one type-only dashboard module and imports that type from the seven reviewed consumers. It changes no methods, SQL, classes, storage schemas, telemetry behavior, queues, Worker code, or runtime exports.

The matching declarations in active failure-telemetry and queue work are intentionally excluded to avoid colliding with those in-flight branches; this is bounded collision avoidance, not an incomplete runtime migration. Their type shape and behavior remain unchanged.

## User Impact

There is no user-visible or runtime behavior change. Dashboard storage typing now has one shared definition across the reviewed modules, reducing maintenance drift.

## OpenClaw Bay Impact

OpenClaw Bay is unaffected. This is a type-only refactor with no dashboard data-contract, status, telemetry, public API, storage schema, or runtime change.

## Documentation Impact

No documentation or changelog update is needed. `AGENTS.md`, `CONTRIBUTING.md`, and `VISION.md` were reviewed; their runtime and operational contracts remain accurate because this is a pure internal type refactor.

## Evidence

- Current signed head: `7ca7921deddc2eac2454d10e6619860cfbfd3189`
- Diff: 8 files, 17 insertions, 63 deletions; `git diff --check` passes.
- Focused dashboard tests on Node.js 26.7.0 and Bash 5.3.12: 199 passed, 0 failed across lifecycle/publication, publication batches, GitHub egress telemetry, record snapshots, and state-writer coordination.
- Fresh Codex review before commit: clean, no actionable findings.
- Fresh Codex review of the committed branch against `origin/main`: clean, no actionable findings.
- Dashboard TypeScript build passes before and after the refactor.
- Pinned Wrangler 4.107.0 dry-run bundle proof: structured multipart parsing produced byte-identical `worker.js` modules, 2,343,844 bytes each, SHA-256 `ea5311a80bd2f4cba4a340bbe8da1b88717a9698c15ff9da9d6e15827f5bd9b4`. Parsed metadata was also identical with SHA-256 `e0d517989f901dcab9c22e5a7800a92374afb32ca1e2f182a35135a912f7c0e5`. Raw transport hashes differed only because Undici generated different multipart boundary delimiters; application JavaScript was not normalized.
- Crabbox AWS validation receipt: run `run_4e8a06f5711f`, lease `cbx_ca0cd6d6f17a`, Linux `c7a.8xlarge`, Node.js 24.18.1, pnpm 11.10.0. Formatting, active-surface checks, dashboard boundary/strict checks, documentation checks, limits, all builds, and all lint targets passed. The test suite reported 4,824 passed, 1 failed, and 18 skipped. The sole failure was environmental: Crabbox's raw sync directory omitted `.git`, while `test/apply-drift-refresh.test.ts` invokes `git rev-parse HEAD`. The exact failed surface was rerun at the committed Git head in a Git checkout and passed 1/1 in 11.3 seconds. The lease was released.

### Real Behavior Proof

**Claim**

Consolidating the duplicate structural types does not change the generated dashboard Worker or the behavior exercised by the affected storage modules.

**Exercised surface**

Dashboard Worker build output plus lifecycle/publication, publication-batch, GitHub-egress, snapshot, and state-writer behavior.

**Scenario or fixture**

The unmodified base and committed candidate were built separately. Wrangler's multipart upload payload was parsed structurally with `Response.formData()`, then the raw module bytes and metadata were compared. Focused repository fixtures exercised the seven affected storage consumers.

**Command and environment**

- Node.js 26.7.0, Bash 5.3.12: dashboard TypeScript build and focused `node:test` suites.
- Wrangler 4.107.0: `deploy --dry-run` only for baseline and candidate.
- Crabbox AWS run `run_4e8a06f5711f`: Linux, Node.js 24.18.1, pnpm 11.10.0, full `pnpm run check`.

**Observable result**

The candidate Worker module and metadata exactly match the baseline. All 199 focused assertions passed. The full remote gate passed every static, build, lint, and product test except one checkout-dependent test that could not read absent Git metadata; that exact test passed from the committed Git checkout.

**Artifact or trace**

- Worker module: 2,343,844 bytes; SHA-256 `ea5311a80bd2f4cba4a340bbe8da1b88717a9698c15ff9da9d6e15827f5bd9b4`
- Worker metadata SHA-256: `e0d517989f901dcab9c22e5a7800a92374afb32ca1e2f182a35135a912f7c0e5`
- Crabbox run: `run_4e8a06f5711f`
- Crabbox lease: `cbx_ca0cd6d6f17a` (released)

**Limits**

No live Cloudflare deployment was performed. The runtime proof is a pinned dry-run bundle identity comparison plus controlled repository tests. No live apply, close, queue, workflow, or GitHub mutation path was exercised. No Rank-up move applies to this bounded type-only refactor.
