### PR TITLE
fix(ci): configure safe context for API Codex workers

### DIFF
--- a/.github/actions/setup-codex/action.yml
+++ b/.github/actions/setup-codex/action.yml
@@ -3,7 +3,7 @@ description: Cache, install, and authenticate the OpenAI Codex CLI.
 inputs:
   codex-version:
     description: Exact Codex CLI npm package version.
-    default: "0.151.0"
+    default: "0.153.3"
   proxy-version:
     description: Exact Codex Responses proxy npm package version.
     default: "0.139.0"
@@ -155,6 +155,11 @@ runs:
         if [[ "${{ inputs['login-status'] }}" == "true" ]]; then
           codex login status
         fi
+
+    - name: Configure direct API context
+      if: ${{ inputs['auth-mode'] == 'proxy' || inputs['auth-mode'] == 'login' }}
+      shell: bash
+      run: node "${{ github.action_path }}/configure-api-context.mjs" "${{ inputs['codex-version'] }}"
 
     - name: Reject unknown Codex auth mode
       if: ${{ inputs['auth-mode'] != 'proxy' && inputs['auth-mode'] != 'login' && inputs['auth-mode'] != 'clawrouter' }}

--- a/.github/actions/setup-codex/configure-api-context.mjs
+++ b/.github/actions/setup-codex/configure-api-context.mjs
@@ -1,0 +1,95 @@
+import { chmodSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+// These API models expose 1,050,000 total tokens and reserve 128,000 for output.
+// Other model selections retain their native limits and existing setup behavior.
+const longContextModels = new Set(["gpt-6-astra", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]);
+
+function withApiContext(model, version) {
+  if (!longContextModels.has(model?.slug)) return model;
+  if (
+    typeof model.model_messages !== "object" ||
+    model.model_messages === null ||
+    Array.isArray(model.model_messages) ||
+    !Array.isArray(model.supported_reasoning_levels) ||
+    typeof model.shell_type !== "string" ||
+    model.supported_in_api !== true ||
+    !Number.isInteger(model.context_window) ||
+    model.context_window <= 0 ||
+    !Number.isInteger(model.max_context_window) ||
+    model.max_context_window <= 0 ||
+    !/^\d+\.\d+\.\d+$/.test(model.minimal_client_version ?? "") ||
+    version.localeCompare(model.minimal_client_version, undefined, { numeric: true }) < 0 ||
+    typeof model.node_repl_auto_review_required !== "boolean" ||
+    typeof model.node_repl_disabled !== "boolean"
+  ) {
+    throw new Error("Complete native model metadata is required.");
+  }
+  return {
+    ...model,
+    context_window: 922_000,
+    max_context_window: 922_000,
+    auto_compact_token_limit: 700_000,
+    effective_context_window_percent: 95,
+  };
+}
+
+async function configure() {
+  const modelId = process.env.CLAWSWEEPER_INTERNAL_MODEL;
+  if (!longContextModels.has(modelId)) {
+    console.log("Direct API context override not applied; retaining native model limits.");
+    return;
+  }
+  const home = process.env.CODEX_HOME;
+  const version = process.argv[2];
+  if (!home || !/^\d+\.\d+\.\d+$/.test(version ?? "")) {
+    throw new Error("Missing setup inputs.");
+  }
+  const response = await fetch(
+    `https://raw.githubusercontent.com/openai/codex/rust-v${version}/codex-rs/models-manager/models.json`,
+    { signal: AbortSignal.timeout(30_000) },
+  );
+  if (!response.ok) throw new Error("Native model catalogue unavailable.");
+  const document = await response.json();
+  if (
+    !Array.isArray(document.models) ||
+    !document.models.some((model) => model?.slug === modelId)
+  ) {
+    throw new Error("Selected native model metadata is required.");
+  }
+  // The catalogue is authoritative, not an overlay: retain native reviewer and
+  // sibling metadata, changing only the documented API models' context allowance.
+  const catalog = {
+    ...document,
+    models: document.models.map((model) => withApiContext(model, version)),
+  };
+  const catalogPath = join(home, "api-models.json");
+  const configPath = join(home, "config.toml");
+  const config = readFileSync(configPath, "utf8");
+  writeFileSync(catalogPath, JSON.stringify(catalog), { mode: 0o600 });
+  chmodSync(catalogPath, 0o600);
+  writeFileSync(
+    configPath,
+    [
+      "model_context_window = 922000",
+      "model_auto_compact_token_limit = 700000",
+      'model_auto_compact_token_limit_scope = "total"',
+      `model_catalog_json = ${JSON.stringify(catalogPath)}`,
+      "",
+      config,
+    ].join("\n"),
+    { mode: 0o600 },
+  );
+  chmodSync(configPath, 0o600);
+  console.log(
+    "Configured direct API context with native model metadata and total-token compaction.",
+  );
+}
+
+configure().catch(() => {
+  // Native metadata and errors can contain private model routing identifiers.
+  console.error(
+    "Direct API context setup failed; check the pinned client and native model catalogue.",
+  );
+  process.exitCode = 1;
+});

--- a/docs/private-inference.md
+++ b/docs/private-inference.md
@@ -59,3 +59,14 @@ choice uses the repository's current authentication mode.
 The default `proxy` mode and explicit legacy `login` mode retain their existing
 API-key configuration. Changing the authentication-mode variable affects new
 jobs; it does not stop or reconfigure jobs already running.
+
+Those direct API modes use the complete native model catalogue from the exact
+Codex release installed by setup. For supported models with a documented
+1,050,000-token API window and 128,000-token maximum output, setup reserves
+922,000 input tokens and compacts at 700,000 total active tokens. It preserves
+the complete catalogue, including native reviewer models, instructions, tool
+capabilities, and required review behavior. The four supported model entries
+receive the context allowance; all other entries remain unchanged. Missing
+native metadata fails setup; other model selections retain
+their native limits. The private ClawRouter mode continues to use the context
+and safety metadata supplied in its configuration secret.

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2284,7 +2284,7 @@ test("agent workflows install pinned CLI releases and keep runner models secret"
     ".github/workflows/sweep.yml",
   ].map((file) => readText(file));
 
-  assert.match(action, /codex-version:[\s\S]*default: "0\.151\.0"/);
+  assert.match(action, /codex-version:[\s\S]*default: "0\.153\.3"/);
   assert.match(action, /proxy-version:[\s\S]*default: "0\.139\.0"/);
   assert.match(action, /@openai\/codex@\$\{\{ inputs\['codex-version'\] \}\}/);
   assert.match(action, /@openai\/codex-responses-api-proxy@\$\{\{ inputs\['proxy-version'\] \}\}/);

--- a/test/setup-codex-context.test.ts
+++ b/test/setup-codex-context.test.ts
@@ -1,0 +1,167 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import test from "node:test";
+import { pathToFileURL } from "node:url";
+import { parse } from "yaml";
+
+const actionPath = resolve(".github/actions/setup-codex");
+const action = parse(readFileSync(join(actionPath, "action.yml"), "utf8"));
+const step = action.runs.steps.find((entry) => entry.name === "Configure direct API context");
+const version = action.inputs["codex-version"].default;
+const modelInfo = {
+  slug: "gpt-6-astra",
+  display_name: "Synthetic native model",
+  model_messages: { instructions_template: "SYNTHETIC_NATIVE_INSTRUCTIONS" },
+  supported_reasoning_levels: [{ effort: "high", description: "High" }],
+  shell_type: "unified_exec",
+  supported_in_api: true,
+  context_window: 272000,
+  max_context_window: 872000,
+  minimal_client_version: "0.153.0",
+  node_repl_auto_review_required: true,
+  node_repl_disabled: false,
+  tool_mode: "code_mode_only",
+  use_responses_lite: true,
+  auto_review_model_override: null,
+  future_native_requirement: { preserve: true },
+};
+const originalConfig = `model = "gpt-6-astra"
+model_provider = "clawsweeper-responses-proxy"
+
+[model_providers.clawsweeper-responses-proxy]
+name = "ClawSweeper Responses Proxy"
+base_url = "http://127.0.0.1:12345/v1"
+wire_api = "responses"
+`;
+
+function fixture(document: unknown, model = modelInfo.slug) {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-api-context-"));
+  const config = join(root, "config.toml");
+  const preload = join(root, "fetch.mjs");
+  const request = join(root, "request.json");
+  writeFileSync(config, originalConfig.replaceAll(modelInfo.slug, model));
+  writeFileSync(
+    preload,
+    `
+import { writeFileSync } from "node:fs";
+globalThis.fetch = async (url) => {
+  writeFileSync(${JSON.stringify(request)}, JSON.stringify({ url }));
+  return new Response(${JSON.stringify(JSON.stringify(document))});
+};
+`,
+  );
+  const run = () =>
+    spawnSync(
+      process.execPath,
+      [
+        "--import",
+        pathToFileURL(preload).href,
+        join(actionPath, "configure-api-context.mjs"),
+        version,
+      ],
+      {
+        encoding: "utf8",
+        env: { CODEX_HOME: root, CLAWSWEEPER_INTERNAL_MODEL: model },
+      },
+    );
+  return { root, config, request, run, original: readFileSync(config, "utf8") };
+}
+
+test("direct API setup preserves the complete native catalogue and existing proxy authentication", () => {
+  const supportedModels = [
+    modelInfo,
+    ...["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"].map((slug) => ({
+      ...modelInfo,
+      slug,
+      node_repl_auto_review_required: false,
+    })),
+  ];
+  const reviewer = {
+    ...modelInfo,
+    slug: "synthetic-native-reviewer",
+    max_context_window: 272000,
+    model_messages: { instructions_template: "SYNTHETIC_NATIVE_REVIEW_POLICY" },
+  };
+  const document = { models: [...supportedModels, reviewer], future_catalog_field: "preserve" };
+  const f = fixture(document);
+  try {
+    assert.equal(
+      step.if,
+      "${{ inputs['auth-mode'] == 'proxy' || inputs['auth-mode'] == 'login' }}",
+    );
+    const result = f.run();
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(JSON.parse(readFileSync(f.request, "utf8")), {
+      url: `https://raw.githubusercontent.com/openai/codex/rust-v${version}/codex-rs/models-manager/models.json`,
+    });
+    const catalogPath = join(f.root, "api-models.json");
+    assert.deepEqual(JSON.parse(readFileSync(catalogPath, "utf8")), {
+      ...document,
+      models: [
+        ...supportedModels.map((entry) => ({
+          ...entry,
+          context_window: 922000,
+          max_context_window: 922000,
+          auto_compact_token_limit: 700000,
+          effective_context_window_percent: 95,
+        })),
+        reviewer,
+      ],
+    });
+    const config = readFileSync(f.config, "utf8");
+    assert.ok(config.endsWith(f.original));
+    assert.ok(
+      config.startsWith(
+        'model_context_window = 922000\nmodel_auto_compact_token_limit = 700000\nmodel_auto_compact_token_limit_scope = "total"\n',
+      ),
+    );
+    assert.ok(config.includes(`model_catalog_json = ${JSON.stringify(catalogPath)}`));
+    if (process.platform !== "win32") {
+      assert.equal(statSync(catalogPath).mode & 0o777, 0o600);
+      assert.equal(statSync(f.config).mode & 0o777, 0o600);
+    }
+    assert.doesNotMatch(result.stdout + result.stderr, /gpt-6-astra|SYNTHETIC_NATIVE/);
+  } finally {
+    rmSync(f.root, { recursive: true, force: true });
+  }
+});
+
+test("other model selections keep native context without fetching or changing setup", () => {
+  const f = fixture(null, "synthetic-private-selection");
+  try {
+    const result = f.run();
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /override not applied; retaining native model limits/);
+    assert.equal(readFileSync(f.config, "utf8"), f.original);
+    assert.equal(existsSync(f.request), false);
+    assert.equal(existsSync(join(f.root, "api-models.json")), false);
+    assert.doesNotMatch(result.stdout + result.stderr, /synthetic-private-selection/);
+  } finally {
+    rmSync(f.root, { recursive: true, force: true });
+  }
+});
+
+test("recognized API models fail before changing config when native metadata is unavailable", () => {
+  for (const document of [
+    { models: [] },
+    { models: [{ slug: modelInfo.slug }] },
+    { models: [{ ...modelInfo, node_repl_auto_review_required: undefined }] },
+    { models: [{ ...modelInfo, minimal_client_version: "99.0.0" }] },
+    { models: [modelInfo, { slug: "gpt-5.6-sol" }] },
+  ]) {
+    const f = fixture(document);
+    try {
+      const result = f.run();
+      assert.equal(result.status, 1);
+      assert.equal(readFileSync(f.config, "utf8"), f.original);
+      assert.equal(existsSync(join(f.root, "api-models.json")), false);
+      assert.match(result.stderr, /Direct API context setup failed/);
+      assert.doesNotMatch(result.stdout + result.stderr, /gpt-6-astra|SYNTHETIC_NATIVE/);
+    } finally {
+      rmSync(f.root, { recursive: true, force: true });
+    }
+  }
+});


