### PR TITLE
fix(review): recognize browser profile redaction fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,6 +585,7 @@ the reviewed OpenClaw Browser CDP authentication and credential-redaction fixtur
 [`chrome.test.ts`](https://github.com/openclaw/openclaw/blob/8e03b0c62e76dc25c77045a84ab3098a111a7be3/extensions/browser/src/browser/chrome.test.ts),
 the [remote-CDP coverage](https://github.com/openclaw/openclaw/blob/58da2f5897feb6840937d8e50cf7ee6f26aa57d7/extensions/browser/src/browser/chrome.test.ts),
 the [server-context redaction test](https://github.com/openclaw/openclaw/blob/4b5987829d0f82ea44ae50f2f418ffe5ea445e7f/extensions/browser/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts),
+the [profile-status redaction fixture](https://github.com/openclaw/openclaw/blob/6419496e10404f624728f47d9ebcd874aaf60a79/extensions/browser/src/browser/server-context.list-profiles.test.ts#L424-L453),
 the [remote-CDP documentation example](https://github.com/openclaw/openclaw/blob/bf15c87d2b1223610b42775b8154b8eec60b541d/docs/tools/browser.md),
 the [credentialed-page rejection fixtures](https://github.com/openclaw/openclaw/blob/d5fb4903f1b13a4309d479f1011d995b1fc706ae/extensions/browser/src/browser-tool.test.ts),
 the [guarded CDP authentication fixtures](https://github.com/openclaw/openclaw/blob/1cf6ff3bdc08a6ac08facb1006b1d7aabc0eaff4/extensions/browser/src/browser/cdp.helpers.test.ts),

--- a/src/agent-input-scan-fixtures.ts
+++ b/src/agent-input-scan-fixtures.ts
@@ -38,6 +38,11 @@ const REVIEWED_FIXTURES: readonly ReviewedFixture[] = [
     ],
   },
   {
+    // Profile-status redaction repeats this synthetic URI in config and a mocked-call assertion.
+    fixtureSha256: "d15184614e748450d49a726f84955ca7745b87d0728afbd6bb6b50d84cce4fe0",
+    sources: ["extensions/browser/src/browser/server-context.list-profiles.test.ts"],
+  },
+  {
     // OpenClaw remote-CDP documentation example introduced by bf15c87d2b12.
     fixtureSha256: "e6907dddaccdec944b0f02e14fe9186293e2d513ff753db0a95b3460aa5dc1d9",
     sources: ["docs/tools/browser.md"],

--- a/test/agent-input-scan.test.ts
+++ b/test/agent-input-scan.test.ts
@@ -550,6 +550,7 @@ const browserDocsSource = "docs/tools/browser.md";
 const browserToolSource = "extensions/browser/src/browser-tool.test.ts";
 const browserCdpHelpersSource = "extensions/browser/src/browser/cdp.helpers.test.ts";
 const browserMcpSource = "extensions/browser/src/browser/chrome-mcp.test.ts";
+const browserProfilesSource = "extensions/browser/src/browser/server-context.list-profiles.test.ts";
 const macDashboardSource = "apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift";
 const mcpAppsSource = "src/config/config-misc.test.ts";
 const marketplaceFeedSource = "src/cli/plugins-cli.marketplace-refresh.test.ts";
@@ -711,13 +712,37 @@ for (const scenarioName of [
   ]),
   "marketplace feed query mutation",
   "gateway config query mutation",
+  ...[
+    "reviewed fixture",
+    "HTML repeated literal",
+    "changed raw",
+    "changed full URI",
+    "changed matching raw values",
+    "other file",
+    "executable source",
+    "prompt",
+    "schema",
+    "additional",
+    "diff",
+    "decoded only",
+    "verified",
+    "mixed findings",
+    "wrong detector",
+    "wrong source type",
+    "wrong decoder",
+    "wrong secret parts",
+    "missing verification error",
+    "wrong version",
+    "missing completion",
+  ].map((scenario) => `browser profiles ${scenario}`),
 ]) {
+  const browserProfilesFixture = scenarioName.startsWith("browser profiles ");
   const macDashboardFixture = scenarioName.startsWith("mac dashboard ");
   const mcpAppsFixture = scenarioName.startsWith("mcp apps ");
   const marketplaceFeedFixture = scenarioName.startsWith("marketplace feed ");
   const gatewayConfigFixture = scenarioName.startsWith("gateway config ");
   const scenario = scenarioName.replace(
-    /^(?:mac dashboard|mcp apps|marketplace feed|gateway config) /,
+    /^(?:mac dashboard|mcp apps|marketplace feed|gateway config|browser profiles) /,
     "",
   );
   test(`reviewed synthetic fixture admission: ${scenarioName}`, (t) => {
@@ -758,7 +783,9 @@ for (const scenarioName of [
     const scannerLine = scenario.includes("shifted BASE64") ? literalLine - 4 : literalLine;
     const primaryDecoder = scenario.includes("BASE64")
       ? "BASE64"
-      : scenario === "browser CDP encoded HTML fixture" || scenario === "unreviewed HTML"
+      : scenario === "browser CDP encoded HTML fixture" ||
+          scenario === "unreviewed HTML" ||
+          (browserProfilesFixture && scenario === "HTML repeated literal")
         ? "HTML"
         : "PLAIN";
     if (browserExactFixture) {
@@ -833,6 +860,12 @@ for (const scenarioName of [
       const url = new URL("https://chrome.remote.example.com");
       url.username = "alice";
       url.password = "secret";
+      uri = url.href.slice(0, -1);
+    }
+    if (browserProfilesFixture) {
+      const url = new URL("http://127.0.0.1:9222");
+      url.username = "openclaw";
+      url.password = "relay-token";
       uri = url.href.slice(0, -1);
     }
     assert.ok(uri, "reviewed synthetic fixture is present");
@@ -920,6 +953,8 @@ for (const scenarioName of [
       files = [scenario === "other file" ? "other.test.ts" : marketplaceFeedSource];
     if (gatewayConfigFixture)
       files = [scenario === "other file" ? "other.test.ts" : gatewayConfigSource];
+    if (browserProfilesFixture)
+      files = [scenario === "other file" ? "other.test.ts" : browserProfilesSource];
     const value =
       scenario === "decoded only" || scenario.endsWith("encoded-only")
         ? primaryDecoder === "BASE64"
@@ -1145,6 +1180,7 @@ process.exit(scenario === 'unexpected successful output' ? 0 : 183);
     if (
       [
         "reviewed fixture",
+        "HTML repeated literal",
         "browser local Chrome fixture",
         "browser remote Chrome fixture",
         "browser remote server fixture",


### PR DESCRIPTION
Related: [OpenClaw Chrome MCP initialization-cleanup repair](https://github.com/openclaw/openclaw/pull/138524).

<details>
<summary>Additional instructions</summary>

This branch is in the shared repository and is editable by maintainers with repository write access.

</details>

## What Problem This Solves

Fixes an issue where ClawSweeper cannot review the Chrome MCP cleanup repair because input admission rejects an existing synthetic profile-status redaction fixture. The same dummy relay URI appears in the profile configuration and its mocked reachability assertion; neither occurrence is introduced or changed by the browser repair.

## Why This Change Was Made

Adds one expressly maintainer-approved fingerprint/source pair to the existing host-owned fixture policy. It uses the existing exact native-URI digest, exact source path, regular-file mode, literal-presence, native metadata, complete-scan, and final source-fence checks. Repeated identical literal witnesses remain allowed by the existing non-line-bound entry contract. It does not add a domain exemption, change the classifier or scanner arguments, approve arbitrary content in the file, or bypass review/merge gates.

The other detected browser endpoint-redaction and documentation examples already have exact policy entries and are unchanged. The user explicitly approved adding and publishing these scoped synthetic-fixture qualifications; live GitHub membership confirmed active OpenClaw organization-admin status.

## User Impact

The browser cleanup repair can pass normal scan admission and receive an actual review. Different URI bytes, source paths or file modes, encoded-only material, prompt/diff findings, mixed findings, verified findings, invalid native metadata, and incomplete scans remain blocking. No OpenClaw runtime behavior changes here.

## OpenClaw Bay Impact

None. There is no Bay UI, API, data-contract, queue, or publication change. Bay continues to observe normal review progress after the input is admitted.

## Documentation Impact

The existing active README Safety Model now links the approved profile-status fixture. Its host-policy owner, exact-match rules, repeated-literal semantics, and scanner-version requalification trigger are unchanged. No new runbook or translated documentation is introduced.

## Evidence

Production policy: +5/-0 lines. Tests: +38/-2 lines. Documentation: +1 line. Production growth is solely the new approved table entry; no matching or control-flow code changes.

The two new positive regression cases failed against the original policy with `literal_not_reviewed`. All 21 added cases then passed, including refusal coverage at the provider-admission boundary and checks that refused material launches no provider and emits no success notice.

```bash
node --test --test-name-pattern='reviewed synthetic fixture admission: browser profiles ' test/agent-input-scan.test.ts
```

Fresh isolated Codex reviews of both the uncommitted patch and committed branch returned `scoped-clean` at P0 with no accepted findings. Formatting and `git diff --check` passed. [Exact-head CI run 33926173846](https://github.com/openclaw/clawsweeper/actions/runs/33926173846) passed: the complete `pnpm run check` gate, sparse repair builds, and native Windows launcher coverage. The [full-check job](https://github.com/openclaw/clawsweeper/actions/runs/33926173846/job/101195061703) passed **4,951 tests**, with 18 skipped and zero failures or cancellations, plus the separate 13-test focused coverage gate.

The first nested-checkout local check inherited the containing OpenClaw repository's unrelated lint rules and failed on existing ClawSweeper code. No lint policy or unrelated source was changed. An identical neutral temporary clone with its own frozen dependencies passed static checks, all builds, every lint lane, and focused coverage. Local macOS claims here are those checks, the 21 scoped admission cases, and the native scanner proof below; the complete whole-repository test/coverage result cited above is the exact-head Linux CI run.

## Review Disposition: Pinned Fixture Provenance

The [review's remaining provenance item](https://github.com/openclaw/clawsweeper/pull/1427#issuecomment-5547284140) is addressed by direct source inspection, also repeated by a separate read-only verifier against replacement-disabled Git object reads. This is not a request to infer safety from a filename, an unverified scan result, or an already-approved neighboring fixture.

- The [pinned redaction case](https://github.com/openclaw/openclaw/blob/6419496e10404f624728f47d9ebcd874aaf60a79/extensions/browser/src/browser/server-context.list-profiles.test.ts#L424-L453) is fixed in-source test data: head blob `958f3f5425c3452a25dba3d0937b5ba5d8a48625`, mode `100644`. It has two identical URI occurrences, at lines 428 and 449: one supplies the profile, and one asserts the argument to the reachability mock. The entire redaction case is byte-identical in base blob `2bac28122b940cddb40d5f534d1cc5eb8a16bcdf` at lines 426–455.
- The test imports its [Chrome mock harness](https://github.com/openclaw/openclaw/blob/6419496e10404f624728f47d9ebcd874aaf60a79/extensions/browser/src/browser/server-context.chrome-test-harness.ts#L26-L46), blob `782547c0218731d9137b0251679afe0c79557372`, which replaces reachability with `vi.fn` and rejects unexpected launches. The case sets that mock's result at lines 442–443 and asserts credential-free profile output at line 453. Its state factory constructs in-memory state from the supplied profile, not stored credentials.
- Independently hashing the exact literal bytes, excluding source quotes/newline and without normalization, yields `d15184614e748450d49a726f84955ca7745b87d0728afbd6bb6b50d84cce4fe0` for all four base/head occurrences. That is precisely the new policy key. The literal contains no interpolation, query, or environment/credential-store reference. Raw values are intentionally not reproduced here.

Maintainer disposition: retain only this expressly approved fingerprint/source qualification under the existing matching rules. The direct source evidence resolves the review's provenance uncertainty; it does not authorize another URI/path pair or relax any scanner, metadata, source-fence, or merge gate. The separate verifier performed source inspection only; native scanner behavior and hosted full-suite results remain the separate evidence above and below.

## Real Behavior Proof

**Claim and surface:** production `scanAgentInput` with native TruffleHog 3.97.1 admits the full browser repair after the one missing qualification, while retaining all existing scanner and source checks.

**Scenario:** the complete committed OpenClaw diff and all changed-file base/head blobs, from `0062f2b127bbbdc9fd7db65c679066a11101b6c3` to `6419496e10404f624728f47d9ebcd874aaf60a79`. This is not a fake scanner or a single-string-only scan.

**Environment and command:** macOS, Node 24.20.0, actual installed TruffleHog 3.97.1, with the entire Node/scanner process tree under a network-denying sandbox. The production scanner arguments are unchanged. Equivalent invocation from a built ClawSweeper checkout, with the clean target browser checkout at `../openclaw`:

```bash
sandbox-exec -p '(version 1)(allow default)(deny network*)' node --input-type=module - ../openclaw <<'JS'
import { scanAgentInput } from './dist/agent-input-scan.js';
scanAgentInput({
  cwd: process.argv[2],
  prompt: 'Review Chrome MCP cleanup ownership.',
  source: {
    kind: 'committed',
    baseSha: '0062f2b127bbbdc9fd7db65c679066a11101b6c3',
    headSha: '6419496e10404f624728f47d9ebcd874aaf60a79',
  },
  timeoutMs: 120_000,
});
JS
```

**Observed before:** the native scan refused with `findings` / `literal_not_reviewed` at the profile-status fixture in base blob `2bac28122b940cddb40d5f534d1cc5eb8a16bcdf`, line 430.

**Observed after:** the native scan completed and emitted three explicit `agent_input_scan_classified` fixture/source notices: profile-status redaction, MCP endpoint redaction, and the existing browser documentation example. Both target endpoints were covered. The target checkout remained clean, and the scanner-only proof launched no provider.

**Artifacts and limits:** safe before/after JSON receipts and command logs are retained in the task artifacts; the observations above are their public, value-free summary. Raw scanner output and matched values are not published. Network denial prevents verification from contacting either the operator's loopback service or an external endpoint and deliberately exercises unreachable-verification classification. This proves the real scanner/admission boundary, not live credential verification, model inference, hosted review publication, or cross-platform behavior. A normal hosted review of the browser repair follows publication of this qualification.
