### PR TITLE
refactor(test): use tracked publication clocks

### DIFF
--- a/test/exact-review-publication-batches.test.ts
+++ b/test/exact-review-publication-batches.test.ts
@@ -1409,723 +1409,636 @@ test("queue batch claim defaults off and additive schema keeps the legacy versio
   assert.equal(stats.lanes.publication.batches.leased, 0);
 });
 
-test("critical publication health does not override review pressure", async () => {
-  const originalNow = Date.now;
+test("critical publication health does not override review pressure", async (t) => {
   let now = 1_000_000;
-  Date.now = () => now;
-  try {
-    const queue = new ExactReviewQueue({ storage: new TestStorage() }, {});
-    await queue.fetch(publicationRequest("delivery-critical", 102, "1002"));
-    now += 6 * 60 * 60 * 1_000;
+  t.mock.method(Date, "now", () => now);
+  const queue = new ExactReviewQueue({ storage: new TestStorage() }, {});
+  await queue.fetch(publicationRequest("delivery-critical", 102, "1002"));
+  now += 6 * 60 * 60 * 1_000;
 
-    const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
-    assert.deepEqual(stats.lanes.publication.health, {
-      status: "critical",
-      reason: "oldest_pending_over_6h",
-    });
-    assert.equal(stats.pressure.status, "idle");
-    assert.equal(stats.pressure.reason, "no_ready_backlog");
-  } finally {
-    Date.now = originalNow;
-  }
+  const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.deepEqual(stats.lanes.publication.health, {
+    status: "critical",
+    reason: "oldest_pending_over_6h",
+  });
+  assert.equal(stats.pressure.status, "idle");
+  assert.equal(stats.pressure.reason, "no_ready_backlog");
 });
 
-test("legacy queue migration preserves receipts while adding empty batch tables", async () => {
-  const originalNow = Date.now;
-  Date.now = () => 3_000_000;
-  try {
-    const storage = new TestStorage();
-    await storage.put("exact-review-queue", {
-      items: {},
-      deliveries: { "legacy-delivery": 3_000_000 },
-    });
-    const queue = new ExactReviewQueue({ storage }, {});
-    const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+test("legacy queue migration preserves receipts while adding empty batch tables", async (t) => {
+  t.mock.method(Date, "now", () => 3_000_000);
+  const storage = new TestStorage();
+  await storage.put("exact-review-queue", {
+    items: {},
+    deliveries: { "legacy-delivery": 3_000_000 },
+  });
+  const queue = new ExactReviewQueue({ storage }, {});
+  const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
 
-    assert.equal(stats.delivery_receipts, 1);
-    assert.equal(stats.storage_schema_version, 1);
-    assert.equal(stats.lanes.publication.batches.active_items, 0);
-    assert.equal(
-      storage.scalar("SELECT COUNT(*) AS value FROM exact_review_publication_batches"),
-      0,
-    );
-  } finally {
-    Date.now = originalNow;
-  }
+  assert.equal(stats.delivery_receipts, 1);
+  assert.equal(stats.storage_schema_version, 1);
+  assert.equal(stats.lanes.publication.batches.active_items, 0);
+  assert.equal(storage.scalar("SELECT COUNT(*) AS value FROM exact_review_publication_batches"), 0);
 });
 
-test("batch claim honors the existing dispatcher pause gate", async () => {
-  const originalNow = Date.now;
-  Date.now = () => 4_000_000;
-  try {
-    const storage = new TestStorage();
-    const queue = new ExactReviewQueue(
-      { storage },
-      { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" },
+test("batch claim honors the existing dispatcher pause gate", async (t) => {
+  t.mock.method(Date, "now", () => 4_000_000);
+  const storage = new TestStorage();
+  const queue = new ExactReviewQueue(
+    { storage },
+    { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" },
+  );
+  await queue.fetch(publicationRequest("delivery-paused", 104, "1004"));
+  Array.from(
+    storage.sql.exec(
+      "UPDATE exact_review_queue_meta SET dispatcher_json = ? WHERE singleton_id = 1",
+      JSON.stringify({
+        state: "paused",
+        checkedAt: 4_000_000,
+        retryAt: 4_060_000,
+        reason: "workflow_not_active",
+      }),
+    ),
+  );
+
+  const claim = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-paused",
+        lease_owner: "worker-1",
+        max_items: 1,
+      }),
+    )
+  ).json();
+  assert.equal(claim.claimed, false);
+  assert.equal(claim.batch, null);
+});
+
+test("an active batch blocks the legacy publisher until its lease expires", async (t) => {
+  t.mock.method(Date, "now", () => 5_000_000);
+  const storage = new TestStorage();
+  const queue = new ExactReviewQueue(
+    { storage },
+    {
+      EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+      EXACT_REVIEW_PUBLICATION_BATCH_LEASE_MS: "60000",
+      EXACT_REVIEW_PUBLICATION_BASE_CONCURRENT: "1",
+      EXACT_REVIEW_PUBLICATION_MAX_CONCURRENT: "1",
+      EXACT_REVIEW_PUBLICATION_MIN_CONCURRENT: "1",
+    },
+  );
+  await queue.fetch(publicationRequest("delivery-owned", 105, "1005"));
+  await queue.fetch(publicationRequest("delivery-unowned", 106, "1006"));
+  await queue.fetch(publicationRequest("delivery-unowned-2", 107, "1007"));
+
+  const claim = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-blocks-legacy",
+        lease_owner: "worker-1",
+        max_items: 2,
+      }),
+    )
+  ).json();
+  assert.equal(claim.claimed, true, JSON.stringify(claim));
+  assert.equal(claim.batch.items.length, 2);
+
+  await queue.alarm();
+  const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(stats.lanes.publication.pending, 3);
+  assert.equal(stats.lanes.publication.dispatching, 0);
+  assert.equal(stats.admissible_pending, 0);
+  assert.equal(storage.scheduledAlarm(), 5_060_000);
+});
+
+test("queue claims distinct batches up to the configured concurrent owner cap", async (t) => {
+  t.mock.method(Date, "now", () => 5_500_000);
+  const storage = new TestStorage();
+  const queue = new ExactReviewQueue(
+    { storage },
+    {
+      EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+      EXACT_REVIEW_PUBLICATION_BATCH_SIZE: "2",
+      EXACT_REVIEW_PUBLICATION_BATCH_MAX_CONCURRENT: "2",
+    },
+  );
+  for (let itemNumber = 120; itemNumber < 125; itemNumber += 1) {
+    await queue.fetch(
+      publicationRequest(`delivery-parallel-${itemNumber}`, itemNumber, String(4000 + itemNumber)),
     );
-    await queue.fetch(publicationRequest("delivery-paused", 104, "1004"));
-    Array.from(
-      storage.sql.exec(
-        "UPDATE exact_review_queue_meta SET dispatcher_json = ? WHERE singleton_id = 1",
-        JSON.stringify({
-          state: "paused",
-          checkedAt: 4_000_000,
-          retryAt: 4_060_000,
-          reason: "workflow_not_active",
+  }
+
+  const claim = async (id: string) =>
+    (
+      await queue.fetch(
+        batchRequest("/publication-batches/claim", {
+          claim_id: id,
+          lease_owner: id,
+          max_items: 2,
         }),
+      )
+    ).json();
+  const first = await claim("parallel-claim-1");
+  const second = await claim("parallel-claim-2");
+  const third = await claim("parallel-claim-3");
+
+  assert.equal(first.claimed, true, JSON.stringify(first));
+  assert.equal(second.claimed, true, JSON.stringify(second));
+  assert.equal(third.claimed, false, JSON.stringify(third));
+  assert.deepEqual(
+    [
+      ...first.batch.items.map((item: { item_key: string }) => item.item_key),
+      ...second.batch.items.map((item: { item_key: string }) => item.item_key),
+    ],
+    [
+      "openclaw/openclaw#120@publish:4120:1",
+      "openclaw/openclaw#121@publish:4121:1",
+      "openclaw/openclaw#122@publish:4122:1",
+      "openclaw/openclaw#123@publish:4123:1",
+    ],
+  );
+  const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(stats.lanes.publication.batches.max_concurrent, 2);
+  assert.equal(stats.lanes.publication.batches.leased, 2);
+  assert.equal(stats.lanes.publication.batches.active_items, 4);
+});
+
+test("batch claim serializes distinct publication events for the same durable item", async (t) => {
+  t.mock.method(Date, "now", () => 6_000_000);
+  const storage = new TestStorage();
+  const queue = new ExactReviewQueue(
+    { storage },
+    { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" },
+  );
+  await queue.fetch(publicationRequest("delivery-duplicate-old", 108676, "2001"));
+  await queue.fetch(publicationRequest("delivery-duplicate-new", 108676, "2002"));
+  await queue.fetch(publicationRequest("delivery-distinct", 108677, "2003"));
+
+  const claim = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-unique-durable-items",
+        lease_owner: "worker-1",
+        max_items: 2,
+      }),
+    )
+  ).json();
+
+  assert.equal(claim.claimed, true, JSON.stringify(claim));
+  assert.deepEqual(
+    claim.batch.items.map((item: { item_key: string }) => item.item_key),
+    ["openclaw/openclaw#108676@publish:2001:1", "openclaw/openclaw#108677@publish:2003:1"],
+  );
+});
+
+test("publication ingress is never shed by the review pending soft limit", async (t) => {
+  t.mock.method(Date, "now", () => 6_100_000);
+  const queue = new ExactReviewQueue(
+    { storage: new TestStorage() },
+    {
+      EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+      EXACT_REVIEW_PENDING_SOFT_LIMIT: "1",
+    },
+  );
+  await queue.fetch(reviewRequest("delivery-review-cap", 108699));
+  const response = await (
+    await queue.fetch(
+      publicationRequest(
+        "delivery-publication-over-cap",
+        108699,
+        "2099",
+        "openclaw/openclaw",
+        null,
+        1,
+      ),
+    )
+  ).json();
+
+  assert.equal(response.queued, true);
+  assert.equal(response.shed, undefined);
+  const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(stats.lanes.publication.pending, 1);
+});
+
+test("newer publication revisions supersede unowned pending rows at enqueue", async (t) => {
+  t.mock.method(Date, "now", () => 6_200_000);
+  const queue = new ExactReviewQueue(
+    { storage: new TestStorage() },
+    { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" },
+  );
+  await queue.fetch(
+    publicationRequest("delivery-revision-1", 108700, "2101", "openclaw/openclaw", 1),
+  );
+  const response = await (
+    await queue.fetch(
+      publicationRequest("delivery-revision-2", 108700, "2102", "openclaw/openclaw", 2),
+    )
+  ).json();
+
+  assert.equal(response.queued, true);
+  assert.equal(response.superseded_publications, 1);
+  const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(stats.lanes.publication.pending, 1);
+  assert.equal(stats.lanes.publication.completed_total, 1);
+  assert.equal(stats.lanes.publication.superseded_total, 1);
+});
+
+test("semantic lineage dedupe cannot leave obsolete rows eligible for a batch", async (t) => {
+  t.mock.method(Date, "now", () => 6_250_000);
+  const queue = new ExactReviewQueue(
+    { storage: new TestStorage() },
+    {
+      EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+      EXACT_REVIEW_PUBLICATION_BATCH_SIZE: "8",
+    },
+  );
+  for (let index = 0; index < 101; index += 1) {
+    await queue.fetch(
+      publicationRequest(
+        `delivery-many-old-${index}`,
+        108703,
+        String(2400 + index),
+        "openclaw/openclaw",
+        1,
       ),
     );
-
-    const claim = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "claim-paused",
-          lease_owner: "worker-1",
-          max_items: 1,
-        }),
-      )
-    ).json();
-    assert.equal(claim.claimed, false);
-    assert.equal(claim.batch, null);
-  } finally {
-    Date.now = originalNow;
   }
-});
+  await queue.fetch(
+    publicationRequest("delivery-many-new", 108703, "2600", "openclaw/openclaw", 2),
+  );
 
-test("an active batch blocks the legacy publisher until its lease expires", async () => {
-  const originalNow = Date.now;
-  Date.now = () => 5_000_000;
-  try {
-    const storage = new TestStorage();
-    const queue = new ExactReviewQueue(
-      { storage },
-      {
-        EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
-        EXACT_REVIEW_PUBLICATION_BATCH_LEASE_MS: "60000",
-        EXACT_REVIEW_PUBLICATION_BASE_CONCURRENT: "1",
-        EXACT_REVIEW_PUBLICATION_MAX_CONCURRENT: "1",
-        EXACT_REVIEW_PUBLICATION_MIN_CONCURRENT: "1",
-      },
-    );
-    await queue.fetch(publicationRequest("delivery-owned", 105, "1005"));
-    await queue.fetch(publicationRequest("delivery-unowned", 106, "1006"));
-    await queue.fetch(publicationRequest("delivery-unowned-2", 107, "1007"));
-
-    const claim = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "claim-blocks-legacy",
-          lease_owner: "worker-1",
-          max_items: 2,
-        }),
-      )
-    ).json();
-    assert.equal(claim.claimed, true, JSON.stringify(claim));
-    assert.equal(claim.batch.items.length, 2);
-
-    await queue.alarm();
-    const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
-    assert.equal(stats.lanes.publication.pending, 3);
-    assert.equal(stats.lanes.publication.dispatching, 0);
-    assert.equal(stats.admissible_pending, 0);
-    assert.equal(storage.scheduledAlarm(), 5_060_000);
-  } finally {
-    Date.now = originalNow;
-  }
-});
-
-test("queue claims distinct batches up to the configured concurrent owner cap", async () => {
-  const originalNow = Date.now;
-  Date.now = () => 5_500_000;
-  try {
-    const storage = new TestStorage();
-    const queue = new ExactReviewQueue(
-      { storage },
-      {
-        EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
-        EXACT_REVIEW_PUBLICATION_BATCH_SIZE: "2",
-        EXACT_REVIEW_PUBLICATION_BATCH_MAX_CONCURRENT: "2",
-      },
-    );
-    for (let itemNumber = 120; itemNumber < 125; itemNumber += 1) {
-      await queue.fetch(
-        publicationRequest(
-          `delivery-parallel-${itemNumber}`,
-          itemNumber,
-          String(4000 + itemNumber),
-        ),
-      );
-    }
-
-    const claim = async (id: string) =>
-      (
-        await queue.fetch(
-          batchRequest("/publication-batches/claim", {
-            claim_id: id,
-            lease_owner: id,
-            max_items: 2,
-          }),
-        )
-      ).json();
-    const first = await claim("parallel-claim-1");
-    const second = await claim("parallel-claim-2");
-    const third = await claim("parallel-claim-3");
-
-    assert.equal(first.claimed, true, JSON.stringify(first));
-    assert.equal(second.claimed, true, JSON.stringify(second));
-    assert.equal(third.claimed, false, JSON.stringify(third));
-    assert.deepEqual(
-      [
-        ...first.batch.items.map((item: { item_key: string }) => item.item_key),
-        ...second.batch.items.map((item: { item_key: string }) => item.item_key),
-      ],
-      [
-        "openclaw/openclaw#120@publish:4120:1",
-        "openclaw/openclaw#121@publish:4121:1",
-        "openclaw/openclaw#122@publish:4122:1",
-        "openclaw/openclaw#123@publish:4123:1",
-      ],
-    );
-    const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
-    assert.equal(stats.lanes.publication.batches.max_concurrent, 2);
-    assert.equal(stats.lanes.publication.batches.leased, 2);
-    assert.equal(stats.lanes.publication.batches.active_items, 4);
-  } finally {
-    Date.now = originalNow;
-  }
-});
-
-test("batch claim serializes distinct publication events for the same durable item", async () => {
-  const originalNow = Date.now;
-  Date.now = () => 6_000_000;
-  try {
-    const storage = new TestStorage();
-    const queue = new ExactReviewQueue(
-      { storage },
-      { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" },
-    );
-    await queue.fetch(publicationRequest("delivery-duplicate-old", 108676, "2001"));
-    await queue.fetch(publicationRequest("delivery-duplicate-new", 108676, "2002"));
-    await queue.fetch(publicationRequest("delivery-distinct", 108677, "2003"));
-
-    const claim = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "claim-unique-durable-items",
-          lease_owner: "worker-1",
-          max_items: 2,
-        }),
-      )
-    ).json();
-
-    assert.equal(claim.claimed, true, JSON.stringify(claim));
-    assert.deepEqual(
-      claim.batch.items.map((item: { item_key: string }) => item.item_key),
-      ["openclaw/openclaw#108676@publish:2001:1", "openclaw/openclaw#108677@publish:2003:1"],
-    );
-  } finally {
-    Date.now = originalNow;
-  }
-});
-
-test("publication ingress is never shed by the review pending soft limit", async () => {
-  const originalNow = Date.now;
-  Date.now = () => 6_100_000;
-  try {
-    const queue = new ExactReviewQueue(
-      { storage: new TestStorage() },
-      {
-        EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
-        EXACT_REVIEW_PENDING_SOFT_LIMIT: "1",
-      },
-    );
-    await queue.fetch(reviewRequest("delivery-review-cap", 108699));
-    const response = await (
-      await queue.fetch(
-        publicationRequest(
-          "delivery-publication-over-cap",
-          108699,
-          "2099",
-          "openclaw/openclaw",
-          null,
-          1,
-        ),
-      )
-    ).json();
-
-    assert.equal(response.queued, true);
-    assert.equal(response.shed, undefined);
-    const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
-    assert.equal(stats.lanes.publication.pending, 1);
-  } finally {
-    Date.now = originalNow;
-  }
-});
-
-test("newer publication revisions supersede unowned pending rows at enqueue", async () => {
-  const originalNow = Date.now;
-  Date.now = () => 6_200_000;
-  try {
-    const queue = new ExactReviewQueue(
-      { storage: new TestStorage() },
-      { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" },
-    );
+  const before = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(before.lanes.publication.pending, 1);
+  assert.equal(before.lanes.publication.semantic_deduped_total, 100);
+  const claim = await (
     await queue.fetch(
-      publicationRequest("delivery-revision-1", 108700, "2101", "openclaw/openclaw", 1),
-    );
-    const response = await (
-      await queue.fetch(
-        publicationRequest("delivery-revision-2", 108700, "2102", "openclaw/openclaw", 2),
-      )
-    ).json();
-
-    assert.equal(response.queued, true);
-    assert.equal(response.superseded_publications, 1);
-    const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
-    assert.equal(stats.lanes.publication.pending, 1);
-    assert.equal(stats.lanes.publication.completed_total, 1);
-    assert.equal(stats.lanes.publication.superseded_total, 1);
-  } finally {
-    Date.now = originalNow;
-  }
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-skips-obsolete-remainder",
+        lease_owner: "worker-1",
+        max_items: 32,
+      }),
+    )
+  ).json();
+  assert.deepEqual(
+    claim.batch.items.map((item: { item_key: string }) => item.item_key),
+    ["openclaw/openclaw#108703@publish:2600:1"],
+  );
 });
 
-test("semantic lineage dedupe cannot leave obsolete rows eligible for a batch", async () => {
-  const originalNow = Date.now;
-  Date.now = () => 6_250_000;
-  try {
-    const queue = new ExactReviewQueue(
-      { storage: new TestStorage() },
-      {
-        EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
-        EXACT_REVIEW_PUBLICATION_BATCH_SIZE: "8",
-      },
-    );
-    for (let index = 0; index < 101; index += 1) {
-      await queue.fetch(
-        publicationRequest(
-          `delivery-many-old-${index}`,
-          108703,
-          String(2400 + index),
-          "openclaw/openclaw",
-          1,
-        ),
-      );
-    }
-    await queue.fetch(
-      publicationRequest("delivery-many-new", 108703, "2600", "openclaw/openclaw", 2),
-    );
+test("stale publication ingress is acknowledged without replacing a newer revision", async (t) => {
+  t.mock.method(Date, "now", () => 6_300_000);
+  const storage = new TestStorage();
+  const queue = new ExactReviewQueue(
+    { storage },
+    { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" },
+  );
+  await queue.fetch(publicationRequest("delivery-newer", 108701, "2202", "openclaw/openclaw", 2));
+  storage.run(
+    "DELETE FROM exact_review_queue_items WHERE item_key = ?",
+    "openclaw/openclaw#108701@publish:2202:1",
+  );
+  const response = await (
+    await queue.fetch(publicationRequest("delivery-stale", 108701, "2201", "openclaw/openclaw", 1))
+  ).json();
 
-    const before = await (await queue.fetch(new Request("https://queue/stats"))).json();
-    assert.equal(before.lanes.publication.pending, 1);
-    assert.equal(before.lanes.publication.semantic_deduped_total, 100);
-    const claim = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "claim-skips-obsolete-remainder",
-          lease_owner: "worker-1",
-          max_items: 32,
-        }),
-      )
-    ).json();
-    assert.deepEqual(
-      claim.batch.items.map((item: { item_key: string }) => item.item_key),
-      ["openclaw/openclaw#108703@publish:2600:1"],
-    );
-  } finally {
-    Date.now = originalNow;
-  }
+  assert.equal(response.deduped, true);
+  assert.equal(response.superseded, true);
+  assert.equal(response.publication_revision, 1);
+  assert.equal(response.superseded_by_revision, 2);
+  const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(stats.lanes.publication.pending, 0);
 });
 