### PR DESCRIPTION
ClawSweeper creates an isolated Codex home for each job, so operator-level context settings never reach its API-backed workers. Update the shared setup action to Codex 0.153.3 and configure supported long-context API models with 922,000 safe input tokens and compaction at 700,000 total active tokens. Other model selections retain their native limits; private ClawRouter setup retains its separately supplied configuration.

The context catalog is generated from the complete native catalog of the exact installed Codex release. Because custom catalogs are authoritative, setup preserves every native model, reviewer, instruction, tool capability, and safety field, changing only the documented context fields for supported API models. Missing metadata or an insufficient client version fails before rewriting configuration. Model selection and credentials remain private.

Controlled behavior proof exercised the final shared helper with the real Codex 0.153.3 binary and Responses proxy 0.139.0 on macOS/Node 24. The proxy held the API credential; the isolated read-only client successfully read a synthetic sentinel through its shell tool and returned matching strict JSON. Runtime token accounting reported 875,900 usable tokens, and all 11 native catalog entries matched the official release apart from the four intended context fields. This proves real setup, transport, tool use, schema output, and the reported context guard; it does not claim a full-window stress test or a production Actions rollout.

Validation: all nine final setup/scanner/private-route tests, the separate workflow privacy/version assertion, formatting, lint, syntax, and diff checks passed. Fresh native reviews before commit and on committed branch `7f73d80fdd` found no actionable regressions; structured autoreview was clean at its requested P0 scope. The new catalog-preservation regression fails against the previous selected-row-only implementation. Native Windows preload paths use file URLs, and POSIX mode assertions remain platform-specific.

