### PR TITLE
refactor: reuse record coercion helper

### DIFF
--- a/dashboard/apply-observability.ts
+++ b/dashboard/apply-observability.ts
@@ -1,3 +1,5 @@
+import { recordOrEmpty as object } from "../src/value-coerce.ts";
+
 export const APPLY_OBSERVABILITY_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 export const APPLY_OBSERVABILITY_RANGES = {
   "6h": 6 * 60 * 60 * 1000,
@@ -335,11 +337,6 @@ function unknownQueue() {
     oldest_backoff_age_seconds: null,
     oldest_lease_age_seconds: null,
   };
-}
-function object(value: unknown): Record<string, unknown> {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : {};
 }
 function timestamp(value: unknown) {
   const time = Date.parse(String(value || ""));

--- a/dashboard/exact-review-artifact-cache.ts
+++ b/dashboard/exact-review-artifact-cache.ts
@@ -1,3 +1,5 @@
+import { recordOrEmpty as objectValue } from "../src/value-coerce.ts";
+
 export const EXACT_REVIEW_ARTIFACT_RECEIPT_TABLE = "exact_review_artifact_receipts";
 const EXACT_REVIEW_ARTIFACT_CACHE_META_TABLE = "exact_review_artifact_cache_meta";
 export const EXACT_REVIEW_ARTIFACT_CACHE_PREFIX = "artifacts/exact-review/v1/";
@@ -344,10 +346,4 @@ function artifactBucket(value: unknown): ArtifactR2Bucket | null {
 
 function firstRow(rows: Iterable<SqlRow>): SqlRow | undefined {
   return Array.from(rows)[0];
-}
-
-function objectValue(value: unknown): Record<string, unknown> {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : {};
 }

--- a/dashboard/github-etag-cache.ts
+++ b/dashboard/github-etag-cache.ts
@@ -3,6 +3,7 @@ import {
   githubEtagCacheKeyFromValue,
   type GithubEtagCacheKey,
 } from "../src/github-etag-cache-contract.ts";
+import { recordOrEmpty as objectValue } from "../src/value-coerce.ts";
 
 export const GITHUB_ETAG_CACHE_TABLE = "github_etag_response_cache_v1";
 export const GITHUB_ETAG_CACHE_MAX_ENTRIES = 2_048;
@@ -330,10 +331,4 @@ async function sha256Bytes(value: Uint8Array<ArrayBuffer>): Promise<string> {
 
 function firstRow(rows: Iterable<SqlRow>): SqlRow | undefined {
   return Array.from(rows)[0];
-}
-
-function objectValue(value: unknown): Record<string, unknown> {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : {};
 }

--- a/src/clawsweeper-github-runtime.ts
+++ b/src/clawsweeper-github-runtime.ts
@@ -20,6 +20,7 @@ import {
 } from "./github-etag-read-broker.js";
 import { recordGithubEgressBrokerEvent } from "./github-egress-observer.js";
 import { GitHubRateLimitError, ghRetryKind, type GitHubCredentialScope } from "./github-retry.js";
+import { recordOrEmpty as objectValue } from "./value-coerce.js";
 
 interface CreateGitHubRuntimeDependencies {
   ROOT: string;
@@ -659,12 +660,6 @@ export function createGitHubRuntime(dependencies: CreateGitHubRuntimeDependencie
       body,
       ...(headers.get("etag") ? { etag: headers.get("etag") } : {}),
     };
-  }
-
-  function objectValue(value: unknown): Record<string, unknown> {
-    return value && typeof value === "object" && !Array.isArray(value)
-      ? (value as Record<string, unknown>)
-      : {};
   }
 
   function stringValue(value: unknown): string {

--- a/src/clawsweeper-review-planning-inventory.ts
+++ b/src/clawsweeper-review-planning-inventory.ts
@@ -32,6 +32,7 @@ import {
   githubReadModelRequestSync,
   usableGithubReadModelResponse,
 } from "./github-webhook-read-model-client.js";
+import { recordOrEmpty as jsonRecord } from "./value-coerce.js";
 
 export {
   PR_ACTIVITY_REVISION_CONNECTION_LIMIT,
@@ -367,12 +368,6 @@ export function createReviewPlanningInventory(dependencies: ReviewPlanningDepend
     fetchOpenItemCounts,
     fetchPlannedPrActivityRevisions,
   };
-}
-
-function jsonRecord(value: unknown): Record<string, unknown> {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : {};
 }
 
 function validGraphQlName(value: string | undefined): value is string {

--- a/src/pr-comment-activity-revision.ts
+++ b/src/pr-comment-activity-revision.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { compareCodeUnits, stableJson } from "./stable-json.js";
+import { recordOrEmpty as jsonRecord } from "./value-coerce.js";
 
 export const PR_ACTIVITY_REVISION_QUERY_PAGE_SIZE = 100;
 export const PR_ACTIVITY_REVISION_CONNECTION_LIMIT = 40;
@@ -112,12 +113,6 @@ export function prCommentActivityRevision(value: unknown): string | null {
   return `sha256:${createHash("sha256")
     .update(stableJson({ reviewCount, threadCount, threads }))
     .digest("hex")}`;
-}
-
-function jsonRecord(value: unknown): Record<string, unknown> {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : {};
 }
 
 function nonnegativeIntegerOrNull(value: unknown): number | null {


### PR DESCRIPTION
## What Problem This Solves

Several parsing paths maintained identical five-line record coercers. Keeping
those copies local made a basic input boundary easier to drift and harder to
audit consistently.

## Why This Change Was Made

Reuse the existing `recordOrEmpty` helper in six parsing/runtime modules while
preserving each module's local call name through import aliases. This is a
strict internal refactor: validation, authorization, queue behavior, storage
contracts, and public types are unchanged.

The similarly shaped helper in `src/github-etag-cache-contract.ts` is
intentionally excluded. That source is loaded both as native TypeScript by the
dashboard and as compiled JavaScript by Node, so adding a normal source-relative
helper import would cross its current dual-loader boundary. Exported queue
contracts, hosted-target admission, exact-review security clones, the already
landed egress-telemetry cleanup, and unreviewed adjacent dead code are also out
of scope.

## User Impact

No user-visible behavior changes. Maintainers have 27 fewer duplicate lines and
one existing coercion implementation to audit across these six paths.

## OpenClaw Bay Impact

OpenClaw Bay is unaffected. Apply observability is exercised transitively, but
its normalized output, schema, status fields, and observer-only action boundary
are byte-for-byte unchanged.

## Documentation Impact

`AGENTS.md`, `CONTRIBUTING.md`, and `VISION.md` were reviewed. No documentation
or changelog update is needed because this changes no public, operational,
security, queue, API, or release contract.

## Evidence

- Focused build and tests: 86 tests passed across apply observability, artifact
  cache, durable ETag reads, fixed-SHA pull resolution, PR comment activity, and
  scheduler policy.
- Required uncommitted and committed reviews found no actionable regressions.
- Configured Crabbox AWS run `run_3bb55013f360`, lease
  `cbx_d37200b9e57a`, cloned the public task branch, asserted
  `f14a4997a8787f5d5a47ec50763242eea56e7dd6`, installed the pinned
  `pnpm@11.10.0`, and passed `pnpm run check`.
- The full check passed 4,848 tests with 18 platform skips and zero failures.
  Aggregate coverage was 85.71% lines, 76.23% branches, and 89.61% functions.
- The owned AWS lease was released after the run.

## Real Behavior Proof

**Claim:** The six changed production parsing/runtime paths preserve record
acceptance, rejected-value fallbacks, accepted-object identity, fresh empty
objects, and downstream results.

**Exercised surface:** Actual exported consumers were invoked for apply
observability normalization, exact-review artifact receipt parsing, dashboard
ETag storage, review-planning GraphQL parsing, PR comment activity revisions,
and the production `createGitHubRuntime` durable ETag `confirm304` path.

**Scenario or fixture:** The general corpus covered `null`, arrays, primitives,
functions, plain records, null-prototype records, and `Date` objects. The
runtime confirmation fixture covered malformed JSON response entries plus a
valid `{ etag, bodyDigest }` record. It used local fake `gh`/`curl` transports:
malformed confirmations fell back to fresh data, while the valid record served
the digest-matched cached body.

**Command and environment:** Node 26.7.0 and pinned project tooling generated
deterministic base/candidate JSON artifacts. The remote full check used the
configured AWS provider with a real Git checkout and
`corepack pnpm install --frozen-lockfile && corepack pnpm run check`.

**Observable result:** The five directly exposed parser/storage consumers plus
the helper identity/freshness contract produced byte-identical base and
candidate artifacts with SHA-256
`c34e905dea10ae348aa30e8d0dcbb121926db0089975708e64b352fe4d17bd8a`.
The separate production-runtime confirmation artifact was also byte-identical
with SHA-256
`961745735a5a87f0e844092d5ba2d80d922c00483df2fb0024b93a920b1d7f78`.

**Artifact or trace:** Deterministic JSON proof artifacts and their scripts are
retained in the operator handoff. The Crabbox run and lease IDs above identify
the exact-head remote check.

**Limits:** The proof used controlled local transports and did not contact live
GitHub or Cloudflare mutation endpoints. No queue, workflow, deployment, apply,
close, or Bay action was triggered.