-test("stale publication ingress is acknowledged without replacing a newer revision", async () => {
-  const originalNow = Date.now;
-  Date.now = () => 6_300_000;
-  try {
-    const storage = new TestStorage();
-    const queue = new ExactReviewQueue(
-      { storage },
-      { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" },
-    );
-    await queue.fetch(publicationRequest("delivery-newer", 108701, "2202", "openclaw/openclaw", 2));
-    storage.run(
-      "DELETE FROM exact_review_queue_items WHERE item_key = ?",
-      "openclaw/openclaw#108701@publish:2202:1",
-    );
-    const response = await (
-      await queue.fetch(
-        publicationRequest("delivery-stale", 108701, "2201", "openclaw/openclaw", 1),
-      )
-    ).json();
-
-    assert.equal(response.deduped, true);
-    assert.equal(response.superseded, true);
-    assert.equal(response.publication_revision, 1);
-    assert.equal(response.superseded_by_revision, 2);
-    const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
-    assert.equal(stats.lanes.publication.pending, 0);
-  } finally {
-    Date.now = originalNow;
-  }
-});
-
-test("publication reconcile preserves active batches and removes older revisions after expiry", async () => {
-  const originalNow = Date.now;
+test("publication reconcile preserves active batches and removes older revisions after expiry", async (t) => {
   let now = 6_400_000;
-  Date.now = () => now;
-  try {
-    const storage = new TestStorage();
-    const queue = new ExactReviewQueue(
-      { storage },
-      {
-        EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
-        EXACT_REVIEW_PUBLICATION_BATCH_LEASE_MS: "60000",
-      },
-    );
+  t.mock.method(Date, "now", () => now);
+  const storage = new TestStorage();
+  const queue = new ExactReviewQueue(
+    { storage },
+    {
+      EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+      EXACT_REVIEW_PUBLICATION_BATCH_LEASE_MS: "60000",
+    },
+  );
+  await queue.fetch(
+    publicationRequest("delivery-owned-old", 108702, "2301", "openclaw/openclaw", 1),
+  );
+  const claim = await (
     await queue.fetch(
-      publicationRequest("delivery-owned-old", 108702, "2301", "openclaw/openclaw", 1),
-    );
-    const claim = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "claim-reconcile-protection",
-          lease_owner: "worker-1",
-          max_items: 1,
-        }),
-      )
-    ).json();
-    assert.equal(claim.claimed, true);
-    await queue.fetch(
-      publicationRequest("delivery-unowned-new", 108702, "2302", "openclaw/openclaw", 2),
-    );
-    storage.run(
-      "DELETE FROM exact_review_queue_items WHERE item_key = ?",
-      "openclaw/openclaw#108702@publish:2302:1",
-    );
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-reconcile-protection",
+        lease_owner: "worker-1",
+        max_items: 1,
+      }),
+    )
+  ).json();
+  assert.equal(claim.claimed, true);
+  await queue.fetch(
+    publicationRequest("delivery-unowned-new", 108702, "2302", "openclaw/openclaw", 2),
+  );
+  storage.run(
+    "DELETE FROM exact_review_queue_items WHERE item_key = ?",
+    "openclaw/openclaw#108702@publish:2302:1",
+  );
 
-    const protectedResult = await (
-      await queue.fetch(batchRequest("/publications/reconcile", { apply: true, max_items: 100 }))
-    ).json();
-    assert.equal(protectedResult.changed, 0);
-    assert.equal(protectedResult.eligible, 0);
+  const protectedResult = await (
+    await queue.fetch(batchRequest("/publications/reconcile", { apply: true, max_items: 100 }))
+  ).json();
+  assert.equal(protectedResult.changed, 0);
+  assert.equal(protectedResult.eligible, 0);
 
-    now += 60_001;
-    const dryRun = await (
-      await queue.fetch(batchRequest("/publications/reconcile", { max_items: 100 }))
-    ).json();
-    assert.equal(dryRun.apply, false);
-    assert.equal(dryRun.eligible, 1);
-    assert.equal(dryRun.changed, 0);
+  now += 60_001;
+  const dryRun = await (
+    await queue.fetch(batchRequest("/publications/reconcile", { max_items: 100 }))
+  ).json();
+  assert.equal(dryRun.apply, false);
+  assert.equal(dryRun.eligible, 1);
+  assert.equal(dryRun.changed, 0);
 
-    const applied = await (
-      await queue.fetch(batchRequest("/publications/reconcile", { apply: true, max_items: 100 }))
-    ).json();
-    assert.equal(applied.changed, 1);
-    assert.equal(applied.eligible_remaining, 0);
-    const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
-    assert.equal(stats.lanes.publication.pending, 0);
-  } finally {
-    Date.now = originalNow;
-  }
+  const applied = await (
+    await queue.fetch(batchRequest("/publications/reconcile", { apply: true, max_items: 100 }))
+  ).json();
+  assert.equal(applied.changed, 1);
+  assert.equal(applied.eligible_remaining, 0);
+  const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(stats.lanes.publication.pending, 0);
 });
 
-test("publication reconcile backfills historical duplicate lineages in bounded passes", async () => {
-  const originalNow = Date.now;
+test("publication reconcile backfills historical duplicate lineages in bounded passes", async (t) => {
   const now = 6_450_000;
-  Date.now = () => now;
-  try {
-    const storage = new TestStorage();
-    const decisions = await Promise.all(
-      ["2401", "2402", "2403"].map(async (producerRunId) => {
-        const payload = (await publicationRequest(
-          `legacy-lineage-${producerRunId}`,
-          108703,
-          producerRunId,
-        ).json()) as { decision: Record<string, unknown> };
-        return payload.decision;
+  t.mock.method(Date, "now", () => now);
+  const storage = new TestStorage();
+  const decisions = await Promise.all(
+    ["2401", "2402", "2403"].map(async (producerRunId) => {
+      const payload = (await publicationRequest(
+        `legacy-lineage-${producerRunId}`,
+        108703,
+        producerRunId,
+      ).json()) as { decision: Record<string, unknown> };
+      return payload.decision;
+    }),
+  );
+  const keys = ["2401", "2402", "2403"].map(
+    (producerRunId) => `openclaw/openclaw#108703@publish:${producerRunId}:1`,
+  );
+  await storage.put("exact-review-queue", {
+    items: Object.fromEntries(
+      keys.map((key, index) => [
+        key,
+        {
+          decision: decisions[index],
+          state: "pending",
+          revision: 1,
+          createdAt: now - (3 - index) * 100_000,
+          updatedAt: now - (3 - index) * 100_000,
+          nextAttemptAt: now - (3 - index) * 100_000,
+          attempts: index === 0 ? 7 : 0,
+          ...(index === 0
+            ? {
+                publicationFailureAttempts: 2,
+                firstFailureAt: now - 300_000,
+                lastFailureReason: "state_contention",
+              }
+            : {}),
+        },
+      ]),
+    ),
+    deliveries: {},
+  });
+  const queue = new ExactReviewQueue({ storage }, {});
+
+  const dryRun = await (
+    await queue.fetch(batchRequest("/publications/reconcile", { max_items: 1 }))
+  ).json();
+  assert.equal(dryRun.apply, false);
+  assert.equal(dryRun.eligible, 2);
+  assert.equal(dryRun.changed, 0);
+  assert.equal(dryRun.lineage_duplicate_eligible, 2);
+  assert.equal(dryRun.oldest_eligible_age_seconds, 200);
+  assert.equal(dryRun.oldest_remaining_age_seconds, 200);
+  assert.equal(dryRun.sample[0].reason, "duplicate_lineage");
+  assert.equal(dryRun.sample[0].retained_item_key, keys[0]);
+
+  const firstPass = await (
+    await queue.fetch(batchRequest("/publications/reconcile", { apply: true, max_items: 1 }))
+  ).json();
+  assert.equal(firstPass.changed, 0);
+  assert.equal(firstPass.eligible_remaining, 2);
+  assert.equal(firstPass.lineage_duplicate_changed, 0);
+  assert.equal(firstPass.lineage_refreshed, 0);
+  assert.equal(firstPass.oldest_remaining_age_seconds, 200);
+  assert.equal(firstPass.sample[0].item_key, keys[1]);
+  assert.equal(firstPass.sample[0].supersede_safe, true);
+  assert.equal(firstPass.sample[0].acknowledgement_unavailable_reason, null);
+
+  const afterFirstPass = await (
+    await queue.fetch(batchRequest("/publications/list", { limit: 100 }))
+  ).json();
+  const retained = afterFirstPass.publications.find(
+    (item: { item_key: string }) => item.item_key === keys[0],
+  );
+  assert.equal(retained.attempts, 7);
+  assert.equal(retained.revision, 1);
+  assert.equal(retained.decision.publication.producerRunId, "2401");
+  assert.equal(afterFirstPass.publications.length, 3);
+
+  const staleSupersede = await (
+    await queue.fetch(
+      batchRequest("/publications/supersede", {
+        items: [{ item_key: keys[0], revision: 1 }],
       }),
-    );
-    const keys = ["2401", "2402", "2403"].map(
-      (producerRunId) => `openclaw/openclaw#108703@publish:${producerRunId}:1`,
-    );
-    await storage.put("exact-review-queue", {
-      items: Object.fromEntries(
-        keys.map((key, index) => [
-          key,
-          {
-            decision: decisions[index],
-            state: "pending",
-            revision: 1,
-            createdAt: now - (3 - index) * 100_000,
-            updatedAt: now - (3 - index) * 100_000,
-            nextAttemptAt: now - (3 - index) * 100_000,
-            attempts: index === 0 ? 7 : 0,
-            ...(index === 0
-              ? {
-                  publicationFailureAttempts: 2,
-                  firstFailureAt: now - 300_000,
-                  lastFailureReason: "state_contention",
-                }
-              : {}),
-          },
-        ]),
-      ),
-      deliveries: {},
-    });
-    const queue = new ExactReviewQueue({ storage }, {});
+    )
+  ).json();
+  assert.equal(staleSupersede.superseded, 0);
 
-    const dryRun = await (
-      await queue.fetch(batchRequest("/publications/reconcile", { max_items: 1 }))
-    ).json();
-    assert.equal(dryRun.apply, false);
-    assert.equal(dryRun.eligible, 2);
-    assert.equal(dryRun.changed, 0);
-    assert.equal(dryRun.lineage_duplicate_eligible, 2);
-    assert.equal(dryRun.oldest_eligible_age_seconds, 200);
-    assert.equal(dryRun.oldest_remaining_age_seconds, 200);
-    assert.equal(dryRun.sample[0].reason, "duplicate_lineage");
-    assert.equal(dryRun.sample[0].retained_item_key, keys[0]);
+  const secondPass = await (
+    await queue.fetch(batchRequest("/publications/reconcile", { apply: true, max_items: 100 }))
+  ).json();
+  assert.equal(secondPass.changed, 2);
+  assert.equal(secondPass.eligible_remaining, 0);
+  assert.equal(secondPass.lineage_duplicate_changed, 2);
+  assert.equal(secondPass.lineage_refreshed, 1);
+  assert.equal(secondPass.oldest_remaining_age_seconds, null);
 
-    const firstPass = await (
-      await queue.fetch(batchRequest("/publications/reconcile", { apply: true, max_items: 1 }))
-    ).json();
-    assert.equal(firstPass.changed, 0);
-    assert.equal(firstPass.eligible_remaining, 2);
-    assert.equal(firstPass.lineage_duplicate_changed, 0);
-    assert.equal(firstPass.lineage_refreshed, 0);
-    assert.equal(firstPass.oldest_remaining_age_seconds, 200);
-    assert.equal(firstPass.sample[0].item_key, keys[1]);
-    assert.equal(firstPass.sample[0].supersede_safe, true);
-    assert.equal(firstPass.sample[0].acknowledgement_unavailable_reason, null);
-
-    const afterFirstPass = await (
-      await queue.fetch(batchRequest("/publications/list", { limit: 100 }))
-    ).json();
-    const retained = afterFirstPass.publications.find(
-      (item: { item_key: string }) => item.item_key === keys[0],
-    );
-    assert.equal(retained.attempts, 7);
-    assert.equal(retained.revision, 1);
-    assert.equal(retained.decision.publication.producerRunId, "2401");
-    assert.equal(afterFirstPass.publications.length, 3);
-
-    const staleSupersede = await (
-      await queue.fetch(
-        batchRequest("/publications/supersede", {
-          items: [{ item_key: keys[0], revision: 1 }],
-        }),
-      )
-    ).json();
-    assert.equal(staleSupersede.superseded, 0);
-
-    const secondPass = await (
-      await queue.fetch(batchRequest("/publications/reconcile", { apply: true, max_items: 100 }))
-    ).json();
-    assert.equal(secondPass.changed, 2);
-    assert.equal(secondPass.eligible_remaining, 0);
-    assert.equal(secondPass.lineage_duplicate_changed, 2);
-    assert.equal(secondPass.lineage_refreshed, 1);
-    assert.equal(secondPass.oldest_remaining_age_seconds, null);
-
-    const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
-    assert.equal(stats.lanes.publication.pending, 1);
-    assert.equal(stats.lanes.publication.superseded_total, 2);
-    assert.equal(stats.lanes.publication.semantic_deduped_total, 2);
-  } finally {
-    Date.now = originalNow;
-  }
+  const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(stats.lanes.publication.pending, 1);
+  assert.equal(stats.lanes.publication.superseded_total, 2);
+  assert.equal(stats.lanes.publication.semantic_deduped_total, 2);
 });
 
-test("publication lineage refresh preserves a retained command decision", async () => {
-  const originalNow = Date.now;
+test("publication lineage refresh preserves a retained command decision", async (t) => {
   const now = 6_460_000;
-  Date.now = () => now;
-  try {
-    const storage = new TestStorage();
-    const decisions = await Promise.all(
-      ["2411", "2412"].map(async (producerRunId) => {
-        const payload = (await publicationRequest(
-          `command-lineage-${producerRunId}`,
-          108705,
-          producerRunId,
-        ).json()) as { decision: Record<string, any> };
-        return payload.decision;
-      }),
-    );
-    decisions[0].publication.producerDecision.statusCommentId = 24_111;
-    const keys = ["2411", "2412"].map(
-      (producerRunId) => `openclaw/openclaw#108705@publish:${producerRunId}:1`,
-    );
-    await storage.put("exact-review-queue", {
-      items: Object.fromEntries(
-        keys.map((key, index) => [
-          key,
-          {
-            decision: decisions[index],
-            state: "pending",
-            revision: 1,
-            createdAt: now - (2 - index) * 100_000,
-            updatedAt: now - (2 - index) * 100_000,
-            nextAttemptAt: now - (2 - index) * 100_000,
-            attempts: 0,
-          },
-        ]),
-      ),
-      deliveries: {},
-    });
-    const queue = new ExactReviewQueue({ storage }, {});
+  t.mock.method(Date, "now", () => now);
+  const storage = new TestStorage();
+  const decisions = await Promise.all(
+    ["2411", "2412"].map(async (producerRunId) => {
+      const payload = (await publicationRequest(
+        `command-lineage-${producerRunId}`,
+        108705,
+        producerRunId,
+      ).json()) as { decision: Record<string, any> };
+      return payload.decision;
+    }),
+  );
+  decisions[0].publication.producerDecision.statusCommentId = 24_111;
+  const keys = ["2411", "2412"].map(
+    (producerRunId) => `openclaw/openclaw#108705@publish:${producerRunId}:1`,
+  );
+  await storage.put("exact-review-queue", {
+    items: Object.fromEntries(
+      keys.map((key, index) => [
+        key,
+        {
+          decision: decisions[index],
+          state: "pending",
+          revision: 1,
+          createdAt: now - (2 - index) * 100_000,
+          updatedAt: now - (2 - index) * 100_000,
+          nextAttemptAt: now - (2 - index) * 100_000,
+          attempts: 0,
+        },
+      ]),
+    ),
+    deliveries: {},
+  });
+  const queue = new ExactReviewQueue({ storage }, {});
 
-    const result = await (
-      await queue.fetch(batchRequest("/publications/reconcile", { apply: true, max_items: 100 }))
-    ).json();
-    assert.equal(result.changed, 1);
-    assert.equal(result.lineage_duplicate_changed, 1);
-    assert.equal(result.lineage_refreshed, 0);
+  const result = await (
+    await queue.fetch(batchRequest("/publications/reconcile", { apply: true, max_items: 100 }))
+  ).json();
+  assert.equal(result.changed, 1);
+  assert.equal(result.lineage_duplicate_changed, 1);
+  assert.equal(result.lineage_refreshed, 0);
 
-    const after = await (
-      await queue.fetch(batchRequest("/publications/list", { limit: 100 }))
-    ).json();
-    assert.equal(after.publications.length, 1);
-    assert.equal(after.publications[0].item_key, keys[0]);
-    assert.equal(after.publications[0].revision, 1);
-    assert.equal(
-      after.publications[0].decision.publication.producerDecision.statusCommentId,
-      24_111,
-    );
-    assert.equal(after.publications[0].decision.publication.producerRunId, "2411");
-  } finally {
-    Date.now = originalNow;
-  }
+  const after = await (
+    await queue.fetch(batchRequest("/publications/list", { limit: 100 }))
+  ).json();
+  assert.equal(after.publications.length, 1);
+  assert.equal(after.publications[0].item_key, keys[0]);
+  assert.equal(after.publications[0].revision, 1);
+  assert.equal(after.publications[0].decision.publication.producerDecision.statusCommentId, 24_111);
+  assert.equal(after.publications[0].decision.publication.producerRunId, "2411");
 });
 
-test("publication lineage reconcile defers the whole lineage while a batch owns it", async () => {
-  const originalNow = Date.now;
+test("publication lineage reconcile defers the whole lineage while a batch owns it", async (t) => {
   let now = 6_475_000;
-  Date.now = () => now;
-  try {
-    const storage = new TestStorage();
-    const producerRunIds = ["2501", "2502"];
-    const decisions = await Promise.all(
-      producerRunIds.map(async (producerRunId) => {
-        const payload = (await publicationRequest(
-          `legacy-owned-lineage-${producerRunId}`,
-          108704,
-          producerRunId,
-        ).json()) as { decision: Record<string, unknown> };
-        return payload.decision;
+  t.mock.method(Date, "now", () => now);
+  const storage = new TestStorage();
+  const producerRunIds = ["2501", "2502"];
+  const decisions = await Promise.all(
+    producerRunIds.map(async (producerRunId) => {
+      const payload = (await publicationRequest(
+        `legacy-owned-lineage-${producerRunId}`,
+        108704,
+        producerRunId,
+      ).json()) as { decision: Record<string, unknown> };
+      return payload.decision;
+    }),
+  );
+  const keys = producerRunIds.map(
+    (producerRunId) => `openclaw/openclaw#108704@publish:${producerRunId}:1`,
+  );
+  await storage.put("exact-review-queue", {
+    items: Object.fromEntries(
+      keys.map((key, index) => [
+        key,
+        {
+          decision: decisions[index],
+          state: "pending",
+          revision: 1,
+          createdAt: now - (2 - index) * 100_000,
+          updatedAt: now - (2 - index) * 100_000,
+          nextAttemptAt: now - (2 - index) * 100_000,
+          attempts: 0,
+        },
+      ]),
+    ),
+    deliveries: {},
+  });
+  const queue = new ExactReviewQueue(
+    { storage },
+    {
+      EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+      EXACT_REVIEW_PUBLICATION_BATCH_LEASE_MS: "60000",
+    },
+  );
+  const claim = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-lineage-reconcile-protection",
+        lease_owner: "worker-1",
+        max_items: 1,
       }),
-    );
-    const keys = producerRunIds.map(
-      (producerRunId) => `openclaw/openclaw#108704@publish:${producerRunId}:1`,
-    );
-    await storage.put("exact-review-queue", {
-      items: Object.fromEntries(
-        keys.map((key, index) => [
-          key,
-          {
-            decision: decisions[index],
-            state: "pending",
-            revision: 1,
-            createdAt: now - (2 - index) * 100_000,
-            updatedAt: now - (2 - index) * 100_000,
-            nextAttemptAt: now - (2 - index) * 100_000,
-            attempts: 0,
-          },
-        ]),
-      ),
-      deliveries: {},
-    });
-    const queue = new ExactReviewQueue(
-      { storage },
-      {
-        EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
-        EXACT_REVIEW_PUBLICATION_BATCH_LEASE_MS: "60000",
-      },
-    );
-    const claim = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "claim-lineage-reconcile-protection",
-          lease_owner: "worker-1",
-          max_items: 1,
-        }),
-      )
-    ).json();
-    assert.equal(claim.claimed, true);
-    assert.equal(claim.batch.items[0].item_key, keys[0]);
+    )
+  ).json();
+  assert.equal(claim.claimed, true);
+  assert.equal(claim.batch.items[0].item_key, keys[0]);
 
-    const applied = await (
-      await queue.fetch(batchRequest("/publications/reconcile", { apply: true, max_items: 100 }))
-    ).json();
-    assert.equal(applied.changed, 0);
-    assert.equal(applied.eligible, 0);
-    assert.equal(applied.lineage_duplicate_changed, 0);
-    assert.equal(applied.protected_batch_items, 1);
-    assert.equal(applied.protected_lineage_items, 2);
+  const applied = await (
+    await queue.fetch(batchRequest("/publications/reconcile", { apply: true, max_items: 100 }))
+  ).json();
+  assert.equal(applied.changed, 0);
+  assert.equal(applied.eligible, 0);
+  assert.equal(applied.lineage_duplicate_changed, 0);
+  assert.equal(applied.protected_batch_items, 1);
+  assert.equal(applied.protected_lineage_items, 2);
 
-    const fetched = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/fetch", {
-          batch_id: claim.batch.batch_id,
-          lease_owner: "worker-1",
-        }),
-      )
-    ).json();
-    assert.equal(fetched.batch.items[0].item_key, keys[0]);
-    assert.equal(fetched.items[0].item_key, keys[0]);
+  const fetched = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/fetch", {
+        batch_id: claim.batch.batch_id,
+        lease_owner: "worker-1",
+      }),
+    )
+  ).json();
+  assert.equal(fetched.batch.items[0].item_key, keys[0]);
+  assert.equal(fetched.items[0].item_key, keys[0]);
 
