### PR TITLE
fix(repair): expose bounded reconciliation samples

### DIFF
--- a/.github/workflows/exact-review-queue-maintenance.yml
+++ b/.github/workflows/exact-review-queue-maintenance.yml
@@ -13,6 +13,11 @@ on:
         required: true
         type: string
         default: "1"
+      max_items:
+        description: "Maximum reconciliation candidates to inspect"
+        required: true
+        type: number
+        default: 1
 
 concurrency:
   group: exact-review-queue-maintenance
@@ -44,8 +49,9 @@ jobs:
         env:
           EXECUTE: ${{ inputs.execute }}
           PASSES: ${{ inputs.passes }}
+          MAX_ITEMS: ${{ inputs.max_items }}
         run: |
-          args=(--max-items 100)
+          args=(--max-items "$MAX_ITEMS")
           if [[ "$EXECUTE" == "true" ]]; then
             args+=(--apply)
           fi

--- a/src/repair/exact-review-batch-queue-client.ts
+++ b/src/repair/exact-review-batch-queue-client.ts
@@ -62,6 +62,23 @@ export type ExactReviewBatchFetch = {
   superseded: number;
 };
 
+export type ExactReviewPublicationReconcileSample = {
+  itemKey: string;
+  queueRevision: number;
+  reason:
+    | "stale_revision"
+    | "duplicate_lineage"
+    | "legacy_terminal"
+    | "legacy_state_batch_terminal";
+  targetKey: string;
+  publicationRevision: number | null;
+  supersededByRevision: number | null;
+  lineageClaimGeneration: number | null;
+  retainedItemKey: string | null;
+  producerRunId?: string;
+  producerRunAttempt?: number;
+};
+
 export type ExactReviewPublicationReconcileResult = {
   apply: boolean;
   scanned: number;
@@ -87,6 +104,7 @@ export type ExactReviewPublicationReconcileResult = {
   protectedLineageItems: number;
   oldestEligibleAgeSeconds: number | null;
   oldestRemainingAgeSeconds: number | null;
+  sample: ExactReviewPublicationReconcileSample[];
 };
 
 export interface ExactReviewBatchQueue {
@@ -143,6 +161,13 @@ const REQUEST_TIMEOUT_MS = 20_000;
 const RETRY_DEADLINE_MS = 45_000;
 const MAX_ATTEMPTS = 3;
 const MAX_RETRY_AFTER_MS = 10_000;
+const RECONCILIATION_SAMPLE_LIMIT = 20;
+const RECONCILIATION_REASONS = new Set<ExactReviewPublicationReconcileSample["reason"]>([
+  "stale_revision",
+  "duplicate_lineage",
+  "legacy_terminal",
+  "legacy_state_batch_terminal",
+]);
 
 type TransportFailureReason = "network_error" | "timeout" | `HTTP_${number}`;
 
@@ -357,6 +382,9 @@ export class ExactReviewBatchQueueClient implements ExactReviewBatchQueue {
         response.oldest_remaining_age_seconds,
         "oldest_remaining_age_seconds",
       ),
+      sample: arrayValue(response.sample)
+        .slice(0, RECONCILIATION_SAMPLE_LIMIT)
+        .map(parseReconciliationSample),
     } satisfies ExactReviewPublicationReconcileResult;
   }
 
@@ -593,6 +621,47 @@ function parseMember(value: unknown): ExactReviewBatchMember {
   };
 }
 
+function parseReconciliationSample(value: unknown): ExactReviewPublicationReconcileSample {
+  const sample = objectValue(value);
+  const reason = stringValue(sample.reason, "sample reason");
+  if (!RECONCILIATION_REASONS.has(reason as ExactReviewPublicationReconcileSample["reason"])) {
+    throw new Error("Invalid batch queue sample reason");
+  }
+  const producerRunId =
+    sample.producer_run_id === undefined
+      ? undefined
+      : stringValue(sample.producer_run_id, "sample producer_run_id");
+  const producerRunAttempt =
+    sample.producer_run_attempt === undefined
+      ? undefined
+      : positiveInteger(sample.producer_run_attempt, "sample producer_run_attempt");
+  if ((producerRunId === undefined) !== (producerRunAttempt === undefined)) {
+    throw new Error("Invalid batch queue sample producer identity");
+  }
+  return {
+    itemKey: stringValue(sample.item_key, "sample item_key"),
+    queueRevision: positiveInteger(sample.queue_revision, "sample queue_revision"),
+    reason: reason as ExactReviewPublicationReconcileSample["reason"],
+    targetKey: stringValue(sample.target_key, "sample target_key"),
+    publicationRevision: nullablePositiveInteger(
+      sample.publication_revision,
+      "sample publication_revision",
+    ),
+    supersededByRevision: nullablePositiveInteger(
+      sample.superseded_by_revision,
+      "sample superseded_by_revision",
+    ),
+    lineageClaimGeneration: nullablePositiveInteger(
+      sample.lineage_claim_generation,
+      "sample lineage_claim_generation",
+    ),
+    retainedItemKey: nullableStringValue(sample.retained_item_key, "sample retained_item_key"),
+    ...(producerRunId === undefined
+      ? {}
+      : { producerRunId, producerRunAttempt: producerRunAttempt! }),
+  };
+}
+
 function objectValue(value: unknown): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     throw new Error("Invalid batch queue response object");