The full local check passed build/lint/static gates but reported two failures in unchanged tests. The apply-drift fixture invokes Apple's Bash 3.2, which lacks `mapfile`; it passes unchanged with installed Homebrew Bash 5.3.15. The label-identity case passes both alone and in its complete 14-test file in original order; the broader-suite failure remains unreproduced. The full local suite is therefore not claimed green. Hosted Linux and Windows validation is tracked in [CI run 33937880314](https://github.com/openclaw/clawsweeper/actions/runs/33937880314).

The controlled proof invoked `configure-api-context.mjs 0.153.3`, followed by `codex exec --skip-git-repo-check --sandbox read-only --output-schema schema.json -o reply.json --json` with a synthetic sentinel-reading prompt in an isolated home. The helper SHA-256 was `2a94b9dca0f7a7579b84a0291e342484795b6c04e7edd09539ec4165c6cb0ad4`; the private raw trace is retained by the maintainer. No selected model identifier or credential is included in this proof.

OpenClaw Bay is unaffected: this changes the worker's inference setup only, with no queue, publication, status, or public data-contract changes. Production/workflow delta is +100 lines for the shared catalog/configuration owner; tests are +167 and documentation +11. No live sweep was paused or dispatched for this change.

Review disposition: retain the documented strict startup policy. This rollout requires the configured large-context budget and genuine native metadata before workers start; a failed catalog check therefore stops setup. Continuing at a smaller native limit would silently change the requested operating configuration. This is an intentional deployment prerequisite, not a newly discovered implementation defect. The remaining user approval is approval to merge this reviewed behavior.