-    now += 60_001;
-    const reconciled = await (
-      await queue.fetch(batchRequest("/publications/reconcile", { apply: true, max_items: 100 }))
-    ).json();
-    assert.equal(reconciled.changed, 1);
-    assert.equal(reconciled.lineage_duplicate_changed, 1);
-    assert.equal(reconciled.lineage_refreshed, 1);
+  now += 60_001;
+  const reconciled = await (
+    await queue.fetch(batchRequest("/publications/reconcile", { apply: true, max_items: 100 }))
+  ).json();
+  assert.equal(reconciled.changed, 1);
+  assert.equal(reconciled.lineage_duplicate_changed, 1);
+  assert.equal(reconciled.lineage_refreshed, 1);
 
-    const publications = await (
-      await queue.fetch(batchRequest("/publications/list", { limit: 100 }))
-    ).json();
-    assert.equal(publications.publications.length, 1);
-    assert.equal(publications.publications[0].item_key, keys[0]);
-    assert.equal(publications.publications[0].decision.publication.producerRunId, "2502");
-  } finally {
-    Date.now = originalNow;
-  }
+  const publications = await (
+    await queue.fetch(batchRequest("/publications/list", { limit: 100 }))
+  ).json();
+  assert.equal(publications.publications.length, 1);
+  assert.equal(publications.publications[0].item_key, keys[0]);
+  assert.equal(publications.publications[0].decision.publication.producerRunId, "2502");
 });
 
-test("batch claim scans beyond but cannot exceed the configured rollout size", async () => {
-  const originalNow = Date.now;
-  Date.now = () => 6_500_000;
-  try {
-    const queue = new ExactReviewQueue(
-      { storage: new TestStorage() },
-      {
-        EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
-        EXACT_REVIEW_PUBLICATION_BATCH_SIZE: "4",
-      },
+test("batch claim scans beyond but cannot exceed the configured rollout size", async (t) => {
+  t.mock.method(Date, "now", () => 6_500_000);
+  const queue = new ExactReviewQueue(
+    { storage: new TestStorage() },
+    {
+      EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+      EXACT_REVIEW_PUBLICATION_BATCH_SIZE: "4",
+    },
+  );
+  for (let itemNumber = 1; itemNumber <= 8; itemNumber += 1) {
+    await queue.fetch(
+      publicationRequest(`delivery-cap-${itemNumber}`, itemNumber, `${3000 + itemNumber}`),
     );
-    for (let itemNumber = 1; itemNumber <= 8; itemNumber += 1) {
-      await queue.fetch(
-        publicationRequest(`delivery-cap-${itemNumber}`, itemNumber, `${3000 + itemNumber}`),
-      );
-    }
-
-    const claim = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "claim-configured-cap",
-          lease_owner: "worker-1",
-          max_items: 50,
-        }),
-      )
-    ).json();
-
-    assert.equal(claim.claimed, true, JSON.stringify(claim));
-    assert.equal(claim.requested_max_items, 50);
-    assert.equal(claim.effective_max_items, 4);
-    assert.equal(claim.batch.items.length, 4);
-  } finally {
-    Date.now = originalNow;
   }
+
+  const claim = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-configured-cap",
+        lease_owner: "worker-1",
+        max_items: 50,
+      }),
+    )
+  ).json();
+
+  assert.equal(claim.claimed, true, JSON.stringify(claim));
+  assert.equal(claim.requested_max_items, 50);
+  assert.equal(claim.effective_max_items, 4);
+  assert.equal(claim.batch.items.length, 4);
 });
 
 test("rollout dispatches one full batch workflow without admitting legacy publishers", async () => {
@@ -2432,43 +2345,38 @@ test("rollout refills concurrent batch owner slots without exceeding the cap", a
   }
 });
 
-test("batch rollout wakes a retryable publication at its next eligibility time", async () => {
-  const originalNow = Date.now;
-  Date.now = () => 9_000_000;
-  try {
-    const storage = new TestStorage();
-    const queue = new ExactReviewQueue(
-      { storage },
-      {
-        EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
-        EXACT_REVIEW_PUBLICATION_BATCH_SIZE: "2",
-        EXACT_REVIEW_PUBLICATION_BATCH_WAIT_MS: "60000",
-      },
-    );
-    await queue.fetch(publicationRequest("delivery-future-retry", 113, "1013"));
-    const [row] = Array.from(
-      storage.sql.exec(
-        "SELECT item_key, item_json FROM exact_review_queue_items WHERE item_key LIKE ?",
-        "%#113@publish:%",
-      ),
-    ) as Array<{ item_key: string; item_json: string }>;
-    assert.ok(row);
-    const item = JSON.parse(row.item_json);
-    item.nextAttemptAt = 9_030_000;
-    Array.from(
-      storage.sql.exec(
-        "UPDATE exact_review_queue_items SET item_json = ? WHERE item_key = ?",
-        JSON.stringify(item),
-        row.item_key,
-      ),
-    );
+test("batch rollout wakes a retryable publication at its next eligibility time", async (t) => {
+  t.mock.method(Date, "now", () => 9_000_000);
+  const storage = new TestStorage();
+  const queue = new ExactReviewQueue(
+    { storage },
+    {
+      EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+      EXACT_REVIEW_PUBLICATION_BATCH_SIZE: "2",
+      EXACT_REVIEW_PUBLICATION_BATCH_WAIT_MS: "60000",
+    },
+  );
+  await queue.fetch(publicationRequest("delivery-future-retry", 113, "1013"));
+  const [row] = Array.from(
+    storage.sql.exec(
+      "SELECT item_key, item_json FROM exact_review_queue_items WHERE item_key LIKE ?",
+      "%#113@publish:%",
+    ),
+  ) as Array<{ item_key: string; item_json: string }>;
+  assert.ok(row);
+  const item = JSON.parse(row.item_json);
+  item.nextAttemptAt = 9_030_000;
+  Array.from(
+    storage.sql.exec(
+      "UPDATE exact_review_queue_items SET item_json = ? WHERE item_key = ?",
+      JSON.stringify(item),
+      row.item_key,
+    ),
+  );
 
-    await queue.alarm();
+  await queue.alarm();
 
-    assert.equal(storage.scheduledAlarm(), 9_030_000);
-  } finally {
-    Date.now = originalNow;
-  }
+  assert.equal(storage.scheduledAlarm(), 9_030_000);
 });
 
 test("batch protocol routes require the shared internal signature", async () => {
@@ -2607,262 +2515,252 @@ test("publication batch observability retains the most recently completed termin
   );
 });
 
-test("reservation-to-claim observability traces one batch without exposing lease credentials", async () => {
-  const originalNow = Date.now;
+test("reservation-to-claim observability traces one batch without exposing lease credentials", async (t) => {
   let now = 18_000_000;
-  Date.now = () => now;
-  try {
-    const queue = new ExactReviewQueue(
-      { storage: new TestStorage() },
-      { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" },
-    );
-    await queue.fetch(publicationRequest("reservation-claim-trace", 729, "2729"));
-    now += 2_000;
-    const claim = await (
+  t.mock.method(Date, "now", () => now);
+  const queue = new ExactReviewQueue(
+    { storage: new TestStorage() },
+    { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" },
+  );
+  await queue.fetch(publicationRequest("reservation-claim-trace", 729, "2729"));
+  now += 2_000;
+  const claim = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/claim", {
+        claim_id: "trace-batch-729",
+        lease_owner: "worker-secret-not-public",
+        max_items: 1,
+        dispatch_id: "publication-batch-dispatch:trace-729",
+        dispatched_at: new Date(now - 1_000).toISOString(),
+        runner_run_id: "92729",
+        runner_run_attempt: 3,
+        runner_started_at: new Date(now - 500).toISOString(),
+      }),
+    )
+  ).json();
+  const member = claim.batch.items[0];
+  const claimedStats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(claimedStats.reservation_claim_observability.queue_slots.active_items, 1);
+  assert.equal(claimedStats.reservation_claim_observability.queue_slots.unassigned_pending, 0);
+  assert.ok(
+    !claimedStats.reservation_claim_observability.alerts.some(
+      (alert: { kind: string }) => alert.kind === "no_capacity",
+    ),
+  );
+  const heartbeat = (
+    timelineStage: string,
+    observedAt: number,
+    progress?: Record<string, unknown>,
+  ) =>
+    batchRequest("/publication-batches/heartbeat", {
+      batch_id: claim.batch.batch_id,
+      lease_owner: "worker-secret-not-public",
+      items: [member],
+      ...(progress ? { state_writer_progress: progress } : {}),
+      ...(timelineStage
+        ? { timeline_stage: timelineStage, observed_at: new Date(observedAt).toISOString() }
+        : {}),
+    });
+  now += 500;
+  assert.equal((await queue.fetch(heartbeat("preparation_started", now))).status, 200);
+  now += 500;
+  assert.equal((await queue.fetch(heartbeat("preparation_finished", now))).status, 200);
+  now += 500;
+  assert.equal(
+    (
       await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "trace-batch-729",
-          lease_owner: "worker-secret-not-public",
-          max_items: 1,
-          dispatch_id: "publication-batch-dispatch:trace-729",
-          dispatched_at: new Date(now - 1_000).toISOString(),
-          runner_run_id: "92729",
-          runner_run_attempt: 3,
-          runner_started_at: new Date(now - 500).toISOString(),
+        heartbeat("", now, {
+          schema_version: 1,
+          operation_id: `batch:${claim.batch.batch_id}`,
+          mode: "batch",
+          phase: "waiting",
+          sequence: 1,
+          observed_at: new Date(now).toISOString(),
+          configured_batch_size: 1,
+          actual_batch_size: 1,
         }),
       )
-    ).json();
-    const member = claim.batch.items[0];
-    const claimedStats = await (await queue.fetch(new Request("https://queue/stats"))).json();
-    assert.equal(claimedStats.reservation_claim_observability.queue_slots.active_items, 1);
-    assert.equal(claimedStats.reservation_claim_observability.queue_slots.unassigned_pending, 0);
-    assert.ok(
-      !claimedStats.reservation_claim_observability.alerts.some(
-        (alert: { kind: string }) => alert.kind === "no_capacity",
-      ),
-    );
-    const heartbeat = (
-      timelineStage: string,
-      observedAt: number,
-      progress?: Record<string, unknown>,
-    ) =>
-      batchRequest("/publication-batches/heartbeat", {
+    ).status,
+    200,
+  );
+  now += 500;
+  assert.equal((await queue.fetch(heartbeat("final_github_apply", now))).status, 200);
+  now += 500;
+  assert.equal((await queue.fetch(heartbeat("github_throttle", now))).status, 200);
+  now += 500;
+  const completed = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/complete", {
         batch_id: claim.batch.batch_id,
         lease_owner: "worker-secret-not-public",
-        items: [member],
-        ...(progress ? { state_writer_progress: progress } : {}),
-        ...(timelineStage
-          ? { timeline_stage: timelineStage, observed_at: new Date(observedAt).toISOString() }
-          : {}),
-      });
-    now += 500;
-    assert.equal((await queue.fetch(heartbeat("preparation_started", now))).status, 200);
-    now += 500;
-    assert.equal((await queue.fetch(heartbeat("preparation_finished", now))).status, 200);
-    now += 500;
-    assert.equal(
-      (
-        await queue.fetch(
-          heartbeat("", now, {
-            schema_version: 1,
-            operation_id: `batch:${claim.batch.batch_id}`,
-            mode: "batch",
-            phase: "waiting",
-            sequence: 1,
-            observed_at: new Date(now).toISOString(),
-            configured_batch_size: 1,
-            actual_batch_size: 1,
-          }),
-        )
-      ).status,
-      200,
-    );
-    now += 500;
-    assert.equal((await queue.fetch(heartbeat("final_github_apply", now))).status, 200);
-    now += 500;
-    assert.equal((await queue.fetch(heartbeat("github_throttle", now))).status, 200);
-    now += 500;
-    const completed = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/complete", {
-          batch_id: claim.batch.batch_id,
-          lease_owner: "worker-secret-not-public",
-          state_commit_sha: "a".repeat(40),
-          failure_fingerprint: "failure-body-secret-not-public",
-          state_writer: {
-            schema_version: 1,
-            operation_id: `batch:${claim.batch.batch_id}`,
-            mode: "batch",
-            started_at: new Date(now - 1_000).toISOString(),
-            finished_at: new Date(now).toISOString(),
-            wait_ms: 500,
-            acquire_attempts: 1,
-            acquired: true,
-            hold_ms: 500,
-            renewals: 0,
-            released: true,
-            git_duration_ms: 1_000,
-            git_processes: 1,
-            commit_count: 1,
-            materialized_items: 1,
-            configured_batch_size: 1,
-            actual_batch_size: 1,
-            batch_wait_ms: 0,
-            outcome: "materialized",
+        state_commit_sha: "a".repeat(40),
+        failure_fingerprint: "failure-body-secret-not-public",
+        state_writer: {
+          schema_version: 1,
+          operation_id: `batch:${claim.batch.batch_id}`,
+          mode: "batch",
+          started_at: new Date(now - 1_000).toISOString(),
+          finished_at: new Date(now).toISOString(),
+          wait_ms: 500,
+          acquire_attempts: 1,
+          acquired: true,
+          hold_ms: 500,
+          renewals: 0,
+          released: true,
+          git_duration_ms: 1_000,
+          git_processes: 1,
+          commit_count: 1,
+          materialized_items: 1,
+          configured_batch_size: 1,
+          actual_batch_size: 1,
+          batch_wait_ms: 0,
+          outcome: "materialized",
+        },
+        items: [
+          {
+            item_key: member.item_key,
+            revision: member.revision,
+            claim_generation: member.claim_generation,
+            terminal_outcome: "published",
           },
-          items: [
-            {
-              item_key: member.item_key,
-              revision: member.revision,
-              claim_generation: member.claim_generation,
-              terminal_outcome: "published",
-            },
-          ],
-        }),
-      )
-    ).json();
-    assert.equal(completed.accepted, 1, JSON.stringify(completed));
+        ],
+      }),
+    )
+  ).json();
+  assert.equal(completed.accepted, 1, JSON.stringify(completed));
 
-    const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
-    const observability = stats.reservation_claim_observability;
-    assert.deepEqual(observability.publication_paths, {
-      cloudflare_canonical_direct: {
-        enabled: true,
-        reservation_to_claim: "not_applicable",
-        state_writer_timing: "not_applicable",
-      },
-      legacy_state_repo_batch: {
-        enabled: true,
-        reservation_to_claim: "tracked",
-        state_writer_timing: "tracked",
-      },
-    });
-    const batch = observability.batches.find(
-      (entry: { batch_id: string }) => entry.batch_id === claim.batch.batch_id,
-    );
-    assert.ok(batch, JSON.stringify(observability));
-    assert.equal(batch.publication_path, "legacy_state_repo_batch");
-    assert.equal(batch.dispatch.id, "publication-batch-dispatch:trace-729");
-    assert.equal(batch.workflow.run_id, "92729");
-    assert.equal(batch.workflow.run_attempt, 3);
-    assert.ok(batch.workflow.runner_started_at);
-    assert.ok(batch.timeline.preparation_started_at);
-    assert.ok(batch.timeline.preparation_finished_at);
-    assert.ok(batch.timeline.state_writer_wait_at);
-    assert.ok(batch.timeline.state_writer_committed_at);
-    assert.ok(batch.timeline.final_github_apply_at);
-    assert.ok(batch.timeline.github_throttle_at);
-    assert.equal(batch.items[0].producer_run_id, "2729");
-    assert.equal(batch.items[0].reservation_to_claim_ms, 1_000);
-    assert.equal(batch.items[0].enqueue_to_claim_ms, 2_000);
-    assert.equal(observability.delay_buckets.metric, "reservation_to_claim_ms");
-    assert.ok(
-      observability.alerts.some((alert: { kind: string }) => alert.kind === "github_throttle"),
-    );
-    assert.match(JSON.stringify(observability), /publication-batch-dispatch:trace-729/);
-    assert.doesNotMatch(JSON.stringify(observability), /worker-secret-not-public/);
-    assert.doesNotMatch(JSON.stringify(observability), /failure-body-secret-not-public/);
-  } finally {
-    Date.now = originalNow;
-  }
+  const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  const observability = stats.reservation_claim_observability;
+  assert.deepEqual(observability.publication_paths, {
+    cloudflare_canonical_direct: {
+      enabled: true,
+      reservation_to_claim: "not_applicable",
+      state_writer_timing: "not_applicable",
+    },
+    legacy_state_repo_batch: {
+      enabled: true,
+      reservation_to_claim: "tracked",
+      state_writer_timing: "tracked",
+    },
+  });
+  const batch = observability.batches.find(
+    (entry: { batch_id: string }) => entry.batch_id === claim.batch.batch_id,
+  );
+  assert.ok(batch, JSON.stringify(observability));
+  assert.equal(batch.publication_path, "legacy_state_repo_batch");
+  assert.equal(batch.dispatch.id, "publication-batch-dispatch:trace-729");
+  assert.equal(batch.workflow.run_id, "92729");
+  assert.equal(batch.workflow.run_attempt, 3);
+  assert.ok(batch.workflow.runner_started_at);
+  assert.ok(batch.timeline.preparation_started_at);
+  assert.ok(batch.timeline.preparation_finished_at);
+  assert.ok(batch.timeline.state_writer_wait_at);
+  assert.ok(batch.timeline.state_writer_committed_at);
+  assert.ok(batch.timeline.final_github_apply_at);
+  assert.ok(batch.timeline.github_throttle_at);
+  assert.equal(batch.items[0].producer_run_id, "2729");
+  assert.equal(batch.items[0].reservation_to_claim_ms, 1_000);
+  assert.equal(batch.items[0].enqueue_to_claim_ms, 2_000);
+  assert.equal(observability.delay_buckets.metric, "reservation_to_claim_ms");
+  assert.ok(
+    observability.alerts.some((alert: { kind: string }) => alert.kind === "github_throttle"),
+  );
+  assert.match(JSON.stringify(observability), /publication-batch-dispatch:trace-729/);
+  assert.doesNotMatch(JSON.stringify(observability), /worker-secret-not-public/);
+  assert.doesNotMatch(JSON.stringify(observability), /failure-body-secret-not-public/);
 });
 
