### PR TITLE
refactor(dashboard): share SQL column inventory

### DIFF
--- a/dashboard/durable-storage.ts
+++ b/dashboard/durable-storage.ts
@@ -5,3 +5,11 @@ export type DurableStorage = {
   sql: SqlStorage;
   transactionSync: <T>(callback: () => T) => T;
 };
+
+export function sqlColumnNames(storage: DurableStorage, table: string): Set<string> {
+  return new Set(
+    Array.from(storage.sql.exec(`SELECT name FROM pragma_table_info('${table}')`)).map((row) =>
+      String(row.name || ""),
+    ),
+  );
+}

--- a/dashboard/exact-review-direct-publication.ts
+++ b/dashboard/exact-review-direct-publication.ts
@@ -1,5 +1,5 @@
 import { EXACT_REVIEW_DIRECT_PUBLICATION_MAX_FILE_BYTES } from "../src/exact-review-publication-limits.ts";
-import type { DurableStorage } from "./durable-storage.ts";
+import { sqlColumnNames, type DurableStorage } from "./durable-storage.ts";
 
 export { EXACT_REVIEW_DIRECT_PUBLICATION_MAX_FILE_BYTES };
 
@@ -228,12 +228,9 @@ export class ExactReviewDirectPublicationStore {
          PRIMARY KEY (item_key, revision)
        ) STRICT`,
     );
-    const directPublicationColumns = new Set(
-      Array.from(
-        this.storage.sql.exec(
-          `SELECT name FROM pragma_table_info('${EXACT_REVIEW_DIRECT_PUBLICATION_TABLE}')`,
-        ),
-      ).map((row) => String(row.name || "")),
+    const directPublicationColumns = sqlColumnNames(
+      this.storage,
+      EXACT_REVIEW_DIRECT_PUBLICATION_TABLE,
     );
     if (!directPublicationColumns.has("canonical_target_key")) {
       this.storage.sql.exec(

--- a/dashboard/exact-review-lifecycle-telemetry.ts
+++ b/dashboard/exact-review-lifecycle-telemetry.ts
@@ -5,7 +5,7 @@ import {
   type ExactReviewLifecycleProjection,
   type LifecycleTerminalDisposition,
 } from "./exact-review-lifecycle.ts";
-import type { DurableStorage } from "./durable-storage.ts";
+import { sqlColumnNames, type DurableStorage } from "./durable-storage.ts";
 
 export const EXACT_REVIEW_LIFECYCLE_TELEMETRY_DIRECT_TABLE =
   "exact_review_lifecycle_telemetry_direct_v1";
@@ -347,13 +347,7 @@ export class ExactReviewLifecycleTelemetryStore {
          ON ${EXACT_REVIEW_LIFECYCLE_BAY_TIDE_BUFFER_TABLE}
          (repository_scope, bucket, completed_at, event_id)`,
     );
