### PR TITLE
refactor(repair): consolidate shared primitives

### DIFF
--- a/src/repair/command-ack-convergence.ts
+++ b/src/repair/command-ack-convergence.ts
@@ -100,19 +100,17 @@ export function compareCommentsByCreatedAt(left: LooseRecord, right: LooseRecord
   );
 }
 
-function compareCommandAckKeepPriority(left: LooseRecord, right: LooseRecord): number {
-  const leftStatus = commandAckStatusScore(left);
-  const rightStatus = commandAckStatusScore(right);
+export function compareCommandAckKeepPriority(left: LooseRecord, right: LooseRecord): number {
+  const leftStatus = isCommandAckStatusComment(left) ? 1 : 0;
+  const rightStatus = isCommandAckStatusComment(right) ? 1 : 0;
   if (leftStatus !== rightStatus) return rightStatus - leftStatus;
   if (leftStatus > 0) return compareCommentsByUpdatedAtDesc(left, right);
   return compareCommentsByCreatedAt(left, right);
 }
 
-function commandAckStatusScore(comment: LooseRecord): number {
+export function isCommandAckStatusComment(comment: LooseRecord): boolean {
   const body = String(comment.body ?? "");
-  return body.includes("clawsweeper-command-status:") || body.includes(COMMAND_PROGRESS_START)
-    ? 1
-    : 0;
+  return body.includes("clawsweeper-command-status:") || body.includes(COMMAND_PROGRESS_START);
 }
 
 function compareCommentsByUpdatedAtDesc(left: LooseRecord, right: LooseRecord): number {

--- a/src/repair/comment-webhook.ts
+++ b/src/repair/comment-webhook.ts
@@ -27,6 +27,10 @@ import {
 } from "./comment-command-text.js";
 import { directReReviewIntake } from "./direct-re-review-admission.js";
 import { postExactReviewCommandIntake } from "./exact-review-command-queue.js";
+import {
+  compareCommandAckKeepPriority,
+  isCommandAckStatusComment,
+} from "./command-ack-convergence.js";
 
 const DEFAULT_PORT = 8787;
 export const WEBHOOK_MAX_BODY_BYTES = 2 * 1024 * 1024;
@@ -746,13 +750,13 @@ async function pruneFastAckComments({
 }) {
   const comments = await listFastAckComments({ token, repo, itemNumber, sourceCommentId });
   if (comments.length === 0) return null;
-  const hasStatusComment = comments.some(isStatusBearingFastAckComment);
-  comments.sort(compareFastAckKeepPriority);
+  const hasStatusComment = comments.some(isCommandAckStatusComment);
+  comments.sort(compareCommandAckKeepPriority);
   const keepId = Number(comments[0]?.id) || null;
   for (const comment of comments) {
     const id = Number(comment.id) || 0;
     if (id <= 0 || id === keepId) continue;
-    if (hasStatusComment && isStatusBearingFastAckComment(comment)) continue;
+    if (hasStatusComment && isCommandAckStatusComment(comment)) continue;
     await githubFetch({
       token,
       path: `/repos/${repo}/issues/comments/${id}`,
@@ -763,38 +767,6 @@ async function pruneFastAckComments({
     });
   }
   return keepId;
-}
-
-function compareFastAckKeepPriority(left: LooseRecord, right: LooseRecord) {
-  const leftStatus = isStatusBearingFastAckComment(left) ? 1 : 0;
-  const rightStatus = isStatusBearingFastAckComment(right) ? 1 : 0;
-  if (leftStatus !== rightStatus) return rightStatus - leftStatus;
-  if (leftStatus > 0) return compareCommentsByUpdatedAtDesc(left, right);
-  return compareCommentsByCreatedAt(left, right);
-}
-
-function isStatusBearingFastAckComment(comment: LooseRecord) {
-  const body = String(comment.body ?? "");
-  return (
-    body.includes("clawsweeper-command-status:") ||
-    body.includes("<!-- clawsweeper-command-progress:start -->")
-  );
-}
-
-function compareCommentsByUpdatedAtDesc(left: LooseRecord, right: LooseRecord) {
-  const leftUpdated = String(left.updated_at ?? left.created_at ?? "");
-  const rightUpdated = String(right.updated_at ?? right.created_at ?? "");
-  return (
-    rightUpdated.localeCompare(leftUpdated) || (Number(right.id) || 0) - (Number(left.id) || 0)
-  );
-}
-
-function compareCommentsByCreatedAt(left: LooseRecord, right: LooseRecord) {
-  const leftCreated = String(left.created_at ?? "");
-  const rightCreated = String(right.created_at ?? "");
-  return (
-    leftCreated.localeCompare(rightCreated) || (Number(left.id) || 0) - (Number(right.id) || 0)
-  );
 }
 
 async function listFastAckComments({

--- a/src/repair/json-file.ts
+++ b/src/repair/json-file.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import path from "node:path";
 
 import type { JsonValue } from "./json-types.js";
 
@@ -8,4 +9,9 @@ export function readJsonFile(filePath: string): JsonValue {
 
 export function readJsonFileIfExists(filePath: string): JsonValue | null {
   return fs.existsSync(filePath) ? readJsonFile(filePath) : null;
+}
+
+export function writeJsonFile(filePath: string, value: JsonValue): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
 }

--- a/src/repair/notify-events.ts
+++ b/src/repair/notify-events.ts
@@ -5,7 +5,7 @@ import { pathToFileURL } from "node:url";
 import type { JsonObject, JsonValue } from "./json-types.js";
 import { asJsonObject } from "./json-types.js";
 import { parseArgs, repoRoot } from "./lib.js";
-import { readJsonFile } from "./json-file.js";
+import { readJsonFile, writeJsonFile } from "./json-file.js";
 import {
   errorText,
   postOpenClawAgentHook,
@@ -713,11 +713,6 @@ function summaryRow(
   reason: string | null,
 ): ClawSweeperEventNotifierSummary {
   return { status, considered, pending, sent, failed, skipped, exitCode: 0, reason };
-}
-
-function writeJsonFile(filePath: string, value: JsonValue) {
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
 }
 
 async function main() {

--- a/src/repair/notify-github-activity.ts
+++ b/src/repair/notify-github-activity.ts
@@ -5,6 +5,7 @@ import { pathToFileURL } from "node:url";
 import { DEFAULT_TRUSTED_BOTS } from "./config.js";
 import type { JsonObject, JsonValue } from "./json-types.js";
 import { asJsonObject } from "./json-types.js";
+import { writeJsonFile } from "./json-file.js";
 import { parseArgs, repoRoot } from "./lib.js";
 import {
   boolEnv,
@@ -680,11 +681,6 @@ function summaryRow(
   reason: string | null,
 ): GithubActivityNotifierSummary {
   return { status, sent, failed, exitCode: 0, reason };
-}
-
-function writeJsonFile(filePath: string, value: JsonValue) {
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
 }
 
 async function main() {

--- a/src/repair/notify-maintainer-report.ts
+++ b/src/repair/notify-maintainer-report.ts
@@ -2,8 +2,9 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import type { JsonObject, JsonValue } from "./json-types.js";
+import type { JsonObject } from "./json-types.js";
 import { asJsonObject } from "./json-types.js";
+import { writeJsonFile } from "./json-file.js";
 import { parseArgs, repoRoot } from "./lib.js";
 import {
   boolEnv,
@@ -387,11 +388,6 @@ function formatDate(value: string): string {
     year: "numeric",
     timeZone: "UTC",
   }).format(date);
-}
-
-function writeJsonFile(filePath: string, value: JsonValue) {
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
 }
 
 async function main() {

--- a/src/repair/notify-merge.ts
+++ b/src/repair/notify-merge.ts
@@ -5,8 +5,15 @@ import { pathToFileURL } from "node:url";
 import type { JsonObject, JsonValue } from "./json-types.js";
 import { asJsonObject } from "./json-types.js";
 import { parseArgs, repoRoot } from "./lib.js";
-import { readJsonFile } from "./json-file.js";
-import { errorText, postOpenClawAgentHook, resolveOpenClawHookConfig } from "./openclaw-hook.js";
+import { readJsonFile, writeJsonFile } from "./json-file.js";
+import {
+  errorText,
+  normalizeString,
+  postOpenClawAgentHook,
+  resolveOpenClawHookConfig,
+  stringArg,
+  stringOrNull,
+} from "./openclaw-hook.js";
 import type {
   CollectionResult,
   MergeLedgerEntry,
@@ -352,28 +359,11 @@ function reportRow(
   };
 }
 
-function writeJsonFile(filePath: string, value: JsonValue) {
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
-}
-
 function parseTargetNumber(value: JsonValue): number | null {
   const match = String(value ?? "").match(/^#?([0-9]+)$/);
   if (!match?.[1]) return null;
   const parsed = Number.parseInt(match[1], 10);
   return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
-}
-
-function stringArg(value: JsonValue): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
-
-function stringOrNull(value: JsonValue): string | null {
-  return typeof value === "string" && value.trim() ? value.trim() : null;
-}
-
-function normalizeString(value: string | undefined): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/src/repair/target-toolchain-config.ts
+++ b/src/repair/target-toolchain-config.ts
@@ -224,8 +224,3 @@ function formatError(error: unknown): string {
   if (error instanceof Error) return `${error.name}: ${error.message}`;
   return String(error);
 }
-
-/** Test-only: clear the per-message warning suppression cache. */
-export function __resetTargetRepoToolchainWarnings(): void {
-  warnedMessages.clear();
-}


### PR DESCRIPTION
## What Problem This Solves

Several repair entrypoints independently implemented the same command acknowledgement ordering and synchronous JSON persistence behavior. That duplication made behavior-preserving maintenance harder and increased the chance that one path would drift from the others.

## Why This Change Was Made

This consolidates the existing command acknowledgement comparator and status predicate, the synchronous JSON writer used by four notifiers, and existing string normalization helpers. It also removes one unused warning-reset test export while preserving the existing cache reset contract.

The change is deliberately mechanical: keeper selection, in-place comment ordering, protected status comments, DELETE order and 404 handling, synchronous write failures, and ledger-before-report ordering are unchanged.

Concurrent draft https://github.com/openclaw/clawsweeper/pull/1436 touches GitHub activity rendering and filtering in separate hunks. This PR only replaces that notifier's local JSON writer with the shared implementation.

## User Impact

No user-visible behavior changes. Repair paths have fewer duplicate implementations and a smaller maintenance surface.

## OpenClaw Bay Impact

OpenClaw Bay is unaffected. This does not change dashboard, lifecycle, queue, status, telemetry, or public data contracts.

## Documentation Impact

No documentation changes are needed. `AGENTS.md` and `CONTRIBUTING.md` were reviewed, and the documented repair behavior and operational contracts remain unchanged.

## Evidence

- Exact head: `c1bb26fb685bf4bc47cb1d03c626a0fca08f6c53`
- Exact tree: `c15ac3bf63e1dbef407d4fc6490922fad7e83eba`
- Fresh committed Codex review against the branch base: no actionable findings.
- Configured AWS Crabbox proof: lease `cbx_5d4e9a2c6ff4`, image `ami-0461d919be7deb53c`, Node `24.18.1`, direct managed execution with no provider run ID.
- Frozen install used the repository-pinned `pnpm 11.10.0`. A post-run host Corepack probe reported `11.25.0`; it was not the package manager used for the frozen install.
- `pnpm run build:node`: passed.
- Eight focused test files: 101 passed, 0 failed, 0 cancelled, 0 skipped.
- `pnpm run check`: 4,977 tests; 4,959 passed, 18 skipped, 0 failed, 0 cancelled.
- AWS evidence archive SHA-256: `91a344af2dff6a37843aa24df53cc52581adc49c77d7f01e97aab86b1c08c5c3`.

## Real Behavior Proof

### Command acknowledgement convergence

- **Claim:** keeper selection, keeper body, protected status comments, ordered duplicate deletion, dispatch status id, and ignored DELETE 404 behavior are unchanged.
- **Exercised surface:** the frozen base and exact candidate were compiled and invoked through the exported `handleGitHubWebhook` entrypoint with controlled GitHub API responses.
- **Scenarios:** one mixed status-bearing/bare acknowledgement set and one bare-only tie set.
- **Observed result:** both builds produced identical results in both scenarios. The mixed case kept id `303`, protected ids `202` and `303`, deleted ids `404` then `101`, and ignored the `404`; the bare case kept id `7` and deleted ids `8` then `9`.
- **Artifact:** command acknowledgement receipt inside the redacted AWS evidence archive above.
- **Limits:** controlled fetch responses only; no live GitHub mutation.

### Notifier persistence

- **Claim:** retry behavior, recursive synchronous JSON writes, exact pretty JSON with one trailing newline, and ledger-before-report ordering are unchanged.
- **Exercised surface:** the compiled merge notifier used a real loopback HTTP server and temporary filesystem.
- **Scenario:** HTTP `503` followed by `200`, followed by a forced report-write failure.
- **Observed result:** delivery retried exactly once and succeeded; ledger and report bytes were exact; the ledger already existed when report writing threw.
- **Artifact:** notifier receipt inside the redacted AWS evidence archive above.
- **Limits:** loopback HTTP and controlled temporary files only.

### Target toolchain warnings

- **Claim:** removing the redundant warning-reset export does not change cache or warning behavior.
- **Exercised surface:** the compiled resolver read a malformed real temporary configuration twice, reset the existing cache, then read it again.
- **Observed result:** one warning before reset, a second warning after reset, and the same fallback toolchain on all reads.
- **Artifact:** toolchain receipt inside the redacted AWS evidence archive above.
- **Limits:** controlled temporary filesystem only.