-test("authenticated publication reconciliation dry-run reports without mutation", async () => {
-  const originalNow = Date.now;
+test("authenticated publication reconciliation dry-run reports without mutation", async (t) => {
   const now = 13_000_000;
-  Date.now = () => now;
-  try {
-    const secret = "test-secret";
-    const producerRunIds = ["2601", "2602"];
-    const decisions = await Promise.all(
-      producerRunIds.map(async (producerRunId) => {
-        const payload = (await publicationRequest(
-          `authenticated-dry-run-${producerRunId}`,
-          108705,
-          producerRunId,
-        ).json()) as { decision: Record<string, unknown> };
-        return payload.decision;
+  t.mock.method(Date, "now", () => now);
+  const secret = "test-secret";
+  const producerRunIds = ["2601", "2602"];
+  const decisions = await Promise.all(
+    producerRunIds.map(async (producerRunId) => {
+      const payload = (await publicationRequest(
+        `authenticated-dry-run-${producerRunId}`,
+        108705,
+        producerRunId,
+      ).json()) as { decision: Record<string, unknown> };
+      return payload.decision;
+    }),
+  );
+  const storage = new TestStorage();
+  await storage.put("exact-review-queue", {
+    items: Object.fromEntries(
+      producerRunIds.map((producerRunId, index) => [
+        `openclaw/openclaw#108705@publish:${producerRunId}:1`,
+        {
+          decision: decisions[index],
+          state: "pending",
+          revision: 1,
+          createdAt: now - (2 - index) * 60_000,
+          updatedAt: now - (2 - index) * 60_000,
+          nextAttemptAt: now - (2 - index) * 60_000,
+          attempts: 0,
+        },
+      ]),
+    ),
+    deliveries: {},
+  });
+  const queue = new ExactReviewQueue({ storage }, {});
+  let forwardedPath = "";
+  const env = {
+    CLAWSWEEPER_WEBHOOK_SECRET: secret,
+    EXACT_REVIEW_QUEUE: {
+      idFromName: () => "global",
+      get: () => ({
+        fetch: async (request: Request) => {
+          forwardedPath = new URL(request.url).pathname;
+          return queue.fetch(request);
+        },
       }),
-    );
-    const storage = new TestStorage();
-    await storage.put("exact-review-queue", {
-      items: Object.fromEntries(
-        producerRunIds.map((producerRunId, index) => [
-          `openclaw/openclaw#108705@publish:${producerRunId}:1`,
-          {
-            decision: decisions[index],
-            state: "pending",
-            revision: 1,
-            createdAt: now - (2 - index) * 60_000,
-            updatedAt: now - (2 - index) * 60_000,
-            nextAttemptAt: now - (2 - index) * 60_000,
-            attempts: 0,
-          },
-        ]),
-      ),
-      deliveries: {},
-    });
-    const queue = new ExactReviewQueue({ storage }, {});
-    let forwardedPath = "";
-    const env = {
-      CLAWSWEEPER_WEBHOOK_SECRET: secret,
-      EXACT_REVIEW_QUEUE: {
-        idFromName: () => "global",
-        get: () => ({
-          fetch: async (request: Request) => {
-            forwardedPath = new URL(request.url).pathname;
-            return queue.fetch(request);
-          },
-        }),
-      },
-    };
-    const body = JSON.stringify({ apply: false, max_items: 1 });
-    const url = "https://clawsweeper.openclaw.ai/internal/exact-review/publications/reconcile";
-    const unauthorized = await worker.fetch(new Request(url, { method: "POST", body }), env);
-    assert.equal(unauthorized.status, 401);
+    },
+  };
+  const body = JSON.stringify({ apply: false, max_items: 1 });
+  const url = "https://clawsweeper.openclaw.ai/internal/exact-review/publications/reconcile";
+  const unauthorized = await worker.fetch(new Request(url, { method: "POST", body }), env);
+  assert.equal(unauthorized.status, 401);
 
-    const signature = `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
-    const authorized = await worker.fetch(
-      new Request(url, {
-        method: "POST",
-        headers: { "x-clawsweeper-exact-review-signature": signature },
-        body,
-      }),
-      env,
-    );
-    assert.equal(authorized.status, 200);
-    assert.equal(forwardedPath, "/publications/reconcile");
-    const result = await authorized.json();
-    assert.equal(result.apply, false);
-    assert.equal(result.eligible, 1);
-    assert.equal(result.changed, 0);
-    assert.equal(result.eligible_remaining, 1);
-    assert.equal(result.lineage_duplicate_eligible, 1);
-    assert.equal(result.protected_lineage_items, 0);
-    assert.equal(result.oldest_eligible_age_seconds, 60);
-    const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
-    assert.equal(stats.lanes.publication.pending, 2);
+  const signature = `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
+  const authorized = await worker.fetch(
+    new Request(url, {
+      method: "POST",
+      headers: { "x-clawsweeper-exact-review-signature": signature },
+      body,
+    }),
+    env,
+  );
+  assert.equal(authorized.status, 200);
+  assert.equal(forwardedPath, "/publications/reconcile");
+  const result = await authorized.json();
+  assert.equal(result.apply, false);
+  assert.equal(result.eligible, 1);
+  assert.equal(result.changed, 0);
+  assert.equal(result.eligible_remaining, 1);
+  assert.equal(result.lineage_duplicate_eligible, 1);
+  assert.equal(result.protected_lineage_items, 0);
+  assert.equal(result.oldest_eligible_age_seconds, 60);
+  const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(stats.lanes.publication.pending, 2);
 
-    if (process.env.CLAWSWEEPER_EVIDENCE_TRANSCRIPT === "1") {
-      console.log(
-        `AUTHENTICATED_PUBLICATION_RECONCILE_DRY_RUN=${JSON.stringify({
-          http_status: authorized.status,
-          apply: result.apply,
-          scanned: result.scanned,
-          eligible: result.eligible,
-          changed: result.changed,
-          eligible_remaining: result.eligible_remaining,
-          lineage_duplicate_eligible: result.lineage_duplicate_eligible,
-          protected_batch_items: result.protected_batch_items,
-          protected_lineage_items: result.protected_lineage_items,
-          oldest_eligible_age_seconds: result.oldest_eligible_age_seconds,
-          pending_before: 2,
-          pending_after: stats.lanes.publication.pending,
-        })}`,
-      );
-    }
-  } finally {
-    Date.now = originalNow;
+  if (process.env.CLAWSWEEPER_EVIDENCE_TRANSCRIPT === "1") {
+    console.log(
+      `AUTHENTICATED_PUBLICATION_RECONCILE_DRY_RUN=${JSON.stringify({
+        http_status: authorized.status,
+        apply: result.apply,
+        scanned: result.scanned,
+        eligible: result.eligible,
+        changed: result.changed,
+        eligible_remaining: result.eligible_remaining,
+        lineage_duplicate_eligible: result.lineage_duplicate_eligible,
+        protected_batch_items: result.protected_batch_items,
+        protected_lineage_items: result.protected_lineage_items,
+        oldest_eligible_age_seconds: result.oldest_eligible_age_seconds,
+        pending_before: 2,
+        pending_after: stats.lanes.publication.pending,
+      })}`,
+    );
   }
 });
 
@@ -2911,293 +2809,273 @@ test("batch claim, fetch, and heartbeat responses carry current server time", as
   }
 });
 
-test("queue fetch terminalizes a stale batch revision before dispatch", async () => {
-  const originalNow = Date.now;
-  Date.now = () => 1_000_000;
-  try {
-    const storage = new TestStorage();
-    const queue = new ExactReviewQueue(
-      { storage },
-      {
-        EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
-        EXACT_REVIEW_PUBLICATION_BATCH_LEASE_MS: "60000",
-      },
-    );
-    const enqueued = await queue.fetch(publicationRequest("delivery-stale-1", 102, "1002"));
-    assert.equal(enqueued.status, 202, JSON.stringify(await enqueued.clone().json()));
-    const beforeClaim = await (await queue.fetch(new Request("https://queue/stats"))).json();
-    assert.equal(beforeClaim.lanes.publication.pending, 1, JSON.stringify(beforeClaim));
-    const claim = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "claim-stale-revision-1",
-          lease_owner: "worker-1",
-          max_items: 1,
-          runner_run_id: "91002",
-          runner_run_attempt: 1,
-          runner_started_at: "2026-07-30T12:00:00.000Z",
-        }),
-      )
-    ).json();
-    assert.equal(claim.claimed, true, JSON.stringify(claim));
-    assert.equal(claim.batch.items[0].revision, 1);
+test("queue fetch terminalizes a stale batch revision before dispatch", async (t) => {
+  t.mock.method(Date, "now", () => 1_000_000);
+  const storage = new TestStorage();
+  const queue = new ExactReviewQueue(
+    { storage },
+    {
+      EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+      EXACT_REVIEW_PUBLICATION_BATCH_LEASE_MS: "60000",
+    },
+  );
+  const enqueued = await queue.fetch(publicationRequest("delivery-stale-1", 102, "1002"));
+  assert.equal(enqueued.status, 202, JSON.stringify(await enqueued.clone().json()));
+  const beforeClaim = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(beforeClaim.lanes.publication.pending, 1, JSON.stringify(beforeClaim));
+  const claim = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-stale-revision-1",
+        lease_owner: "worker-1",
+        max_items: 1,
+        runner_run_id: "91002",
+        runner_run_attempt: 1,
+        runner_started_at: "2026-07-30T12:00:00.000Z",
+      }),
+    )
+  ).json();
+  assert.equal(claim.claimed, true, JSON.stringify(claim));
+  assert.equal(claim.batch.items[0].revision, 1);
 
-    const retriedClaim = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "claim-stale-revision-1",
-          lease_owner: "worker-1",
-          max_items: 1,
-        }),
-      )
-    ).json();
-    assert.deepEqual(retriedClaim, claim);
+  const retriedClaim = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-stale-revision-1",
+        lease_owner: "worker-1",
+        max_items: 1,
+      }),
+    )
+  ).json();
+  assert.deepEqual(retriedClaim, claim);
 
-    const competingClaim = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "claim-competing",
-          lease_owner: "worker-2",
-          max_items: 1,
-        }),
-      )
-    ).json();
-    assert.equal(competingClaim.claimed, false);
-    assert.equal(competingClaim.batch, null);
-
-    await queue.alarm();
-    const ownedStats = await (await queue.fetch(new Request("https://queue/stats"))).json();
-    assert.equal(ownedStats.lanes.publication.pending, 1);
-    assert.equal(ownedStats.lanes.publication.dispatching, 0);
-    assert.equal(storage.scheduledAlarm(), 1_060_000);
-
-    await queue.fetch(publicationRequest("delivery-stale-2", 102, "1002"));
-    const fetched = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/fetch", {
-          batch_id: claim.batch.batch_id,
-          lease_owner: "worker-1",
-        }),
-      )
-    ).json();
-    assert.equal(fetched.superseded, 1);
-    assert.equal(fetched.items.length, 0);
-    assert.equal(fetched.batch.state, "completed");
-    assert.equal(fetched.batch.items[0].terminal_outcome, "superseded");
-    assert.equal(storage.scheduledAlarm(), 1_060_000);
-    const lifecycleRow = Array.from(
-      storage.sql.exec(
-        `SELECT projection_json FROM ${EXACT_REVIEW_LIFECYCLE_PROJECTION_TABLE}
-          WHERE canonical_target_key = ? AND fence_key = ? AND revision = ?`,
-        "openclaw/openclaw#102",
-        claim.batch.items[0].item_key,
-        1,
-      ),
-    )[0] as { projection_json: string };
-    const lifecycle = JSON.parse(lifecycleRow.projection_json) as {
-      terminalDisposition: { kind: string } | null;
-      reviewResults: Array<{ outcome: string }>;
-    };
-    assert.equal(lifecycle.terminalDisposition?.kind, "superseded");
-    assert.equal(lifecycle.reviewResults[0]?.outcome, "completed");
-
-    const retriedFetch = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/fetch", {
-          batch_id: claim.batch.batch_id,
-          lease_owner: "worker-1",
-        }),
-      )
-    ).json();
-    assert.equal(retriedFetch.batch.state, "completed");
-    assert.equal(retriedFetch.superseded, 1);
-
-    const next = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "claim-stale-revision-2",
-          lease_owner: "worker-2",
-          max_items: 1,
-        }),
-      )
-    ).json();
-    assert.equal(next.batch.items[0].revision, 2);
-    assert.equal(next.batch.items[0].claim_generation, 2);
-  } finally {
-    Date.now = originalNow;
-  }
-});
-
-test("batch heartbeat extends only the active fenced lease", async () => {
-  const originalNow = Date.now;
-  Date.now = () => 1_500_000;
-  try {
-    const queue = new ExactReviewQueue(
-      { storage: new TestStorage() },
-      {
-        EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
-        EXACT_REVIEW_PUBLICATION_BATCH_LEASE_MS: "60000",
-      },
-    );
-    await queue.fetch(publicationRequest("delivery-heartbeat-1", 110, "1010"));
-    await queue.fetch(publicationRequest("delivery-heartbeat-2", 111, "1011"));
-    const claim = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "claim-heartbeat",
-          lease_owner: "worker-1",
-          max_items: 2,
-        }),
-      )
-    ).json();
-    assert.equal(claim.batch.lease_expires_at, new Date(1_560_000).toISOString());
-    const members = claim.batch.items.map((item) => ({
-      item_key: item.item_key,
-      revision: item.revision,
-      claim_generation: item.claim_generation,
-    }));
-
-    Date.now = () => 1_530_000;
-    const heartbeat = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/heartbeat", {
-          batch_id: claim.batch.batch_id,
-          lease_owner: "worker-1",
-          items: members,
-        }),
-      )
-    ).json();
-    assert.equal(heartbeat.batch.lease_expires_at, new Date(1_590_000).toISOString());
-
-    await queue.fetch(publicationRequest("delivery-heartbeat-3", 110, "1010"));
-    const fetched = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/fetch", {
-          batch_id: claim.batch.batch_id,
-          lease_owner: "worker-1",
-        }),
-      )
-    ).json();
-    assert.equal(fetched.superseded, 1);
-    assert.equal(fetched.items.length, 1);
-
-    Date.now = () => 1_540_000;
-    const originalFence = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/heartbeat", {
-          batch_id: claim.batch.batch_id,
-          lease_owner: "worker-1",
-          items: members,
-        }),
-      )
-    ).json();
-    assert.equal(originalFence.batch.lease_expires_at, new Date(1_600_000).toISOString());
-
-    const staleOwner = await queue.fetch(
-      batchRequest("/publication-batches/heartbeat", {
-        batch_id: claim.batch.batch_id,
+  const competingClaim = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-competing",
         lease_owner: "worker-2",
-        items: members,
+        max_items: 1,
       }),
-    );
-    assert.equal(staleOwner.status, 409);
+    )
+  ).json();
+  assert.equal(competingClaim.claimed, false);
+  assert.equal(competingClaim.batch, null);
 
-    const staleGeneration = await queue.fetch(
-      batchRequest("/publication-batches/heartbeat", {
+  await queue.alarm();
+  const ownedStats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(ownedStats.lanes.publication.pending, 1);
+  assert.equal(ownedStats.lanes.publication.dispatching, 0);
+  assert.equal(storage.scheduledAlarm(), 1_060_000);
+
+  await queue.fetch(publicationRequest("delivery-stale-2", 102, "1002"));
+  const fetched = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/fetch", {
         batch_id: claim.batch.batch_id,
         lease_owner: "worker-1",
-        items: members.map((item) => ({
-          ...item,
-          claim_generation: item.claim_generation + 1,
-        })),
       }),
-    );
-    assert.equal(staleGeneration.status, 409);
+    )
+  ).json();
+  assert.equal(fetched.superseded, 1);
+  assert.equal(fetched.items.length, 0);
+  assert.equal(fetched.batch.state, "completed");
+  assert.equal(fetched.batch.items[0].terminal_outcome, "superseded");
+  assert.equal(storage.scheduledAlarm(), 1_060_000);
+  const lifecycleRow = Array.from(
+    storage.sql.exec(
+      `SELECT projection_json FROM ${EXACT_REVIEW_LIFECYCLE_PROJECTION_TABLE}
+        WHERE canonical_target_key = ? AND fence_key = ? AND revision = ?`,
+      "openclaw/openclaw#102",
+      claim.batch.items[0].item_key,
+      1,
+    ),
+  )[0] as { projection_json: string };
+  const lifecycle = JSON.parse(lifecycleRow.projection_json) as {
+    terminalDisposition: { kind: string } | null;
+    reviewResults: Array<{ outcome: string }>;
+  };
+  assert.equal(lifecycle.terminalDisposition?.kind, "superseded");
+  assert.equal(lifecycle.reviewResults[0]?.outcome, "completed");
 
-    Date.now = () => 1_600_000;
-    const expired = await queue.fetch(
-      batchRequest("/publication-batches/heartbeat", {
+  const retriedFetch = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/fetch", {
         batch_id: claim.batch.batch_id,
         lease_owner: "worker-1",
-        items: members,
       }),
-    );
-    assert.equal(expired.status, 409);
-  } finally {
-    Date.now = originalNow;
-  }
+    )
+  ).json();
+  assert.equal(retriedFetch.batch.state, "completed");
+  assert.equal(retriedFetch.superseded, 1);
+
+  const next = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-stale-revision-2",
+        lease_owner: "worker-2",
+        max_items: 1,
+      }),
+    )
+  ).json();
+  assert.equal(next.batch.items[0].revision, 2);
+  assert.equal(next.batch.items[0].claim_generation, 2);
 });
 
-test("batch admission keeps one target owner for least-privilege credentials", async () => {
-  const originalNow = Date.now;
+test("batch heartbeat extends only the active fenced lease", async (t) => {
+  t.mock.method(Date, "now", () => 1_500_000);
+  const queue = new ExactReviewQueue(
+    { storage: new TestStorage() },
+    {
+      EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+      EXACT_REVIEW_PUBLICATION_BATCH_LEASE_MS: "60000",
+    },
+  );
+  await queue.fetch(publicationRequest("delivery-heartbeat-1", 110, "1010"));
+  await queue.fetch(publicationRequest("delivery-heartbeat-2", 111, "1011"));
+  const claim = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-heartbeat",
+        lease_owner: "worker-1",
+        max_items: 2,
+      }),
+    )
+  ).json();
+  assert.equal(claim.batch.lease_expires_at, new Date(1_560_000).toISOString());
+  const members = claim.batch.items.map((item) => ({
+    item_key: item.item_key,
+    revision: item.revision,
+    claim_generation: item.claim_generation,
+  }));
+
+  Date.now = () => 1_530_000;
+  const heartbeat = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/heartbeat", {
+        batch_id: claim.batch.batch_id,
+        lease_owner: "worker-1",
+        items: members,
+      }),
+    )
+  ).json();
+  assert.equal(heartbeat.batch.lease_expires_at, new Date(1_590_000).toISOString());
+
+  await queue.fetch(publicationRequest("delivery-heartbeat-3", 110, "1010"));
+  const fetched = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/fetch", {
+        batch_id: claim.batch.batch_id,
+        lease_owner: "worker-1",
+      }),
+    )
+  ).json();
+  assert.equal(fetched.superseded, 1);
+  assert.equal(fetched.items.length, 1);
+
+  Date.now = () => 1_540_000;
+  const originalFence = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/heartbeat", {
+        batch_id: claim.batch.batch_id,
+        lease_owner: "worker-1",
+        items: members,
+      }),
+    )
+  ).json();
+  assert.equal(originalFence.batch.lease_expires_at, new Date(1_600_000).toISOString());
+
+  const staleOwner = await queue.fetch(
+    batchRequest("/publication-batches/heartbeat", {
+      batch_id: claim.batch.batch_id,
+      lease_owner: "worker-2",
+      items: members,
+    }),
+  );
+  assert.equal(staleOwner.status, 409);
+
+  const staleGeneration = await queue.fetch(
+    batchRequest("/publication-batches/heartbeat", {
+      batch_id: claim.batch.batch_id,
+      lease_owner: "worker-1",
+      items: members.map((item) => ({
+        ...item,
+        claim_generation: item.claim_generation + 1,
+      })),
+    }),
+  );
+  assert.equal(staleGeneration.status, 409);
+
+  Date.now = () => 1_600_000;
+  const expired = await queue.fetch(
+    batchRequest("/publication-batches/heartbeat", {
+      batch_id: claim.batch.batch_id,
+      lease_owner: "worker-1",
+      items: members,
+    }),
+  );
+  assert.equal(expired.status, 409);
+});
+
+test("batch admission keeps one target owner for least-privilege credentials", async (t) => {
   let now = 1_700_000;
-  Date.now = () => now;
-  try {
-    const queue = new ExactReviewQueue(
-      { storage: new TestStorage() },
-      { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" },
-    );
-    await queue.fetch(publicationRequest("owner-a-1", 120, "1020"));
-    now += 1;
-    await queue.fetch(publicationRequest("owner-b", 121, "1021", "example/project"));
-    now += 1;
-    await queue.fetch(publicationRequest("owner-a-2", 122, "1022"));
-    const claim = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "claim-owner-scoped",
-          lease_owner: "worker-1",
-          max_items: 3,
-        }),
-      )
-    ).json();
-    assert.deepEqual(
-      claim.batch.items.map((item) => item.item_key),
-      ["openclaw/openclaw#120@publish:1020:1", "openclaw/openclaw#122@publish:1022:1"],
-    );
-  } finally {
-    Date.now = originalNow;
-  }
+  t.mock.method(Date, "now", () => now);
+  const queue = new ExactReviewQueue(
+    { storage: new TestStorage() },
+    { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" },
+  );
+  await queue.fetch(publicationRequest("owner-a-1", 120, "1020"));
+  now += 1;
+  await queue.fetch(publicationRequest("owner-b", 121, "1021", "example/project"));
+  now += 1;
+  await queue.fetch(publicationRequest("owner-a-2", 122, "1022"));
+  const claim = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-owner-scoped",
+        lease_owner: "worker-1",
+        max_items: 3,
+      }),
+    )
+  ).json();
+  assert.deepEqual(
+    claim.batch.items.map((item) => item.item_key),
+    ["openclaw/openclaw#120@publish:1020:1", "openclaw/openclaw#122@publish:1022:1"],
+  );
 });
 
-test("batch ask widens owner scanning without exceeding the configured lease size", async () => {
-  const originalNow = Date.now;
+test("batch ask widens owner scanning without exceeding the configured lease size", async (t) => {
   let now = 1_800_000;
-  Date.now = () => now;
-  try {
-    const queue = new ExactReviewQueue(
-      { storage: new TestStorage() },
-      {
-        EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
-        EXACT_REVIEW_PUBLICATION_BATCH_SIZE: "2",
-      },
-    );
-    await queue.fetch(publicationRequest("owner-a-oldest", 130, "1030"));
-    now += 1;
-    await queue.fetch(publicationRequest("owner-b-interleaved", 131, "1031", "example/project"));
-    now += 1;
-    await queue.fetch(publicationRequest("owner-a-second", 132, "1032"));
-    now += 1;
-    await queue.fetch(publicationRequest("owner-a-over-cap", 133, "1033"));
+  t.mock.method(Date, "now", () => now);
+  const queue = new ExactReviewQueue(
+    { storage: new TestStorage() },
+    {
+      EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+      EXACT_REVIEW_PUBLICATION_BATCH_SIZE: "2",
+    },
+  );
+  await queue.fetch(publicationRequest("owner-a-oldest", 130, "1030"));
+  now += 1;
+  await queue.fetch(publicationRequest("owner-b-interleaved", 131, "1031", "example/project"));
+  now += 1;
+  await queue.fetch(publicationRequest("owner-a-second", 132, "1032"));
+  now += 1;
+  await queue.fetch(publicationRequest("owner-a-over-cap", 133, "1033"));
 
-    const claim = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "claim-owner-scan-cap",
-          lease_owner: "worker-1",
-          max_items: 4,
-        }),
-      )
-    ).json();
+  const claim = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-owner-scan-cap",
+        lease_owner: "worker-1",
+        max_items: 4,
+      }),
+    )
+  ).json();
 
-    assert.deepEqual(
-      claim.batch.items.map((item) => item.item_key),
-      ["openclaw/openclaw#130@publish:1030:1", "openclaw/openclaw#132@publish:1032:1"],
-    );
-    assert.equal(claim.configured_batch_size, 2);
-  } finally {
-    Date.now = originalNow;
-  }
+  assert.deepEqual(
+    claim.batch.items.map((item) => item.item_key),
+    ["openclaw/openclaw#130@publish:1030:1", "openclaw/openclaw#132@publish:1032:1"],
+  );
+  assert.equal(claim.configured_batch_size, 2);
 });
 
 test("aged superseded publication does not dispatch a fresh owner before its deadline", async () => {
@@ -3701,461 +3579,372 @@ test("Bay no-progress recovery backs off without duplicating an aged publication
   }
 });
 