The dependency-source audit is complete on the exact official Codex release commit `b1a547b1f73ce86205d9222ac19cff334b3b7a2e` (`rust-v0.153.3`), independently of the hosted reviewer's retrieval limitation. Direct inspection confirmed that [the static manager consumes the supplied catalog as authoritative](https://github.com/openai/codex/blob/b1a547b1f73ce86205d9222ac19cff334b3b7a2e/codex-rs/models-manager/src/manager.rs#L287), [configured context is clamped by model metadata](https://github.com/openai/codex/blob/b1a547b1f73ce86205d9222ac19cff334b3b7a2e/codex-rs/models-manager/src/model_info.rs#L24), [the effective-window reserve and compaction ceiling are applied](https://github.com/openai/codex/blob/b1a547b1f73ce86205d9222ac19cff334b3b7a2e/codex-rs/protocol/src/openai_models.rs#L493), and [native reviewer selection depends on the available catalog](https://github.com/openai/codex/blob/b1a547b1f73ce86205d9222ac19cff334b3b7a2e/codex-rs/core/src/guardian/review.rs#L872). The complete [release catalog](https://github.com/openai/codex/blob/b1a547b1f73ce86205d9222ac19cff334b3b7a2e/codex-rs/models-manager/models.json) was read and compared with the generated catalog: all 11 entries retain their non-context fields. The source-matched real-client proof above independently confirms runtime behavior. The full hosted Linux CI run and Windows launcher checks have now passed.