-    const bayEventColumns = new Set(
-      Array.from(
-        this.storage.sql.exec(
-          `SELECT name FROM pragma_table_info('${EXACT_REVIEW_LIFECYCLE_BAY_EVENT_TABLE}')`,
-        ),
-      ).map((row) => String(row.name || "")),
-    );
+    const bayEventColumns = sqlColumnNames(this.storage, EXACT_REVIEW_LIFECYCLE_BAY_EVENT_TABLE);
     if (!bayEventColumns.has("legacy_batch_path")) {
       this.storage.sql.exec(
         `ALTER TABLE ${EXACT_REVIEW_LIFECYCLE_BAY_EVENT_TABLE}
@@ -413,12 +407,9 @@ export class ExactReviewLifecycleTelemetryStore {
         );
       }
     }
-    const tideBufferColumns = new Set(
-      Array.from(
-        this.storage.sql.exec(
-          `SELECT name FROM pragma_table_info('${EXACT_REVIEW_LIFECYCLE_BAY_TIDE_BUFFER_TABLE}')`,
-        ),
-      ).map((row) => String(row.name || "")),
+    const tideBufferColumns = sqlColumnNames(
+      this.storage,
+      EXACT_REVIEW_LIFECYCLE_BAY_TIDE_BUFFER_TABLE,
     );
     if (!tideBufferColumns.has("legacy_batch_path")) {
       this.storage.sql.exec(
@@ -503,11 +494,7 @@ export class ExactReviewLifecycleTelemetryStore {
       EXACT_REVIEW_LIFECYCLE_BAY_META_TABLE,
       EXACT_REVIEW_LIFECYCLE_BAY_SCOPE_TABLE,
     ]) {
-      const columns = new Set(
-        Array.from(this.storage.sql.exec(`SELECT name FROM pragma_table_info('${table}')`)).map(
-          (row) => String(row.name || ""),
-        ),
-      );
+      const columns = sqlColumnNames(this.storage, table);
       if (!columns.has("tide_base_count")) {
         tideProgressBackfillTables.add(table);
         this.storage.sql.exec(
@@ -520,13 +507,7 @@ export class ExactReviewLifecycleTelemetryStore {
         this.storage.sql.exec(`ALTER TABLE ${table} ADD COLUMN last_tide_at INTEGER`);
       }
     }
-    const scopeColumns = new Set(
-      Array.from(
-        this.storage.sql.exec(
-          `SELECT name FROM pragma_table_info('${EXACT_REVIEW_LIFECYCLE_BAY_SCOPE_TABLE}')`,
-        ),
-      ).map((row) => String(row.name || "")),
-    );
+    const scopeColumns = sqlColumnNames(this.storage, EXACT_REVIEW_LIFECYCLE_BAY_SCOPE_TABLE);
     if (!scopeColumns.has("trigger_coverage_started_at")) {
       this.storage.sql.exec(
         `ALTER TABLE ${EXACT_REVIEW_LIFECYCLE_BAY_SCOPE_TABLE}

--- a/dashboard/exact-review-publication-batches.ts
+++ b/dashboard/exact-review-publication-batches.ts
@@ -1,4 +1,4 @@
-import type { DurableStorage } from "./durable-storage.ts";
+import { sqlColumnNames, type DurableStorage } from "./durable-storage.ts";
 
 export const EXACT_REVIEW_PUBLICATION_BATCH_TABLE = "exact_review_publication_batches";
 export const EXACT_REVIEW_PUBLICATION_BATCH_ITEM_TABLE = "exact_review_publication_batch_items";
@@ -111,13 +111,7 @@ export class ExactReviewPublicationBatchStore {
          failure_fingerprint TEXT
        ) STRICT`,
     );
-    const batchColumns = new Set(
-      Array.from(
-        this.storage.sql.exec(
-          `SELECT name FROM pragma_table_info('${EXACT_REVIEW_PUBLICATION_BATCH_TABLE}')`,
-        ),
-      ).map((row) => String(row.name || "")),
-    );
+    const batchColumns = sqlColumnNames(this.storage, EXACT_REVIEW_PUBLICATION_BATCH_TABLE);
     if (!batchColumns.has("configured_batch_size")) {
       this.storage.sql.exec(
         `ALTER TABLE ${EXACT_REVIEW_PUBLICATION_BATCH_TABLE}
@@ -160,12 +154,9 @@ export class ExactReviewPublicationBatchStore {
            ON DELETE CASCADE
        ) STRICT`,
     );
-    const batchItemColumns = new Set(
-      Array.from(
-        this.storage.sql.exec(
-          `SELECT name FROM pragma_table_info('${EXACT_REVIEW_PUBLICATION_BATCH_ITEM_TABLE}')`,
-        ),
-      ).map((row) => String(row.name || "")),
+    const batchItemColumns = sqlColumnNames(
+      this.storage,
+      EXACT_REVIEW_PUBLICATION_BATCH_ITEM_TABLE,
     );
     const telemetryItemColumns = [
       ["producer_run_id", "TEXT"],

--- a/dashboard/github-egress-telemetry.ts
+++ b/dashboard/github-egress-telemetry.ts
@@ -12,7 +12,7 @@ import {
   GITHUB_EGRESS_STATUS_BUCKETS,
   GITHUB_EGRESS_UNITS,
 } from "../src/github-egress-telemetry-contract.ts";
-import type { DurableStorage } from "./durable-storage.ts";
+import { sqlColumnNames, type DurableStorage } from "./durable-storage.ts";
 
 const ROLLUP_TABLE = "exact_review_github_egress_rollups_v2";
 const RATE_LIMIT_TABLE = "exact_review_github_rate_limits_v2";
@@ -191,13 +191,7 @@ export class GithubEgressTelemetryStore {
          credential_circuits_json TEXT NOT NULL DEFAULT '[]'
        ) STRICT`,
     );
-    const receiptColumns = new Set(
-      (
-        Array.from(
-          this.storage.sql.exec(`SELECT name FROM pragma_table_info('${RECEIPT_TABLE}')`),
-        ) as Array<Record<string, unknown>>
-      ).map((row) => String(row.name || "")),
-    );
+    const receiptColumns = sqlColumnNames(this.storage, RECEIPT_TABLE);
     if (!receiptColumns.has("credential_circuits_json")) {
       this.storage.sql.exec(
         `ALTER TABLE ${RECEIPT_TABLE}
@@ -227,13 +221,7 @@ export class GithubEgressTelemetryStore {
          last_observed_at INTEGER
        ) STRICT`,
     );
-    const diagnosticColumns = new Set(
-      (
-        Array.from(
-          this.storage.sql.exec(`SELECT name FROM pragma_table_info('${DIAGNOSTICS_TABLE}')`),
-        ) as Array<Record<string, unknown>>
-      ).map((row) => String(row.name || "")),
-    );
+    const diagnosticColumns = sqlColumnNames(this.storage, DIAGNOSTICS_TABLE);
     for (const [column, definition] of [
       ["evicted_five_minute_rollup_rows", "INTEGER NOT NULL DEFAULT 0"],
       ["evicted_hour_rollup_rows", "INTEGER NOT NULL DEFAULT 0"],

--- a/dashboard/state-writer-coordinator.ts
+++ b/dashboard/state-writer-coordinator.ts
@@ -1,4 +1,4 @@
-import type { DurableStorage } from "./durable-storage.ts";
+import { sqlColumnNames, type DurableStorage } from "./durable-storage.ts";
 
 const STATE_WRITER_TICKET_TABLE = "state_writer_tickets";
 const STATE_WRITER_META_TABLE = "state_writer_meta";
@@ -379,11 +379,7 @@ export class StateWriterCoordinator {
   }
 
   private ensureMetaColumnsSync(): void {
-    const columns = new Set(
-      Array.from(
-        this.storage.sql.exec(`SELECT name FROM pragma_table_info('${STATE_WRITER_META_TABLE}')`),
-      ).map((row) => String(row.name || "")),
-    );
+    const columns = sqlColumnNames(this.storage, STATE_WRITER_META_TABLE);
     for (const column of [
       "admitted_total",
       "completed_total",
@@ -404,11 +400,7 @@ export class StateWriterCoordinator {
   }
 
   private ensureTicketColumnsSync(): void {
-    const columns = new Set(
-      Array.from(
-        this.storage.sql.exec(`SELECT name FROM pragma_table_info('${STATE_WRITER_TICKET_TABLE}')`),
-      ).map((row) => String(row.name || "")),
-    );
+    const columns = sqlColumnNames(this.storage, STATE_WRITER_TICKET_TABLE);
     // The absolute deadline was added after the first coordinator prototype.
     // Preserve already-queued tickets during deployment; a leased legacy row
     // remains bounded by lease_expires_at; every subsequently admitted ticket

--- a/test/durable-storage.test.ts
+++ b/test/durable-storage.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { sqlColumnNames, type DurableStorage } from "../dashboard/durable-storage.ts";
+
+test("SQL column names preserve query, coercion, Set order, and errors", () => {
+  const calls: unknown[][] = [];
+  const error = new Error("inventory failed");
+  let failed = false;
+  const storage = {
+    sql: {
+      exec: (...args: unknown[]) => {
+        calls.push(args);
+        if (failed) throw error;
+        return [{ name: "second" }, { name: 0 }, { name: "first" }, { name: "second" }];
+      },
+    },
+  } as DurableStorage;
+
+  assert.deepEqual([...sqlColumnNames(storage, "example_table")], ["second", "", "first"]);
+  assert.deepEqual(calls, [["SELECT name FROM pragma_table_info('example_table')"]]);
+  failed = true;
+  assert.throws(
+    () => sqlColumnNames(storage, "example_table"),
+    (thrown) => thrown === error,
+  );
+});


### PR DESCRIPTION
## What Problem This Solves

Repeated SQL column inventory blocks made durable schema migrations harder to
review consistently and easier to drift apart.

## Why This Change Was Made

Adds one dependency-free `sqlColumnNames` helper and replaces the 11 exact
normalized `pragma_table_info` blocks in the reviewed durable stores. The
literal SQL, zero bindings, string coercion, Set insertion order, synchronous
errors, migration ordering, backfills, and transaction boundaries are
unchanged.

## User Impact

No user-visible behavior changes. Dashboard durable schema maintenance now uses
one shared implementation for the same existing query contract.

## OpenClaw Bay Impact

OpenClaw Bay is unaffected. Controlled base/candidate proof produced identical
ordered SQL and bindings, schema dumps, row dumps, and lifecycle projection
results. No Bay route, projection contract, UI, or action surface changed.

## Documentation Impact

No documentation changes are needed because this is a mechanical internal
refactor with no runtime, operator, API, or policy contract change.

## Evidence

### Real Behavior Proof

- Claim: extracting SQL column inventory into the shared helper preserves the
  exact behavior of all migrated callers.
- Surface: five real file-backed SQLite durable stores covering 11 static
  inventory sites and 12 runtime inventory executions.
- Scenarios: fresh schemas for every store; every seeded legacy missing-column
  migration and backfill; second-run idempotence; synchronous injected failure
  at every inventory execution.
- Environment: configured AWS Crabbox, Ubuntu 26.04 amd64, Node `v24.18.1`,
  SQLite `3.53.1`, image `ami-0461d919be7deb53c`, lease
  `cbx_69df06fadfb8`, direct managed SSH run with no wrapper run ID.
- Source pins: base `e5fffb689e4ae012121be84dbb47c0b8306b14b4`
  (tree `ee2d7a9a9aa8bc6acb96f86d53131e46391b8973`), candidate
  `92696015b72a2aed55f3dd3b45ece0bff7cafeef`
  (tree `7d28452c840a6d01a1eb01d82b95550f2b7f39ff`), with all seven
  scoped blob IDs verified before execution and a clean checkout verified
  before and after.
- Commands: `CI=1 pnpm install --frozen-lockfile`, the three repository builds,
  the controlled SQLite proof, 319 focused migration/lifecycle
  Bay/GitHub-egress/state-writer/publication tests, and
  `CI=1 pnpm run check`.
- Result: all base/candidate comparisons passed, 319/319 focused tests passed,
  and the full repository check passed.
- Artifact: private maintainer evidence archive SHA-256
  `b3846a6d38e7d546ea31e3c582a14b8a153aed3d2fa30a7d3a838145afac03d8`;
  proof receipt SHA-256
  `65b5e4eac93794aa4634aaa2241a97e5aba66611b637bfdbdd66f6c343e207dd`.
- Limits: proof used local SQLite semantics inside the configured AWS image. It
  did not deploy Bay or mutate GitHub, Cloudflare, R2, or live Durable Object
  storage.

### Review

- Pre-commit Codex review: no actionable findings.
- Current committed-range Codex review: no actionable findings; 317 focused
  tests plus dashboard typecheck, formatting, and diff checks passed.

No changelog entry is included because the change is mechanical and has no
user-visible or operational behavior change.