-test("fresh publication owner still wins when no owner's work has aged", async () => {
-  const originalNow = Date.now;
+test("fresh publication owner still wins when no owner's work has aged", async (t) => {
   let now = 1_950_000;
-  Date.now = () => now;
-  try {
-    const queue = new ExactReviewQueue(
-      { storage: new TestStorage() },
-      {
-        EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
-        EXACT_REVIEW_PUBLICATION_BATCH_SIZE: "2",
-        EXACT_REVIEW_PUBLICATION_BATCH_WAIT_MS: "300000",
-        EXACT_REVIEW_PUBLICATION_FRESH_LANE_ENABLED: "1",
-        EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_ITEMS: "1",
-        EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_AGE_MS: "60000",
-      },
-    );
-    await queue.fetch(publicationRequest("owner-full-1", 150, "1050", "full/repo"));
-    now += 1;
-    await queue.fetch(publicationRequest("owner-full-2", 151, "1051", "full/repo"));
-    now += 60_001;
-    await queue.fetch(publicationRequest("owner-fresh-only", 152, "1052", "fresh/repo"));
+  t.mock.method(Date, "now", () => now);
+  const queue = new ExactReviewQueue(
+    { storage: new TestStorage() },
+    {
+      EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+      EXACT_REVIEW_PUBLICATION_BATCH_SIZE: "2",
+      EXACT_REVIEW_PUBLICATION_BATCH_WAIT_MS: "300000",
+      EXACT_REVIEW_PUBLICATION_FRESH_LANE_ENABLED: "1",
+      EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_ITEMS: "1",
+      EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_AGE_MS: "60000",
+    },
+  );
+  await queue.fetch(publicationRequest("owner-full-1", 150, "1050", "full/repo"));
+  now += 1;
+  await queue.fetch(publicationRequest("owner-full-2", 151, "1051", "full/repo"));
+  now += 60_001;
+  await queue.fetch(publicationRequest("owner-fresh-only", 152, "1052", "fresh/repo"));
 
-    const claim = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "claim-fresh-owner",
-          lease_owner: "worker-1",
-          max_items: 50,
-        }),
-      )
-    ).json();
+  const claim = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-fresh-owner",
+        lease_owner: "worker-1",
+        max_items: 50,
+      }),
+    )
+  ).json();
 
-    assert.equal(claim.claimed, true, JSON.stringify(claim));
-    assert.deepEqual(
-      claim.batch.items.map((item: { item_key: string }) => item.item_key),
-      ["fresh/repo#152@publish:1052:1"],
-    );
-  } finally {
-    Date.now = originalNow;
-  }
+  assert.equal(claim.claimed, true, JSON.stringify(claim));
+  assert.deepEqual(
+    claim.batch.items.map((item: { item_key: string }) => item.item_key),
+    ["fresh/repo#152@publish:1052:1"],
+  );
 });
 
-test("fresh publication admission reserves bounded service and preserves historical FIFO", async () => {
-  const originalNow = Date.now;
+test("fresh publication admission reserves bounded service and preserves historical FIFO", async (t) => {
   let now = 2_000_000;
-  Date.now = () => now;
-  try {
-    const queue = new ExactReviewQueue(
-      { storage: new TestStorage() },
-      {
-        EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
-        EXACT_REVIEW_PUBLICATION_BATCH_SIZE: "4",
-        EXACT_REVIEW_PUBLICATION_FRESH_LANE_ENABLED: "1",
-        EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_ITEMS: "1",
-        EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_AGE_MS: "60000",
-      },
+  t.mock.method(Date, "now", () => now);
+  const queue = new ExactReviewQueue(
+    { storage: new TestStorage() },
+    {
+      EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+      EXACT_REVIEW_PUBLICATION_BATCH_SIZE: "4",
+      EXACT_REVIEW_PUBLICATION_FRESH_LANE_ENABLED: "1",
+      EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_ITEMS: "1",
+      EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_AGE_MS: "60000",
+    },
+  );
+  for (let itemNumber = 10; itemNumber <= 13; itemNumber += 1) {
+    await queue.fetch(
+      publicationRequest(`historical-${itemNumber}`, itemNumber, String(7000 + itemNumber)),
     );
-    for (let itemNumber = 10; itemNumber <= 13; itemNumber += 1) {
-      await queue.fetch(
-        publicationRequest(`historical-${itemNumber}`, itemNumber, String(7000 + itemNumber)),
-      );
-      now += 1;
-    }
-    now += 60_001;
-    for (let itemNumber = 90; itemNumber <= 92; itemNumber += 1) {
-      await queue.fetch(
-        publicationRequest(`fresh-${itemNumber}`, itemNumber, String(7100 + itemNumber)),
-      );
-      now += 1;
-    }
-
-    const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
-    assert.deepEqual(stats.lanes.publication.batches.fresh_lane, {
-      enabled: true,
-      reserved_items: 1,
-      max_age_seconds: 60,
-      ready_items: 3,
-      historical_ready_items: 4,
-    });
-
-    const claim = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "claim-fresh-reserve",
-          lease_owner: "worker-1",
-          max_items: 50,
-        }),
-      )
-    ).json();
-    assert.deepEqual(
-      claim.batch.items.map((item: { item_key: string }) => item.item_key),
-      [
-        "openclaw/openclaw#10@publish:7010:1",
-        "openclaw/openclaw#11@publish:7011:1",
-        "openclaw/openclaw#12@publish:7012:1",
-        "openclaw/openclaw#90@publish:7190:1",
-      ],
-    );
-  } finally {
-    Date.now = originalNow;
+    now += 1;
   }
+  now += 60_001;
+  for (let itemNumber = 90; itemNumber <= 92; itemNumber += 1) {
+    await queue.fetch(
+      publicationRequest(`fresh-${itemNumber}`, itemNumber, String(7100 + itemNumber)),
+    );
+    now += 1;
+  }
+
+  const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.deepEqual(stats.lanes.publication.batches.fresh_lane, {
+    enabled: true,
+    reserved_items: 1,
+    max_age_seconds: 60,
+    ready_items: 3,
+    historical_ready_items: 4,
+  });
+
+  const claim = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-fresh-reserve",
+        lease_owner: "worker-1",
+        max_items: 50,
+      }),
+    )
+  ).json();
+  assert.deepEqual(
+    claim.batch.items.map((item: { item_key: string }) => item.item_key),
+    [
+      "openclaw/openclaw#10@publish:7010:1",
+      "openclaw/openclaw#11@publish:7011:1",
+      "openclaw/openclaw#12@publish:7012:1",
+      "openclaw/openclaw#90@publish:7190:1",
+    ],
+  );
 });
 
-test("continuously replenished fresh work preserves historical progress across batches", async () => {
-  const originalNow = Date.now;
+test("continuously replenished fresh work preserves historical progress across batches", async (t) => {
   let now = 2_500_000;
-  Date.now = () => now;
-  try {
-    const queue = new ExactReviewQueue(
-      { storage: new TestStorage() },
-      {
-        EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
-        EXACT_REVIEW_PUBLICATION_BATCH_SIZE: "4",
-        EXACT_REVIEW_PUBLICATION_BATCH_MAX_CONCURRENT: "2",
-        EXACT_REVIEW_PUBLICATION_FRESH_LANE_ENABLED: "1",
-        EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_ITEMS: "1",
-        EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_AGE_MS: "60000",
-      },
+  t.mock.method(Date, "now", () => now);
+  const queue = new ExactReviewQueue(
+    { storage: new TestStorage() },
+    {
+      EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+      EXACT_REVIEW_PUBLICATION_BATCH_SIZE: "4",
+      EXACT_REVIEW_PUBLICATION_BATCH_MAX_CONCURRENT: "2",
+      EXACT_REVIEW_PUBLICATION_FRESH_LANE_ENABLED: "1",
+      EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_ITEMS: "1",
+      EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_AGE_MS: "60000",
+    },
+  );
+  for (let itemNumber = 30; itemNumber <= 37; itemNumber += 1) {
+    await queue.fetch(
+      publicationRequest(`continuous-old-${itemNumber}`, itemNumber, String(7400 + itemNumber)),
     );
-    for (let itemNumber = 30; itemNumber <= 37; itemNumber += 1) {
-      await queue.fetch(
-        publicationRequest(`continuous-old-${itemNumber}`, itemNumber, String(7400 + itemNumber)),
-      );
-      now += 1;
-    }
-    now += 60_001;
-    await queue.fetch(publicationRequest("continuous-fresh-90", 90, "7490"));
     now += 1;
-    await queue.fetch(publicationRequest("continuous-fresh-91", 91, "7491"));
-
-    const claim = async (id: string) =>
-      (
-        await queue.fetch(
-          batchRequest("/publication-batches/claim", {
-            claim_id: id,
-            lease_owner: id,
-            max_items: 50,
-          }),
-        )
-      ).json();
-    const first = await claim("continuous-claim-1");
-    assert.deepEqual(
-      new Set(first.batch.items.map((item: { item_key: string }) => item.item_key)),
-      new Set([
-        "openclaw/openclaw#30@publish:7430:1",
-        "openclaw/openclaw#31@publish:7431:1",
-        "openclaw/openclaw#32@publish:7432:1",
-        "openclaw/openclaw#90@publish:7490:1",
-      ]),
-    );
-
-    now += 1;
-    await queue.fetch(publicationRequest("continuous-fresh-92", 92, "7492"));
-    const second = await claim("continuous-claim-2");
-    assert.deepEqual(
-      new Set(second.batch.items.map((item: { item_key: string }) => item.item_key)),
-      new Set([
-        "openclaw/openclaw#33@publish:7433:1",
-        "openclaw/openclaw#34@publish:7434:1",
-        "openclaw/openclaw#35@publish:7435:1",
-        "openclaw/openclaw#91@publish:7491:1",
-      ]),
-    );
-  } finally {
-    Date.now = originalNow;
   }
-});
+  now += 60_001;
+  await queue.fetch(publicationRequest("continuous-fresh-90", 90, "7490"));
+  now += 1;
+  await queue.fetch(publicationRequest("continuous-fresh-91", 91, "7491"));
 
-test("fresh publication admission flag restores strict historical FIFO", async () => {
-  const originalNow = Date.now;
-  let now = 3_000_000;
-  Date.now = () => now;
-  try {
-    const queue = new ExactReviewQueue(
-      { storage: new TestStorage() },
-      {
-        EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
-        EXACT_REVIEW_PUBLICATION_BATCH_SIZE: "2",
-        EXACT_REVIEW_PUBLICATION_FRESH_LANE_ENABLED: "0",
-        EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_ITEMS: "1",
-        EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_AGE_MS: "60000",
-      },
-    );
-    await queue.fetch(publicationRequest("rollback-old-1", 20, "7201"));
-    now += 1;
-    await queue.fetch(publicationRequest("rollback-old-2", 21, "7202"));
-    now += 60_001;
-    await queue.fetch(publicationRequest("rollback-fresh", 99, "7299"));
-
-    const claim = await (
+  const claim = async (id: string) =>
+    (
       await queue.fetch(
         batchRequest("/publication-batches/claim", {
-          claim_id: "claim-fresh-disabled",
-          lease_owner: "worker-1",
+          claim_id: id,
+          lease_owner: id,
           max_items: 50,
         }),
       )
     ).json();
-    assert.deepEqual(
-      claim.batch.items.map((item: { item_key: string }) => item.item_key),
-      ["openclaw/openclaw#20@publish:7201:1", "openclaw/openclaw#21@publish:7202:1"],
-    );
-  } finally {
-    Date.now = originalNow;
-  }
+  const first = await claim("continuous-claim-1");
+  assert.deepEqual(
+    new Set(first.batch.items.map((item: { item_key: string }) => item.item_key)),
+    new Set([
+      "openclaw/openclaw#30@publish:7430:1",
+      "openclaw/openclaw#31@publish:7431:1",
+      "openclaw/openclaw#32@publish:7432:1",
+      "openclaw/openclaw#90@publish:7490:1",
+    ]),
+  );
+
+  now += 1;
+  await queue.fetch(publicationRequest("continuous-fresh-92", 92, "7492"));
+  const second = await claim("continuous-claim-2");
+  assert.deepEqual(
+    new Set(second.batch.items.map((item: { item_key: string }) => item.item_key)),
+    new Set([
+      "openclaw/openclaw#33@publish:7433:1",
+      "openclaw/openclaw#34@publish:7434:1",
+      "openclaw/openclaw#35@publish:7435:1",
+      "openclaw/openclaw#91@publish:7491:1",
+    ]),
+  );
 });
 
-test("batch fetch supersedes a claimed publication when the source head advances", async () => {
-  const originalNow = Date.now;
-  Date.now = () => 4_000_000;
-  try {
-    const queue = new ExactReviewQueue(
-      { storage: new TestStorage() },
-      {
-        EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
-        EXACT_REVIEW_PUBLICATION_BATCH_SIZE: "2",
-      },
-    );
-    await queue.fetch(publicationRequest("source-head-1", 200, "7301", "openclaw/openclaw", 1));
-    const claim = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "claim-source-head-1",
-          lease_owner: "worker-1",
-          max_items: 1,
-        }),
-      )
-    ).json();
-    await queue.fetch(publicationRequest("source-head-2", 200, "7302", "openclaw/openclaw", 2));
+test("fresh publication admission flag restores strict historical FIFO", async (t) => {
+  let now = 3_000_000;
+  t.mock.method(Date, "now", () => now);
+  const queue = new ExactReviewQueue(
+    { storage: new TestStorage() },
+    {
+      EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+      EXACT_REVIEW_PUBLICATION_BATCH_SIZE: "2",
+      EXACT_REVIEW_PUBLICATION_FRESH_LANE_ENABLED: "0",
+      EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_ITEMS: "1",
+      EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_AGE_MS: "60000",
+    },
+  );
+  await queue.fetch(publicationRequest("rollback-old-1", 20, "7201"));
+  now += 1;
+  await queue.fetch(publicationRequest("rollback-old-2", 21, "7202"));
+  now += 60_001;
+  await queue.fetch(publicationRequest("rollback-fresh", 99, "7299"));
 
-    const fetched = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/fetch", {
-          batch_id: claim.batch.batch_id,
-          lease_owner: "worker-1",
-        }),
-      )
-    ).json();
-    assert.equal(fetched.superseded, 1);
-    assert.equal(fetched.items.length, 0);
-    assert.equal(fetched.batch.items[0].terminal_outcome, "superseded");
-
-    const afterFetch = await (await queue.fetch(new Request("https://queue/stats"))).json();
-    assert.equal(afterFetch.lanes.publication.pending, 1);
-    assert.equal(afterFetch.lanes.publication.completed_total, 1);
-    assert.equal(afterFetch.lanes.publication.superseded_total, 1);
-
-    const next = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "claim-source-head-2",
-          lease_owner: "worker-2",
-          max_items: 1,
-        }),
-      )
-    ).json();
-    assert.equal(next.batch.items[0].revision, 1);
-    assert.equal(next.batch.items[0].item_key, "openclaw/openclaw#200@publish:7302:1");
-  } finally {
-    Date.now = originalNow;
-  }
+  const claim = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-fresh-disabled",
+        lease_owner: "worker-1",
+        max_items: 50,
+      }),
+    )
+  ).json();
+  assert.deepEqual(
+    claim.batch.items.map((item: { item_key: string }) => item.item_key),
+    ["openclaw/openclaw#20@publish:7201:1", "openclaw/openclaw#21@publish:7202:1"],
+  );
 });
 
-test("idempotent batch claims retain the cap recorded by the original lease", async () => {
-  const originalNow = Date.now;
-  Date.now = () => 1_900_000;
-  try {
-    const storage = new TestStorage();
-    const initialQueue = new ExactReviewQueue(
+test("batch fetch supersedes a claimed publication when the source head advances", async (t) => {
+  t.mock.method(Date, "now", () => 4_000_000);
+  const queue = new ExactReviewQueue(
+    { storage: new TestStorage() },
+    {
+      EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+      EXACT_REVIEW_PUBLICATION_BATCH_SIZE: "2",
+    },
+  );
+  await queue.fetch(publicationRequest("source-head-1", 200, "7301", "openclaw/openclaw", 1));
+  const claim = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-source-head-1",
+        lease_owner: "worker-1",
+        max_items: 1,
+      }),
+    )
+  ).json();
+  await queue.fetch(publicationRequest("source-head-2", 200, "7302", "openclaw/openclaw", 2));
+
+  const fetched = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/fetch", {
+        batch_id: claim.batch.batch_id,
+        lease_owner: "worker-1",
+      }),
+    )
+  ).json();
+  assert.equal(fetched.superseded, 1);
+  assert.equal(fetched.items.length, 0);
+  assert.equal(fetched.batch.items[0].terminal_outcome, "superseded");
+
+  const afterFetch = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(afterFetch.lanes.publication.pending, 1);
+  assert.equal(afterFetch.lanes.publication.completed_total, 1);
+  assert.equal(afterFetch.lanes.publication.superseded_total, 1);
+
+  const next = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-source-head-2",
+        lease_owner: "worker-2",
+        max_items: 1,
+      }),
+    )
+  ).json();
+  assert.equal(next.batch.items[0].revision, 1);
+  assert.equal(next.batch.items[0].item_key, "openclaw/openclaw#200@publish:7302:1");
+});
+
+test("idempotent batch claims retain the cap recorded by the original lease", async (t) => {
+  t.mock.method(Date, "now", () => 1_900_000);
+  const storage = new TestStorage();
+  const initialQueue = new ExactReviewQueue(
+    { storage },
+    {
+      EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+      EXACT_REVIEW_PUBLICATION_BATCH_SIZE: "2",
+    },
+  );
+  await initialQueue.fetch(publicationRequest("stable-cap-1", 140, "1040"));
+  await initialQueue.fetch(publicationRequest("stable-cap-2", 141, "1041"));
+  const requestBody = {
+    claim_id: "claim-stable-cap",
+    lease_owner: "worker-1",
+    max_items: 4,
+  };
+  const initial = await (
+    await initialQueue.fetch(batchRequest("/publication-batches/claim", requestBody))
+  ).json();
+  assert.equal(initial.configured_batch_size, 2);
+
+  for (const configuredSize of [1, 4]) {
+    const retryQueue = new ExactReviewQueue(
       { storage },
       {
         EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
-        EXACT_REVIEW_PUBLICATION_BATCH_SIZE: "2",
+        EXACT_REVIEW_PUBLICATION_BATCH_SIZE: String(configuredSize),
       },
     );
-    await initialQueue.fetch(publicationRequest("stable-cap-1", 140, "1040"));
-    await initialQueue.fetch(publicationRequest("stable-cap-2", 141, "1041"));
-    const requestBody = {
-      claim_id: "claim-stable-cap",
-      lease_owner: "worker-1",
-      max_items: 4,
-    };
-    const initial = await (
-      await initialQueue.fetch(batchRequest("/publication-batches/claim", requestBody))
+    const retried = await (
+      await retryQueue.fetch(batchRequest("/publication-batches/claim", requestBody))
     ).json();
-    assert.equal(initial.configured_batch_size, 2);
-
-    for (const configuredSize of [1, 4]) {
-      const retryQueue = new ExactReviewQueue(
-        { storage },
-        {
-          EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
-          EXACT_REVIEW_PUBLICATION_BATCH_SIZE: String(configuredSize),
-        },
-      );
-      const retried = await (
-        await retryQueue.fetch(batchRequest("/publication-batches/claim", requestBody))
-      ).json();
-      assert.equal(retried.configured_batch_size, 2);
-      assert.equal(retried.batch.configured_batch_size, 2);
-      assert.equal(retried.batch.items.length, 2);
-    }
-  } finally {
-    Date.now = originalNow;
+    assert.equal(retried.configured_batch_size, 2);
+    assert.equal(retried.batch.configured_batch_size, 2);
+    assert.equal(retried.batch.items.length, 2);
   }
 });
 
-test("queue completion atomically removes only the owned publication revision", async () => {
-  const originalNow = Date.now;
-  Date.now = () => 2_000_000;
-  try {
-    const queue = new ExactReviewQueue(
-      { storage: new TestStorage() },
-      { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" },
-    );
-    const enqueued = await queue.fetch(publicationRequest("delivery-complete", 103, "1003"));
-    assert.equal(enqueued.status, 202, JSON.stringify(await enqueued.clone().json()));
-    const beforeClaim = await (await queue.fetch(new Request("https://queue/stats"))).json();
-    assert.equal(beforeClaim.lanes.publication.pending, 1, JSON.stringify(beforeClaim));
-    const claim = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "claim-complete",
-          lease_owner: "worker-1",
-          max_items: 1,
-        }),
-      )
-    ).json();
-    assert.equal(claim.claimed, true, JSON.stringify(claim));
-    assert.equal(claim.batch_wait_ms, 0);
-    const member = claim.batch.items[0];
-    const progress = {
-      schema_version: 1,
-      operation_id: "batch:claim-complete",
-      mode: "batch",
-      phase: "holding",
-      sequence: 2,
-      observed_at: new Date(1_999_500).toISOString(),
-      configured_batch_size: 1,
-      actual_batch_size: 1,
-    };
-    const heartbeat = await queue.fetch(
-      batchRequest("/publication-batches/heartbeat", {
-        batch_id: claim.batch.batch_id,
+test("queue completion atomically removes only the owned publication revision", async (t) => {
+  t.mock.method(Date, "now", () => 2_000_000);
+  const queue = new ExactReviewQueue(
+    { storage: new TestStorage() },
+    { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" },
+  );
+  const enqueued = await queue.fetch(publicationRequest("delivery-complete", 103, "1003"));
+  assert.equal(enqueued.status, 202, JSON.stringify(await enqueued.clone().json()));
+  const beforeClaim = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(beforeClaim.lanes.publication.pending, 1, JSON.stringify(beforeClaim));
+  const claim = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-complete",
         lease_owner: "worker-1",
-        items: [member],
-        state_writer_progress: progress,
+        max_items: 1,
       }),
-    );
-    assert.equal(heartbeat.status, 200, JSON.stringify(await heartbeat.clone().json()));
-    const stateWriter = {
-      schema_version: 1,
-      operation_id: "batch:claim-complete",
-      mode: "batch",
-      started_at: new Date(1_999_000).toISOString(),
-      finished_at: new Date(2_000_000).toISOString(),
-      wait_ms: 500,
-      acquire_attempts: 2,
-      acquired: true,
-      hold_ms: 500,
-      renewals: 0,
-      released: true,
-      git_duration_ms: 1_000,
-      git_processes: 8,
-      commit_count: 1,
-      materialized_items: 1,
-      configured_batch_size: 1,
-      actual_batch_size: 1,
-      batch_wait_ms: 0,
-      outcome: "materialized",
-    };
-    const completion = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/complete", {
-          batch_id: claim.batch.batch_id,
-          lease_owner: "worker-1",
-          state_commit_sha: "b".repeat(40),
-          state_writer: stateWriter,
-          items: [
-            {
-              item_key: member.item_key,
-              revision: member.revision,
-              claim_generation: member.claim_generation,
-              terminal_outcome: "published",
-            },
-          ],
-        }),
-      )
-    ).json();
-    assert.equal(completion.accepted, 1);
-    assert.equal(completion.batch.state, "completed");
-
-    const retriedCompletion = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/complete", {
-          batch_id: claim.batch.batch_id,
-          lease_owner: "worker-1",
-          state_commit_sha: "b".repeat(40),
-          items: [
-            {
-              item_key: member.item_key,
-              revision: member.revision,
-              claim_generation: member.claim_generation,
-              terminal_outcome: "retryable_failure",
-              reason_code: "workflow_cancelled",
-            },
-          ],
-        }),
-      )
-    ).json();
-    assert.equal(retriedCompletion.accepted, 0);
-    assert.equal(retriedCompletion.batch.state, "completed");
-
-    const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
-    assert.equal(stats.lanes.publication.pending, 0);
-    assert.equal(stats.lanes.publication.published_total, 1);
-    assert.equal(stats.lanes.publication.batches.completed, 1);
-    assert.equal(stats.state_writer.mode, "batch");
-    assert.equal(stats.state_writer.collection.status, "fresh");
-    assert.equal(stats.state_writer.last_15_minutes.state_commits, 1);
-    assert.equal(stats.state_writer.last_15_minutes.materialized_items, 1);
-  } finally {
-    Date.now = originalNow;
-  }
-});
-
-test("direct fenced cleanup treats an expired batch as an idempotent no-op", async () => {
-  const originalNow = Date.now;
-  let now = 2_500_000;
-  Date.now = () => now;
-  try {
-    const queue = new ExactReviewQueue(
-      { storage: new TestStorage() },
-      {
-        EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
-        EXACT_REVIEW_PUBLICATION_BATCH_LEASE_MS: "60000",
-      },
-    );
-    await queue.fetch(publicationRequest("delivery-expired-cleanup", 126, "1026"));
-    const claim = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "claim-expired-cleanup",
-          lease_owner: "worker-1",
-          max_items: 1,
-        }),
-      )
-    ).json();
-    const member = claim.batch.items[0];
-
-    now += 60_001;
-    const cleanup = await queue.fetch(
+    )
+  ).json();
+  assert.equal(claim.claimed, true, JSON.stringify(claim));
+  assert.equal(claim.batch_wait_ms, 0);
+  const member = claim.batch.items[0];
+  const progress = {
+    schema_version: 1,
+    operation_id: "batch:claim-complete",
+    mode: "batch",
+    phase: "holding",
+    sequence: 2,
+    observed_at: new Date(1_999_500).toISOString(),
+    configured_batch_size: 1,
+    actual_batch_size: 1,
+  };
+  const heartbeat = await queue.fetch(
+    batchRequest("/publication-batches/heartbeat", {
+      batch_id: claim.batch.batch_id,
+      lease_owner: "worker-1",
+      items: [member],
+      state_writer_progress: progress,
+    }),
+  );
+  assert.equal(heartbeat.status, 200, JSON.stringify(await heartbeat.clone().json()));
+  const stateWriter = {
+    schema_version: 1,
+    operation_id: "batch:claim-complete",
+    mode: "batch",
+    started_at: new Date(1_999_000).toISOString(),
+    finished_at: new Date(2_000_000).toISOString(),
+    wait_ms: 500,
+    acquire_attempts: 2,
+    acquired: true,
+    hold_ms: 500,
+    renewals: 0,
+    released: true,
+    git_duration_ms: 1_000,
+    git_processes: 8,
+    commit_count: 1,
+    materialized_items: 1,
+    configured_batch_size: 1,
+    actual_batch_size: 1,
+    batch_wait_ms: 0,
+    outcome: "materialized",
+  };
+  const completion = await (
+    await queue.fetch(
       batchRequest("/publication-batches/complete", {
         batch_id: claim.batch.batch_id,
         lease_owner: "worker-1",
+        state_commit_sha: "b".repeat(40),
+        state_writer: stateWriter,
+        items: [
+          {
+            item_key: member.item_key,
+            revision: member.revision,
+            claim_generation: member.claim_generation,
+            terminal_outcome: "published",
+          },
+        ],
+      }),
+    )
+  ).json();
+  assert.equal(completion.accepted, 1);
+  assert.equal(completion.batch.state, "completed");
+
+  const retriedCompletion = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/complete", {
+        batch_id: claim.batch.batch_id,
+        lease_owner: "worker-1",
+        state_commit_sha: "b".repeat(40),
         items: [
           {
             item_key: member.item_key,
@@ -4166,50 +3955,182 @@ test("direct fenced cleanup treats an expired batch as an idempotent no-op", asy
           },
         ],
       }),
