### PR TITLE
refactor(test): deduplicate apply workspaces

### DIFF
--- a/test/apply-pr-coverage-proof-close.test.ts
+++ b/test/apply-pr-coverage-proof-close.test.ts
@@ -18,7 +18,9 @@ import {
   promotionGhMock,
   reportWithSyncedReviewComment,
   runApplyDecisionsForTest,
+  runOpenClawApplyDecisionsForTest,
   tmpPrefix,
+  withApplyTestWorkspace,
   withMockCodexProof,
   withMockGh,
 } from "./helpers.ts";
@@ -128,15 +130,8 @@ test("apply-decisions skips stale close reports before duplicate PR coverage pro
 });
 
 test("apply-decisions checks duplicate PR coverage proof before syncing corrected review comments", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const commentWriteLogPath = join(root, "comment-writes.log");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     const reportMarkdown = lowSignalCloseReport({
       number: 354,
       title: "Unsynced duplicate close",
@@ -181,19 +176,11 @@ test("apply-decisions checks duplicate PR coverage proof before syncing correcte
             reason: "PR A still has unique fallback route behavior that PR B does not cover.",
           },
           () => {
-            runApplyDecisionsForTest({
+            runOpenClawApplyDecisionsForTest({
               itemsDir,
               closedDir,
               plansDir,
               reportPath,
-              extraArgs: [
-                "--target-repo",
-                "openclaw/openclaw",
-                "--apply-kind",
-                "all",
-                "--processed-limit",
-                "3",
-              ],
             });
           },
         );
@@ -221,20 +208,11 @@ test("apply-decisions checks duplicate PR coverage proof before syncing correcte
     const blockedReport = readFileSync(join(itemsDir, "354.md"), "utf8");
     assert.match(blockedReport, /^decision: keep_open$/m);
     assert.match(blockedReport, /^review_comment_synced_at:/m);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });
 
 test("apply-decisions closes existing duplicate PR close proposals when coverage proof says covered", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const synced = reportWithSyncedReviewComment(
       lowSignalCloseReport({
         number: 349,
@@ -280,20 +258,12 @@ test("apply-decisions closes existing duplicate PR close proposals when coverage
             reason: "PR B carries forward PR A's fallback route behavior.",
           },
           () => {
-            runApplyDecisionsForTest({
+            runOpenClawApplyDecisionsForTest({
               itemsDir,
               closedDir,
               plansDir,
               reportPath,
-              extraArgs: [
-                "--target-repo",
-                "openclaw/openclaw",
-                "--dry-run",
-                "--apply-kind",
-                "all",
-                "--processed-limit",
-                "3",
-              ],
+              dryRun: true,
             });
           },
         );
@@ -312,20 +282,11 @@ test("apply-decisions closes existing duplicate PR close proposals when coverage
       report.find((entry) => entry.action === "closed")?.reason ?? "",
       /duplicate or superseded/,
     );
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });
 
 test("apply-decisions permits a trusted deferred close-proof command status through post-proof freshness", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const synced = reportWithSyncedReviewComment(
       lowSignalCloseReport({
         number: 363,
@@ -400,20 +361,12 @@ test("apply-decisions permits a trusted deferred close-proof command status thro
             reason: "PR B carries forward PR A's fallback route behavior.",
           },
           () => {
-            runApplyDecisionsForTest({
+            runOpenClawApplyDecisionsForTest({
               itemsDir,
               closedDir,
               plansDir,
               reportPath,
-              extraArgs: [
-                "--target-repo",
-                "openclaw/openclaw",
-                "--dry-run",
-                "--apply-kind",
-                "all",
-                "--processed-limit",
-                "3",
-              ],
+              dryRun: true,
             });
           },
         );
@@ -433,21 +386,12 @@ test("apply-decisions permits a trusted deferred close-proof command status thro
       report.find((entry) => entry.action === "closed")?.reason ?? "",
       /duplicate or superseded/,
     );
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });
 
 test("apply-decisions rejects a source edit masked by a deferred close-proof status", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const proofLogPath = join(root, "proof.log");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     const reviewedTitle = "Provider route fallback";
     const synced = reportWithSyncedReviewComment(
       lowSignalCloseReport({
@@ -516,20 +460,12 @@ test("apply-decisions rejects a source edit masked by a deferred close-proof sta
             invocationLogPath: proofLogPath,
           },
           () => {
-            runApplyDecisionsForTest({
+            runOpenClawApplyDecisionsForTest({
               itemsDir,
               closedDir,
               plansDir,
               reportPath,
-              extraArgs: [
-                "--target-repo",
-                "openclaw/openclaw",
-                "--dry-run",
-                "--apply-kind",
-                "all",
-                "--processed-limit",
-                "3",
-              ],
+              dryRun: true,
             });
           },
         );
@@ -543,21 +479,12 @@ test("apply-decisions rejects a source edit masked by a deferred close-proof sta
     assert.equal(report[0]?.action, "skipped_changed_since_review");
     assert.match(report[0]?.reason ?? "", /updated_at changed/);
     assert.equal(existsSync(proofLogPath), false);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });
 
 test("apply-decisions records successful duplicate PR coverage proof for closed PRs", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const closeAppliedBodyLogPath = join(root, "close-applied-body.log");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     const synced = reportWithSyncedReviewComment(
       lowSignalCloseReport({
         number: 360,
@@ -605,19 +532,11 @@ test("apply-decisions records successful duplicate PR coverage proof for closed 
             reason: "PR B carries forward PR A's fallback route behavior.",
           },
           () => {
-            runApplyDecisionsForTest({
+            runOpenClawApplyDecisionsForTest({
               itemsDir,
               closedDir,
               plansDir,
               reportPath,
-              extraArgs: [
-                "--target-repo",
-                "openclaw/openclaw",
-                "--apply-kind",
-                "all",
-                "--processed-limit",
-                "3",
-              ],
             });
           },
         );
@@ -636,9 +555,7 @@ test("apply-decisions records successful duplicate PR coverage proof for closed 
       closeAppliedBody,
       /Covering PR: https:\/\/github\.com\/openclaw\/openclaw\/pull\/400\./,
     );
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });
 
 test("apply-decisions consumes a bound precomputed proof without invoking Codex", () => {
@@ -995,14 +912,7 @@ test("apply-decisions fails closed when a required precomputed proof is missing"
 });
 
 test("apply-decisions filters covering PR bot comments from coverage proof", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const synced = reportWithSyncedReviewComment(
       lowSignalCloseReport({
         number: 363,
@@ -1071,20 +981,12 @@ test("apply-decisions filters covering PR bot comments from coverage proof", () 
             unexpectedPromptIncludes: "AUTOMATION_SHOULD_NOT_REACH_SWEEP_PROOF",
           },
           () => {
-            runApplyDecisionsForTest({
+            runOpenClawApplyDecisionsForTest({
               itemsDir,
               closedDir,
               plansDir,
               reportPath,
-              extraArgs: [
-                "--target-repo",
-                "openclaw/openclaw",
-                "--dry-run",
-                "--apply-kind",
-                "all",
-                "--processed-limit",
-                "3",
-              ],
+              dryRun: true,
             });
           },
         );
@@ -1098,21 +1000,12 @@ test("apply-decisions filters covering PR bot comments from coverage proof", () 
       report.some((entry) => entry.action === "closed"),
       true,
     );
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });
 
 test("apply-decisions rechecks duplicate PR freshness after coverage proof passes", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const proofLogPath = join(root, "proof.log");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     const synced = reportWithSyncedReviewComment(
       lowSignalCloseReport({
         number: 357,
@@ -1161,19 +1054,11 @@ test("apply-decisions rechecks duplicate PR freshness after coverage proof passe
             invocationLogPath: proofLogPath,
           },
           () => {
-            runApplyDecisionsForTest({
+            runOpenClawApplyDecisionsForTest({
               itemsDir,
               closedDir,
               plansDir,
               reportPath,
-              extraArgs: [
-                "--target-repo",
-                "openclaw/openclaw",
-                "--apply-kind",
-                "all",
-                "--processed-limit",
-                "3",
-              ],
             });
           },
         );
@@ -1191,21 +1076,12 @@ test("apply-decisions rechecks duplicate PR freshness after coverage proof passe
     assert.equal(report[0]?.action, "skipped_changed_since_review");
     assert.match(report[0]?.reason ?? "", /updated_at changed/);
     assert.equal(existsSync(join(closedDir, "357.md")), false);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });
 
 test("apply-decisions rejects a same-timestamp covering PR snapshot change after proof", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const proofLogPath = join(root, "proof.log");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     const synced = reportWithSyncedReviewComment(
       lowSignalCloseReport({
         number: 360,
@@ -1269,19 +1145,11 @@ test("apply-decisions rejects a same-timestamp covering PR snapshot change after
             invocationLogPath: proofLogPath,
           },
           () => {
-            runApplyDecisionsForTest({
+            runOpenClawApplyDecisionsForTest({
               itemsDir,
               closedDir,
               plansDir,
               reportPath,
-              extraArgs: [
-                "--target-repo",
-                "openclaw/openclaw",
-                "--apply-kind",
-                "all",
-                "--processed-limit",
-                "3",
-              ],
             });
           },
         );
@@ -1302,7 +1170,5 @@ test("apply-decisions rejects a same-timestamp covering PR snapshot change after
       JSON.stringify(report, null, 2),
     );
     assert.equal(existsSync(join(closedDir, "360.md")), false);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });

--- a/test/apply-pr-coverage-proof-recheck.test.ts
+++ b/test/apply-pr-coverage-proof-recheck.test.ts
@@ -12,7 +12,9 @@ import {
   promotionGhMock,
   reportWithSyncedReviewComment,
   runApplyDecisionsForTest,
+  runOpenClawApplyDecisionsForTest,
   tmpPrefix,
+  withApplyTestWorkspace,
   withMockCodexProof,
   withMockGh,
 } from "./helpers.ts";
@@ -183,16 +185,9 @@ function boundDuplicateCloseComment(number: number, canonicalUrl: string): strin
 }
 
 test("apply-decisions fails closed when a self-mutation receipt is truncated", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const proofLogPath = join(root, "proof.log");
     const labelLogPath = join(root, "labels.log");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     const synced = reportWithSyncedReviewComment(
       lowSignalCloseReport({
         number: 359,
@@ -245,19 +240,11 @@ test("apply-decisions fails closed when a self-mutation receipt is truncated", (
             invocationLogPath: proofLogPath,
           },
           () => {
-            runApplyDecisionsForTest({
+            runOpenClawApplyDecisionsForTest({
               itemsDir,
               closedDir,
               plansDir,
               reportPath,
-              extraArgs: [
-                "--target-repo",
-                "openclaw/openclaw",
-                "--apply-kind",
-                "all",
-                "--processed-limit",
-                "3",
-              ],
             });
           },
         );
@@ -277,22 +264,13 @@ test("apply-decisions fails closed when a self-mutation receipt is truncated", (
     assert.equal(report[0]?.action, "skipped_changed_since_review");
     assert.match(report[0]?.reason ?? "", /same-second activity requires a fresh review/);
     assert.equal(existsSync(join(closedDir, "359.md")), false);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });
 
 test("apply-decisions blocks same-second human timeline activity hidden by self-updates", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const proofLogPath = join(root, "proof.log");
     const labelLogPath = join(root, "labels.log");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     const synced = reportWithSyncedReviewComment(
       lowSignalCloseReport({
         number: 362,
@@ -355,19 +333,11 @@ test("apply-decisions blocks same-second human timeline activity hidden by self-
             invocationLogPath: proofLogPath,
           },
           () => {
-            runApplyDecisionsForTest({
+            runOpenClawApplyDecisionsForTest({
               itemsDir,
               closedDir,
               plansDir,
               reportPath,
-              extraArgs: [
-                "--target-repo",
-                "openclaw/openclaw",
-                "--apply-kind",
-                "all",
-                "--processed-limit",
-                "3",
-              ],
             });
           },
         );
@@ -386,21 +356,12 @@ test("apply-decisions blocks same-second human timeline activity hidden by self-
     assert.match(report[0]?.reason ?? "", /same-second activity requires a fresh review/);
     assert.match(readFileSync(labelLogPath, "utf8"), /issue edit 362/);
     assert.equal(existsSync(join(closedDir, "362.md")), false);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });
 
 test("apply-decisions accepts same-second human activity already captured by the review", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const proofLogPath = join(root, "proof.log");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     const reviewedTimeline = [
       {
         id: 9364,
@@ -460,19 +421,11 @@ test("apply-decisions accepts same-second human activity already captured by the
             invocationLogPath: proofLogPath,
           },
           () => {
-            runApplyDecisionsForTest({
+            runOpenClawApplyDecisionsForTest({
               itemsDir,
               closedDir,
               plansDir,
               reportPath,
-              extraArgs: [
-                "--target-repo",
-                "openclaw/openclaw",
-                "--apply-kind",
-                "all",
-                "--processed-limit",
-                "3",
-              ],
             });
           },
         );
@@ -489,20 +442,11 @@ test("apply-decisions accepts same-second human activity already captured by the
       JSON.stringify(report, null, 2),
     );
     assert.equal(existsSync(join(closedDir, "364.md")), true);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });
 
 test("apply-decisions keeps existing duplicate PR close proposals open when coverage proof fails", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const synced = reportWithSyncedReviewComment(
       lowSignalCloseReport({
         number: 350,
@@ -541,20 +485,12 @@ test("apply-decisions keeps existing duplicate PR close proposals open when cove
       }),
       () => {
         withMockCodexProof(root, { type: "failure", message: "model unavailable" }, () => {
-          runApplyDecisionsForTest({
+          runOpenClawApplyDecisionsForTest({
             itemsDir,
             closedDir,
             plansDir,
             reportPath,
-            extraArgs: [
-              "--target-repo",
-              "openclaw/openclaw",
-              "--dry-run",
-              "--apply-kind",
-              "all",
-              "--processed-limit",
-              "3",
-            ],
+            dryRun: true,
           });
         });
       },
@@ -572,21 +508,12 @@ test("apply-decisions keeps existing duplicate PR close proposals open when cove
       report.find((entry) => entry.action === "retry_pr_close_coverage_proof")?.reason ?? "",
       /PR close coverage proof failed/,
     );
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });
 
 test("apply-decisions retries transient duplicate PR coverage proof failures", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const proofLogPath = join(root, "proof.log");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     const synced = reportWithSyncedReviewComment(
       lowSignalCloseReport({
         number: 353,
@@ -633,19 +560,11 @@ test("apply-decisions retries transient duplicate PR coverage proof failures", (
             invocationLogPath: proofLogPath,
           },
           () => {
-            runApplyDecisionsForTest({
+            runOpenClawApplyDecisionsForTest({
               itemsDir,
               closedDir,
               plansDir,
               reportPath,
-              extraArgs: [
-                "--target-repo",
-                "openclaw/openclaw",
-                "--apply-kind",
-                "all",
-                "--processed-limit",
-                "3",
-              ],
             });
           },
         );
@@ -698,19 +617,11 @@ test("apply-decisions retries transient duplicate PR coverage proof failures", (
             invocationLogPath: proofLogPath,
           },
           () => {
-            runApplyDecisionsForTest({
+            runOpenClawApplyDecisionsForTest({
               itemsDir,
               closedDir,
               plansDir,
               reportPath,
-              extraArgs: [
-                "--target-repo",
-                "openclaw/openclaw",
-                "--apply-kind",
-                "all",
-                "--processed-limit",
-                "3",
-              ],
             });
           },
         );
@@ -727,9 +638,7 @@ test("apply-decisions retries transient duplicate PR coverage proof failures", (
     );
     assert.equal(readFileSync(proofLogPath, "utf8").trim().split("\n").length, 2);
     assert.ok(existsSync(join(closedDir, "353.md")));
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });
 
 test("apply-decisions checks age before duplicate PR coverage proof", () => {
@@ -819,14 +728,7 @@ test("apply-decisions checks age before duplicate PR coverage proof", () => {
 });
 
 test("apply-decisions ignores unrelated unsafe PR links when canonical PR is safe", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const reportMarkdown = lowSignalCloseReport({
       number: 347,
       title: "Already proposed duplicate close",
@@ -877,20 +779,12 @@ test("apply-decisions ignores unrelated unsafe PR links when canonical PR is saf
             reason: "PR B is the merged canonical PR covering PR A.",
           },
           () => {
-            runApplyDecisionsForTest({
+            runOpenClawApplyDecisionsForTest({
               itemsDir,
               closedDir,
               plansDir,
               reportPath,
-              extraArgs: [
-                "--target-repo",
-                "openclaw/openclaw",
-                "--dry-run",
-                "--apply-kind",
-                "all",
-                "--processed-limit",
-                "3",
-              ],
+              dryRun: true,
             });
           },
         );
@@ -902,20 +796,11 @@ test("apply-decisions ignores unrelated unsafe PR links when canonical PR is saf
       report.some((entry) => entry.action === "closed"),
       true,
     );
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });
 
 test("apply-decisions blocks duplicate close when canonical PR is a bare cluster ref", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const synced = reportWithSyncedReviewComment(
       lowSignalCloseReport({
         number: 341,
@@ -946,20 +831,12 @@ test("apply-decisions blocks duplicate close when canonical PR is a bare cluster
         },
       }),
       () => {
-        runApplyDecisionsForTest({
+        runOpenClawApplyDecisionsForTest({
           itemsDir,
           closedDir,
           plansDir,
           reportPath,
-          extraArgs: [
-            "--target-repo",
-            "openclaw/openclaw",
-            "--dry-run",
-            "--apply-kind",
-            "all",
-            "--processed-limit",
-            "3",
-          ],
+          dryRun: true,
         });
       },
     );
@@ -976,20 +853,11 @@ test("apply-decisions blocks duplicate close when canonical PR is a bare cluster
       report.find((entry) => entry.action === "kept_open")?.reason ?? "",
       /closed and unmerged/,
     );
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });
 
 test("apply-decisions retries duplicate close when linked canonical PR comments cannot be read", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const synced = reportWithSyncedReviewComment(
       lowSignalCloseReport({
         number: 340,
@@ -1025,20 +893,12 @@ test("apply-decisions retries duplicate close when linked canonical PR comments 
         },
       }),
       () => {
-        runApplyDecisionsForTest({
+        runOpenClawApplyDecisionsForTest({
           itemsDir,
           closedDir,
           plansDir,
           reportPath,
-          extraArgs: [
-            "--target-repo",
-            "openclaw/openclaw",
-            "--dry-run",
-            "--apply-kind",
-            "all",
-            "--processed-limit",
-            "3",
-          ],
+          dryRun: true,
         });
       },
     );
@@ -1055,7 +915,5 @@ test("apply-decisions retries duplicate close when linked canonical PR comments 
       report.find((entry) => entry.action === "retry_pr_close_coverage_proof")?.reason ?? "",
       /temporary comments outage/,
     );
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });

--- a/test/apply-pr-duplicate-proof.test.ts
+++ b/test/apply-pr-duplicate-proof.test.ts
@@ -13,7 +13,9 @@ import {
   promotionGhMock,
   reportWithSyncedReviewComment,
   runApplyDecisionsForTest,
+  runOpenClawApplyDecisionsForTest,
   tmpPrefix,
+  withApplyTestWorkspace,
   withMockCodexProof,
   withMockGh,
 } from "./helpers.ts";
@@ -41,14 +43,7 @@ function boundDuplicateCloseComment(number: number, canonicalUrl: string): strin
 }
 
 test("apply-decisions blocks duplicate close when linked canonical PR closed unmerged", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const synced = reportWithSyncedReviewComment(
       lowSignalCloseReport({
         number: 336,
@@ -81,20 +76,12 @@ test("apply-decisions blocks duplicate close when linked canonical PR closed unm
         },
       }),
       () => {
-        runApplyDecisionsForTest({
+        runOpenClawApplyDecisionsForTest({
           itemsDir,
           closedDir,
           plansDir,
           reportPath,
-          extraArgs: [
-            "--target-repo",
-            "openclaw/openclaw",
-            "--dry-run",
-            "--apply-kind",
-            "all",
-            "--processed-limit",
-            "3",
-          ],
+          dryRun: true,
         });
       },
     );
@@ -111,9 +98,7 @@ test("apply-decisions blocks duplicate close when linked canonical PR closed unm
       report.find((entry) => entry.action === "kept_open")?.reason ?? "",
       /closed and unmerged/,
     );
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });
 
 test("locked duplicate reviews retain newly discovered canonical correction work", () => {
@@ -413,14 +398,7 @@ test("unchanged changed-duplicate records do not consume a bounded comment-sync 
 });
 
 test("apply-decisions blocks duplicate close when canonical PR is only in close comment", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const reportMarkdown = lowSignalCloseReport({
       number: 346,
       title: "Already proposed duplicate close",
@@ -455,20 +433,12 @@ test("apply-decisions blocks duplicate close when canonical PR is only in close 
         },
       }),
       () => {
-        runApplyDecisionsForTest({
+        runOpenClawApplyDecisionsForTest({
           itemsDir,
           closedDir,
           plansDir,
           reportPath,
-          extraArgs: [
-            "--target-repo",
-            "openclaw/openclaw",
-            "--dry-run",
-            "--apply-kind",
-            "all",
-            "--processed-limit",
-            "3",
-          ],
+          dryRun: true,
         });
       },
     );
@@ -485,21 +455,12 @@ test("apply-decisions blocks duplicate close when canonical PR is only in close 
       report.find((entry) => entry.action === "kept_open")?.reason ?? "",
       /closed and unmerged/,
     );
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });
 
 test("apply-decisions keeps existing duplicate PR close proposals open when coverage proof says keep_open", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const commentWriteLogPath = join(root, "comment-write.log");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     const synced = reportWithSyncedReviewComment(
       lowSignalCloseReport({
         number: 348,
@@ -555,19 +516,11 @@ test("apply-decisions keeps existing duplicate PR close proposals open when cove
             reason: "PR A still has unique fallback route behavior that PR B does not cover.",
           },
           () => {
-            runApplyDecisionsForTest({
+            runOpenClawApplyDecisionsForTest({
               itemsDir,
               closedDir,
               plansDir,
               reportPath,
-              extraArgs: [
-                "--target-repo",
-                "openclaw/openclaw",
-                "--apply-kind",
-                "all",
-                "--processed-limit",
-                "3",
-              ],
             });
           },
         );
@@ -629,20 +582,12 @@ test("apply-decisions keeps existing duplicate PR close proposals open when cove
       }),
       () => {
         withMockCodexProof(root, { type: "failure", message: "proof should not rerun" }, () => {
-          runApplyDecisionsForTest({
+          runOpenClawApplyDecisionsForTest({
             itemsDir,
             closedDir,
             plansDir,
             reportPath,
-            extraArgs: [
-              "--target-repo",
-              "openclaw/openclaw",
-              "--apply-kind",
-              "all",
-              "--sync-comments-only",
-              "--processed-limit",
-              "3",
-            ],
+            extraArgs: ["--sync-comments-only"],
           });
         });
       },
@@ -664,9 +609,7 @@ test("apply-decisions keeps existing duplicate PR close proposals open when cove
     );
     assert.equal(readFileSync(commentWriteLogPath, "utf8"), "");
     assert.equal(existsSync(join(closedDir, "348.md")), false);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });
 
 test("apply-decisions skips duplicate PR coverage proof during synced comment-only runs", () => {
@@ -1631,15 +1574,8 @@ test("apply-decisions keeps an unreadable canonical PR in the comment-sync queue
 });
 
 test("apply-decisions gates duplicate PR closes with shorthand canonical refs", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const proofLogPath = join(root, "proof.log");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     const synced = reportWithSyncedReviewComment(
       lowSignalCloseReport({
         number: 356,
@@ -1693,19 +1629,11 @@ test("apply-decisions gates duplicate PR closes with shorthand canonical refs", 
             invocationLogPath: proofLogPath,
           },
           () => {
-            runApplyDecisionsForTest({
+            runOpenClawApplyDecisionsForTest({
               itemsDir,
               closedDir,
               plansDir,
               reportPath,
-              extraArgs: [
-                "--target-repo",
-                "openclaw/openclaw",
-                "--apply-kind",
-                "all",
-                "--processed-limit",
-                "3",
-              ],
             });
           },
         );
@@ -1730,21 +1658,12 @@ test("apply-decisions gates duplicate PR closes with shorthand canonical refs", 
       report.find((entry) => entry.number === 356)?.reason ?? "",
       /unique fallback route behavior/,
     );
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });
 
 test("apply-decisions gates duplicate PR closes when unrelated bare issue refs accompany one PR URL", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const proofLogPath = join(root, "proof.log");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     const synced = reportWithSyncedReviewComment(
       lowSignalCloseReport({
         number: 359,
@@ -1801,19 +1720,11 @@ test("apply-decisions gates duplicate PR closes when unrelated bare issue refs a
             invocationLogPath: proofLogPath,
           },
           () => {
-            runApplyDecisionsForTest({
+            runOpenClawApplyDecisionsForTest({
               itemsDir,
               closedDir,
               plansDir,
               reportPath,
-              extraArgs: [
-                "--target-repo",
-                "openclaw/openclaw",
-                "--apply-kind",
-                "all",
-                "--processed-limit",
-                "3",
-              ],
             });
           },
         );
@@ -1838,7 +1749,5 @@ test("apply-decisions gates duplicate PR closes when unrelated bare issue refs a
       report.find((entry) => entry.number === 359)?.reason ?? "",
       /unique fallback route behavior/,
     );
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });

--- a/test/apply-pr-duplicate-ref-proof.test.ts
+++ b/test/apply-pr-duplicate-ref-proof.test.ts
@@ -8,21 +8,16 @@ import {
   promotionGhMock,
   reportWithSyncedReviewComment,
   runApplyDecisionsForTest,
+  runOpenClawApplyDecisionsForTest,
   tmpPrefix,
+  withApplyTestWorkspace,
   withMockCodexProof,
   withMockGh,
 } from "./helpers.ts";
 
 test("apply-decisions ignores bare refs inside cross-repo markdown link labels for duplicate proof", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const proofLogPath = join(root, "proof.log");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     const synced = reportWithSyncedReviewComment(
       lowSignalCloseReport({
         number: 357,
@@ -68,20 +63,12 @@ test("apply-decisions ignores bare refs inside cross-repo markdown link labels f
             invocationLogPath: proofLogPath,
           },
           () => {
-            runApplyDecisionsForTest({
+            runOpenClawApplyDecisionsForTest({
               itemsDir,
               closedDir,
               plansDir,
               reportPath,
-              extraArgs: [
-                "--target-repo",
-                "openclaw/openclaw",
-                "--dry-run",
-                "--apply-kind",
-                "all",
-                "--processed-limit",
-                "3",
-              ],
+              dryRun: true,
             });
           },
         );
@@ -89,21 +76,12 @@ test("apply-decisions ignores bare refs inside cross-repo markdown link labels f
     );
 
     assert.equal(existsSync(proofLogPath), false);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });
 
 test("apply-decisions ignores bare refs inside same-repo markdown link labels for duplicate proof", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const proofLogPath = join(root, "proof.log");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     const synced = reportWithSyncedReviewComment(
       lowSignalCloseReport({
         number: 358,
@@ -163,19 +141,11 @@ test("apply-decisions ignores bare refs inside same-repo markdown link labels fo
             expectedPromptIncludes: "Canonical provider replacement",
           },
           () => {
-            runApplyDecisionsForTest({
+            runOpenClawApplyDecisionsForTest({
               itemsDir,
               closedDir,
               plansDir,
               reportPath,
-              extraArgs: [
-                "--target-repo",
-                "openclaw/openclaw",
-                "--apply-kind",
-                "all",
-                "--processed-limit",
-                "3",
-              ],
             });
           },
         );
@@ -191,21 +161,12 @@ test("apply-decisions ignores bare refs inside same-repo markdown link labels fo
       "skipped_pr_close_coverage_proof",
     );
     assert.match(readFileSync(proofLogPath, "utf8"), /proof/);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });
 
 test("apply-decisions keeps newline-start bare PR refs tied to their own line", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const proofLogPath = join(root, "proof.log");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     const synced = reportWithSyncedReviewComment(
       lowSignalCloseReport({
         number: 358,
@@ -259,19 +220,11 @@ test("apply-decisions keeps newline-start bare PR refs tied to their own line", 
             invocationLogPath: proofLogPath,
           },
           () => {
-            runApplyDecisionsForTest({
+            runOpenClawApplyDecisionsForTest({
               itemsDir,
               closedDir,
               plansDir,
               reportPath,
-              extraArgs: [
-                "--target-repo",
-                "openclaw/openclaw",
-                "--apply-kind",
-                "all",
-                "--processed-limit",
-                "3",
-              ],
             });
           },
         );
@@ -296,20 +249,11 @@ test("apply-decisions keeps newline-start bare PR refs tied to their own line", 
       report.find((entry) => entry.number === 358)?.reason ?? "",
       /unique fallback route behavior/,
     );
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });
 
 test("apply-decisions ignores unrelated same-line bare PR refs for duplicate proof", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const synced = reportWithSyncedReviewComment(
       lowSignalCloseReport({
         number: 361,
@@ -363,20 +307,12 @@ test("apply-decisions ignores unrelated same-line bare PR refs for duplicate pro
             reason: "PR B carries forward PR A's fallback route behavior.",
           },
           () => {
-            runApplyDecisionsForTest({
+            runOpenClawApplyDecisionsForTest({
               itemsDir,
               closedDir,
               plansDir,
               reportPath,
-              extraArgs: [
-                "--target-repo",
-                "openclaw/openclaw",
-                "--dry-run",
-                "--apply-kind",
-                "all",
-                "--processed-limit",
-                "3",
-              ],
+              dryRun: true,
             });
           },
         );
@@ -396,9 +332,7 @@ test("apply-decisions ignores unrelated same-line bare PR refs for duplicate pro
       report.find((entry) => entry.action === "closed")?.reason ?? "",
       /duplicate or superseded/,
     );
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });
 
 for (const scenario of [
@@ -527,14 +461,7 @@ for (const scenario of [
 }
 
 test("apply-decisions does not proof-gate duplicate PR closes with bare issue refs", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const synced = reportWithSyncedReviewComment(
       lowSignalCloseReport({
         number: 357,
@@ -568,20 +495,12 @@ test("apply-decisions does not proof-gate duplicate PR closes with bare issue re
       }),
       () => {
         withMockCodexProof(root, { type: "failure", message: "proof should not run" }, () => {
-          runApplyDecisionsForTest({
+          runOpenClawApplyDecisionsForTest({
             itemsDir,
             closedDir,
             plansDir,
             reportPath,
-            extraArgs: [
-              "--target-repo",
-              "openclaw/openclaw",
-              "--dry-run",
-              "--apply-kind",
-              "all",
-              "--processed-limit",
-              "3",
-            ],
+            dryRun: true,
           });
         });
       },
@@ -596,21 +515,12 @@ test("apply-decisions does not proof-gate duplicate PR closes with bare issue re
       true,
     );
     assert.equal(JSON.stringify(report).includes("proof should not run"), false);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });
 
 test("apply-decisions preserves full PR URL evidence over later bare refs", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const proofLogPath = join(root, "proof.log");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     const synced = reportWithSyncedReviewComment(
       lowSignalCloseReport({
         number: 348,
@@ -654,19 +564,11 @@ test("apply-decisions preserves full PR URL evidence over later bare refs", () =
             invocationLogPath: proofLogPath,
           },
           () => {
-            runApplyDecisionsForTest({
+            runOpenClawApplyDecisionsForTest({
               itemsDir,
               closedDir,
               plansDir,
               reportPath,
-              extraArgs: [
-                "--target-repo",
-                "openclaw/openclaw",
-                "--apply-kind",
-                "all",
-                "--processed-limit",
-                "3",
-              ],
             });
           },
         );
@@ -687,7 +589,5 @@ test("apply-decisions preserves full PR URL evidence over later bare refs", () =
     );
     assert.equal(existsSync(proofLogPath), false);
     assert.equal(existsSync(join(closedDir, "348.md")), false);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });

--- a/test/apply-pr-promotion.test.ts
+++ b/test/apply-pr-promotion.test.ts
@@ -8,8 +8,10 @@ import {
   promotionGhMock,
   reportWithSyncedReviewComment,
   runApplyDecisionsForTest,
+  runOpenClawApplyDecisionsForTest,
   stalePullRequestReport,
   tmpPrefix,
+  withApplyTestWorkspace,
   withMockCodexProof,
   withMockGh,
   workPlanCandidateReport,
@@ -344,14 +346,7 @@ test("apply leaves a promotable old report unchanged while exact-head review is 
 });
 
 test("apply-decisions upgrades live no-diff kept-open PRs to duplicate closes", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     writeFileSync(
       join(itemsDir, "322.md"),
       workPlanCandidateReport({
@@ -460,20 +455,12 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/322\\/timeline(?:\\?|$
         root,
         { type: "failure", message: "proof should not run for no-diff PR" },
         () => {
-          runApplyDecisionsForTest({
+          runOpenClawApplyDecisionsForTest({
             itemsDir,
             closedDir,
             plansDir,
             reportPath,
-            extraArgs: [
-              "--target-repo",
-              "openclaw/openclaw",
-              "--dry-run",
-              "--apply-kind",
-              "all",
-              "--processed-limit",
-              "3",
-            ],
+            dryRun: true,
           });
         },
       );
@@ -492,21 +479,12 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/322\\/timeline(?:\\?|$
           "dry-run: would close as duplicate or superseded; dry-run: would post close-applied comment",
       },
     ]);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });
 
 test("apply-decisions promotes old F-rated stale PRs with low-signal close semantics", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const closeAppliedBodyLogPath = join(root, "close-applied-body.log");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
     const staleReport = stalePullRequestReport({
       pull_head_sha: "head-sha",
       work_cluster_refs: JSON.stringify(["Related discussion in #400"]),
@@ -542,19 +520,11 @@ test("apply-decisions promotes old F-rated stale PRs with low-signal close seman
           root,
           { type: "failure", message: "proof should not run for stale promotion incidental ref" },
           () => {
-            runApplyDecisionsForTest({
+            runOpenClawApplyDecisionsForTest({
               itemsDir,
               closedDir,
               plansDir,
               reportPath,
-              extraArgs: [
-                "--target-repo",
-                "openclaw/openclaw",
-                "--apply-kind",
-                "all",
-                "--processed-limit",
-                "3",
-              ],
             });
           },
         );
@@ -592,9 +562,7 @@ test("apply-decisions promotes old F-rated stale PRs with low-signal close seman
     assert.match(closeAppliedBody, /Review evidence: \[durable ClawSweeper review\]/);
     assert.doesNotMatch(closeAppliedBody, /Implementation evidence:/);
     assert.doesNotMatch(closeAppliedBody, /Keep open:/);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });
 
 test("apply-decisions keeps MERGEABLE UNSTABLE low-signal proposals open", () => {
@@ -945,14 +913,7 @@ test("apply-decisions does not fall through from filtered no-diff to low-signal 
 });
 
 test("apply-decisions promotes stale PRs after automation-only drift", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const synced = reportWithSyncedReviewComment(stalePullRequestReport(), 330, "none");
     writeFileSync(join(itemsDir, "330.md"), synced.report, "utf8");
 
@@ -972,20 +933,12 @@ test("apply-decisions promotes stale PRs after automation-only drift", () => {
             reason: "PR B is the canonical PR covering PR A.",
           },
           () => {
-            runApplyDecisionsForTest({
+            runOpenClawApplyDecisionsForTest({
               itemsDir,
               closedDir,
               plansDir,
               reportPath,
-              extraArgs: [
-                "--target-repo",
-                "openclaw/openclaw",
-                "--dry-run",
-                "--apply-kind",
-                "all",
-                "--processed-limit",
-                "3",
-              ],
+              dryRun: true,
             });
           },
         );
@@ -997,20 +950,11 @@ test("apply-decisions promotes stale PRs after automation-only drift", () => {
       report.some((entry) => entry.action === "closed"),
       true,
     );
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });
 
 test("apply-decisions does not promote stale PRs from truncated activity", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const synced = reportWithSyncedReviewComment(stalePullRequestReport(), 330, "none");
     writeFileSync(join(itemsDir, "330.md"), synced.report, "utf8");
 
@@ -1033,20 +977,12 @@ test("apply-decisions does not promote stale PRs from truncated activity", () =>
       }),
       () => {
         withMockCodexProof(root, { type: "failure", message: "proof should not run" }, () => {
-          runApplyDecisionsForTest({
+          runOpenClawApplyDecisionsForTest({
             itemsDir,
             closedDir,
             plansDir,
             reportPath,
-            extraArgs: [
-              "--target-repo",
-              "openclaw/openclaw",
-              "--dry-run",
-              "--apply-kind",
-              "all",
-              "--processed-limit",
-              "3",
-            ],
+            dryRun: true,
           });
         });
       },
@@ -1058,20 +994,11 @@ test("apply-decisions does not promote stale PRs from truncated activity", () =>
       false,
     );
     assert.doesNotMatch(JSON.stringify(report), /proof should not run/);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });
 
 test("apply-decisions does not promote stale PRs after human follow-up", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const synced = reportWithSyncedReviewComment(stalePullRequestReport(), 330, "none");
     writeFileSync(join(itemsDir, "330.md"), synced.report, "utf8");
 
@@ -1101,20 +1028,12 @@ test("apply-decisions does not promote stale PRs after human follow-up", () => {
       }),
       () => {
         withMockCodexProof(root, { type: "failure", message: "proof should not run" }, () => {
-          runApplyDecisionsForTest({
+          runOpenClawApplyDecisionsForTest({
             itemsDir,
             closedDir,
             plansDir,
             reportPath,
-            extraArgs: [
-              "--target-repo",
-              "openclaw/openclaw",
-              "--dry-run",
-              "--apply-kind",
-              "all",
-              "--processed-limit",
-              "3",
-            ],
+            dryRun: true,
           });
         });
       },
@@ -1127,20 +1046,11 @@ test("apply-decisions does not promote stale PRs after human follow-up", () => {
     );
     assert.doesNotMatch(JSON.stringify(report), /proof should not run/);
     assert.match(readFileSync(join(itemsDir, "330.md"), "utf8"), /^action_taken: kept_open$/m);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });
 
 test("apply-decisions does not promote stale PRs after a command-only re-review request", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const synced = reportWithSyncedReviewComment(stalePullRequestReport(), 330, "none");
     writeFileSync(join(itemsDir, "330.md"), synced.report, "utf8");
 
@@ -1178,20 +1088,12 @@ test("apply-decisions does not promote stale PRs after a command-only re-review 
       }),
       () => {
         withMockCodexProof(root, { type: "failure", message: "proof should not run" }, () => {
-          runApplyDecisionsForTest({
+          runOpenClawApplyDecisionsForTest({
             itemsDir,
             closedDir,
             plansDir,
             reportPath,
-            extraArgs: [
-              "--target-repo",
-              "openclaw/openclaw",
-              "--dry-run",
-              "--apply-kind",
-              "all",
-              "--processed-limit",
-              "3",
-            ],
+            dryRun: true,
           });
         });
       },
@@ -1204,20 +1106,11 @@ test("apply-decisions does not promote stale PRs after a command-only re-review 
     );
     assert.doesNotMatch(JSON.stringify(report), /proof should not run/);
     assert.match(readFileSync(join(itemsDir, "330.md"), "utf8"), /^action_taken: kept_open$/m);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });
 
 test("apply-decisions promotes recommended pause-or-close PRs", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const synced = reportWithSyncedReviewComment(
       stalePullRequestReport({
         number: 331,
@@ -1243,20 +1136,12 @@ test("apply-decisions promotes recommended pause-or-close PRs", () => {
       root,
       promotionGhMock({ number: 331, title: "Superseded prompt PR", comment: synced.comment }),
       () => {
-        runApplyDecisionsForTest({
+        runOpenClawApplyDecisionsForTest({
           itemsDir,
           closedDir,
           plansDir,
           reportPath,
-          extraArgs: [
-            "--target-repo",
-            "openclaw/openclaw",
-            "--dry-run",
-            "--apply-kind",
-            "all",
-            "--processed-limit",
-            "3",
-          ],
+          dryRun: true,
         });
       },
     );
@@ -1266,20 +1151,11 @@ test("apply-decisions promotes recommended pause-or-close PRs", () => {
       report.some((entry) => entry.action === "closed"),
       true,
     );
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });
 
 test("apply-decisions does not promote docs-only PRs superseded by code-only pull requests", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const docsOnlyReport = stalePullRequestReport({
       number: 337,
       title: "ENETDOWN docs companion",
@@ -1321,20 +1197,12 @@ test("apply-decisions does not promote docs-only PRs superseded by code-only pul
         },
       }),
       () => {
-        runApplyDecisionsForTest({
+        runOpenClawApplyDecisionsForTest({
           itemsDir,
           closedDir,
           plansDir,
           reportPath,
-          extraArgs: [
-            "--target-repo",
-            "openclaw/openclaw",
-            "--dry-run",
-            "--apply-kind",
-            "all",
-            "--processed-limit",
-            "3",
-          ],
+          dryRun: true,
         });
       },
     );
@@ -1344,7 +1212,5 @@ test("apply-decisions does not promote docs-only PRs superseded by code-only pul
       report.some((entry) => entry.action === "closed"),
       false,
     );
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });

--- a/test/apply-pr-supersession-promotion.test.ts
+++ b/test/apply-pr-supersession-promotion.test.ts
@@ -8,8 +8,10 @@ import {
   promotionGhMock,
   reportWithSyncedReviewComment,
   runApplyDecisionsForTest,
+  runOpenClawApplyDecisionsForTest,
   stalePullRequestReport,
   tmpPrefix,
+  withApplyTestWorkspace,
   withMockGh,
 } from "./helpers.ts";
 
@@ -187,14 +189,7 @@ test("apply-decisions does not promote PRs superseded by skipped close proposal 
 });
 
 test("apply-decisions does not promote unrelated linked open PRs", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const synced = reportWithSyncedReviewComment(
       stalePullRequestReport({
         number: 333,
@@ -226,20 +221,12 @@ test("apply-decisions does not promote unrelated linked open PRs", () => {
         },
       }),
       () => {
-        runApplyDecisionsForTest({
+        runOpenClawApplyDecisionsForTest({
           itemsDir,
           closedDir,
           plansDir,
           reportPath,
-          extraArgs: [
-            "--target-repo",
-            "openclaw/openclaw",
-            "--dry-run",
-            "--apply-kind",
-            "all",
-            "--processed-limit",
-            "3",
-          ],
+          dryRun: true,
         });
       },
     );
@@ -249,20 +236,11 @@ test("apply-decisions does not promote unrelated linked open PRs", () => {
       report.some((entry) => entry.action === "closed"),
       false,
     );
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });
 
 test("apply-decisions does not promote unrelated linked merged PRs", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const synced = reportWithSyncedReviewComment(
       stalePullRequestReport({
         number: 334,
@@ -294,20 +272,12 @@ test("apply-decisions does not promote unrelated linked merged PRs", () => {
         },
       }),
       () => {
-        runApplyDecisionsForTest({
+        runOpenClawApplyDecisionsForTest({
           itemsDir,
           closedDir,
           plansDir,
           reportPath,
-          extraArgs: [
-            "--target-repo",
-            "openclaw/openclaw",
-            "--dry-run",
-            "--apply-kind",
-            "all",
-            "--processed-limit",
-            "3",
-          ],
+          dryRun: true,
         });
       },
     );
@@ -317,7 +287,5 @@ test("apply-decisions does not promote unrelated linked merged PRs", () => {
       report.some((entry) => entry.action === "closed"),
       false,
     );
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });

--- a/test/apply-pr-supersession-safety.test.ts
+++ b/test/apply-pr-supersession-safety.test.ts
@@ -7,9 +7,11 @@ import {
   promotionGhMock,
   reportWithSyncedReviewComment,
   runApplyDecisionsForTest,
+  runOpenClawApplyDecisionsForTest,
   stalePullRequestReport,
   stripProofAndRatingFrontMatter,
   tmpPrefix,
+  withApplyTestWorkspace,
   withMockCodexProof,
   withMockGh,
 } from "./helpers.ts";
@@ -215,14 +217,7 @@ test("apply-decisions does not promote PRs superseded by no-proof linked pull re
 });
 
 test("apply-decisions does not promote PRs superseded by unsafe linked pull requests", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const synced = reportWithSyncedReviewComment(
       stalePullRequestReport({
         number: 335,
@@ -258,20 +253,12 @@ test("apply-decisions does not promote PRs superseded by unsafe linked pull requ
       }),
       () => {
         withMockCodexProof(root, { type: "failure", message: "proof should not run" }, () => {
-          runApplyDecisionsForTest({
+          runOpenClawApplyDecisionsForTest({
             itemsDir,
             closedDir,
             plansDir,
             reportPath,
-            extraArgs: [
-              "--target-repo",
-              "openclaw/openclaw",
-              "--dry-run",
-              "--apply-kind",
-              "all",
-              "--processed-limit",
-              "3",
-            ],
+            dryRun: true,
           });
         });
       },
@@ -283,20 +270,11 @@ test("apply-decisions does not promote PRs superseded by unsafe linked pull requ
       false,
     );
     assert.doesNotMatch(JSON.stringify(report), /proof should not run/);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });
 
 test("apply-decisions does not promote PRs superseded by F-rated linked pull requests", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const sourceReport = stalePullRequestReport({
       number: 338,
       title: "Old activity PR",
@@ -336,20 +314,12 @@ test("apply-decisions does not promote PRs superseded by F-rated linked pull req
       }),
       () => {
         withMockCodexProof(root, { type: "failure", message: "proof should not run" }, () => {
-          runApplyDecisionsForTest({
+          runOpenClawApplyDecisionsForTest({
             itemsDir,
             closedDir,
             plansDir,
             reportPath,
-            extraArgs: [
-              "--target-repo",
-              "openclaw/openclaw",
-              "--dry-run",
-              "--apply-kind",
-              "all",
-              "--processed-limit",
-              "3",
-            ],
+            dryRun: true,
           });
         });
       },
@@ -361,9 +331,7 @@ test("apply-decisions does not promote PRs superseded by F-rated linked pull req
       false,
     );
     assert.doesNotMatch(JSON.stringify(report), /proof should not run/);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });
 
 test("apply-decisions does not promote PRs superseded by section-only unsafe linked reports", () => {
@@ -552,14 +520,7 @@ test("apply-decisions does not promote PRs when live labels supersede stale proo
 });
 
 test("apply-decisions does not promote PRs superseded by unknown-mergeability PRs", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const sourceReport = stalePullRequestReport({
       number: 343,
       title: "Old activity PR",
@@ -598,20 +559,12 @@ test("apply-decisions does not promote PRs superseded by unknown-mergeability PR
         },
       }),
       () => {
-        runApplyDecisionsForTest({
+        runOpenClawApplyDecisionsForTest({
           itemsDir,
           closedDir,
           plansDir,
           reportPath,
-          extraArgs: [
-            "--target-repo",
-            "openclaw/openclaw",
-            "--dry-run",
-            "--apply-kind",
-            "all",
-            "--processed-limit",
-            "3",
-          ],
+          dryRun: true,
         });
       },
     );
@@ -621,20 +574,11 @@ test("apply-decisions does not promote PRs superseded by unknown-mergeability PR
       report.some((entry) => entry.action === "closed"),
       false,
     );
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });
 
 test("apply-decisions does not promote PRs superseded by non-clean linked pull requests", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
+  withApplyTestWorkspace(tmpPrefix, ({ root, itemsDir, closedDir, plansDir, reportPath }) => {
     const sourceReport = stalePullRequestReport({
       number: 345,
       title: "Old activity PR",
@@ -673,20 +617,12 @@ test("apply-decisions does not promote PRs superseded by non-clean linked pull r
         },
       }),
       () => {
-        runApplyDecisionsForTest({
+        runOpenClawApplyDecisionsForTest({
           itemsDir,
           closedDir,
           plansDir,
           reportPath,
-          extraArgs: [
-            "--target-repo",
-            "openclaw/openclaw",
-            "--dry-run",
-            "--apply-kind",
-            "all",
-            "--processed-limit",
-            "3",
-          ],
+          dryRun: true,
         });
       },
     );
@@ -696,7 +632,5 @@ test("apply-decisions does not promote PRs superseded by non-clean linked pull r
       report.some((entry) => entry.action === "closed"),
       false,
     );
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 });

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import { writeFakeScanner } from "./agent-input-scan-helpers.ts";
@@ -1089,6 +1089,59 @@ export function runApplyDecisionsForTest(options: {
     "0",
     ...(options.extraArgs ?? []),
   ]);
+}
+
+export function withApplyTestWorkspace(
+  prefix: string,
+  run: (workspace: {
+    root: string;
+    itemsDir: string;
+    closedDir: string;
+    plansDir: string;
+    reportPath: string;
+  }) => void,
+): void {
+  const root = mkdtempSync(prefix);
+  const workspace = {
+    root,
+    itemsDir: join(root, "items"),
+    closedDir: join(root, "closed"),
+    plansDir: join(root, "plans"),
+    reportPath: join(root, "apply-report.json"),
+  };
+  try {
+    mkdirSync(workspace.itemsDir, { recursive: true });
+    mkdirSync(workspace.plansDir, { recursive: true });
+    run(workspace);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+export function runOpenClawApplyDecisionsForTest(options: {
+  itemsDir: string;
+  closedDir: string;
+  plansDir: string;
+  reportPath: string;
+  dryRun?: boolean;
+  extraArgs?: string[];
+}): void {
+  runApplyDecisionsForTest({
+    itemsDir: options.itemsDir,
+    closedDir: options.closedDir,
+    plansDir: options.plansDir,
+    reportPath: options.reportPath,
+    extraArgs: [
+      "--target-repo",
+      "openclaw/openclaw",
+      ...(options.dryRun ? ["--dry-run"] : []),
+      "--apply-kind",
+      "all",
+      ...(options.extraArgs ?? []),
+      "--processed-limit",
+      "3",
+    ],
+  });
 }
 
 export const git = {


### PR DESCRIPTION
## What Problem This Solves

The apply-path tests repeated the same temporary workspace layout and CLI invocation across seven files. That made fixture maintenance noisy and allowed small setup or cleanup differences to accumulate between otherwise equivalent scenarios.

## Why This Change Was Made

Adds one shared apply-test workspace helper and one shared CLI runner, then uses them in the seven matching test files. Scenario fixtures, mock behavior, assertions, local test names, CLI limits, and production behavior remain unchanged.

## User Impact

No user-visible behavior changes. Test maintenance is smaller and more consistent: 646 net lines are removed while the existing scenario set and observable apply behavior are preserved.

## OpenClaw Bay Impact

OpenClaw Bay is unaffected. This changes test scaffolding only; no lifecycle publication, queue, status, telemetry, dashboard contract, or observer surface changes.

## Documentation Impact

No documentation update is needed because no product, operator, API, configuration, or workflow contract changes.

## Evidence

- Exact candidate: `e58b5f009e62e99294b74b4792fdcd1d771d9d87`
- Exact base: `e5fffb689e4ae012121be84dbb47c0b8306b14b4`
- Scope: 8 files, 220 insertions, 866 deletions; no overlap with current open PRs
- Focused parity: base 88/88 and candidate 88/88, with identical test names and order
- Source structure: all 75 literal test names remained identical and ordered
- Representative fixtures: actual-close and keep-open workspace manifests were identical after normalizing only the temporary root path
- Full gate: `CI=1 pnpm run check` passed
- Reviews: uncommitted and committed-range Codex reviews completed with no actionable findings
- Post-check: exact candidate HEAD/tree remained checked out; tracked and staged diffs were clean; all eight scoped working-file blob IDs matched `HEAD`
- Changelog: omitted because this is a pure test refactor with no user-visible or operational change

## Real Behavior Proof

**Claim:** Consolidating the apply-test workspace and CLI runner preserves the production apply-decision behavior exercised by the seven refactored test files.

**Exercised surface:** The built `openclaw` apply-decisions CLI was executed through real subprocesses. Both the base and candidate ran the same seven-file suite and representative close/keep-open scenarios.

**Scenarios and fixtures:** The proof covered 88 named tests per revision, 75 literal source scenarios, an actual close path that archived report `360`, and a keep-open path for report `348`. Fake GitHub and Codex executables supplied deterministic external responses; the production CLI handled the decisions and filesystem mutations.

**Command and environment:** `CI=1 NODE_OPTIONS=--max-old-space-size=4096 bash apply-test-workspaces-focused.sh` on a Crabbox-managed AWS `c7a.8xlarge` lease using image `ami-0461d919be7deb53c`, Node `v24.18.1`, pnpm `11.10.0`, and a fixed scenario clock. Provisioning run `run_2be2b26aacf6`; lease `cbx_69df06fadfb8`; direct managed execution has no separate run ID.

**Observed result:** Base and candidate each passed 88/88 tests with identical names/order. The close and keep-open normalized file manifests matched exactly. The candidate then passed the full repository check.

**Artifacts and traces:** Summary SHA-256 `623de6f2b80a6dcd2b392ba256b4b7bc1b423e755ce3f7736f7cfdc77291a176`; full proof log `cba17a41d9312137d9663b0ebe6e024e33c02d75a6b0a91dfd83cdf6353f6382`; full-check log `87fba6d6f48c29a51f9212bd9dc083b0ee57f36a3ffc63c1063b6952b437aee6`; close manifests shared SHA-256 `a8b3dc5b75495eb802e6ef678e1b0477c5220e2b8138199e8627fa382d0eb396`; keep-open manifests shared SHA-256 `06b08e3aea626699ac36569a0e51b16bc8ca7f657349892d4f30681f3a640db1`.

**Limits:** External GitHub and Codex behavior was mocked; no live GitHub mutation occurred. The proof covers the seven refactored test files and two representative production-CLI fixtures, plus the repository's full check.
