### PR TITLE
fix(review): prove hosted tool round in canary

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,8 +665,13 @@ No dashboard projection or observer API changes; OpenClaw Bay is unaffected.
 Maintainers can run the dispatch-only `Hosted native review scan smoke` job in
 `ci.yml`. It uses the existing `OPENAI_API_KEY` and `CLAWSWEEPER_MODEL` secrets
 only during host setup, with no App mutation token. The proof artifact records
-zero provider starts on refusal, one clean native structured run, exact fixture
-and runner identities, and coverage limits without exposing the configured model.
+zero Codex launches on refusal, then proves the production review path completed
+a read-only command over a synthetic committed diff before returning a
+schema-valid decision and terminal turn. Raw commands, output, prompts,
+transcripts, fixture values, runner identities, and model identities stay in
+ephemeral private files; the uploaded artifact contains only booleans and counts,
+including explicit false coverage flags for external repositories, review
+publication, and queue lifecycle.
 
 - Review and repair base fetches use fully qualified branch refspecs so inherited
   `fetch.prune` or `remote.origin.prune` settings do not delete the requested

--- a/docs/private-inference.md
+++ b/docs/private-inference.md
@@ -47,9 +47,14 @@ gh workflow run ci.yml --ref main -f codex_auth_mode=clawrouter
 ```
 
 This override affects only the dispatch-only native review smoke job. It proves
-scanner refusals, native sandbox execution, and a structured review against a
-synthetic repository without GitHub mutation. The default `configured` choice
-uses the repository's current authentication mode.
+scanner refusals, then uses the production review runner and decision schema to
+inspect a synthetic committed diff with a read-only command, consume that tool
+result in the final review, and reach terminal turn completion without GitHub
+mutation. Raw commands, output, prompts, transcripts, fixture values, and
+runtime identities remain ephemeral; the uploaded artifact contains only
+booleans and counts, including explicit false coverage flags for external
+repositories, review publication, and queue lifecycle. The default `configured`
+choice uses the repository's current authentication mode.
 
 The default `proxy` mode and explicit legacy `login` mode retain their existing
 API-key configuration. Changing the authentication-mode variable affects new

--- a/scripts/hosted-review-canary-proof.mjs
+++ b/scripts/hosted-review-canary-proof.mjs
@@ -1,0 +1,201 @@
+import assert from "node:assert/strict";
+
+function parseJsonl(jsonl) {
+  return jsonl
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+export function assertMatchesJsonSchema(value, schema, path = "$") {
+  if (schema.anyOf) {
+    const matches = schema.anyOf.filter((candidate) => {
+      try {
+        assertMatchesJsonSchema(value, candidate, path);
+        return true;
+      } catch {
+        return false;
+      }
+    });
+    assert.ok(matches.length > 0, `${path} did not match any allowed schema`);
+  }
+  if (schema.type) {
+    const allowedTypes = Array.isArray(schema.type) ? schema.type : [schema.type];
+    const actualType =
+      value === null
+        ? "null"
+        : Array.isArray(value)
+          ? "array"
+          : Number.isInteger(value)
+            ? "integer"
+            : typeof value;
+    assert.ok(
+      allowedTypes.includes(actualType) ||
+        (actualType === "integer" && allowedTypes.includes("number")),
+      `${path} has invalid type`,
+    );
+  }
+  if (schema.const !== undefined)
+    assert.deepEqual(value, schema.const, `${path} has invalid value`);
+  if (schema.enum) {
+    assert.ok(
+      schema.enum.some((candidate) => JSON.stringify(candidate) === JSON.stringify(value)),
+      `${path} has invalid enum value`,
+    );
+  }
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    for (const key of schema.required ?? []) {
+      assert.ok(Object.hasOwn(value, key), `${path}.${key} is required`);
+    }
+    if (schema.additionalProperties === false) {
+      for (const key of Object.keys(value)) {
+        assert.ok(Object.hasOwn(schema.properties ?? {}, key), `${path}.${key} is not allowed`);
+      }
+    }
+    for (const [key, child] of Object.entries(schema.properties ?? {})) {
+      if (Object.hasOwn(value, key)) assertMatchesJsonSchema(value[key], child, `${path}.${key}`);
+    }
+  }
+  if (Array.isArray(value)) {
+    if (schema.minItems !== undefined)
+      assert.ok(value.length >= schema.minItems, `${path} has too few items`);
+    if (schema.maxItems !== undefined)
+      assert.ok(value.length <= schema.maxItems, `${path} has too many items`);
+    if (schema.items) {
+      value.forEach((entry, index) =>
+        assertMatchesJsonSchema(entry, schema.items, `${path}[${index}]`),
+      );
+    }
+  }
+  if (typeof value === "string") {
+    if (schema.minLength !== undefined)
+      assert.ok(value.length >= schema.minLength, `${path} is too short`);
+    if (schema.maxLength !== undefined)
+      assert.ok(value.length <= schema.maxLength, `${path} is too long`);
+    if (schema.pattern !== undefined)
+      assert.match(value, new RegExp(schema.pattern, "u"), `${path} does not match its pattern`);
+  }
+  if (typeof value === "number") {
+    if (schema.minimum !== undefined)
+      assert.ok(value >= schema.minimum, `${path} is below its minimum`);
+    if (schema.maximum !== undefined)
+      assert.ok(value <= schema.maximum, `${path} is above its maximum`);
+    if (schema.exclusiveMinimum !== undefined)
+      assert.ok(value > schema.exclusiveMinimum, `${path} is below its exclusive minimum`);
+  }
+}
+
+function posixShellQuote(value) {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+function hasExactShellPayload(serializedCommand, expectedCommand) {
+  const quotedPayloads = [posixShellQuote(expectedCommand), JSON.stringify(expectedCommand)];
+  const suffixes = quotedPayloads.flatMap((payload) => [` -c ${payload}`, ` -lc ${payload}`]);
+  return suffixes.some((suffix) => {
+    if (!serializedCommand.endsWith(suffix)) return false;
+    return /^\S+$/.test(serializedCommand.slice(0, -suffix.length));
+  });
+}
+
+const TOOL_ITEM_TYPES = new Set([
+  "command_execution",
+  "file_change",
+  "mcp_tool_call",
+  "collab_tool_call",
+  "web_search",
+  "todo_list",
+]);
+
+export function summarizeHostedReviewTrace({
+  jsonl,
+  marker,
+  expectedCommand,
+  finalDecisionText,
+  checkoutUnchanged,
+}) {
+  const events = parseJsonl(jsonl);
+  const toolEvents = events.flatMap((event, index) => {
+    if (
+      !["item.started", "item.completed"].includes(event?.type) ||
+      !TOOL_ITEM_TYPES.has(event.item?.type)
+    ) {
+      return [];
+    }
+    return [{ event, index }];
+  });
+  const toolAttemptIds = new Set(toolEvents.map(({ event }) => event.item.id));
+  assert.ok(!toolAttemptIds.has(undefined), "canary tool attempt did not have an id");
+  assert.equal(toolAttemptIds.size, 1, "canary must attempt exactly one review tool");
+  const completedCommands = toolEvents.filter(
+    ({ event }) =>
+      event.type === "item.completed" &&
+      event.item.type === "command_execution" &&
+      event.item.status === "completed" &&
+      event.item.exit_code === 0,
+  );
+  assert.equal(completedCommands.length, 1, "canary must complete exactly one review command");
+  assert.ok(
+    hasExactShellPayload(String(completedCommands[0].event.item.command ?? ""), expectedCommand),
+    "canary command did not match the required diff inspection",
+  );
+  const markerCommands = completedCommands.filter(({ event }) =>
+    String(event.item.aggregated_output ?? "").includes(marker),
+  );
+  assert.ok(markerCommands.length > 0, "no completed command returned the fixture marker");
+
+  const markerCommandIndex = markerCommands.at(-1).index;
+  const finalReviewIndex = events.findIndex(
+    (event, index) =>
+      index > markerCommandIndex &&
+      event?.type === "item.completed" &&
+      event.item?.type === "agent_message" &&
+      event.item.text.trim() === finalDecisionText.trim(),
+  );
+  assert.ok(
+    finalReviewIndex > markerCommandIndex,
+    "final review was not emitted after the command",
+  );
+
+  const finalReview = JSON.parse(finalDecisionText);
+  assert.ok(
+    String(finalReview.summary ?? "").includes(marker),
+    "final review did not use the fixture marker",
+  );
+  const turnCompletions = events.filter((event) => event?.type === "turn.completed");
+  assert.equal(turnCompletions.length, 1, "canary must complete exactly one turn");
+  assert.ok(
+    events.findIndex(
+      (event, index) => index > finalReviewIndex && event?.type === "turn.completed",
+    ) > finalReviewIndex,
+    "turn.completed was not emitted after the final review",
+  );
+
+  return {
+    eventCount: events.length,
+    toolAttemptCount: toolAttemptIds.size,
+    completedToolCount: completedCommands.length,
+    fixtureToolCount: markerCommands.length,
+    reviewAfterToolCount: 1,
+    terminalTurnCount: turnCompletions.length,
+    checkoutUnchanged: Boolean(checkoutUnchanged),
+  };
+}
+
+export function assertBooleanCountArtifact(value) {
+  assert.ok(value && typeof value === "object" && !Array.isArray(value));
+  for (const entry of Object.values(value)) {
+    assert.ok(
+      typeof entry === "boolean" || (typeof entry === "number" && Number.isInteger(entry)),
+      "hosted canary artifacts may contain only booleans and integer counts",
+    );
+  }
+}
+
+export function runWithWithheldDiagnostics(message, operation) {
+  try {
+    return operation();
+  } catch {
+    throw new Error(message);
+  }
+}

--- a/scripts/hosted-review-scan-smoke.mjs
+++ b/scripts/hosted-review-scan-smoke.mjs
@@ -16,14 +16,22 @@ import { join } from "node:path";
 import { runAgentProcess } from "../dist/agent-runner.js";
 import { codexEnv } from "../dist/codex-env.js";
 import { AgentInputScanError } from "../dist/agent-input-scan.js";
+import { runCodexForTest } from "../dist/clawsweeper.js";
+import {
+  assertBooleanCountArtifact,
+  assertMatchesJsonSchema,
+  runWithWithheldDiagnostics,
+  summarizeHostedReviewTrace,
+} from "./hosted-review-canary-proof.mjs";
 
-// Dispatch-only proof: no GitHub credentials, publications, or target repository.
+// Dispatch-only proof: no GitHub credentials, publications, or external target repository.
 assert.equal(process.platform, "linux");
+assert.equal(process.env.CLAWSWEEPER_RUNNER?.trim() || "codex", "codex");
 const originalPath = process.env.PATH;
 const originalScannerCache = process.env.CLAWSWEEPER_REVIEW_TOOLS_DIR;
+const originalCodexBin = process.env.CODEX_BIN;
 const artifact = process.argv[2];
 assert.ok(artifact, "pass a proof JSON destination");
-const sourceHead = execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim();
 const gitExecutable = execFileSync("which", ["git"], { encoding: "utf8" }).trim();
 const codex = execFileSync("which", ["codex"], { encoding: "utf8" }).trim();
 const versionProbe = spawnSync("trufflehog", ["--version"], { encoding: "utf8" });
@@ -41,16 +49,21 @@ try {
   git("config", "user.name", "ClawSweeper smoke");
   git("config", "user.email", "smoke@example.invalid");
   git("config", "commit.gpgsign", "false");
-  writeFileSync(join(cwd, "value.txt"), "one\n");
+  writeFileSync(join(cwd, "review-fixture.js"), 'export const canaryValue = "before";\n');
   git("add", ".");
   git("commit", "-qm", "base");
   const baseSha = git("rev-parse", "HEAD");
   const marker = randomUUID();
-  writeFileSync(join(cwd, "value.txt"), `two ${marker}\n`);
+  const changedFixture = [
+    'export const canaryValue = "after";',
+    `export const canaryMarker = "${marker}";`,
+    "",
+  ].join("\n");
+  writeFileSync(join(cwd, "review-fixture.js"), changedFixture);
   git("add", ".");
   git("commit", "-qm", "change");
   const headSha = git("rev-parse", "HEAD");
-  const calls = join(root, "provider-starts");
+  const calls = join(root, "codex-launches");
   const wrapper = join(bin, "codex");
   // Negative cases can only hit this no-inference executable, even if the
   // admission gate regresses. Real Codex is wired only after these assertions.
@@ -65,57 +78,38 @@ ${live ? `const child = require('node:child_process').spawnSync(${JSON.stringify
       { mode: 0o700 },
     );
   writeProvider(false);
-  const schemaPath = join(root, "schema.json");
-  writeFileSync(
-    schemaPath,
-    JSON.stringify({
-      type: "object",
-      additionalProperties: false,
-      required: ["status", "marker"],
-      properties: { status: { type: "string", enum: ["clean"] }, marker: { type: "string" } },
-    }),
-    { mode: 0o600 },
-  );
-  const output = join(root, "decision.json");
+  const itemNumber = 990_001;
+  const workDir = join(root, "review-work");
+  mkdirSync(workDir);
+  const output = join(workDir, `${itemNumber}.json`);
   const diagnosticPromptPath = join(root, "review.prompt.md");
-  const prompt =
-    "Review the synthetic change in value.txt. Read that file and return its UUID as marker with status clean in the required JSON object. Do not run nested reviewers or network tools.";
-  const run = () =>
-    runAgentProcess({
-      label: "hosted-scan-smoke",
-      cwd,
-      model: "internal",
-      reasoningEffort: "low",
-      prompt,
-      diagnosticPromptPath,
-      scanSource: { kind: "committed", baseSha, headSha },
-      timeoutMs: 180_000,
-      env: { ...codexEnv(), CODEX_BIN: wrapper },
-      codexExtraArgs: [
-        "--sandbox",
-        "read-only",
-        "-c",
-        'approval_policy="never"',
-        "-c",
-        'web_search="disabled"',
-        "--output-schema",
-        schemaPath,
-        "--output-last-message",
-        output,
-        "--json",
-        "-",
-      ],
-    });
+  const reviewCommand = `git diff --no-ext-diff --unified=0 ${baseSha} ${headSha} -- review-fixture.js`;
+  const prompt = [
+    "This is a hosted ClawSweeper transport canary over a synthetic pull request.",
+    "First use the shell tool to inspect review-fixture.js in the committed diff.",
+    `Run: ${reviewCommand}`,
+    "Do not use any other tool or network access.",
+    "Read the UUID from that command output, then return one valid ClawSweeper decision using the required schema.",
+    'Use decision "keep_open", closeReason "none", no findings, no risks, no required next step, and overallCorrectness "patch is correct".',
+    'Set summary exactly to "Hosted review canary observed marker <UUID>.", replacing <UUID> with the command result.',
+    "Use one low-confidence synthetic owner with history null. This fixture is not real maintainer work.",
+  ].join("\n");
   const scratch = () =>
     readdirSync(tmpdir())
       .filter((name) => name.startsWith("clawsweeper-input-scan-"))
       .sort();
   const initialScratch = scratch();
   const assertCheckout = () => {
-    assert.equal(git("rev-parse", "HEAD"), headSha);
-    assert.equal(git("status", "--porcelain"), "");
-    assert.equal(readFileSync(join(cwd, "value.txt"), "utf8"), `two ${marker}\n`);
-    assert.deepEqual(scratch(), initialScratch);
+    assert.ok(git("rev-parse", "HEAD") === headSha, "synthetic checkout head changed");
+    assert.ok(git("status", "--porcelain") === "", "synthetic checkout became dirty");
+    assert.ok(
+      readFileSync(join(cwd, "review-fixture.js"), "utf8") === changedFixture,
+      "synthetic checkout bytes changed",
+    );
+    assert.ok(
+      JSON.stringify(scratch()) === JSON.stringify(initialScratch),
+      "scanner scratch files were retained",
+    );
   };
   // A missing PATH scanner can now bootstrap automatically. Make that second
   // source unavailable only for the synthetic refusal cases, before any download.
@@ -156,59 +150,97 @@ ${live ? `const child = require('node:child_process').spawnSync(${JSON.stringify
   if (originalScannerCache === undefined) delete process.env.CLAWSWEEPER_REVIEW_TOOLS_DIR;
   else process.env.CLAWSWEEPER_REVIEW_TOOLS_DIR = originalScannerCache;
   writeProvider(true);
-  const result = run();
-  // Raw model output/diagnostics and configured model identity never enter proof artifacts.
-  assert.ok(!result.error, "native runner failed");
-  assert.equal(result.status, 0, "native runner exited unsuccessfully");
-  let parsed;
-  try {
-    parsed = JSON.parse(readFileSync(output, "utf8"));
-  } catch {
-    throw new Error("Native review did not produce valid JSON; diagnostics withheld.");
-  }
-  assert.ok(
-    parsed?.status === "clean" && parsed.marker === marker && Object.keys(parsed).length === 2,
-    "Native structured response did not match the fixture; diagnostics withheld.",
+  process.env.CODEX_BIN = wrapper;
+  const decision = runWithWithheldDiagnostics(
+    "Hosted production review failed; diagnostics withheld.",
+    () =>
+      runCodexForTest({
+        item: {
+          repo: "openclaw/clawsweeper",
+          number: itemNumber,
+          kind: "pull_request",
+          title: "Synthetic hosted review canary",
+          url: "https://github.com/openclaw/clawsweeper",
+          createdAt: "2026-09-04T00:00:00Z",
+          updatedAt: "2026-09-04T00:00:00Z",
+          author: "clawsweeper-canary",
+          authorAssociation: "NONE",
+          labels: [],
+        },
+        context: {
+          issue: {},
+          comments: [],
+          timeline: [],
+          pullRequest: { base: { sha: baseSha }, head: { sha: headSha } },
+        },
+        git: { mainSha: baseSha, latestRelease: null },
+        model: "internal",
+        openclawDir: cwd,
+        reasoningEffort: "medium",
+        sandboxMode: "read-only",
+        serviceTier: "",
+        preserveCodexAuth: true,
+        timeoutMs: 300_000,
+        workDir,
+        prompt,
+        quietLogs: true,
+        extraCodexConfig: ['web_search="disabled"'],
+      }),
   );
-  const decision = { status: "clean", marker };
-  assertCheckout();
-  assert.equal(readFileSync(calls, "utf8"), "1");
+  assert.ok(decision.localCheckoutAccess === "verified", "checkout verification failed");
   assert.ok(
-    readFileSync(diagnosticPromptPath, "utf8") === prompt,
+    decision.summary === `Hosted review canary observed marker ${marker}.`,
+    "Hosted review decision did not match the fixture; diagnostics withheld.",
+  );
+  runWithWithheldDiagnostics(
+    "Hosted review output did not match the decision schema; diagnostics withheld.",
+    () =>
+      assertMatchesJsonSchema(
+        JSON.parse(readFileSync(output, "utf8")),
+        JSON.parse(
+          readFileSync(join(process.cwd(), "schema", "clawsweeper-decision.schema.json"), "utf8"),
+        ),
+      ),
+  );
+  assertCheckout();
+  assert.equal(readFileSync(calls, "utf8").length, 2);
+  const productionPromptPath = join(workDir, `${itemNumber}.prompt.md`);
+  assert.ok(
+    readFileSync(productionPromptPath, "utf8") === prompt,
     "Admitted prompt diagnostic did not match; contents withheld.",
   );
-  const diagnosticPromptMode = statSync(diagnosticPromptPath).mode & 0o777;
+  const diagnosticPromptMode = statSync(productionPromptPath).mode & 0o777;
   assert.equal(diagnosticPromptMode, 0o600);
-  writeFileSync(
-    artifact,
-    JSON.stringify(
-      {
-        sourceHead,
-        provider: "github-hosted",
-        imageOS: process.env.ImageOS,
-        imageVersion: process.env.ImageVersion,
-        runId: process.env.GITHUB_RUN_ID,
-        runAttempt: process.env.GITHUB_RUN_ATTEMPT,
-        scannerVersion,
-        codexVersion: execFileSync(codex, ["--version"], { encoding: "utf8" }).trim(),
-        baseSha,
-        headSha,
-        refusalProviderStarts: 0,
-        cleanProviderStarts: 1,
-        refusalPromptArtifacts: 0,
-        diagnosticPromptMode: `0${diagnosticPromptMode.toString(8)}`,
-        decision,
-        model: "configured model (redacted)",
-        limits:
-          "Explicit initial prompt, schema and introduced before/after bytes. No universal provider-egress, project-doc, resumed-history or later tool-result coverage.",
-      },
-      null,
-      2,
-    ) + "\n",
-    { mode: 0o600 },
+  const trace = runWithWithheldDiagnostics(
+    "Hosted review trace did not prove the tool round; diagnostics withheld.",
+    () =>
+      summarizeHostedReviewTrace({
+        jsonl: readFileSync(join(workDir, `${itemNumber}.1.codex.stdout.log`), "utf8"),
+        marker,
+        expectedCommand: reviewCommand,
+        finalDecisionText: readFileSync(output, "utf8"),
+        checkoutUnchanged: true,
+      }),
   );
+  const proof = {
+    refusalScenarioCount: 4,
+    refusalCodexLaunchCount: 0,
+    reviewCodexLaunchCount: 2,
+    productionReviewPath: true,
+    syntheticCommittedDiffScenarioCount: 1,
+    externalRepositoryCovered: false,
+    reviewPublicationCovered: false,
+    queueLifecycleCovered: false,
+    decisionSchemaValid: true,
+    admissionArtifactOwnerOnly: diagnosticPromptMode === 0o600,
+    ...trace,
+  };
+  assertBooleanCountArtifact(proof);
+  writeFileSync(artifact, JSON.stringify(proof, null, 2) + "\n", { mode: 0o600 });
 } finally {
   process.env.PATH = originalPath;
+  if (originalCodexBin === undefined) delete process.env.CODEX_BIN;
+  else process.env.CODEX_BIN = originalCodexBin;
   if (originalScannerCache === undefined) delete process.env.CLAWSWEEPER_REVIEW_TOOLS_DIR;
   else process.env.CLAWSWEEPER_REVIEW_TOOLS_DIR = originalScannerCache;
   rmSync(root, { recursive: true, force: true });

--- a/test/hosted-review-canary-proof.test.ts
+++ b/test/hosted-review-canary-proof.test.ts
@@ -1,0 +1,297 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  assertBooleanCountArtifact,
+  assertMatchesJsonSchema,
+  runWithWithheldDiagnostics,
+  summarizeHostedReviewTrace,
+} from "../scripts/hosted-review-canary-proof.mjs";
+
+test("hosted review trace proves a command round before the final review", () => {
+  const marker = "9ccfabf3-8158-437d-a168-173ee10d102a";
+  const expectedCommand = "git diff --no-ext-diff --unified=0 base head -- review-fixture.js";
+  const finalDecisionText = JSON.stringify({
+    summary: `Hosted review canary observed marker ${marker}.`,
+  });
+  const jsonl = [
+    { type: "thread.started", thread_id: "private-thread" },
+    { type: "turn.started" },
+    {
+      type: "item.started",
+      item: {
+        id: "private-command",
+        type: "command_execution",
+        command: `/bin/bash -lc "${expectedCommand}"`,
+        aggregated_output: "",
+        exit_code: null,
+        status: "in_progress",
+      },
+    },
+    {
+      type: "item.completed",
+      item: {
+        id: "private-command",
+        type: "command_execution",
+        command: `/bin/bash -lc "${expectedCommand}"`,
+        aggregated_output: `private output ${marker}`,
+        exit_code: 0,
+        status: "completed",
+      },
+    },
+    {
+      type: "item.completed",
+      item: { id: "private-message", type: "agent_message", text: finalDecisionText },
+    },
+    { type: "turn.completed", usage: { input_tokens: 1, output_tokens: 1 } },
+  ]
+    .map((event) => JSON.stringify(event))
+    .join("\n");
+
+  const proof = summarizeHostedReviewTrace({
+    jsonl,
+    marker,
+    expectedCommand,
+    finalDecisionText,
+    checkoutUnchanged: true,
+  });
+  assert.deepEqual(proof, {
+    eventCount: 6,
+    toolAttemptCount: 1,
+    completedToolCount: 1,
+    fixtureToolCount: 1,
+    reviewAfterToolCount: 1,
+    terminalTurnCount: 1,
+    checkoutUnchanged: true,
+  });
+  assertBooleanCountArtifact(proof);
+  const published = JSON.stringify(proof);
+  assert.doesNotMatch(published, /private|9ccfabf3|command":|output|prompt|transcript/i);
+});
+
+test("hosted review trace rejects a final review emitted before its tool result", () => {
+  const marker = "0fcb2fea-c4f8-4c7e-9fc9-f854f66b7e15";
+  const expectedCommand = "git diff --no-ext-diff --unified=0 base head -- review-fixture.js";
+  const finalDecisionText = JSON.stringify({
+    summary: `Hosted review canary observed marker ${marker}.`,
+  });
+  const jsonl = [
+    {
+      type: "item.completed",
+      item: { type: "agent_message", text: finalDecisionText },
+    },
+    {
+      type: "item.completed",
+      item: {
+        id: "expected-command",
+        type: "command_execution",
+        command: `/bin/bash -c '${expectedCommand}'`,
+        aggregated_output: marker,
+        exit_code: 0,
+        status: "completed",
+      },
+    },
+    { type: "turn.completed", usage: {} },
+  ]
+    .map((event) => JSON.stringify(event))
+    .join("\n");
+
+  assert.throws(
+    () =>
+      summarizeHostedReviewTrace({
+        jsonl,
+        marker,
+        expectedCommand,
+        finalDecisionText,
+        checkoutUnchanged: true,
+      }),
+    /final review was not emitted after the command/,
+  );
+});
+
+test("hosted review trace rejects a different marker-emitting command", () => {
+  const marker = "73c2d862-ff1a-4681-b2df-204dd24a26e5";
+  const expectedCommand = "git diff --no-ext-diff --unified=0 base head -- review-fixture.js";
+  const finalDecisionText = JSON.stringify({
+    summary: `Hosted review canary observed marker ${marker}.`,
+  });
+  const jsonl = [
+    {
+      type: "item.completed",
+      item: {
+        id: "different-command",
+        type: "command_execution",
+        command: "/bin/bash -lc 'cat review-fixture.js'",
+        aggregated_output: marker,
+        exit_code: 0,
+        status: "completed",
+      },
+    },
+    {
+      type: "item.completed",
+      item: { type: "agent_message", text: finalDecisionText },
+    },
+    { type: "turn.completed", usage: {} },
+  ]
+    .map((event) => JSON.stringify(event))
+    .join("\n");
+
+  assert.throws(
+    () =>
+      summarizeHostedReviewTrace({
+        jsonl,
+        marker,
+        expectedCommand,
+        finalDecisionText,
+        checkoutUnchanged: true,
+      }),
+    /command did not match the required diff inspection/,
+  );
+});
+
+test("hosted review trace rejects an additional failed command attempt", () => {
+  const marker = "cb32ac71-5dfc-4258-a2bb-26e99857cc34";
+  const expectedCommand = "git diff --no-ext-diff --unified=0 base head -- review-fixture.js";
+  const finalDecisionText = JSON.stringify({
+    summary: `Hosted review canary observed marker ${marker}.`,
+  });
+  const jsonl = [
+    {
+      type: "item.completed",
+      item: {
+        id: "failed-command",
+        type: "command_execution",
+        command: "/bin/bash -lc 'cat missing'",
+        aggregated_output: "",
+        exit_code: 1,
+        status: "failed",
+      },
+    },
+    {
+      type: "item.completed",
+      item: {
+        id: "expected-command",
+        type: "command_execution",
+        command: `/bin/bash -lc '${expectedCommand}'`,
+        aggregated_output: marker,
+        exit_code: 0,
+        status: "completed",
+      },
+    },
+    {
+      type: "item.completed",
+      item: { type: "agent_message", text: finalDecisionText },
+    },
+    { type: "turn.completed", usage: {} },
+  ]
+    .map((event) => JSON.stringify(event))
+    .join("\n");
+
+  assert.throws(
+    () =>
+      summarizeHostedReviewTrace({
+        jsonl,
+        marker,
+        expectedCommand,
+        finalDecisionText,
+        checkoutUnchanged: true,
+      }),
+    /must attempt exactly one review tool/,
+  );
+});
+
+test("hosted review trace rejects an additional non-command tool attempt", () => {
+  const marker = "6cf142b3-e43a-4dc7-a0c4-acaa99de4818";
+  const expectedCommand = "git diff --no-ext-diff --unified=0 base head -- review-fixture.js";
+  const finalDecisionText = JSON.stringify({
+    summary: `Hosted review canary observed marker ${marker}.`,
+  });
+  const jsonl = [
+    {
+      type: "item.completed",
+      item: { id: "todo", type: "todo_list", items: [], status: "completed" },
+    },
+    {
+      type: "item.completed",
+      item: {
+        id: "expected-command",
+        type: "command_execution",
+        command: `/bin/bash -lc '${expectedCommand}'`,
+        aggregated_output: marker,
+        exit_code: 0,
+        status: "completed",
+      },
+    },
+    {
+      type: "item.completed",
+      item: { id: "final-message", type: "agent_message", text: finalDecisionText },
+    },
+    { type: "turn.completed", usage: {} },
+  ]
+    .map((event) => JSON.stringify(event))
+    .join("\n");
+
+  assert.throws(
+    () =>
+      summarizeHostedReviewTrace({
+        jsonl,
+        marker,
+        expectedCommand,
+        finalDecisionText,
+        checkoutUnchanged: true,
+      }),
+    /must attempt exactly one review tool/,
+  );
+});
+
+test("hosted review output must match the checked-in schema", () => {
+  const schema = {
+    type: "object",
+    additionalProperties: false,
+    required: ["nextStep", "score"],
+    properties: {
+      nextStep: {
+        anyOf: [
+          {
+            type: "object",
+            additionalProperties: false,
+            required: ["kind", "text"],
+            properties: {
+              kind: { type: "string", const: "none" },
+              text: { type: "string", const: "" },
+            },
+          },
+        ],
+      },
+      score: { type: "number", exclusiveMinimum: 0, maximum: 1 },
+    },
+  };
+  assertMatchesJsonSchema({ nextStep: { kind: "none", text: "" }, score: 0.75 }, schema);
+  assert.throws(() => assertMatchesJsonSchema({ score: 0.75 }, schema), /nextStep is required/);
+  assert.throws(
+    () => assertMatchesJsonSchema({ nextStep: { kind: "none", text: "" }, score: 2 }, schema),
+    /above its maximum/,
+  );
+});
+
+test("hosted review artifacts reject string payloads", () => {
+  assert.throws(
+    () => assertBooleanCountArtifact({ safe: true, leaked: "raw transcript" }),
+    /only booleans and integer counts/,
+  );
+});
+
+test("hosted review failures withhold private diagnostics", () => {
+  const privateMarker = "a36a5710-0818-4680-969c-86496901b59f";
+  assert.throws(
+    () =>
+      runWithWithheldDiagnostics("Hosted review failed; diagnostics withheld.", () => {
+        throw new Error(`provider output ${privateMarker}`);
+      }),
+    (error: Error) => {
+      assert.equal(error.message, "Hosted review failed; diagnostics withheld.");
+      assert.doesNotMatch(error.message, new RegExp(privateMarker));
+      return true;
+    },
+  );
+});


### PR DESCRIPTION
## What Problem This Solves

Resolves a gap where the hosted review canary could pass without proving that the production review path completed a genuine tool round and consumed its result before returning a schema-valid decision.

## Why This Change Was Made

The canary now runs the production `runCodexForTest` path against a synthetic two-commit repository, requires one exact read-only diff command, validates the raw decision against the checked-in schema, and verifies the JSONL event order through `turn.completed`. Raw prompts, commands, output, transcripts, fixture values, and runtime identities remain ephemeral.

This does not change provider selection, authentication routing, queues, publication, or workflow configuration. The repository remains in `proxy` mode.

## User Impact

Maintainers get a stronger dispatch-only signal that hosted Codex review can perform a real second model round after a tool result. The uploaded proof remains restricted to booleans and integer counts.

## OpenClaw Bay Impact

OpenClaw Bay is unaffected. This changes only a dispatch-only CI canary and its private proof parser; no observer, status, queue, lifecycle, or dashboard contract changes.

## Documentation Impact

Updated the active hosted-canary descriptions in `README.md` and `docs/private-inference.md` to state the production review path, privacy boundary, and explicit non-coverage. No changelog entry: this is operational validation infrastructure, not a released user-facing behavior change.

## Evidence

- Exact head: `cc9eff63ce1345f5a848a7c97d6d992ea1fd7c4c`
- Base: `70a0a787eaf8fa3424d88a7a07302fd4a7e0d783`
- Hosted proxy proof: https://github.com/openclaw/clawsweeper/actions/runs/33865238465
- `Hosted native review scan smoke`: success
- `Windows Codex launcher`: success
- Focused test: `node --test test/hosted-review-canary-proof.test.ts` (8 passed)
- Typecheck: `node_modules/.bin/tsc -p tsconfig.json --noEmit`
- Lint and formatting: changed scripts/tests/docs passed `oxlint` and `oxfmt --check`
- Documentation and whitespace: `node scripts/check-docs.mjs`; `git diff --check`
- Fresh committed Codex review: no actionable defects
- Privacy scrub: no private paths, IPs, credentials, or non-placeholder email addresses in the diff

The operational-script delta is +233 net production lines; tests add +297 net lines and docs add +10 net lines. The production growth implements the new owner boundary: exact JSONL tool-attempt/order validation, checked-in schema validation, failure-diagnostic withholding, unchanged-checkout proof, and primitive-only artifact enforcement.

## Real Behavior Proof

**Claim:** The hosted `proxy` route exercises the production review runner, performs exactly one successful fixture diff command, consumes that command output in a valid final decision, reaches `turn.completed`, and leaves the checkout unchanged without publishing private content.

**Exercised surface:** GitHub-hosted Ubuntu 24.04; repository `proxy` auth mode; pinned Codex CLI `0.151.0`; production `runCodexForTest`; checked-in ClawSweeper decision schema.

**Scenario:** The canary creates a synthetic repository with base and head commits. A random marker exists only in the committed diff. The model must run the exact bounded `git diff --no-ext-diff --unified=0 <base> <head> -- review-fixture.js` command, then include the observed marker in its structured final review.

**Command and environment:** Workflow dispatch `ci.yml` at exact head `cc9eff63ce1345f5a848a7c97d6d992ea1fd7c4c`, input `codex_auth_mode=configured`, with repository variable `CLAWSWEEPER_CODEX_AUTH_MODE=proxy`.

**Observable result:** The hosted job succeeded. The artifact records two production Codex launches, one tool attempt, one completed fixture command, one final review after the command, one terminal turn, a schema-valid decision, and an unchanged checkout.

**Artifact or trace:** The run uploads `hosted-review-scan-proof`. Its exact key/type/value allowlist was checked locally; every value is a boolean or integer. Private Codex JSONL, command text, output, prompt, transcript, fixture marker, and runtime/model identity are not uploaded.

**Limits:** This is one synthetic committed-diff scenario. The artifact explicitly reports `externalRepositoryCovered=false`, `reviewPublicationCovered=false`, and `queueLifecycleCovered=false`. It does not attest external repository review, GitHub mutation/publication, queue behavior, or universal provider egress.