-    );
-    assert.equal(cleanup.status, 200);
-    assert.deepEqual(await cleanup.json(), {
-      ok: true,
-      accepted: 0,
-      skipped: 1,
-      batch: {
-        ...claim.batch,
-        state: "expired",
-        server_time: new Date(now).toISOString(),
-        completed_at: new Date(now).toISOString(),
-        items: [{ ...member, terminal_outcome: "lease_expired" }],
-      },
-    });
-  } finally {
-    Date.now = originalNow;
-  }
+    )
+  ).json();
+  assert.equal(retriedCompletion.accepted, 0);
+  assert.equal(retriedCompletion.batch.state, "completed");
+
+  const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(stats.lanes.publication.pending, 0);
+  assert.equal(stats.lanes.publication.published_total, 1);
+  assert.equal(stats.lanes.publication.batches.completed, 1);
+  assert.equal(stats.state_writer.mode, "batch");
+  assert.equal(stats.state_writer.collection.status, "fresh");
+  assert.equal(stats.state_writer.last_15_minutes.state_commits, 1);
+  assert.equal(stats.state_writer.last_15_minutes.materialized_items, 1);
 });
 
-test("retryable batch completion releases ownership and preserves queue retry policy", async () => {
-  const originalNow = Date.now;
+test("direct fenced cleanup treats an expired batch as an idempotent no-op", async (t) => {
+  let now = 2_500_000;
+  t.mock.method(Date, "now", () => now);
+  const queue = new ExactReviewQueue(
+    { storage: new TestStorage() },
+    {
+      EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+      EXACT_REVIEW_PUBLICATION_BATCH_LEASE_MS: "60000",
+    },
+  );
+  await queue.fetch(publicationRequest("delivery-expired-cleanup", 126, "1026"));
+  const claim = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-expired-cleanup",
+        lease_owner: "worker-1",
+        max_items: 1,
+      }),
+    )
+  ).json();
+  const member = claim.batch.items[0];
+
+  now += 60_001;
+  const cleanup = await queue.fetch(
+    batchRequest("/publication-batches/complete", {
+      batch_id: claim.batch.batch_id,
+      lease_owner: "worker-1",
+      items: [
+        {
+          item_key: member.item_key,
+          revision: member.revision,
+          claim_generation: member.claim_generation,
+          terminal_outcome: "retryable_failure",
+          reason_code: "workflow_cancelled",
+        },
+      ],
+    }),
+  );
+  assert.equal(cleanup.status, 200);
+  assert.deepEqual(await cleanup.json(), {
+    ok: true,
+    accepted: 0,
+    skipped: 1,
+    batch: {
+      ...claim.batch,
+      state: "expired",
+      server_time: new Date(now).toISOString(),
+      completed_at: new Date(now).toISOString(),
+      items: [{ ...member, terminal_outcome: "lease_expired" }],
+    },
+  });
+});
+
+test("retryable batch completion releases ownership and preserves queue retry policy", async (t) => {
   let now = 2_000_000;
-  Date.now = () => now;
-  try {
-    const storage = new TestStorage();
-    const queue = new ExactReviewQueue(
-      { storage },
-      { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" },
-    );
-    await queue.fetch(publicationRequest("delivery-retryable", 123, "1023"));
-    const claim = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "claim-retryable",
-          lease_owner: "worker-1",
-          max_items: 1,
-          runner_run_id: "9123",
-          runner_run_attempt: 1,
-          runner_started_at: "2026-07-30T12:00:00.000Z",
-        }),
-      )
-    ).json();
-    const member = claim.batch.items[0];
-    const invalidCompletion = await queue.fetch(
+  t.mock.method(Date, "now", () => now);
+  const storage = new TestStorage();
+  const queue = new ExactReviewQueue(
+    { storage },
+    { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" },
+  );
+  await queue.fetch(publicationRequest("delivery-retryable", 123, "1023"));
+  const claim = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-retryable",
+        lease_owner: "worker-1",
+        max_items: 1,
+        runner_run_id: "9123",
+        runner_run_attempt: 1,
+        runner_started_at: "2026-07-30T12:00:00.000Z",
+      }),
+    )
+  ).json();
+  const member = claim.batch.items[0];
+  const invalidCompletion = await queue.fetch(
+    batchRequest("/publication-batches/complete", {
+      batch_id: claim.batch.batch_id,
+      lease_owner: "worker-1",
+      items: [
+        {
+          item_key: member.item_key,
+          revision: member.revision,
+          claim_generation: member.claim_generation,
+          terminal_outcome: "retryable_failure",
+          reason_code: "publication_applied",
+        },
+      ],
+    }),
+  );
+  assert.equal(invalidCompletion.status, 400);
+  const completion = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/complete", {
+        batch_id: claim.batch.batch_id,
+        lease_owner: "worker-1",
+        failure_fingerprint: "state-contention-proof",
+        items: [
+          {
+            item_key: member.item_key,
+            revision: member.revision,
+            claim_generation: member.claim_generation,
+            terminal_outcome: "retryable_failure",
+            reason_code: "state_contention",
+            pool_class: "repository_actions",
+            error_fingerprint: "state-contention-proof",
+          },
+        ],
+      }),
+    )
+  ).json();
+  assert.equal(completion.accepted, 1, JSON.stringify(completion));
+  assert.equal(completion.batch.state, "completed");
+  assert.equal(completion.batch.items[0].terminal_outcome, "lease_expired");
+  const lifecycleRow = Array.from(
+    storage.sql.exec(
+      `SELECT projection_json FROM ${EXACT_REVIEW_LIFECYCLE_PROJECTION_TABLE}
+        WHERE canonical_target_key = ? AND fence_key = ? AND revision = ?`,
+      "openclaw/openclaw#123",
+      member.item_key,
+      member.revision,
+    ),
+  )[0] as { projection_json: string };
+  assert.equal(JSON.parse(lifecycleRow.projection_json).terminalDisposition?.kind, "requeue");
+
+  const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(stats.lanes.publication.pending, 1);
+  assert.equal(stats.lanes.publication.completed_total, 0);
+  assert.equal(stats.lanes.publication.retried_total, 1);
+  assert.equal(stats.lanes.publication.batches.leased, 0);
+  assert.deepEqual(stats.lanes.publication.flow.last_15_minutes.causes.rows, [
+    {
+      transition: "retried",
+      stage: "state_commit",
+      completion_kind: "retryable_failure",
+      reason_code: "state_contention",
+      revision_relation: "same_revision",
+      pool_class: "repository_actions",
+      recovery_cause: "state_retry",
+      backoff_reason: "publication_retry",
+      attempt_bucket: "1",
+      count: 1,
+    },
+  ]);
+
+  now += 10 * 60_000;
+  const replacement = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-after-retryable",
+        lease_owner: "worker-2",
+        max_items: 1,
+      }),
+    )
+  ).json();
+  assert.equal(replacement.claimed, true, JSON.stringify(replacement));
+  assert.equal(replacement.batch.items[0].item_key, member.item_key);
+  assert.notEqual(replacement.batch.items[0].claim_generation, member.claim_generation);
+
+  const stale = await (
+    await queue.fetch(
       batchRequest("/publication-batches/complete", {
         batch_id: claim.batch.batch_id,
         lease_owner: "worker-1",
@@ -4219,136 +4140,48 @@ test("retryable batch completion releases ownership and preserves queue retry po
             revision: member.revision,
             claim_generation: member.claim_generation,
             terminal_outcome: "retryable_failure",
-            reason_code: "publication_applied",
+            reason_code: "state_contention",
           },
         ],
       }),
-    );
-    assert.equal(invalidCompletion.status, 400);
-    const completion = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/complete", {
-          batch_id: claim.batch.batch_id,
-          lease_owner: "worker-1",
-          failure_fingerprint: "state-contention-proof",
-          items: [
-            {
-              item_key: member.item_key,
-              revision: member.revision,
-              claim_generation: member.claim_generation,
-              terminal_outcome: "retryable_failure",
-              reason_code: "state_contention",
-              pool_class: "repository_actions",
-              error_fingerprint: "state-contention-proof",
-            },
-          ],
-        }),
-      )
-    ).json();
-    assert.equal(completion.accepted, 1, JSON.stringify(completion));
-    assert.equal(completion.batch.state, "completed");
-    assert.equal(completion.batch.items[0].terminal_outcome, "lease_expired");
-    const lifecycleRow = Array.from(
-      storage.sql.exec(
-        `SELECT projection_json FROM ${EXACT_REVIEW_LIFECYCLE_PROJECTION_TABLE}
-          WHERE canonical_target_key = ? AND fence_key = ? AND revision = ?`,
-        "openclaw/openclaw#123",
-        member.item_key,
-        member.revision,
-      ),
-    )[0] as { projection_json: string };
-    assert.equal(JSON.parse(lifecycleRow.projection_json).terminalDisposition?.kind, "requeue");
+    )
+  ).json();
+  assert.equal(stale.accepted, 0);
+  const fetchedReplacement = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/fetch", {
+        batch_id: replacement.batch.batch_id,
+        lease_owner: "worker-2",
+      }),
+    )
+  ).json();
+  assert.equal(fetchedReplacement.items.length, 1);
 
-    const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
-    assert.equal(stats.lanes.publication.pending, 1);
-    assert.equal(stats.lanes.publication.completed_total, 0);
-    assert.equal(stats.lanes.publication.retried_total, 1);
-    assert.equal(stats.lanes.publication.batches.leased, 0);
-    assert.deepEqual(stats.lanes.publication.flow.last_15_minutes.causes.rows, [
-      {
-        transition: "retried",
-        stage: "state_commit",
-        completion_kind: "retryable_failure",
-        reason_code: "state_contention",
-        revision_relation: "same_revision",
-        pool_class: "repository_actions",
-        recovery_cause: "state_retry",
-        backoff_reason: "publication_retry",
-        attempt_bucket: "1",
-        count: 1,
-      },
-    ]);
+  const published = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/complete", {
+        batch_id: replacement.batch.batch_id,
+        lease_owner: "worker-2",
+        items: [
+          {
+            item_key: replacement.batch.items[0].item_key,
+            revision: replacement.batch.items[0].revision,
+            claim_generation: replacement.batch.items[0].claim_generation,
+            terminal_outcome: "published",
+          },
+        ],
+      }),
+    )
+  ).json();
+  assert.equal(published.accepted, 1, JSON.stringify(published));
 
