### PR TITLE
refactor(repair): consolidate merge-readiness GitHub reads

### DIFF
--- a/src/repair/apply-result.ts
+++ b/src/repair/apply-result.ts
@@ -32,6 +32,7 @@ import {
   buildRepairSquashMergeMessage,
   writeRepairSquashMergeBody,
 } from "./repair-merge-message.js";
+import { fetchPullRequestView, validateResolvedReviewThreads } from "./merge-readiness-github.js";
 import {
   compactPrCloseCoverageProofComment,
   compactPrCloseCoverageProofText,
@@ -888,58 +889,6 @@ function validateMergedCandidateFix(repo: string, candidateFix: LooseRecord) {
   return "";
 }
 
-function validateResolvedReviewThreads(repo: string, target: LooseRecord) {
-  const [owner, name] = repo.split("/");
-  const query = `
-    query($owner: String!, $name: String!, $number: Int!) {
-      repository(owner: $owner, name: $name) {
-        pullRequest(number: $number) {
-          reviewThreads(first: 100) {
-            pageInfo { hasNextPage }
-            nodes {
-              isResolved
-              path
-              line
-              comments(first: 1) {
-                nodes {
-                  url
-                  author { login }
-                  body
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  `;
-  const data = ghJson([
-    "api",
-    "graphql",
-    "-f",
-    `owner=${owner}`,
-    "-f",
-    `name=${name}`,
-    "-F",
-    `number=${target}`,
-    "-f",
-    `query=${query}`,
-  ]);
-  const threads = data?.data?.repository?.pullRequest?.reviewThreads;
-  if (threads?.pageInfo?.hasNextPage) return "too many review threads to prove resolved";
-  const unresolved = (threads?.nodes ?? []).filter(
-    (thread: JsonValue) => thread && !thread.isResolved,
-  );
-  if (unresolved.length === 0) return "";
-  const examples = unresolved
-    .slice(0, 3)
-    .map(
-      (thread: JsonValue) =>
-        thread.comments?.nodes?.[0]?.url ?? `${thread.path}:${thread.line ?? "?"}`,
-    );
-  return `unresolved review threads remain: ${examples.join(", ")}`;
-}
-
 function validateReplacementCloseout({ result, actionName, target }: LooseRecord) {
   if (!["close_superseded", "close_fixed_by_candidate", "post_merge_close"].includes(actionName))
     return "";
@@ -1693,31 +1642,6 @@ function fetchIssue(repo: string, number: JsonValue) {
 
 function fetchPullRequest(repo: string, number: JsonValue) {
   return ghJson(["api", `repos/${repo}/pulls/${number}`]);
-}
-
-function fetchPullRequestView(repo: string, number: JsonValue) {
-  return ghJson([
-    "pr",
-    "view",
-    String(number),
-    "--repo",
-    repo,
-    "--json",
-    [
-      "baseRefName",
-      "isDraft",
-      "mergeable",
-      "mergeCommit",
-      "mergeStateStatus",
-      "mergedAt",
-      "reviewDecision",
-      "state",
-      "statusCheckRollup",
-      "title",
-      "updatedAt",
-      "url",
-    ].join(","),
-  ]);
 }
 
 function findExistingComment(repo: string, number: JsonValue, marker: LooseRecord, body: string) {

--- a/src/repair/merge-readiness-github.ts
+++ b/src/repair/merge-readiness-github.ts
@@ -1,0 +1,79 @@
+import type { JsonValue } from "./json-types.js";
+import { ghJsonWithRetry as ghJson } from "./github-cli.js";
+
+export function validateResolvedReviewThreads(repo: string, number: JsonValue) {
+  const [owner, name] = repo.split("/");
+  const query = `
+    query($owner: String!, $name: String!, $number: Int!) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $number) {
+          reviewThreads(first: 100) {
+            pageInfo { hasNextPage }
+            nodes {
+              isResolved
+              path
+              line
+              comments(first: 1) {
+                nodes {
+                  url
+                  author { login }
+                  body
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+  const data = ghJson([
+    "api",
+    "graphql",
+    "-f",
+    `owner=${owner}`,
+    "-f",
+    `name=${name}`,
+    "-F",
+    `number=${number}`,
+    "-f",
+    `query=${query}`,
+  ]);
+  const threads = data?.data?.repository?.pullRequest?.reviewThreads;
+  if (threads?.pageInfo?.hasNextPage) return "too many review threads to prove resolved";
+  const unresolved = (threads?.nodes ?? []).filter(
+    (thread: JsonValue) => thread && !thread.isResolved,
+  );
+  if (unresolved.length === 0) return "";
+  const examples = unresolved
+    .slice(0, 3)
+    .map(
+      (thread: JsonValue) =>
+        thread.comments?.nodes?.[0]?.url ?? `${thread.path}:${thread.line ?? "?"}`,
+    );
+  return `unresolved review threads remain: ${examples.join(", ")}`;
+}
+
+export function fetchPullRequestView(repo: string, number: JsonValue) {
+  return ghJson([
+    "pr",
+    "view",
+    String(number),
+    "--repo",
+    repo,
+    "--json",
+    [
+      "baseRefName",
+      "isDraft",
+      "mergeable",
+      "mergeCommit",
+      "mergeStateStatus",
+      "mergedAt",
+      "reviewDecision",
+      "state",
+      "statusCheckRollup",
+      "title",
+      "updatedAt",
+      "url",
+    ].join(","),
+  ]);
+}

--- a/src/repair/post-flight.ts
+++ b/src/repair/post-flight.ts
@@ -30,6 +30,7 @@ import {
   buildRepairSquashMergeMessage,
   writeRepairSquashMergeBody,
 } from "./repair-merge-message.js";
+import { fetchPullRequestView, validateResolvedReviewThreads } from "./merge-readiness-github.js";
 import { compactText as compactPlainText } from "./text-utils.js";
 import { rollUpStatusChecks } from "./status-check-rollup.js";
 
@@ -575,85 +576,8 @@ function shouldRequirePrChecks() {
   return process.env.CLAWSWEEPER_POST_FLIGHT_REQUIRE_PR_CHECKS === "1";
 }
 
-function validateResolvedReviewThreads(repo: string, number: JsonValue) {
-  const [owner, name] = repo.split("/");
-  const query = `
-    query($owner: String!, $name: String!, $number: Int!) {
-      repository(owner: $owner, name: $name) {
-        pullRequest(number: $number) {
-          reviewThreads(first: 100) {
-            pageInfo { hasNextPage }
-            nodes {
-              isResolved
-              path
-              line
-              comments(first: 1) {
-                nodes {
-                  url
-                  author { login }
-                  body
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  `;
-  const data = ghJson([
-    "api",
-    "graphql",
-    "-f",
-    `owner=${owner}`,
-    "-f",
-    `name=${name}`,
-    "-F",
-    `number=${number}`,
-    "-f",
-    `query=${query}`,
-  ]);
-  const threads = data?.data?.repository?.pullRequest?.reviewThreads;
-  if (threads?.pageInfo?.hasNextPage) return "too many review threads to prove resolved";
-  const unresolved = (threads?.nodes ?? []).filter(
-    (thread: JsonValue) => thread && !thread.isResolved,
-  );
-  if (unresolved.length === 0) return "";
-  const examples = unresolved
-    .slice(0, 3)
-    .map(
-      (thread: JsonValue) =>
-        thread.comments?.nodes?.[0]?.url ?? `${thread.path}:${thread.line ?? "?"}`,
-    );
-  return `unresolved review threads remain: ${examples.join(", ")}`;
-}
-
 function fetchPullRequest(repo: string, number: JsonValue) {
   return ghJson(["api", `repos/${repo}/pulls/${number}`]);
-}
-
-function fetchPullRequestView(repo: string, number: JsonValue) {
-  return ghJson([
-    "pr",
-    "view",
-    String(number),
-    "--repo",
-    repo,
-    "--json",
-    [
-      "baseRefName",
-      "isDraft",
-      "mergeable",
-      "mergeCommit",
-      "mergeStateStatus",
-      "mergedAt",
-      "reviewDecision",
-      "state",
-      "statusCheckRollup",
-      "title",
-      "updatedAt",
-      "url",
-    ].join(","),
-  ]);
 }
 
 function findLatestResultPath() {

--- a/test/repair/apply-result.test.ts
+++ b/test/repair/apply-result.test.ts
@@ -1133,6 +1133,8 @@ test("repair apply leaves current-main fixed closeout outside coverage proof", (
 test("post-flight authorization promotes only candidate-bound closeouts into guarded apply", () => {
   const source = fs.readFileSync("src/repair/apply-result.ts", "utf8");
 
+  assert.match(source, /from "\.\/merge-readiness-github\.js"/);
+  assert.doesNotMatch(source, /function (?:fetchPullRequestView|validateResolvedReviewThreads)\(/);
   assert.match(source, /closure_authorization\?\.status !== "authorized"/);
   assert.match(source, /mergedFixes\.has\(candidateFix\)/);
   assert.match(source, /normalizeIssueRef\(entry\.target, result\.repo\) === candidateFix/);

--- a/test/repair/post-flight.test.ts
+++ b/test/repair/post-flight.test.ts
@@ -583,6 +583,8 @@ test("post-flight rechecks repair mode and live authorization immediately before
 test("post-flight records authorization and never closes related items directly", () => {
   const source = fs.readFileSync("src/repair/post-flight.ts", "utf8");
 
+  assert.match(source, /from "\.\/merge-readiness-github\.js"/);
+  assert.doesNotMatch(source, /function (?:fetchPullRequestView|validateResolvedReviewThreads)\(/);
   assert.match(source, /closure_authorization = buildClosureAuthorization/);
   assert.doesNotMatch(source, /finalizePostMergeCloseout/);
   assert.doesNotMatch(source, /postMergeCloseoutComment/);


### PR DESCRIPTION
## What Problem This Solves

The repair apply and post-flight CLIs independently maintained identical GitHub reads for pull-request merge readiness. That duplication made it easier for the two enforcement paths to drift when the shared read contract changed.

## Why This Change Was Made

This refactor moves the identical pull-request view and review-thread reads into one repair-domain helper while preserving separate apply and post-flight policy ownership. It does not combine merge authorization, preflight, freshness, or mutation behavior.

## User Impact

No user-visible behavior changes. Repair maintainers have one implementation of the shared GitHub read contract, reducing future drift risk.

## OpenClaw Bay Impact

OpenClaw Bay is unaffected. This change does not alter lifecycle publication, queues, status or telemetry records, dashboard data, or observer navigation.

## Documentation Impact

No documentation changes are needed. Existing repair ownership and safety contracts remain accurate; this is a mechanical internal refactor.

## Evidence

- Exact reviewed head: `72b4ecccb15df4906597ff6b4ba7ab0fcce5faa5` (tree `d3704161668736e630d901bc81d5c024473d7598`).
- Focused repair tests: `41` passed, `0` failed.
- Scoped repair compilation, formatting, lint, and diff checks: passed.
- Full `CI=1 pnpm run check` on Node `24.18.1` and pnpm `11.10.0`: `4,977` tests, `4,959` passed, `18` skipped, `0` failed, `0` cancelled.
- Fresh Codex reviews before commit and on the committed range: clean, with no findings.
- Product CI: use the checks attached to this exact PR head.

## Real Behavior Proof

- **Claim:** extracting the two identical GitHub merge-readiness reads does not change compiled `apply-result` or `post-flight` CLI behavior.
- **Exercised surface:** actual compiled `dist/repair/apply-result.js` and `dist/repair/post-flight.js` from baseline `e5fffb689e4ae012121be84dbb47c0b8306b14b4` and candidate `72b4ecccb15df4906597ff6b4ba7ab0fcce5faa5`.
- **Scenarios:** resolved threads, unresolved threads, `hasNextPage`, malformed `nodes: {}`, GraphQL failure, missing `reviewThreads`, and `reviewThreads: null` for both CLIs. The harness executed `28` baseline/candidate fake-`gh` CLI runs and `4` baseline/candidate native-`gh` CLI runs.
- **Command and environment:** configured Crabbox direct AWS lease `cbx_5d4e9a2c6ff4`, image `ami-0461d919be7deb53c`, with the focused proof inside Docker `--network none`. The container had only loopback, no IPv4 or IPv6 main routes, Node `24.18.1`, pnpm `11.10.0`, and native GitHub CLI `2.100.0` pinned to SHA-256 `553949e2efa12842771efe6012aa4de21f1d591530ec17fc435f610f10e017ee`.
- **Observable result:** baseline and candidate matched for exit status, normalized stdout and stderr, GitHub argv and payloads, query text and field order, read count and ordering, blocked merge-marker absence, and resolved-path merge-marker presence. Unresolved and paginated review threads remained fail-closed. Native GitHub CLI runs used task-owned loopback TLS, made no mutation requests, and `strace` observed loopback traffic only.
- **Artifact or trace:** focused proof SHA-256 `9da1eb3da0cf7626e45044d50bef82123a072026dcb2c88dbefdf372935602d0`; full-check receipt SHA-256 `639d96eca966b433c29e971e8ced335022dd8de8ed35d8ba396ef8a49226ac5b`; retained evidence archive SHA-256 `fe47368d03d9e79928c6685a164dc0804412792b1041f6e24d990407b1a1dc9e`.
- **Limits:** the native GitHub CLI talked only to the task-owned loopback TLS fixture. No live GitHub or Cloudflare mutation was performed, so this proves the compiled CLI contract rather than external service availability.

No changelog or release-note entry is needed because the change is mechanical and has no user-visible or operational contract change.
