### PR TITLE
refactor(repair): deduplicate restored job path parsing

### DIFF
--- a/scripts/restore-repair-job.sh
+++ b/scripts/restore-repair-job.sh
@@ -19,26 +19,31 @@ write_output() {
   fi
 }
 
+parse_repair_job_path() {
+  local kind="$1" filename stem rest
+  filename="${JOB_PATH##*/}"
+  stem="${filename%.md}"
+  rest="${stem#${kind}-}"
+  PARSED_JOB_NUMBER="${rest##*-}"
+  PARSED_JOB_REPO_SLUG="${rest%-${PARSED_JOB_NUMBER}}"
+  PARSED_JOB_OWNER="${JOB_PATH#jobs/}"
+  PARSED_JOB_OWNER="${PARSED_JOB_OWNER%%/*}"
+  PARSED_JOB_REPO_NAME="${PARSED_JOB_REPO_SLUG#${PARSED_JOB_OWNER}-}"
+  if [ -z "$PARSED_JOB_NUMBER" ] || [ "$PARSED_JOB_NUMBER" = "$rest" ] || [ -z "$PARSED_JOB_REPO_NAME" ] || [ "$PARSED_JOB_REPO_NAME" = "$PARSED_JOB_REPO_SLUG" ]; then
+    return 1
+  fi
+  PARSED_JOB_REPO="$PARSED_JOB_OWNER/$PARSED_JOB_REPO_NAME"
+  PARSED_JOB_REF="#$PARSED_JOB_NUMBER"
+  PARSED_JOB_BRANCH="clawsweeper/$kind-$PARSED_JOB_REPO_SLUG-$PARSED_JOB_NUMBER"
+}
+
 restore_automerge_job() {
   case "$JOB_PATH" in
     jobs/*/inbox/automerge-*.md) ;;
     *) return 1 ;;
   esac
-  local filename stem rest number repo_slug owner repo_name repo ref branch repair_mode labels merge_instruction
-  filename="${JOB_PATH##*/}"
-  stem="${filename%.md}"
-  rest="${stem#automerge-}"
-  number="${rest##*-}"
-  repo_slug="${rest%-${number}}"
-  owner="${JOB_PATH#jobs/}"
-  owner="${owner%%/*}"
-  repo_name="${repo_slug#${owner}-}"
-  if [ -z "$number" ] || [ "$number" = "$rest" ] || [ -z "$repo_name" ] || [ "$repo_name" = "$repo_slug" ]; then
-    return 1
-  fi
-  repo="$owner/$repo_name"
-  ref="#$number"
-  branch="clawsweeper/automerge-$repo_slug-$number"
+  parse_repair_job_path automerge || return 1
+  local number="$PARSED_JOB_NUMBER" repo_slug="$PARSED_JOB_REPO_SLUG" repo="$PARSED_JOB_REPO" ref="$PARSED_JOB_REF" branch="$PARSED_JOB_BRANCH" repair_mode labels merge_instruction
   repair_mode="autofix"
   merge_instruction="Final merge is disabled for autofix. Keep the PR open after a passing ClawSweeper verdict unless a maintainer explicitly changes mode."
   if [[ "${CLAWSWEEPER_REQUESTED_ALLOW_MERGE:-${CLAWSWEEPER_ALLOW_MERGE:-0}}" == 1 ]]; then
@@ -113,21 +118,8 @@ restore_issue_implementation_job() {
     jobs/*/inbox/issue-*.md) ;;
     *) return 1 ;;
   esac
-  local filename stem rest number repo_slug owner repo_name repo ref branch
-  filename="${JOB_PATH##*/}"
-  stem="${filename%.md}"
-  rest="${stem#issue-}"
-  number="${rest##*-}"
-  repo_slug="${rest%-${number}}"
-  owner="${JOB_PATH#jobs/}"
-  owner="${owner%%/*}"
-  repo_name="${repo_slug#${owner}-}"
-  if [ -z "$number" ] || [ "$number" = "$rest" ] || [ -z "$repo_name" ] || [ "$repo_name" = "$repo_slug" ]; then
-    return 1
-  fi
-  repo="$owner/$repo_name"
-  ref="#$number"
-  branch="clawsweeper/issue-$repo_slug-$number"
+  parse_repair_job_path issue || return 1
+  local number="$PARSED_JOB_NUMBER" repo_slug="$PARSED_JOB_REPO_SLUG" repo="$PARSED_JOB_REPO" ref="$PARSED_JOB_REF" branch="$PARSED_JOB_BRANCH"
   mkdir -p "$(dirname "$JOB_PATH")"
   cat > "$JOB_PATH" <<EOF
 ---