-    now += 10 * 60_000;
-    const replacement = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "claim-after-retryable",
-          lease_owner: "worker-2",
-          max_items: 1,
-        }),
-      )
-    ).json();
-    assert.equal(replacement.claimed, true, JSON.stringify(replacement));
-    assert.equal(replacement.batch.items[0].item_key, member.item_key);
-    assert.notEqual(replacement.batch.items[0].claim_generation, member.claim_generation);
-
-    const stale = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/complete", {
-          batch_id: claim.batch.batch_id,
-          lease_owner: "worker-1",
-          items: [
-            {
-              item_key: member.item_key,
-              revision: member.revision,
-              claim_generation: member.claim_generation,
-              terminal_outcome: "retryable_failure",
-              reason_code: "state_contention",
-            },
-          ],
-        }),
-      )
-    ).json();
-    assert.equal(stale.accepted, 0);
-    const fetchedReplacement = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/fetch", {
-          batch_id: replacement.batch.batch_id,
-          lease_owner: "worker-2",
-        }),
-      )
-    ).json();
-    assert.equal(fetchedReplacement.items.length, 1);
-
-    const published = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/complete", {
-          batch_id: replacement.batch.batch_id,
-          lease_owner: "worker-2",
-          items: [
-            {
-              item_key: replacement.batch.items[0].item_key,
-              revision: replacement.batch.items[0].revision,
-              claim_generation: replacement.batch.items[0].claim_generation,
-              terminal_outcome: "published",
-            },
-          ],
-        }),
-      )
-    ).json();
-    assert.equal(published.accepted, 1, JSON.stringify(published));
-
-    const completedStats = await (await queue.fetch(new Request("https://queue/stats"))).json();
-    assert.equal(completedStats.lanes.publication.pending, 0);
-    assert.equal(completedStats.lanes.publication.published_total, 1);
-    const publishedCause = completedStats.lanes.publication.flow.last_15_minutes.causes.rows.find(
-      (row: { transition: string }) => row.transition === "published",
-    );
-    assert.equal(publishedCause?.attempt_bucket, "1");
-  } finally {
-    Date.now = originalNow;
-  }
+  const completedStats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(completedStats.lanes.publication.pending, 0);
+  assert.equal(completedStats.lanes.publication.published_total, 1);
+  const publishedCause = completedStats.lanes.publication.flow.last_15_minutes.causes.rows.find(
+    (row: { transition: string }) => row.transition === "published",
+  );
+  assert.equal(publishedCause?.attempt_bucket, "1");
 });
 
 test("batch completion refreshes deterministic invalid artifacts", async () => {
@@ -4402,393 +4235,78 @@ test("batch completion refreshes deterministic invalid artifacts", async () => {
   assert.equal(state.items["openclaw/openclaw#127"].decision.publication, undefined);
 });
 
-test("credential circuits persist, preserve healthy owners, and defer unattempted members without retry charge", async () => {
-  const originalNow = Date.now;
+test("credential circuits persist, preserve healthy owners, and defer unattempted members without retry charge", async (t) => {
   let now = Date.parse("2026-08-10T14:00:00.000Z");
-  Date.now = () => now;
-  try {
-    const storage = new TestStorage();
-    let queue = new ExactReviewQueue(
-      { storage },
-      { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" },
+  t.mock.method(Date, "now", () => now);
+  const storage = new TestStorage();
+  let queue = new ExactReviewQueue({ storage }, { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" });
+  for (let index = 0; index < 52; index += 1) {
+    await queue.fetch(
+      publicationRequest(`owner-a-${index}`, 201 + index, String(1201 + index), "aaa/repo"),
     );
-    for (let index = 0; index < 52; index += 1) {
-      await queue.fetch(
-        publicationRequest(`owner-a-${index}`, 201 + index, String(1201 + index), "aaa/repo"),
-      );
-    }
-    await queue.fetch(publicationRequest("owner-b", 300, "1300", "bbb/repo"));
-    const claim = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "claim-owner-a",
-          lease_owner: "worker-a",
-          max_items: 1,
-        }),
-      )
-    ).json();
-    const member = claim.batch.items[0];
-    assert.match(member.item_key, /^aaa\/repo#/);
-    const malformedUnattempted = await queue.fetch(
-      batchRequest("/publication-batches/complete", {
-        batch_id: claim.batch.batch_id,
+  }
+  await queue.fetch(publicationRequest("owner-b", 300, "1300", "bbb/repo"));
+  const claim = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-owner-a",
         lease_owner: "worker-a",
-        items: [
-          {
-            item_key: member.item_key,
-            revision: member.revision,
-            claim_generation: member.claim_generation,
-            terminal_outcome: "retryable_failure",
-            reason_code: "github_rate_limit",
-            attempted: false,
-          },
-        ],
+        max_items: 1,
       }),
-    );
-    assert.equal(malformedUnattempted.status, 400);
-    assert.deepEqual(await malformedUnattempted.json(), { error: "invalid_batch_completions" });
-    const longerReset = now + 120_000;
-    const completion = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/complete", {
-          batch_id: claim.batch.batch_id,
-          lease_owner: "worker-a",
-          github_rate_limit_observations: [
-            {
-              scope: "target_app",
-              target_owner: "aaa",
-              observed_at: new Date(now).toISOString(),
-              retry_at: new Date(longerReset).toISOString(),
-              provenance: "rate_limit_status",
-              authoritative: true,
-            },
-            {
-              scope: "target_app",
-              target_owner: "aaa",
-              observed_at: new Date(now + 1).toISOString(),
-              retry_at: new Date(now + 60_000).toISOString(),
-              provenance: "fallback",
-              authoritative: false,
-            },
-          ],
-          github_request_metrics: [
-            {
-              scope: "target_app",
-              category: "item_metadata",
-              mode: "read",
-              outcome: "throttle",
-              repeat_revision: false,
-              count: 1,
-            },
-          ],
-          items: [
-            {
-              item_key: member.item_key,
-              revision: member.revision,
-              claim_generation: member.claim_generation,
-              terminal_outcome: "retryable_failure",
-              reason_code: "github_rate_limit",
-              pool_class: "target_app",
-              retry_at: new Date(longerReset).toISOString(),
-              attempted: false,
-            },
-          ],
-        }),
-      )
-    ).json();
-    assert.equal(completion.accepted, 1, JSON.stringify(completion));
-
-    let stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
-    assert.equal(stats.lanes.publication.retried_total, 0);
-    assert.equal(stats.lanes.publication.credential_circuits.length, 1);
-    const { recovery_until: recoveryUntil, ...credentialCircuit } =
-      stats.lanes.publication.credential_circuits[0];
-    assert.deepEqual(credentialCircuit, {
-      pool: "target_app:aaa",
-      scope: "target_app",
-      target_owner: "aaa",
-      observed_at: new Date(now).toISOString(),
-      blocked_until: new Date(longerReset).toISOString(),
-      reset_source: "rate_limit_status",
-      authoritative: true,
-      active: true,
-      affected_pending: 52,
-    });
-    assert.ok(Date.parse(recoveryUntil) > longerReset);
-    assert.ok(Date.parse(recoveryUntil) <= longerReset + 30_000);
-    assert.equal(
-      stats.lanes.publication.github_request_metrics.counters[
-        "target_app:item_metadata:read:throttle:first"
-      ],
-      1,
-    );
-    assert.equal(stats.lanes.publication.capacity_control.last_failure_kind, "github_rate_limit");
-    assert.deepEqual(stats.lanes.publication.flow.last_15_minutes.causes.rows, [
-      {
-        transition: "backoff",
-        stage: "publication_apply",
-        completion_kind: "retryable_failure",
-        reason_code: "github_rate_limit",
-        revision_relation: "same_revision",
-        pool_class: "target_app",
-        recovery_cause: "credential_circuit",
-        backoff_reason: "publication_retry",
-        attempt_bucket: "0",
-        count: 1,
-      },
-    ]);
-
-    const lateReset = now + 180_000;
-    const lateTelemetry = {
+    )
+  ).json();
+  const member = claim.batch.items[0];
+  assert.match(member.item_key, /^aaa\/repo#/);
+  const malformedUnattempted = await queue.fetch(
+    batchRequest("/publication-batches/complete", {
       batch_id: claim.batch.batch_id,
       lease_owner: "worker-a",
-      github_telemetry_id: "a".repeat(64),
-      github_rate_limit_observations: [
+      items: [
         {
-          scope: "target_app",
-          target_owner: "aaa",
-          observed_at: new Date(now + 2).toISOString(),
-          retry_at: new Date(lateReset).toISOString(),
-          provenance: "retry_after",
-          authoritative: true,
+          item_key: member.item_key,
+          revision: member.revision,
+          claim_generation: member.claim_generation,
+          terminal_outcome: "retryable_failure",
+          reason_code: "github_rate_limit",
+          attempted: false,
         },
       ],
-      github_request_metrics: [
-        {
-          scope: "target_app",
-          category: "workflow_dispatch",
-          mode: "mutation_or_private_read",
-          outcome: "throttle",
-          repeat_revision: true,
-          count: 1,
-        },
-      ],
-      items: [],
-    };
-    storage.failNextSqlMatching(/UPDATE exact_review_queue_meta/);
-    await assert.rejects(
-      queue.fetch(batchRequest("/publication-batches/complete", lateTelemetry)),
-      /injected telemetry state write failure/,
-    );
-    stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
-    assert.equal(
-      stats.lanes.publication.github_request_metrics.counters[
-        "target_app:workflow_dispatch:mutation_or_private_read:throttle:repeat"
-      ],
-      undefined,
-    );
-    assert.equal(
-      stats.lanes.publication.credential_circuits[0].blocked_until,
-      new Date(longerReset).toISOString(),
-    );
-    const late = await (
-      await queue.fetch(batchRequest("/publication-batches/complete", lateTelemetry))
-    ).json();
-    assert.equal(late.accepted, 0);
-    assert.equal(late.telemetry_accepted, true);
-    const duplicate = await (
-      await queue.fetch(batchRequest("/publication-batches/complete", lateTelemetry))
-    ).json();
-    assert.equal(duplicate.telemetry_accepted, true);
-    stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
-    assert.equal(
-      stats.lanes.publication.credential_circuits[0].blocked_until,
-      new Date(lateReset).toISOString(),
-    );
-    assert.equal(
-      stats.lanes.publication.github_request_metrics.counters[
-        "target_app:workflow_dispatch:mutation_or_private_read:throttle:repeat"
-      ],
-      1,
-    );
-    assert.equal(stats.lanes.publication.capacity_control.ceiling, 12);
-    queue = new ExactReviewQueue({ storage }, { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" });
-    const healthyOwner = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "claim-owner-b",
-          lease_owner: "worker-b",
-          max_items: 50,
-        }),
-      )
-    ).json();
-    assert.equal(healthyOwner.claimed, true, JSON.stringify(healthyOwner));
-    assert.match(healthyOwner.batch.items[0].item_key, /^bbb\/repo#/);
-    const replacementLeaseDuplicate = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/complete", {
-          ...lateTelemetry,
-          batch_id: healthyOwner.batch.batch_id,
-          lease_owner: "worker-b",
-        }),
-      )
-    ).json();
-    assert.equal(replacementLeaseDuplicate.telemetry_accepted, true);
-    stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
-    assert.equal(
-      stats.lanes.publication.github_request_metrics.counters[
-        "target_app:workflow_dispatch:mutation_or_private_read:throttle:repeat"
-      ],
-      1,
-    );
-    const independentTelemetry = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/complete", {
-          ...lateTelemetry,
-          batch_id: healthyOwner.batch.batch_id,
-          lease_owner: "worker-b",
-          github_telemetry_id: "b".repeat(64),
-        }),
-      )
-    ).json();
-    assert.equal(independentTelemetry.telemetry_accepted, true);
-    stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
-    assert.equal(
-      stats.lanes.publication.github_request_metrics.counters[
-        "target_app:workflow_dispatch:mutation_or_private_read:throttle:repeat"
-      ],
-      2,
-    );
-    assert.equal(stats.lanes.publication.capacity_control.ceiling, 6);
-    const retainedReceiptPayloads: Record<string, unknown>[] = [];
-    for (let index = 0; index < 201; index += 1) {
-      const payload = {
-        batch_id: healthyOwner.batch.batch_id,
-        lease_owner: "worker-b",
-        github_telemetry_id: index.toString(16).padStart(64, "0"),
-        github_request_metrics: lateTelemetry.github_request_metrics,
-        items: [],
-      };
-      retainedReceiptPayloads.push(payload);
-      const recorded = await (
-        await queue.fetch(batchRequest("/publication-batches/complete", payload))
-      ).json();
-      assert.equal(recorded.telemetry_accepted, true);
-    }
-    const delayedDuplicate = await (
-      await queue.fetch(batchRequest("/publication-batches/complete", retainedReceiptPayloads[0]))
-    ).json();
-    assert.equal(delayedDuplicate.telemetry_accepted, true);
-    stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
-    assert.equal(
-      stats.lanes.publication.github_request_metrics.counters[
-        "target_app:workflow_dispatch:mutation_or_private_read:throttle:repeat"
-      ],
-      203,
-    );
-
-    const receiptFailureReset = lateReset + 60_000;
-    const receiptFailureTelemetry = {
-      batch_id: healthyOwner.batch.batch_id,
-      lease_owner: "worker-b",
-      github_telemetry_id: "c".repeat(64),
-      github_rate_limit_observations: [
-        {
-          scope: "target_app",
-          target_owner: "aaa",
-          observed_at: new Date(now + 3).toISOString(),
-          retry_at: new Date(receiptFailureReset).toISOString(),
-          provenance: "retry_after",
-          authoritative: true,
-        },
-      ],
-      items: [],
-    };
-    storage.failNextSqlMatching(/INSERT INTO exact_review_github_telemetry_receipts/);
-    await assert.rejects(
-      queue.fetch(batchRequest("/publication-batches/complete", receiptFailureTelemetry)),
-      /injected telemetry state write failure/,
-    );
-    stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
-    assert.equal(stats.lanes.publication.capacity_control.ceiling, 6);
-    assert.equal(
-      stats.lanes.publication.credential_circuits[0].blocked_until,
-      new Date(lateReset).toISOString(),
-    );
-    const receiptReplay = await (
-      await queue.fetch(batchRequest("/publication-batches/complete", receiptFailureTelemetry))
-    ).json();
-    assert.equal(receiptReplay.telemetry_accepted, true);
-    stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
-    assert.equal(stats.lanes.publication.capacity_control.ceiling, 4);
-    assert.equal(
-      stats.lanes.publication.credential_circuits[0].blocked_until,
-      new Date(receiptFailureReset).toISOString(),
-    );
-
-    const healthyMember = healthyOwner.batch.items[0];
-    const healthyCompletion = await queue.fetch(
-      batchRequest("/publication-batches/complete", {
-        batch_id: healthyOwner.batch.batch_id,
-        lease_owner: "worker-b",
-        items: [
-          {
-            item_key: healthyMember.item_key,
-            revision: healthyMember.revision,
-            claim_generation: healthyMember.claim_generation,
-            terminal_outcome: "superseded",
-          },
-        ],
-      }),
-    );
-    assert.equal(
-      healthyCompletion.status,
-      200,
-      JSON.stringify(await healthyCompletion.clone().json()),
-    );
-
-    now = receiptFailureReset + 16 * 60_000;
-    stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
-    assert.equal(stats.lanes.publication.credential_circuits[0].active, false);
-    const recoveredOwner = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "claim-owner-a-recovered",
-          lease_owner: "worker-c",
-          max_items: 50,
-        }),
-      )
-    ).json();
-    assert.equal(recoveredOwner.claimed, true, JSON.stringify(recoveredOwner));
-    assert.match(recoveredOwner.batch.items[0].item_key, /^aaa\/repo#/);
-  } finally {
-    Date.now = originalNow;
-  }
-});
-
-test("repository Actions circuit blocks every publication batch until reset", async () => {
-  const originalNow = Date.now;
-  let now = Date.parse("2026-08-10T14:00:00.000Z");
-  Date.now = () => now;
-  try {
-    const queue = new ExactReviewQueue(
-      { storage: new TestStorage() },
-      { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" },
-    );
-    await queue.fetch(publicationRequest("actions-a", 211, "1211", "aaa/repo"));
-    await queue.fetch(publicationRequest("actions-b", 212, "1212", "bbb/repo"));
-    const claim = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "claim-actions-a",
-          lease_owner: "worker-a",
-          max_items: 1,
-        }),
-      )
-    ).json();
-    const member = claim.batch.items[0];
-    const resetAt = now + 90_000;
-    const completed = await queue.fetch(
+    }),
+  );
+  assert.equal(malformedUnattempted.status, 400);
+  assert.deepEqual(await malformedUnattempted.json(), { error: "invalid_batch_completions" });
+  const longerReset = now + 120_000;
+  const completion = await (
+    await queue.fetch(
       batchRequest("/publication-batches/complete", {
         batch_id: claim.batch.batch_id,
         lease_owner: "worker-a",
         github_rate_limit_observations: [
           {
-            scope: "repository_actions",
+            scope: "target_app",
+            target_owner: "aaa",
             observed_at: new Date(now).toISOString(),
-            retry_at: new Date(resetAt).toISOString(),
+            retry_at: new Date(longerReset).toISOString(),
             provenance: "rate_limit_status",
             authoritative: true,
+          },
+          {
+            scope: "target_app",
+            target_owner: "aaa",
+            observed_at: new Date(now + 1).toISOString(),
+            retry_at: new Date(now + 60_000).toISOString(),
+            provenance: "fallback",
+            authoritative: false,
+          },
+        ],
+        github_request_metrics: [
+          {
+            scope: "target_app",
+            category: "item_metadata",
+            mode: "read",
+            outcome: "throttle",
+            repeat_revision: false,
+            count: 1,
           },
         ],
         items: [
@@ -4798,301 +4316,443 @@ test("repository Actions circuit blocks every publication batch until reset", as
             claim_generation: member.claim_generation,
             terminal_outcome: "retryable_failure",
             reason_code: "github_rate_limit",
-            retry_at: new Date(resetAt).toISOString(),
+            pool_class: "target_app",
+            retry_at: new Date(longerReset).toISOString(),
             attempted: false,
           },
         ],
       }),
-    );
-    assert.equal(completed.status, 200, JSON.stringify(await completed.clone().json()));
-    const blocked = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "claim-actions-blocked",
-          lease_owner: "worker-b",
-          max_items: 2,
-        }),
-      )
-    ).json();
-    assert.equal(blocked.claimed, false, JSON.stringify(blocked));
-    const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
-    assert.equal(
-      stats.lanes.publication.credential_circuits[0].pool,
-      "actions:openclaw/clawsweeper",
-    );
-    assert.equal(stats.lanes.publication.credential_circuits[0].affected_pending, 2);
-    assert.ok(Date.parse(stats.lanes.publication.credential_circuits[0].recovery_until) > resetAt);
+    )
+  ).json();
+  assert.equal(completion.accepted, 1, JSON.stringify(completion));
 
-    now = resetAt;
-    const resetBoundary = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "claim-actions-reset-boundary",
-          lease_owner: "worker-boundary",
-          max_items: 2,
-        }),
-      )
-    ).json();
-    assert.equal(resetBoundary.claimed, false, JSON.stringify(resetBoundary));
+  let stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(stats.lanes.publication.retried_total, 0);
+  assert.equal(stats.lanes.publication.credential_circuits.length, 1);
+  const { recovery_until: recoveryUntil, ...credentialCircuit } =
+    stats.lanes.publication.credential_circuits[0];
+  assert.deepEqual(credentialCircuit, {
+    pool: "target_app:aaa",
+    scope: "target_app",
+    target_owner: "aaa",
+    observed_at: new Date(now).toISOString(),
+    blocked_until: new Date(longerReset).toISOString(),
+    reset_source: "rate_limit_status",
+    authoritative: true,
+    active: true,
+    affected_pending: 52,
+  });
+  assert.ok(Date.parse(recoveryUntil) > longerReset);
+  assert.ok(Date.parse(recoveryUntil) <= longerReset + 30_000);
+  assert.equal(
+    stats.lanes.publication.github_request_metrics.counters[
+      "target_app:item_metadata:read:throttle:first"
+    ],
+    1,
+  );
+  assert.equal(stats.lanes.publication.capacity_control.last_failure_kind, "github_rate_limit");
+  assert.deepEqual(stats.lanes.publication.flow.last_15_minutes.causes.rows, [
+    {
+      transition: "backoff",
+      stage: "publication_apply",
+      completion_kind: "retryable_failure",
+      reason_code: "github_rate_limit",
+      revision_relation: "same_revision",
+      pool_class: "target_app",
+      recovery_cause: "credential_circuit",
+      backoff_reason: "publication_retry",
+      attempt_bucket: "0",
+      count: 1,
+    },
+  ]);
 
-    now = resetAt + 31_000;
-    const recovered = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "claim-actions-recovered",
-          lease_owner: "worker-c",
-          max_items: 2,
-        }),
-      )
+  const lateReset = now + 180_000;
+  const lateTelemetry = {
+    batch_id: claim.batch.batch_id,
+    lease_owner: "worker-a",
+    github_telemetry_id: "a".repeat(64),
+    github_rate_limit_observations: [
+      {
+        scope: "target_app",
+        target_owner: "aaa",
+        observed_at: new Date(now + 2).toISOString(),
+        retry_at: new Date(lateReset).toISOString(),
+        provenance: "retry_after",
+        authoritative: true,
+      },
+    ],
+    github_request_metrics: [
+      {
+        scope: "target_app",
+        category: "workflow_dispatch",
+        mode: "mutation_or_private_read",
+        outcome: "throttle",
+        repeat_revision: true,
+        count: 1,
+      },
+    ],
+    items: [],
+  };
+  storage.failNextSqlMatching(/UPDATE exact_review_queue_meta/);
+  await assert.rejects(
+    queue.fetch(batchRequest("/publication-batches/complete", lateTelemetry)),
+    /injected telemetry state write failure/,
+  );
+  stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(
+    stats.lanes.publication.github_request_metrics.counters[
+      "target_app:workflow_dispatch:mutation_or_private_read:throttle:repeat"
+    ],
+    undefined,
+  );
+  assert.equal(
+    stats.lanes.publication.credential_circuits[0].blocked_until,
+    new Date(longerReset).toISOString(),
+  );
+  const late = await (
+    await queue.fetch(batchRequest("/publication-batches/complete", lateTelemetry))
+  ).json();
+  assert.equal(late.accepted, 0);
+  assert.equal(late.telemetry_accepted, true);
+  const duplicate = await (
+    await queue.fetch(batchRequest("/publication-batches/complete", lateTelemetry))
+  ).json();
+  assert.equal(duplicate.telemetry_accepted, true);
+  stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(
+    stats.lanes.publication.credential_circuits[0].blocked_until,
+    new Date(lateReset).toISOString(),
+  );
+  assert.equal(
+    stats.lanes.publication.github_request_metrics.counters[
+      "target_app:workflow_dispatch:mutation_or_private_read:throttle:repeat"
+    ],
+    1,
+  );
+  assert.equal(stats.lanes.publication.capacity_control.ceiling, 12);
+  queue = new ExactReviewQueue({ storage }, { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" });
+  const healthyOwner = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-owner-b",
+        lease_owner: "worker-b",
+        max_items: 50,
+      }),
+    )
+  ).json();
+  assert.equal(healthyOwner.claimed, true, JSON.stringify(healthyOwner));
+  assert.match(healthyOwner.batch.items[0].item_key, /^bbb\/repo#/);
+  const replacementLeaseDuplicate = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/complete", {
+        ...lateTelemetry,
+        batch_id: healthyOwner.batch.batch_id,
+        lease_owner: "worker-b",
+      }),
+    )
+  ).json();
+  assert.equal(replacementLeaseDuplicate.telemetry_accepted, true);
+  stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(
+    stats.lanes.publication.github_request_metrics.counters[
+      "target_app:workflow_dispatch:mutation_or_private_read:throttle:repeat"
+    ],
+    1,
+  );
+  const independentTelemetry = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/complete", {
+        ...lateTelemetry,
+        batch_id: healthyOwner.batch.batch_id,
+        lease_owner: "worker-b",
+        github_telemetry_id: "b".repeat(64),
+      }),
+    )
+  ).json();
+  assert.equal(independentTelemetry.telemetry_accepted, true);
+  stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(
+    stats.lanes.publication.github_request_metrics.counters[
+      "target_app:workflow_dispatch:mutation_or_private_read:throttle:repeat"
+    ],
+    2,
+  );
+  assert.equal(stats.lanes.publication.capacity_control.ceiling, 6);
+  const retainedReceiptPayloads: Record<string, unknown>[] = [];
+  for (let index = 0; index < 201; index += 1) {
+    const payload = {
+      batch_id: healthyOwner.batch.batch_id,
+      lease_owner: "worker-b",
+      github_telemetry_id: index.toString(16).padStart(64, "0"),
+      github_request_metrics: lateTelemetry.github_request_metrics,
+      items: [],
+    };
+    retainedReceiptPayloads.push(payload);
+    const recorded = await (
+      await queue.fetch(batchRequest("/publication-batches/complete", payload))
     ).json();
-    assert.equal(recovered.claimed, true, JSON.stringify(recovered));
-  } finally {
-    Date.now = originalNow;
+    assert.equal(recorded.telemetry_accepted, true);
   }
-});
+  const delayedDuplicate = await (
+    await queue.fetch(batchRequest("/publication-batches/complete", retainedReceiptPayloads[0]))
+  ).json();
+  assert.equal(delayedDuplicate.telemetry_accepted, true);
+  stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(
+    stats.lanes.publication.github_request_metrics.counters[
+      "target_app:workflow_dispatch:mutation_or_private_read:throttle:repeat"
+    ],
+    203,
+  );
 
-test("batch failure completion requeues a newer revision owned by the same lease", async () => {
-  const originalNow = Date.now;
-  let now = 2_500_000;
-  Date.now = () => now;
-  try {
-    const queue = new ExactReviewQueue(
-      { storage: new TestStorage() },
-      { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" },
-    );
-    await queue.fetch(publicationRequest("delivery-owned-revision-1", 127, "1027"));
-    const claim = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "claim-owned-revision-1",
-          lease_owner: "worker-1",
-          max_items: 1,
-        }),
-      )
-    ).json();
-    const member = claim.batch.items[0];
+  const receiptFailureReset = lateReset + 60_000;
+  const receiptFailureTelemetry = {
+    batch_id: healthyOwner.batch.batch_id,
+    lease_owner: "worker-b",
+    github_telemetry_id: "c".repeat(64),
+    github_rate_limit_observations: [
+      {
+        scope: "target_app",
+        target_owner: "aaa",
+        observed_at: new Date(now + 3).toISOString(),
+        retry_at: new Date(receiptFailureReset).toISOString(),
+        provenance: "retry_after",
+        authoritative: true,
+      },
+    ],
+    items: [],
+  };
+  storage.failNextSqlMatching(/INSERT INTO exact_review_github_telemetry_receipts/);
+  await assert.rejects(
+    queue.fetch(batchRequest("/publication-batches/complete", receiptFailureTelemetry)),
+    /injected telemetry state write failure/,
+  );
+  stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(stats.lanes.publication.capacity_control.ceiling, 6);
+  assert.equal(
+    stats.lanes.publication.credential_circuits[0].blocked_until,
+    new Date(lateReset).toISOString(),
+  );
+  const receiptReplay = await (
+    await queue.fetch(batchRequest("/publication-batches/complete", receiptFailureTelemetry))
+  ).json();
+  assert.equal(receiptReplay.telemetry_accepted, true);
+  stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(stats.lanes.publication.capacity_control.ceiling, 4);
+  assert.equal(
+    stats.lanes.publication.credential_circuits[0].blocked_until,
+    new Date(receiptFailureReset).toISOString(),
+  );
 
