### PR TITLE
refactor(read-model): remove unused workflow builder

### DIFF
--- a/src/github-webhook-read-model-client.ts
+++ b/src/github-webhook-read-model-client.ts
@@ -216,28 +216,6 @@ export function githubReadModelCommentObject(
   };
 }
 
-export function githubReadModelWorkflowObject(
-  repository: string,
-  kind: "workflow_run" | "workflow_job" | "check_run" | "check_suite",
-  value: JsonRecord,
-): JsonRecord | null {
-  const id = positiveInteger(value.id);
-  const updatedAt =
-    timestamp(value.updated_at) ??
-    timestamp(value.completed_at) ??
-    timestamp(value.started_at) ??
-    timestamp(value.created_at);
-  if (!validRepository(repository) || !id || !updatedAt) return null;
-  return {
-    kind,
-    repository: repository.toLowerCase(),
-    id,
-    runId: kind === "workflow_run" ? id : positiveInteger(value.run_id),
-    sourceUpdatedAt: updatedAt,
-    snapshot: value,
-  };
-}
-
 function githubReadModelConfig(env: GithubReadModelEnvironment): {
   baseUrl: string;
   secret: string;


### PR DESCRIPTION
## What Problem This Solves

Removes an orphaned read-model workflow-object builder that has no callers or
re-exports, reducing unused code in the GitHub webhook read-model client.

## Why This Change Was Made

The active workflow object construction remains owned by the dashboard worker.
This change deletes only the unused client helper and leaves the retained item,
comment, lease, planning, repair, and placeholder-recovery paths unchanged.

## User Impact

No user-visible behavior changes. The read-model client has 22 fewer lines of
dead code.

## OpenClaw Bay Impact

OpenClaw Bay is unaffected. This does not change lifecycle, publication,
workflow, status, telemetry, dashboard, or public data contracts.

## Documentation Impact

No documentation update is needed. The removed helper is not documented or
part of a supported public contract, and the existing read-model documentation
remains accurate.

## Evidence

- Exact head: `17bf845bf37d62f681d70765054f996cdbee8c4a`
- Diff: one file, 22 deletions, no additions
- Local focused validation: direct TypeScript build plus
  `test/github-webhook-read-model.test.ts` and
  `test/review-placeholder-recovery.test.ts` (`36` passed, `0` failed)
- AWS validation: full `CI=1 pnpm run check` passed on the exact head
- Fresh committed review against `origin/main@3d77465b6b6efa3bc111b069b06b3bfdf05630cf`:
  clean, no findings (`01a06fb6-d6d8-7251-b546-133a51eadb69`)
- Current-main assessment: the owned file, package manifest, lockfile, compiler
  configs, focused tests, and test runner are byte-identical between the proved
  base and current `main`; merge-tree is clean
- Changelog: skipped because this is a pure dead-helper refactor with no
  observable behavior change
- Finding disposition: no accepted or actionable findings; no rank-up exception
  is required

## Real Behavior Proof

**Claim:** deleting `githubReadModelWorkflowObject` does not change any retained
read-model consumer.

**Exercised surface:** review planning inventory, repair comment reads,
placeholder recovery, item/comment/lease request builders, loopback request
bytes, and HMAC verification.

**Scenario:** the proof fetched and built exact base
`e5fffb689e4ae012121be84dbb47c0b8306b14b4` and candidate
`17bf845bf37d62f681d70765054f996cdbee8c4a`, then ran identical loopback HTTP
fixtures against both builds.

**Command and environment:**

```text
CI=1 ./run-behavior-proof.sh \
  e5fffb689e4ae012121be84dbb47c0b8306b14b4 \
  17bf845bf37d62f681d70765054f996cdbee8c4a \
  <artifact-dir>
```

Crabbox AWS, image `ami-0461d919be7deb53c`, lease
`cbx_69df06fadfb8`, managed direct SSH (broker run ID `null`), Node
`v24.18.1`, Git `2.53.0`, and pinned pnpm `11.10.0`.

**Observed result:** normalized outputs were identical; stderr was empty and
identical; all six requests per side had verified HMAC signatures; the only
expected transition was the removed export changing from present to absent.
The exact candidate then passed the full repository check.

**Artifact trace:**

- Normalized base and candidate JSON:
  `f4a970c3663c98927f1b1cce7a85b85dc83ee00fb849130e96bfd8b2e5ba3033`
- Base and candidate stderr:
  `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`
- Full-check log:
  `aace53d1bbc3a83985d1c12c086686703d32d841b3e9a36eb0a186ba5a32ad0b`
- Proof runner:
  `2d926e4a0a3bf345516c30866c9aa0e89565097c489358de88e4b04773b7e85f`

**Limits:** the fixture used loopback HTTP only. It made no live GitHub API,
Cloudflare Worker, R2, or OpenClaw Bay request. Real Git fetches and the
configured AWS provider were used for checkout and execution.