@@ -194,21 +186,8 @@ restore_self_heal_job() {
     jobs/*/inbox/self-heal-*.md) ;;
     *) return 1 ;;
   esac
-  local filename stem rest number repo_slug owner repo_name repo ref branch
-  filename="${JOB_PATH##*/}"
-  stem="${filename%.md}"
-  rest="${stem#self-heal-}"
-  number="${rest##*-}"
-  repo_slug="${rest%-${number}}"
-  owner="${JOB_PATH#jobs/}"
-  owner="${owner%%/*}"
-  repo_name="${repo_slug#${owner}-}"
-  if [ -z "$number" ] || [ "$number" = "$rest" ] || [ -z "$repo_name" ] || [ "$repo_name" = "$repo_slug" ]; then
-    return 1
-  fi
-  repo="$owner/$repo_name"
-  ref="#$number"
-  branch="clawsweeper/self-heal-$repo_slug-$number"
+  parse_repair_job_path self-heal || return 1
+  local number="$PARSED_JOB_NUMBER" repo_slug="$PARSED_JOB_REPO_SLUG" repo="$PARSED_JOB_REPO" ref="$PARSED_JOB_REF" branch="$PARSED_JOB_BRANCH"
   mkdir -p "$(dirname "$JOB_PATH")"
   cat > "$JOB_PATH" <<EOF
 ---


### PR DESCRIPTION
## What Problem This Solves

The repair-job restoration script repeated the same path parsing and validation in each of its three restoration branches, making contract-preserving maintenance harder.

## Why This Change Was Made

Extracts the shared parser into one namespaced helper while retaining each existing case gate, validation condition, policy branch, and generated template. No accepted path grammar or authorization behavior changes.

## User Impact

No user-visible behavior changes. Maintainers get one implementation of the repair-job path derivation contract instead of three copies.

## OpenClaw Bay Impact

OpenClaw Bay is unaffected. This change does not alter lifecycle publication, queues, status, telemetry, dashboard data, or observer controls.

## Documentation Impact

No documentation update is needed. The existing repair workflow and safety contracts remain unchanged.

## Evidence

- `bash -n scripts/restore-repair-job.sh`
- `node --test test/repair/cluster-workflow-security.test.ts`: 10 passed
- Controlled baseline/candidate execution proof: 18 scenario bundles were byte-identical for exit code, stdout, stderr, `GITHUB_OUTPUT`, generated job files, ordered GitHub calls, and authorization-before-write state.
- Independent Codex review before commit: no actionable regressions; 74 Bash 3.2/5.3 equivalence comparisons passed.
- Independent Codex review of committed head `345dac56ec9b92d0eaae2fd99fd4dad2c8c8e50c` against `origin/main`: no actionable regressions; 576 Bash 3.2/5.3 equivalence comparisons passed.
- Configured AWS Crabbox proof on lease `cbx_5d4e9a2c6ff4`, image `ami-0461d919be7deb53c`, Node `v24.18.1`, and pnpm `11.10.0`: passed.
- `pnpm run check` on the same AWS checkout: 4,977 tests total, 4,959 passed, 18 platform skips, 0 failed, 0 cancelled.
- AWS evidence archive SHA-256: `e2d36648897c9be26a4e6e0d12045261b96e60429095fc1c650c2663ed21a278`; all 270 manifest entries verified.
- Postcheck confirmed clean head `345dac56ec9b92d0eaae2fd99fd4dad2c8c8e50c` and tree `52a2b441e305ac335d07965395c4b19432affc3a`.
- Fresh `main` drift audit through `6a56eee17378928c246602b6f85f52866f406983` found no changes to the restore script, workflow call sites, focused test, target resolver, or job-path constructors.

### Review Disposition

- Pre-commit Codex review: no actionable findings.
- Committed-head Codex review: no actionable findings.
- Accepted or unresolved findings: none.
- Rank-up moves: none were requested.

## Real Behavior Proof

**Claim:** repair-job restoration behavior is unchanged after deduplicating its path parser.

**Exercised surface:** the complete `scripts/restore-repair-job.sh` program, executed as a real Bash process from isolated temporary state checkouts.

**Scenarios:** valid automerge, issue implementation, and self-heal jobs; existing files; authorized and protected automerge labels; missing token; GitHub lookup failure; malformed names/directories; nonnumeric suffixes; hyphenated owner/repository names; and previously accepted whitespace.

**Command and environment:** the exact committed head ran on configured AWS Crabbox lease `cbx_5d4e9a2c6ff4` using image `ami-0461d919be7deb53c`, Node `v24.18.1`, pnpm `11.10.0`, GNU Bash `5.3.9`, `CI=1`, a frozen install, and `pnpm run build:node`. The managed control-plane command did not receive a run ID, so execution used direct SSH on the same assigned lease. Baseline and candidate scripts used controlled temporary `GITHUB_OUTPUT` files and a fake `gh` executable that recorded ordered calls and pre-call file state.

**Observed result:** all 18 baseline/candidate bundles were byte-identical for exit status, stdout, stderr, output bytes, generated job bytes, and GitHub call traces. Authorization-required paths called GitHub while both the target job and output were still unwritten; failure paths created no job. The focused security test passed 10/10, and full `pnpm run check` passed with 4,959 tests passing, 18 platform skips, and no failures or cancellations. The checkout was clean before and after proof.

**Artifact or trace:** evidence archive SHA-256 `e2d36648897c9be26a4e6e0d12045261b96e60429095fc1c650c2663ed21a278`; all 270 manifest entries verified. The postcheck recorded the exact head and tree above.

**Limits:** GitHub behavior was exercised through a controlled fake `gh` boundary, not a live GitHub authorization response. The proof did not dispatch a workflow, run a live repair, mutate production state, close or merge an item, or test another operating system or architecture.