-    await queue.fetch(publicationRequest("delivery-owned-revision-2", 127, "1027"));
-    const completion = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/complete", {
-          batch_id: claim.batch.batch_id,
-          lease_owner: "worker-1",
-          items: [
-            {
-              item_key: member.item_key,
-              revision: member.revision,
-              claim_generation: member.claim_generation,
-              terminal_outcome: "retryable_failure",
-              reason_code: "workflow_cancelled",
-            },
-          ],
-        }),
-      )
-    ).json();
-    assert.equal(completion.accepted, 1, JSON.stringify(completion));
-
-    const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
-    assert.equal(stats.lanes.publication.pending, 1);
-    assert.equal(stats.lanes.publication.retried_total, 0);
-    assert.equal(stats.lanes.publication.batches.leased, 0);
-
-    now += 1;
-    const replacement = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "claim-owned-revision-2",
-          lease_owner: "worker-2",
-          max_items: 1,
-        }),
-      )
-    ).json();
-    assert.equal(replacement.claimed, true, JSON.stringify(replacement));
-    assert.equal(replacement.batch.items[0].revision, 2);
-    assert.notEqual(replacement.batch.items[0].claim_generation, member.claim_generation);
-  } finally {
-    Date.now = originalNow;
-  }
-});
-
-test("batch published completion preserves a newer revision owned by the same lease", async () => {
-  const originalNow = Date.now;
-  let now = 2_750_000;
-  Date.now = () => now;
-  try {
-    const queue = new ExactReviewQueue(
-      { storage: new TestStorage() },
-      { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" },
-    );
-    await queue.fetch(publicationRequest("delivery-published-revision-1", 128, "1028"));
-    const claim = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "claim-published-revision-1",
-          lease_owner: "worker-1",
-          max_items: 1,
-        }),
-      )
-    ).json();
-    const member = claim.batch.items[0];
-
-    await queue.fetch(publicationRequest("delivery-published-revision-2", 128, "1028"));
-    const completion = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/complete", {
-          batch_id: claim.batch.batch_id,
-          lease_owner: "worker-1",
-          state_commit_sha: "d".repeat(40),
-          items: [
-            {
-              item_key: member.item_key,
-              revision: member.revision,
-              claim_generation: member.claim_generation,
-              terminal_outcome: "published",
-            },
-          ],
-        }),
-      )
-    ).json();
-    assert.equal(completion.accepted, 1, JSON.stringify(completion));
-
-    const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
-    assert.equal(stats.lanes.publication.pending, 1);
-    assert.equal(stats.lanes.publication.published_total, 1);
-    assert.equal(stats.lanes.publication.batches.leased, 0);
-    assert.equal(
-      stats.lanes.publication.flow.last_15_minutes.causes.reconciliation.published.complete,
-      true,
-    );
-    assert.deepEqual(
-      stats.lanes.publication.flow.last_15_minutes.causes.rows.map((row) => ({
-        transition: row.transition,
-        reason_code: row.reason_code,
-        revision_relation: row.revision_relation,
-        recovery_cause: row.recovery_cause,
-      })),
-      [
+  const healthyMember = healthyOwner.batch.items[0];
+  const healthyCompletion = await queue.fetch(
+    batchRequest("/publication-batches/complete", {
+      batch_id: healthyOwner.batch.batch_id,
+      lease_owner: "worker-b",
+      items: [
         {
-          transition: "backoff",
-          reason_code: "publication_applied",
-          revision_relation: "newer_local_revision",
-          recovery_cause: "newer_revision",
-        },
-        {
-          transition: "published",
-          reason_code: "publication_applied",
-          revision_relation: "newer_local_revision",
-          recovery_cause: "newer_revision",
+          item_key: healthyMember.item_key,
+          revision: healthyMember.revision,
+          claim_generation: healthyMember.claim_generation,
+          terminal_outcome: "superseded",
         },
       ],
-    );
+    }),
+  );
+  assert.equal(
+    healthyCompletion.status,
+    200,
+    JSON.stringify(await healthyCompletion.clone().json()),
+  );
 
-    now += 1;
-    const replacement = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "claim-published-revision-2",
-          lease_owner: "worker-2",
-          max_items: 1,
-        }),
-      )
-    ).json();
-    assert.equal(replacement.claimed, true, JSON.stringify(replacement));
-    assert.equal(replacement.batch.items[0].revision, 2);
-    assert.notEqual(replacement.batch.items[0].claim_generation, member.claim_generation);
-  } finally {
-    Date.now = originalNow;
-  }
+  now = receiptFailureReset + 16 * 60_000;
+  stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(stats.lanes.publication.credential_circuits[0].active, false);
+  const recoveredOwner = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-owner-a-recovered",
+        lease_owner: "worker-c",
+        max_items: 50,
+      }),
+    )
+  ).json();
+  assert.equal(recoveredOwner.claimed, true, JSON.stringify(recoveredOwner));
+  assert.match(recoveredOwner.batch.items[0].item_key, /^aaa\/repo#/);
 });
 
-test("partial batch completion publishes healthy members and releases retryable members", async () => {
-  const originalNow = Date.now;
-  Date.now = () => 3_000_000;
-  try {
-    const queue = new ExactReviewQueue(
-      { storage: new TestStorage() },
-      { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" },
-    );
-    await queue.fetch(publicationRequest("delivery-partial-published", 124, "1024"));
-    await queue.fetch(publicationRequest("delivery-partial-retryable", 125, "1025"));
-    const claim = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "claim-partial",
-          lease_owner: "worker-1",
-          max_items: 2,
-        }),
-      )
-    ).json();
-    const [published, retryable] = claim.batch.items;
-    const completion = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/complete", {
-          batch_id: claim.batch.batch_id,
-          lease_owner: "worker-1",
-          state_commit_sha: "c".repeat(40),
-          items: [
-            {
-              item_key: published.item_key,
-              revision: published.revision,
-              claim_generation: published.claim_generation,
-              terminal_outcome: "published",
-            },
-            {
-              item_key: retryable.item_key,
-              revision: retryable.revision,
-              claim_generation: retryable.claim_generation,
-              terminal_outcome: "retryable_failure",
-              reason_code: "artifact_unavailable",
-            },
-          ],
-        }),
-      )
-    ).json();
-    assert.equal(completion.accepted, 2, JSON.stringify(completion));
-    assert.equal(completion.batch.state, "completed");
+test("repository Actions circuit blocks every publication batch until reset", async (t) => {
+  let now = Date.parse("2026-08-10T14:00:00.000Z");
+  t.mock.method(Date, "now", () => now);
+  const queue = new ExactReviewQueue(
+    { storage: new TestStorage() },
+    { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" },
+  );
+  await queue.fetch(publicationRequest("actions-a", 211, "1211", "aaa/repo"));
+  await queue.fetch(publicationRequest("actions-b", 212, "1212", "bbb/repo"));
+  const claim = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-actions-a",
+        lease_owner: "worker-a",
+        max_items: 1,
+      }),
+    )
+  ).json();
+  const member = claim.batch.items[0];
+  const resetAt = now + 90_000;
+  const completed = await queue.fetch(
+    batchRequest("/publication-batches/complete", {
+      batch_id: claim.batch.batch_id,
+      lease_owner: "worker-a",
+      github_rate_limit_observations: [
+        {
+          scope: "repository_actions",
+          observed_at: new Date(now).toISOString(),
+          retry_at: new Date(resetAt).toISOString(),
+          provenance: "rate_limit_status",
+          authoritative: true,
+        },
+      ],
+      items: [
+        {
+          item_key: member.item_key,
+          revision: member.revision,
+          claim_generation: member.claim_generation,
+          terminal_outcome: "retryable_failure",
+          reason_code: "github_rate_limit",
+          retry_at: new Date(resetAt).toISOString(),
+          attempted: false,
+        },
+      ],
+    }),
+  );
+  assert.equal(completed.status, 200, JSON.stringify(await completed.clone().json()));
+  const blocked = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-actions-blocked",
+        lease_owner: "worker-b",
+        max_items: 2,
+      }),
+    )
+  ).json();
+  assert.equal(blocked.claimed, false, JSON.stringify(blocked));
+  const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(stats.lanes.publication.credential_circuits[0].pool, "actions:openclaw/clawsweeper");
+  assert.equal(stats.lanes.publication.credential_circuits[0].affected_pending, 2);
+  assert.ok(Date.parse(stats.lanes.publication.credential_circuits[0].recovery_until) > resetAt);
 
-    const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
-    assert.equal(stats.lanes.publication.pending, 1);
-    assert.equal(stats.lanes.publication.published_total, 1);
-    assert.equal(stats.lanes.publication.retried_total, 1);
-    assert.equal(stats.lanes.publication.batches.leased, 0);
-  } finally {
-    Date.now = originalNow;
-  }
+  now = resetAt;
+  const resetBoundary = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-actions-reset-boundary",
+        lease_owner: "worker-boundary",
+        max_items: 2,
+      }),
+    )
+  ).json();
+  assert.equal(resetBoundary.claimed, false, JSON.stringify(resetBoundary));
+
+  now = resetAt + 31_000;
+  const recovered = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-actions-recovered",
+        lease_owner: "worker-c",
+        max_items: 2,
+      }),
+    )
+  ).json();
+  assert.equal(recovered.claimed, true, JSON.stringify(recovered));
 });
 
-test("batch completion schedules the remaining partial batch at its departure deadline", async () => {
-  const originalNow = Date.now;
-  Date.now = () => 6_000_000;
-  try {
-    const storage = new TestStorage();
-    const queue = new ExactReviewQueue(
-      { storage },
-      {
-        EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
-        EXACT_REVIEW_PUBLICATION_BATCH_LEASE_MS: "60000",
-      },
-    );
-    await queue.fetch(publicationRequest("delivery-completing", 108, "1008"));
-    await queue.fetch(publicationRequest("delivery-waiting", 109, "1009"));
-    const claim = await (
-      await queue.fetch(
-        batchRequest("/publication-batches/claim", {
-          claim_id: "claim-wakes-legacy",
-          lease_owner: "worker-1",
-          max_items: 1,
-        }),
-      )
-    ).json();
-    await queue.alarm();
-    assert.equal(storage.scheduledAlarm(), 6_060_000);
+test("batch failure completion requeues a newer revision owned by the same lease", async (t) => {
+  let now = 2_500_000;
+  t.mock.method(Date, "now", () => now);
+  const queue = new ExactReviewQueue(
+    { storage: new TestStorage() },
+    { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" },
+  );
+  await queue.fetch(publicationRequest("delivery-owned-revision-1", 127, "1027"));
+  const claim = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-owned-revision-1",
+        lease_owner: "worker-1",
+        max_items: 1,
+      }),
+    )
+  ).json();
+  const member = claim.batch.items[0];
 
-    const member = claim.batch.items[0];
-    const completion = await queue.fetch(
+  await queue.fetch(publicationRequest("delivery-owned-revision-2", 127, "1027"));
+  const completion = await (
+    await queue.fetch(
       batchRequest("/publication-batches/complete", {
         batch_id: claim.batch.batch_id,
         lease_owner: "worker-1",
+        items: [
+          {
+            item_key: member.item_key,
+            revision: member.revision,
+            claim_generation: member.claim_generation,
+            terminal_outcome: "retryable_failure",
+            reason_code: "workflow_cancelled",
+          },
+        ],
+      }),
+    )
+  ).json();
+  assert.equal(completion.accepted, 1, JSON.stringify(completion));
+
+  const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(stats.lanes.publication.pending, 1);
+  assert.equal(stats.lanes.publication.retried_total, 0);
+  assert.equal(stats.lanes.publication.batches.leased, 0);
+
+  now += 1;
+  const replacement = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-owned-revision-2",
+        lease_owner: "worker-2",
+        max_items: 1,
+      }),
+    )
+  ).json();
+  assert.equal(replacement.claimed, true, JSON.stringify(replacement));
+  assert.equal(replacement.batch.items[0].revision, 2);
+  assert.notEqual(replacement.batch.items[0].claim_generation, member.claim_generation);
+});
+
+test("batch published completion preserves a newer revision owned by the same lease", async (t) => {
+  let now = 2_750_000;
+  t.mock.method(Date, "now", () => now);
+  const queue = new ExactReviewQueue(
+    { storage: new TestStorage() },
+    { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" },
+  );
+  await queue.fetch(publicationRequest("delivery-published-revision-1", 128, "1028"));
+  const claim = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-published-revision-1",
+        lease_owner: "worker-1",
+        max_items: 1,
+      }),
+    )
+  ).json();
+  const member = claim.batch.items[0];
+
+  await queue.fetch(publicationRequest("delivery-published-revision-2", 128, "1028"));
+  const completion = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/complete", {
+        batch_id: claim.batch.batch_id,
+        lease_owner: "worker-1",
+        state_commit_sha: "d".repeat(40),
         items: [
           {
             item_key: member.item_key,
@@ -5102,10 +4762,147 @@ test("batch completion schedules the remaining partial batch at its departure de
           },
         ],
       }),
-    );
-    assert.equal(completion.status, 200);
-    assert.equal(storage.scheduledAlarm(), 6_060_000);
-  } finally {
-    Date.now = originalNow;
-  }
+    )
+  ).json();
+  assert.equal(completion.accepted, 1, JSON.stringify(completion));
+
+  const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(stats.lanes.publication.pending, 1);
+  assert.equal(stats.lanes.publication.published_total, 1);
+  assert.equal(stats.lanes.publication.batches.leased, 0);
+  assert.equal(
+    stats.lanes.publication.flow.last_15_minutes.causes.reconciliation.published.complete,
+    true,
+  );
+  assert.deepEqual(
+    stats.lanes.publication.flow.last_15_minutes.causes.rows.map((row) => ({
+      transition: row.transition,
+      reason_code: row.reason_code,
+      revision_relation: row.revision_relation,
+      recovery_cause: row.recovery_cause,
+    })),
+    [
+      {
+        transition: "backoff",
+        reason_code: "publication_applied",
+        revision_relation: "newer_local_revision",
+        recovery_cause: "newer_revision",
+      },
+      {
+        transition: "published",
+        reason_code: "publication_applied",
+        revision_relation: "newer_local_revision",
+        recovery_cause: "newer_revision",
+      },
+    ],
+  );
+
+  now += 1;
+  const replacement = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-published-revision-2",
+        lease_owner: "worker-2",
+        max_items: 1,
+      }),
+    )
+  ).json();
+  assert.equal(replacement.claimed, true, JSON.stringify(replacement));
+  assert.equal(replacement.batch.items[0].revision, 2);
+  assert.notEqual(replacement.batch.items[0].claim_generation, member.claim_generation);
+});
+
+test("partial batch completion publishes healthy members and releases retryable members", async (t) => {
+  t.mock.method(Date, "now", () => 3_000_000);
+  const queue = new ExactReviewQueue(
+    { storage: new TestStorage() },
+    { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" },
+  );
+  await queue.fetch(publicationRequest("delivery-partial-published", 124, "1024"));
+  await queue.fetch(publicationRequest("delivery-partial-retryable", 125, "1025"));
+  const claim = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-partial",
+        lease_owner: "worker-1",
+        max_items: 2,
+      }),
+    )
+  ).json();
+  const [published, retryable] = claim.batch.items;
+  const completion = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/complete", {
+        batch_id: claim.batch.batch_id,
+        lease_owner: "worker-1",
+        state_commit_sha: "c".repeat(40),
+        items: [
+          {
+            item_key: published.item_key,
+            revision: published.revision,
+            claim_generation: published.claim_generation,
+            terminal_outcome: "published",
+          },
+          {
+            item_key: retryable.item_key,
+            revision: retryable.revision,
+            claim_generation: retryable.claim_generation,
+            terminal_outcome: "retryable_failure",
+            reason_code: "artifact_unavailable",
+          },
+        ],
+      }),
+    )
+  ).json();
+  assert.equal(completion.accepted, 2, JSON.stringify(completion));
+  assert.equal(completion.batch.state, "completed");
+
+  const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(stats.lanes.publication.pending, 1);
+  assert.equal(stats.lanes.publication.published_total, 1);
+  assert.equal(stats.lanes.publication.retried_total, 1);
+  assert.equal(stats.lanes.publication.batches.leased, 0);
+});
+
+test("batch completion schedules the remaining partial batch at its departure deadline", async (t) => {
+  t.mock.method(Date, "now", () => 6_000_000);
+  const storage = new TestStorage();
+  const queue = new ExactReviewQueue(
+    { storage },
+    {
+      EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+      EXACT_REVIEW_PUBLICATION_BATCH_LEASE_MS: "60000",
+    },
+  );
+  await queue.fetch(publicationRequest("delivery-completing", 108, "1008"));
+  await queue.fetch(publicationRequest("delivery-waiting", 109, "1009"));
+  const claim = await (
+    await queue.fetch(
+      batchRequest("/publication-batches/claim", {
+        claim_id: "claim-wakes-legacy",
+        lease_owner: "worker-1",
+        max_items: 1,
+      }),
+    )
+  ).json();
+  await queue.alarm();
+  assert.equal(storage.scheduledAlarm(), 6_060_000);
+
+  const member = claim.batch.items[0];
+  const completion = await queue.fetch(
+    batchRequest("/publication-batches/complete", {
+      batch_id: claim.batch.batch_id,
+      lease_owner: "worker-1",
+      items: [
+        {
+          item_key: member.item_key,
+          revision: member.revision,
+          claim_generation: member.claim_generation,
+          terminal_outcome: "published",
+        },
+      ],
+    }),
+  );
+  assert.equal(completion.status, 200);
+  assert.equal(storage.scheduledAlarm(), 6_060_000);
 });


### PR DESCRIPTION
## What Problem This Solves

The exact-review publication batch tests repeat manual `Date.now` capture,
replacement, and restoration scaffolding across dozens of cases.

## Why This Change Was Made

Use the existing `node:test` `MockTracker` pattern for 37 eligible tests so the
runner owns clock restoration. Five tests with mixed clock and fetch cleanup
remain unchanged, and the heartbeat test retains its three later clock
overwrites.

## User Impact

No user-visible behavior changes. The test suite has less manual cleanup code
while preserving the same scenarios, assertions, and execution order.

## OpenClaw Bay Impact

OpenClaw Bay is unaffected. This changes test-only clock cleanup and does not
alter lifecycle publication, queue behavior, telemetry, dashboard contracts,
or observer surfaces.

## Documentation Impact

No documentation update is needed because runtime, workflow, API, and operator
contracts are unchanged.

## Evidence

- Base: `6a3ee13a060a6de078e372e7da666cc929f56cd9`
- Signed head: `e99ff64c73d1e2887b3dba26d65b6c89e2b5813c`
- Full-file baseline and candidate: 95/95 pass with identical emitted test
  names, order, statuses, and summary counts.
- TypeScript 6 AST comparison: 79 test call expressions and 560 assertion call
  expressions retain identical values and order.
- Clock inventory: tracked Date mocks 2 -> 39; direct Date assignments 87 -> 13.
- Five excluded mixed-cleanup test bodies are byte-identical; all three later
  heartbeat clock assignments remain.
- A proof-only intentional-failure child confirms the original `Date.now`
  identity and descriptor are restored before its sibling test.
- Node, repair, and dashboard TypeScript builds, target-file Oxfmt and Oxlint,
  and `git diff --check` pass.
- Uncommitted Codex review: `01a06efd-23bf-7d50-ac69-e99b1c7fbc4b`, no findings.
- Refreshed committed Codex review:
  `01a070a2-239d-7f40-8d15-d2dece05ac59`, no findings.

## Real Behavior Proof

- Claim: runner-managed clock mocks preserve the behavior and isolation of all
  converted publication batch tests.
- Exercised surface: the complete
  `test/exact-review-publication-batches.test.ts` process and the repository
  `pnpm run check` gate at the signed head.
- Scenario: all 95 runtime cases, including the 37 converted tests, five
  excluded mixed-cleanup tests, heartbeat clock overwrites, and restoration
  after an intentional test failure.
- Command and environment: AWS lease `cbx_5d4e9a2c6ff4`, image
  `ami-0461d919be7deb53c`, Node `v24.18.1`, pnpm `11.10.0`, `CI=1`,
  direct-managed SSH execution. The provider returned no execution run ID.
- Observed result: all 10 semantic proof steps exited 0. Baseline and candidate
  each passed 95/95 with strict name, order, status, and summary parity.
  `pnpm run check` reported 4,983 tests: 4,965 passed, 18 skipped, 0 failed,
  and 0 cancelled. The terminal clean-pin check confirmed head
  `e99ff64c73d1e2887b3dba26d65b6c89e2b5813c` and tree
  `bce59ca755a9bdf37948f6698eff22f87910ab3a`, then the process was confirmed
  inactive.
- Artifact or trace: evidence archive SHA-256
  `619ca2f276e2fd2179af2afc34a6fb785ad0bd2c9acf37e3103950df0ededfcc`.
- Limits: after all 10 semantic steps passed, the runner's final summary
  heredoc attached its fallback line to Node stdin and exited 2 while packaging
  `summary.json`. The validator reconstructed the identical summary schema from
  the existing `steps.tsv`; it did not rerun or alter any semantic step. The
  archive retains the raw log, ten zero exit records, correction note, rebuilt
  summary, and exact-head inactive postcheck.