@@ -624,4 +693,12 @@ function nonNegativeInteger(value: unknown, name: string): number {
 
 function nullableNonNegativeInteger(value: unknown, name: string): number | null {
   return value === null || value === undefined ? null : nonNegativeInteger(value, name);
+}
+
+function nullablePositiveInteger(value: unknown, name: string): number | null {
+  return value === null ? null : positiveInteger(value, name);
+}
+
+function nullableStringValue(value: unknown, name: string): string | null {
+  return value === null ? null : stringValue(value, name);
 }

--- a/test/repair/exact-review-batch-queue-client.test.ts
+++ b/test/repair/exact-review-batch-queue-client.test.ts
@@ -295,3 +295,95 @@ test("heartbeat with an expired or invalid lease sends no request", async (t) =>
   await assert.rejects(client.heartbeat({ ...heartbeat, leaseExpiresAt: "invalid" }), /expiry/i);
   assert.equal(calls.length, 0);
 });
+
+test("publication reconciliation returns a bounded allowlisted sample", async (t) => {
+  const sample = Array.from({ length: 21 }, (_, index) => ({
+    item_key: `openclaw/example#${index + 1}@publish:${index + 2}:1`,
+    queue_revision: String(index + 1),
+    reason: "stale_revision",
+    target_key: `openclaw/example#${index + 1}`,
+    publication_revision: String(index + 1),
+    superseded_by_revision: String(index + 2),
+    lineage_claim_generation: null,
+    retained_item_key: null,
+    private_detail: `must-not-escape-${index}`,
+  }));
+  const { client } = fixture(t, () =>
+    Response.json({
+      apply: false,
+      scanned: 21,
+      legacy_terminal_scanned: 0,
+      eligible: 21,
+      changed: 0,
+      eligible_remaining: 21,
+      stale_revision_eligible: 21,
+      stale_revision_changed: 0,
+      lineage_duplicate_eligible: 0,
+      lineage_duplicate_changed: 0,
+      lineage_refreshed: 0,
+      legacy_terminal_candidates: 0,
+      legacy_terminal_selected: 0,
+      legacy_terminal_eligible: 0,
+      legacy_terminal_changed: 0,
+      legacy_state_batch_terminal_candidates: 0,
+      legacy_state_batch_terminal_selected: 0,
+      legacy_state_batch_terminal_producer_succeeded: 0,
+      legacy_state_batch_terminal_eligible: 0,
+      legacy_state_batch_terminal_changed: 0,
+      protected_batch_items: 0,
+      protected_lineage_items: 0,
+      oldest_eligible_age_seconds: 60,
+      oldest_remaining_age_seconds: 60,
+      sample,
+      private_response_detail: "must-not-escape",
+    }),
+  );
+
+  const result = await client.reconcilePublications({ apply: false, maxItems: 1 });
+
+  assert.equal(result.sample.length, 20);
+  assert.deepEqual(result.sample[0], {
+    itemKey: "openclaw/example#1@publish:2:1",
+    queueRevision: 1,
+    reason: "stale_revision",
+    targetKey: "openclaw/example#1",
+    publicationRevision: 1,
+    supersededByRevision: 2,
+    lineageClaimGeneration: null,
+    retainedItemKey: null,
+  });
+  assert.equal("private_detail" in result.sample[0]!, false);
+  assert.equal("private_response_detail" in result, false);
+});
+
+test("publication reconciliation rejects malformed sample rows", async (t) => {
+  const { client } = fixture(t, () =>
+    Response.json({
+      apply: false,
+      scanned: 1,
+      eligible: 1,
+      changed: 0,
+      eligible_remaining: 1,
+      protected_batch_items: 0,
+      oldest_eligible_age_seconds: 60,
+      oldest_remaining_age_seconds: 60,
+      sample: [
+        {
+          item_key: "openclaw/example#1@publish:2:1",
+          queue_revision: 1,
+          reason: "private_reason",
+          target_key: "openclaw/example#1",
+          publication_revision: 1,
+          superseded_by_revision: 2,
+          lineage_claim_generation: null,
+          retained_item_key: null,
+        },
+      ],
+    }),
+  );
+
+  await assert.rejects(
+    client.reconcilePublications({ apply: false, maxItems: 1 }),
+    /sample reason/,
+  );
+});

--- a/test/repair/exact-review-queue-maintenance-workflow.test.ts
+++ b/test/repair/exact-review-queue-maintenance-workflow.test.ts
@@ -21,7 +21,17 @@ const workflow = YAML.parse(source) as {
 
 test("queue maintenance is explicit, bounded, and non-cancelling", () => {
   assert.equal(workflow.on.schedule, undefined);
-  assert.deepEqual(Object.keys(workflow.on.workflow_dispatch.inputs), ["execute", "passes"]);
+  assert.deepEqual(Object.keys(workflow.on.workflow_dispatch.inputs), [
+    "execute",
+    "passes",
+    "max_items",
+  ]);
+  assert.deepEqual(workflow.on.workflow_dispatch.inputs.max_items, {
+    description: "Maximum reconciliation candidates to inspect",
+    required: true,
+    type: "number",
+    default: 1,
+  });
   assert.equal(workflow.concurrency["cancel-in-progress"], false);
   assert.deepEqual(workflow.permissions, { contents: "read" });
   const maintenance = workflow.jobs.reconcile!.steps.find(
@@ -29,9 +39,10 @@ test("queue maintenance is explicit, bounded, and non-cancelling", () => {
   );
   assert.equal(maintenance?.env?.EXECUTE, "${{ inputs.execute }}");
   assert.equal(maintenance?.env?.PASSES, "${{ inputs.passes }}");
+  assert.equal(maintenance?.env?.MAX_ITEMS, "${{ inputs.max_items }}");
   const run = maintenance?.run || "";
   assert.match(run, /repair:exact-review-queue-maintenance/);
-  assert.match(run, /--max-items 100/);
+  assert.match(run, /--max-items "\$MAX_ITEMS"/);
   assert.match(run, /args\+=\(--apply\)/);
   assert.match(run, /--passes "\$PASSES"/);
   assert.match(cliSource, /requestedPasses = integerArg\("--passes", 1, 1, 100\)/);


### PR DESCRIPTION
Related: https://github.com/openclaw/clawsweeper/issues/1396

## What Problem This Solves

Resolves a problem where maintainers could see that publication reconciliation had eligible work, but the repair CLI discarded the Worker's bounded candidate sample and the manual workflow always inspected 100 candidates.

## Why This Change Was Made

The repair client now converts at most 20 reconciliation rows into an explicit allowlist and rejects malformed rows without spreading unknown response fields. The manual workflow adds a numeric `max_items` input with a default of one and forwards it to the existing CLI.

This does not change Worker selection, queue policy, reconciliation mutation behavior, dashboard status, Bay, or publication counts.

## User Impact

Maintainers can inspect one exact publication reconciliation candidate before choosing a separately fenced action. Normal review and publication behavior is unchanged.

## OpenClaw Bay Impact

OpenClaw Bay is unaffected. This is a private signed repair response and a manual workflow input; no public observer route or Bay projection changes.

## Documentation Impact

Reviewed `AGENTS.md`, `CONTRIBUTING.md`, and `docs/README.md`. No documentation change is required because the existing private maintenance workflow remains manual, non-cancelling, and dry-run by default; the workflow UI now exposes its bound directly.

## Evidence

- Head: `0501b18c44ce26f30e218c94dfbc98ae150a65ac` (signed)
- Repair TypeScript build: passed on Node `v26.7.0`
- Focused client/workflow tests: 28 passed
- Worker/client interoperability review: all four reconciliation sample reasons accepted
- Pre-commit Codex reviews: no actionable regressions
- Committed-range Codex review: no actionable regressions; 42 focused tests passed
- `git diff --check`: passed
- Production delta: +83 lines; justified by the explicit private response contract and fail-closed one-item operator control
- Test delta: +103 lines

## Real Behavior Proof

- **Claim:** a maintainer can dry-run one production reconciliation candidate and receive only the bounded allowlisted sample from the exact PR head.
- **Exercised surface:** commit `0501b18c44ce26f30e218c94dfbc98ae150a65ac` of the changed repair client, invoked with the workflow's forwarded `max_items=1` argument against the production exact-review queue.
- **Scenario:** manual dry-run with `execute=false`, `passes=1`, and `max_items=1`.
- **Command and environment:** GitHub-hosted `Maintain exact review queue` run using the repository-managed production URL and signing secret; the proof workflow asserted the checked-out SHA before execution.
- **Observed result:** `apply=false`, `changed=0`, exactly one sample, and exactly the eight allowlisted fields. The exact item identity is retained privately for the post-merge identity-fenced operator action.
- **Artifact:** https://github.com/openclaw/clawsweeper/actions/runs/33867635452
- **Limits:** dry-run only; this proves exact-head parsing, bounding, privacy omission, and one-item forwarding. It does not execute reconciliation or supersede any publication.
