### PR TITLE
fix(queue): unblock stale command publications after batch expiry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Terminalize stale command publications after batch expiry without losing shared acknowledgement obligations.
 - Bound GitHub activity hook prompts to one received event and filtered trusted self-authored review chatter before model intake.
 - Replay durable scheduled enqueue dispositions after transient response loss while preserving signed delivery identity, rejecting mismatched bytes, failing closed on legacy ambiguous receipts, and leaving publication post-effects single-attempt.
 - Use the producer Actions run URL in failed-review retry receipts so ledger validation no longer prevents dispatch and fails the retry command.

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -1731,7 +1731,8 @@ export class ExactReviewQueue {
                 (item.state === "pending" || item.state === "parked") &&
                 (!item.terminalFinalization ||
                   exactReviewTerminalFinalizationSharesCommandStatus(item, decision)) &&
-                !activeBatchItemKeys.has(item.key),
+                !activeBatchItemKeys.has(item.key) &&
+                this.publicationSupersedeSafety(item, true).supersede_safe,
             )
             .sort((left, right) => left.item.key.localeCompare(right.item.key))
             .slice(0, EXACT_REVIEW_PUBLICATION_ENQUEUE_SUPERSEDE_LIMIT)) {
@@ -4708,18 +4709,18 @@ export class ExactReviewQueue {
     await this.processBranchAuthorityReservations(startedAt, hostedTargetMetadataToken);
     await this.processSourceAuthorityReservations(startedAt, hostedTargetMetadataToken);
     await this.processCommandIntakes(startedAt, hostedTargetMetadataToken);
-    const pruneBatchItemKeys = new Set<string>(
-      this.batchStore.activeLeaseSnapshot(startedAt).itemKeys,
-    );
+    const batchItemKeys = new Set<string>(this.batchStore.activeLeaseSnapshot(startedAt).itemKeys);
+    let terminalized: ExactReviewLifecycleProjection[] = [];
     let snapshot = this.storage.transactionSync(() => {
       this.pruneDeliveryReceiptsSync(startedAt);
       this.commandIntakeStore.pruneTerminalReceipts(startedAt);
       this.directPublicationStore.pruneTerminalSync(startedAt);
       const current = this.readStateSync();
       this.syncLegacyCompatibilitySync(current);
-      this.pruneStalePublicationsSync(current, pruneBatchItemKeys);
+      terminalized = this.pruneStalePublicationsSync(current, batchItemKeys, startedAt);
       return current;
     });
+    for (const projection of terminalized) this.syncBayLifecycle(projection);
     let snapshotBatchOwnership = this.batchStore.activeLeaseSnapshot(startedAt);
     const reclaimedSnapshot = reclaimExpiredExactReviewLeases(
       snapshot,
@@ -6812,14 +6813,22 @@ export class ExactReviewQueue {
         (left, right) =>
           left.item.createdAt - right.item.createdAt || left.item.key.localeCompare(right.item.key),
       );
-    return { versioned, newestByTarget, stale };
+    const successors = new Map<string, ExactReviewQueueItem | null>();
+    // Command ownership moves only to one exact, durably admitted successor.
+    // Missing or ambiguous ownership must retain the stale row.
+    for (const { item, revision } of versioned) {
+      if (revision.sourceRevision !== newestByTarget.get(revision.targetKey)) continue;
+      successors.set(revision.targetKey, successors.has(revision.targetKey) ? null : item);
+    }
+    return { versioned, newestByTarget, stale, successors };
   }
 
   private pruneStalePublicationsSync(
     state: ExactReviewQueueState,
     activeBatchItemKeys: ReadonlySet<string>,
+    now: number,
   ) {
-    const { stale, newestByTarget } = this.stalePublicationCandidatesSync(
+    const { stale, newestByTarget, successors } = this.stalePublicationCandidatesSync(
       state,
       activeBatchItemKeys,
     );
@@ -6829,15 +6838,14 @@ export class ExactReviewQueue {
     );
     const hasCommand = exactReviewDecisionHasCommandContext;
     let changed = 0;
-    for (const { item, revision } of stale
-      .filter(({ item }) => !hasCommand(item.decision.publication!.producerDecision))
-      .slice(0, limit)) {
+    const terminalized: ExactReviewLifecycleProjection[] = [];
+    for (const { item, revision } of stale) {
+      if (changed >= limit) break;
       const current = state.items[item.key];
       const currentRevision = current ? exactReviewPublicationRevision(current.decision) : null;
       if (
         !current ||
         current.terminalFinalization ||
-        hasCommand(current.decision.publication!.producerDecision) ||
         current.revision !== item.revision ||
         !currentRevision ||
         currentRevision.sourceRevision !== revision.sourceRevision ||
@@ -6848,7 +6856,42 @@ export class ExactReviewQueue {
       ) {
         continue;
       }
-      delete state.items[current.key];
+      const producer = current.decision.publication!.producerDecision;
+      if (hasCommand(producer)) {
+        const successor = successors.get(currentRevision.targetKey);
+        if (
+          this.publicationSupersedeSafety(current).acknowledgement_unavailable_reason !==
+            "terminal_missing" ||
+          !successor
+        )
+          continue;
+        const successorProducer = successor.decision.publication!.producerDecision;
+        const successorAdmission = this.lifecycleProjectionStore.read(
+          `${successorProducer.targetRepo}#${successorProducer.itemNumber}`,
+          successor.key,
+          successor.revision,
+        )?.admission;
+        if (
+          successorAdmission?.commandOriginated !== hasCommand(successorProducer) ||
+          successorAdmission.statusMarker !== (successorProducer.commandStatusMarker ?? null) ||
+          successorAdmission.statusCommentId !== (successorProducer.statusCommentId ?? null)
+        )
+          continue;
+        const requeue = exactReviewCommandObligationSurvives(producer, successorProducer);
+        terminalized.push(
+          this.recordLifecycleTerminalDispositionSync(
+            exactReviewTerminalFinalizationProjection(current, current.revision),
+            requeue ? "requeue" : "superseded",
+            now,
+            state,
+            undefined,
+            false,
+          ).projection,
+        );
+        if (requeue) delete state.items[current.key];
+      } else {
+        delete state.items[current.key];
+      }
       changed += 1;
     }
     if (changed) {
@@ -6858,6 +6901,7 @@ export class ExactReviewQueue {
         publicationSuperseded: changed,
       });
     }
+    return terminalized;
   }
 
   private async reconcilePublicationCandidates(
@@ -9582,30 +9626,15 @@ export class ExactReviewQueue {
     }
     try {
       const now = Date.now();
-      const result = this.storage.transactionSync(() => {
-        const result = this.lifecycleProjectionStore.recordTerminalDispositionSync({
-          ...identity,
+      const result = this.storage.transactionSync(() =>
+        this.recordLifecycleTerminalDispositionSync(
+          identity,
           kind,
-          operationId,
-          observedAt: now,
-        });
-        if (result.duplicate) return result;
-        const state = this.readStateSync();
-        const driverCancelled =
-          kind === "requeue" ? this.cancelTerminalFinalizationDrivers(state, identity) : false;
-        const driverChanged =
-          kind === "requeue"
-            ? false
-            : this.ensureLifecycleTerminalFinalizationDriver({
-                state,
-                projection: result.projection,
-                terminalDisposition: kind,
-                now,
-              });
-        const receiptRemoved = this.removeTerminalizedLifecycleQueueItem(state, identity);
-        if (driverChanged || driverCancelled || receiptRemoved) this.writeStateSync(state);
-        return result;
-      });
+          now,
+          undefined,
+          typeof operationId === "string" ? operationId : undefined,
+        ),
+      );
       this.syncBayLifecycle(result.projection);
       await this.scheduleNext(this.readStateSync(), now);
       return json({
@@ -9621,6 +9650,37 @@ export class ExactReviewQueue {
       }
       return json({ error: "invalid_lifecycle_terminal_disposition" }, 409);
     }
+  }
+
+  private recordLifecycleTerminalDispositionSync(
+    identity: ExactReviewLifecycleProjectionIdentity,
+    kind: LifecycleTerminalDisposition,
+    now: number,
+    state = this.readStateSync(),
+    operationId?: string,
+    persist = true,
+  ) {
+    const result = this.lifecycleProjectionStore.recordTerminalDispositionSync({
+      ...identity,
+      kind,
+      operationId,
+      observedAt: now,
+    });
+    if (result.duplicate) return result;
+    const driverCancelled =
+      kind === "requeue" ? this.cancelTerminalFinalizationDrivers(state, identity) : false;
+    const driverChanged =
+      kind === "requeue"
+        ? false
+        : this.ensureLifecycleTerminalFinalizationDriver({
+            state,
+            projection: result.projection,
+            terminalDisposition: kind,
+            now,
+          });
+    const receiptRemoved = this.removeTerminalizedLifecycleQueueItem(state, identity);
+    if (persist && (driverChanged || driverCancelled || receiptRemoved)) this.writeStateSync(state);
+    return result;
   }
 
   private requeueDirectLifecyclePublicationSync(

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -645,8 +645,12 @@ older probes, including across tombstone expiry. Tombstones expire lazily after
 at least 30 minutes; probes outliving retention must retry.
 
 Alarms prune up to `EXACT_REVIEW_STALE_PUBLICATION_PRUNE_LIMIT` stale revisions
-(default 100), oldest first, without GitHub reads. Only pending/parked rows without
-active batch ownership, terminal finalization or command context qualify;
+(default 100), oldest first, without GitHub reads. Pending/parked rows require no
+active batch ownership or terminal finalization. A command row with a missing
+terminal requires one exact authoritative successor and matching lifecycle
+admission: the same marker and comment requeues without a finalizer, while a
+changed address or non-command successor records superseded with an acknowledgement
+driver. Missing, ambiguous, or mismatched successor state stays retained fail-closed;
 duplicate-lineage and legacy terminal cleanup remains operator-owned.
 Successful queue handoff expires the workflow's review-start lease to permit
 another exact-head review; terminal publication still deletes the placeholder.

--- a/test/dashboard-worker-publication-lifecycle.test.ts
+++ b/test/dashboard-worker-publication-lifecycle.test.ts
@@ -4302,6 +4302,110 @@ test("publication reconciliation preserves and does not transplant an unsafe com
   assert.ok(state.items[command.key]);
 });
 
+test("alarm stale command terminalization fails closed without exact successor ownership", async () => {
+  for (const scenario of [
+    "stale_projection_mismatch",
+    "existing_requeue",
+    "missing_successor",
+    "ambiguous_successor",
+    "successor_projection_missing",
+    "successor_projection_mismatch",
+  ] as const) {
+    const storage = new MemoryDurableStorage();
+    const number = 18030 + scenario.length;
+    const stale = leasedExactReviewPublicationItem(number, `${number}0`);
+    const fresh = leasedExactReviewPublicationItem(number, `${number}1`);
+    const marker = `<!-- clawsweeper-command-status:${number}:re_review:${"e".repeat(40)} -->`;
+    stale.state = "pending";
+    stale.revision = 4;
+    stale.decision.publication!.leaseRevision = 1;
+    Object.assign(stale.decision.publication!.producerDecision, {
+      commandStatusMarker: marker,
+      statusCommentId: number * 10,
+    });
+    fresh.state = "pending";
+    fresh.decision.publication!.leaseRevision = 2;
+    Object.assign(fresh.decision.publication!.producerDecision, {
+      commandStatusMarker: marker,
+      statusCommentId: number * 10,
+    });
+    const items = { [stale.key]: stale, [fresh.key]: fresh };
+    if (scenario === "missing_successor") delete items[fresh.key];
+    if (scenario === "ambiguous_successor") {
+      const duplicate = leasedExactReviewPublicationItem(number, `${number}2`);
+      duplicate.state = "pending";
+      duplicate.decision.publication!.leaseRevision = 2;
+      Object.assign(duplicate.decision.publication!.producerDecision, {
+        commandStatusMarker: marker,
+        statusCommentId: number * 10,
+      });
+      items[duplicate.key] = duplicate;
+    }
+    await storage.put("exact-review-queue", { deliveries: {}, items });
+    const lifecycle = new ExactReviewLifecycleProjectionStore(storage);
+    const identity = {
+      canonicalTargetKey: `openclaw/openclaw#${number}`,
+      fenceKey: stale.key,
+      revision: stale.revision,
+    };
+    lifecycle.recordAdmission({
+      ...identity,
+      deliveryId: `automatic-terminal-${scenario}`,
+      sourceAction: "re_review",
+      commandOriginated: true,
+      statusMarker: scenario === "stale_projection_mismatch" ? `${marker}:mismatch` : marker,
+      statusCommentId: number * 10,
+      observedAt: 1,
+    });
+    if (scenario === "existing_requeue") {
+      lifecycle.recordTerminalDisposition({ ...identity, kind: "requeue", observedAt: 2 });
+    }
+    const queue = publicPublicationQueue(storage);
+    if (scenario === "missing_successor") {
+      await queue.fetch(new Request("https://queue/stats"));
+      storage.sql.exec(
+        `INSERT INTO exact_review_publication_heads (target_key, source_revision, updated_at)
+         VALUES (?, 2, ?) ON CONFLICT(target_key) DO UPDATE SET source_revision = 2`,
+        `openclaw/openclaw#${number}`,
+        Date.now(),
+      );
+    } else if (scenario !== "successor_projection_missing") {
+      for (const successor of Object.values(items).filter((item) => item !== stale)) {
+        const producer = successor.decision.publication!.producerDecision;
+        lifecycle.recordAdmission({
+          canonicalTargetKey: `openclaw/openclaw#${number}`,
+          fenceKey: successor.key,
+          revision: successor.revision,
+          deliveryId: `successor-${successor.key}`,
+          sourceAction: producer.sourceAction,
+          commandOriginated: true,
+          statusMarker:
+            scenario === "successor_projection_mismatch" ? `${marker}:mismatch` : marker,
+          statusCommentId: number * 10,
+          observedAt: 3,
+        });
+      }
+    }
+    await queue.alarm();
+    const state = storage.sql.readNormalizedQueue() as {
+      items: Record<string, ExactReviewQueueItem>;
+    };
+    assert.ok(state.items[stale.key]);
+    if (scenario !== "missing_successor") assert.ok(state.items[fresh.key]);
+    assert.equal(
+      lifecycle.read(identity.canonicalTargetKey, identity.fenceKey, identity.revision)
+        ?.terminalDisposition?.kind,
+      scenario === "existing_requeue" ? "requeue" : undefined,
+    );
+    await queue.alarm();
+    assert.ok(
+      (storage.sql.readNormalizedQueue() as { items: Record<string, ExactReviewQueueItem> }).items[
+        stale.key
+      ],
+    );
+  }
+});
+
 test("max-items one does not reclaim an unsampled expired lineage lease", async () => {
   const storage = new MemoryDurableStorage();
   const expired = leasedExactReviewPublicationItem(18021, "180210");

--- a/test/exact-review-publication-batches.test.ts
+++ b/test/exact-review-publication-batches.test.ts
@@ -1240,7 +1240,7 @@ for (const [limit, command] of [
 ] as const) {
   test(
     command === "producer"
-      ? "alarm preserves command acknowledgements after batch expiry while pruning ordinary stale publications"
+      ? "alarm terminalizes a stale producer command after batch expiry while pruning ordinary publications"
       : command === "outer"
         ? "alarm treats outer-only command fields as non-command publication context"
         : `alarm prunes stale publication revisions after batch expiry with limit ${limit}`,
@@ -1265,27 +1265,77 @@ for (const [limit, command] of [
       await h.queue.alarm();
       const after = await h.publicationStats();
       const protectedCommand = command === "producer";
-      assert.deepEqual([after.pending, after.completed_total], limit === 1 ? [3, 1] : [2, 2]);
+      assert.deepEqual(
+        [after.pending, after.completed_total],
+        limit === 1 ? [protectedCommand ? 4 : 3, 1] : [2, 2],
+      );
       const remaining = await h.post("/publications/reconcile");
       assert.equal(remaining.stale_revision_eligible, limit === 1 ? 1 : 0);
       if (limit === 1) {
-        assert.equal(
-          remaining.sample[0].item_key,
-          `openclaw/openclaw#${protectedCommand ? 801 : 802}@publish:${protectedCommand ? 801 : 802}:1`,
-        );
-        if (protectedCommand)
-          assert.equal(
-            (await h.post("/publications/reconcile", { apply: true })).stale_revision_changed,
-            0,
-          );
-        else await h.queue.alarm();
+        assert.equal(remaining.sample[0].item_key, "openclaw/openclaw#802@publish:802:1");
+        await h.queue.alarm();
       }
       const final = await h.publicationStats();
-      assert.deepEqual([final.pending, final.completed_total], protectedCommand ? [3, 1] : [2, 2]);
+      assert.deepEqual([final.pending, final.completed_total], protectedCommand ? [3, 2] : [2, 2]);
       assert.equal(h.networkCalls, 0);
+      if (protectedCommand) {
+        const state = await h.storage.get("exact-review-queue");
+        const staleKey = "openclaw/openclaw#801@publish:801:1";
+        const driverKey = `terminal-finalization:${staleKey}:1`;
+        assert.equal(state.items[staleKey], undefined);
+        assert.equal(state.items[driverKey]?.terminalFinalization?.disposition, "superseded");
+        assert.equal(
+          new ExactReviewLifecycleProjectionStore(h.storage).read(
+            "openclaw/openclaw#801",
+            staleKey,
+            1,
+          )?.terminalDisposition?.kind,
+          "superseded",
+        );
+        await h.queue.alarm();
+        const replay = await h.publicationStats();
+        assert.deepEqual(
+          [replay.pending, replay.completed_total, replay.superseded_total],
+          [final.pending, final.completed_total, final.superseded_total],
+        );
+      }
     },
   );
 }
+
+test("alarm skips ineligible command rows before applying the prune limit", async (t) => {
+  const h = admissionQueue(t, {
+    EXACT_REVIEW_PUBLICATION_BATCH_LEASE_MS: "60000",
+    EXACT_REVIEW_STALE_PUBLICATION_PRUNE_LIMIT: "1",
+  });
+  for (const number of [803, 804]) {
+    const body = await publicationRequest(`prune-command-${number}`, number, String(number)).json();
+    body.decision.publication.producerDecision.statusCommentId = number * 10;
+    assert.equal((await h.queue.fetch(batchRequest("/enqueue", body))).status, 202);
+    h.now += 1;
+  }
+  assert.equal((await h.claim()).batch.items.length, 2);
+  for (const number of [803, 804]) await h.enqueue(number, 2);
+  const blockedKey = "openclaw/openclaw#803@publish:803:1";
+  new ExactReviewLifecycleProjectionStore(h.storage).recordTerminalDisposition({
+    canonicalTargetKey: "openclaw/openclaw#803",
+    fenceKey: blockedKey,
+    revision: 1,
+    kind: "requeue",
+    observedAt: h.now,
+  });
+
+  h.now += 60_001;
+  await h.queue.alarm();
+  const state = await h.storage.get("exact-review-queue");
+  const eligibleKey = "openclaw/openclaw#804@publish:804:1";
+  assert.ok(state.items[blockedKey]);
+  assert.equal(state.items[eligibleKey], undefined);
+  assert.equal(
+    state.items[`terminal-finalization:${eligibleKey}:1`]?.terminalFinalization?.disposition,
+    "superseded",
+  );
+});
 
 test("batch claims retain lifecycle identity until canonical routing is durable", async () => {
   const storage = new TestStorage();
@@ -1642,6 +1692,181 @@ test("newer publication revisions supersede unowned pending rows at enqueue", as
   assert.equal(stats.lanes.publication.completed_total, 1);
   assert.equal(stats.lanes.publication.superseded_total, 1);
 });
+
+test("enqueue retains an unacknowledged command for alarm-owned supersession", async (t) => {
+  const h = admissionQueue(t);
+  const stale = await publicationRequest(
+    "delivery-command-revision-1",
+    108704,
+    "2111",
+    "openclaw/openclaw",
+    1,
+  ).json();
+  const marker =
+    "<!-- clawsweeper-command-status:108704:re_review:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa -->";
+  Object.assign(stale.decision.publication.producerDecision, {
+    commandStatusMarker: marker,
+    statusCommentId: 1087040,
+  });
+  assert.equal((await h.queue.fetch(batchRequest("/enqueue", stale))).status, 202);
+  const response = await (
+    await h.queue.fetch(
+      publicationRequest("delivery-command-revision-2", 108704, "2112", "openclaw/openclaw", 2),
+    )
+  ).json();
+  const staleKey = "openclaw/openclaw#108704@publish:2111:1";
+  const freshKey = "openclaw/openclaw#108704@publish:2112:1";
+  assert.equal(response.superseded_publications, 0);
+  assert.ok((await h.storage.get("exact-review-queue")).items[staleKey]);
+
+  await h.queue.alarm();
+  const state = await h.storage.get("exact-review-queue");
+  assert.equal(state.items[staleKey], undefined);
+  assert.ok(state.items[freshKey]);
+  assert.equal(
+    state.items[`terminal-finalization:${staleKey}:1`]?.terminalFinalization?.disposition,
+    "superseded",
+  );
+  assert.equal(
+    new ExactReviewLifecycleProjectionStore(h.storage).read("openclaw/openclaw#108704", staleKey, 1)
+      ?.terminalDisposition?.kind,
+    "superseded",
+  );
+  const metrics = await h.publicationStats();
+  await h.queue.alarm();
+  assert.deepEqual(await h.publicationStats(), metrics);
+});
+
+test("enqueue supersedes a stale command after its acknowledgement is observed", async (t) => {
+  const h = admissionQueue(t);
+  const number = 108705;
+  const marker =
+    "<!-- clawsweeper-command-status:108705:re_review:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa -->";
+  const stale = await publicationRequest(
+    "delivery-command-observed-1",
+    number,
+    "2113",
+    "openclaw/openclaw",
+    1,
+  ).json();
+  Object.assign(stale.decision.publication.producerDecision, {
+    commandStatusMarker: marker,
+    statusCommentId: 1087050,
+  });
+  assert.equal((await h.queue.fetch(batchRequest("/enqueue", stale))).status, 202);
+  const identity = {
+    canonicalTargetKey: `openclaw/openclaw#${number}`,
+    fenceKey: `openclaw/openclaw#${number}@publish:2113:1`,
+    revision: 1,
+  };
+  const lifecycle = new ExactReviewLifecycleProjectionStore(h.storage);
+  lifecycle.recordCanonicalReceipt({
+    ...identity,
+    outcome: "accepted",
+    receiptId: "canonical-observed",
+    observedAt: h.now,
+  });
+  lifecycle.recordRouterReceipt({
+    ...identity,
+    outcome: "durable",
+    receiptId: "router-observed",
+    observedAt: h.now,
+  });
+  lifecycle.recordTerminalDisposition({
+    ...identity,
+    kind: "review_completed_routed",
+    observedAt: h.now,
+  });
+  assert.equal(
+    lifecycle.authorizeCommandAcknowledgement({
+      ...identity,
+      statusMarker: marker,
+      statusCommentId: 1087050,
+      observedAt: h.now,
+    }).allowed,
+    true,
+  );
+  lifecycle.observeCommandAcknowledgement({
+    ...identity,
+    statusMarker: marker,
+    statusCommentId: 1087050,
+    commandCommentId: number,
+    completionCommentId: 1087050,
+    observedAt: h.now,
+  });
+
+  const response = await (
+    await h.queue.fetch(
+      publicationRequest("delivery-command-observed-2", number, "2114", "openclaw/openclaw", 2),
+    )
+  ).json();
+  assert.equal(response.superseded_publications, 1);
+  const state = await h.storage.get("exact-review-queue");
+  assert.equal(state.items[identity.fenceKey], undefined);
+  assert.ok(state.items[`openclaw/openclaw#${number}@publish:2114:1`]);
+});
+
+for (const [scenario, successorMarker, successorComment, terminal] of [
+  ["shared exact command", "same", "same", "requeue"],
+  ["same comment with a different marker", "different", "same", "superseded"],
+  ["same marker with a different comment", "same", "different", "superseded"],
+] as const) {
+  test(`alarm terminalizes ${scenario} after batch expiry`, async (t) => {
+    const h = admissionQueue(t, { EXACT_REVIEW_PUBLICATION_BATCH_LEASE_MS: "60000" });
+    const number = scenario.length + 108710;
+    const marker = `<!-- clawsweeper-command-status:${number}:re_review:${"a".repeat(40)} -->`;
+    const stale = await publicationRequest(
+      `delivery-${number}-1`,
+      number,
+      `${number}1`,
+      "openclaw/openclaw",
+      1,
+    ).json();
+    Object.assign(stale.decision.publication.producerDecision, {
+      commandStatusMarker: marker,
+      statusCommentId: number * 10,
+    });
+    assert.equal((await h.queue.fetch(batchRequest("/enqueue", stale))).status, 202);
+    assert.equal((await h.claim()).batch.items.length, 1);
+    const fresh = await publicationRequest(
+      `delivery-${number}-2`,
+      number,
+      `${number}2`,
+      "openclaw/openclaw",
+      2,
+    ).json();
+    Object.assign(fresh.decision.publication.producerDecision, {
+      commandStatusMarker:
+        successorMarker === "same" ? marker : marker.replace("a".repeat(40), "b".repeat(40)),
+      statusCommentId: successorComment === "same" ? number * 10 : number * 10 + 1,
+    });
+    assert.equal((await h.queue.fetch(batchRequest("/enqueue", fresh))).status, 202);
+    const staleKey = `openclaw/openclaw#${number}@publish:${number}1:1`;
+    await h.queue.alarm();
+    assert.ok((await h.storage.get("exact-review-queue")).items[staleKey]);
+
+    h.now += 60_001;
+    await h.queue.alarm();
+    const state = await h.storage.get("exact-review-queue");
+    assert.equal(state.items[staleKey], undefined);
+    assert.ok(state.items[`openclaw/openclaw#${number}@publish:${number}2:1`]);
+    assert.equal(
+      new ExactReviewLifecycleProjectionStore(h.storage).read(
+        `openclaw/openclaw#${number}`,
+        staleKey,
+        1,
+      )?.terminalDisposition?.kind,
+      terminal,
+    );
+    assert.equal(
+      Boolean(state.items[`terminal-finalization:${staleKey}:1`]),
+      terminal !== "requeue",
+    );
+    const metrics = await h.publicationStats();
+    await h.queue.alarm();
+    assert.deepEqual(await h.publicationStats(), metrics);
+  });
+}
 
 test("semantic lineage dedupe cannot leave obsolete rows eligible for a batch", async (t) => {
   t.mock.method(Date, "now", () => 6_250_000);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where publication FIFO could retain a stale command publication indefinitely after its batch lease expired, even after a newer authoritative publication revision was materialized. The stale row had no lifecycle terminal disposition, while reconciliation required an acknowledgement that could not exist.

Diagnostic context: https://github.com/openclaw/clawsweeper/actions/runs/33935260237

## Why This Change Was Made

The alarm cleanup path now owns this lifecycle transition after batch ownership expires. It requires one unique newest materialized successor and exact lifecycle admission identity; a shared command obligation records `requeue`, while a different or non-command successor records `superseded` and creates the existing acknowledgement driver. Missing, ambiguous, mismatched, or already-requeued state remains fail-closed.

Enqueue still removes ordinary stale rows and acknowledgement-safe command rows immediately. It preserves command rows with outstanding acknowledgement obligations for alarm-owned terminalization.

## User Impact

Operators can expect publication FIFO to recover naturally after an abandoned batch lease instead of leaving a `terminal_missing` command row permanently stranded. Active owners and ambiguous successor state remain protected.

## OpenClaw Bay Impact

Bay receives the new `requeue` or `superseded` lifecycle fact through the existing post-commit `syncBayLifecycle` path. No Bay schema, public API, UI, or control surface changes are needed. The controlled proof observes the canonical lifecycle terminal and queue metrics that Bay already consumes.

## Documentation Impact

Updated `docs/live-dashboard.md` to describe the guarded command cleanup path, its exact successor/admission requirements, `requeue` versus `superseded` outcomes, and fail-closed retention. `CHANGELOG.md` includes one `Fixed` entry for the operational repair.

## Evidence

- Head: `7842e341f314b2154ba0a0546090f158a6b692b9`
- Base: `05ffb996289ca97c2d8d1bfc273bbfbcc6dbabb8`
- Two signed commits; the code commit is a direct child of the pinned base and the documentation commit changes only `docs/live-dashboard.md`.
- Production delta: `+95/-35`, net `+60`.
- `node --test test/exact-review-publication-batches.test.ts`: 101 passed.
- `node --test test/dashboard-worker-publication-lifecycle.test.ts`: 86 passed.
- Three TypeScript builds/typechecks, dashboard strict and queue-boundary checks, targeted formatting/lint, and `git diff --check`: passed.
- Committed-range Codex review: no actionable regressions.
- Offline ClawSweeper committed-range review: no actionable issue; confidence remained inconclusive because it did not read all 28,811 lines of the four changed files.

## Real Behavior Proof

**Claim:** An expired batch-owned stale command publication with `terminal_missing` is atomically superseded only after one exact successor is materialized.

**Exercised surface:** The production `ExactReviewQueue` ran in Miniflare workerd with a real SQLite Durable Object using Wrangler 4.107.0. The proof compared the exact base and candidate source.

**Scenario:** A command-originated revision 1 was claimed by an active publication batch. A non-command revision 2 with exact lifecycle admission was then enqueued. The first alarm preserved the active owner. After advancing the controlled clock by 60,001 ms, the alarm processed the expired owner, followed by an idempotence alarm.

**Command and environment:** `node <temporary-proof>/run-proof.mjs` on Node 26.7.0. Outbound network was blocked; only synthetic public repository identity was used.

**Observed result:**

```json
{
  "baseline": {
    "active_batch_preserved_old": true,
    "old_retained_after_expiry": true,
    "terminal_driver_count": 0,
    "terminal_disposition": null
  },
  "candidate": {
    "active_batch_preserved_old": true,
    "old_retained_after_expiry": false,
    "new_retained_after_expiry": true,
    "terminal_driver_count": 1,
    "terminal_disposition": "superseded",
    "completed_total": 1,
    "superseded_total": 1,
    "replay_metrics_unchanged": true
  }
}
```

**Artifact:** `behavior-report.json`, SHA-256 `34a22bc7bddcec52c777d848443acd32c0b998da17638e763e513d679eb925ba`.

**Limits:** No GitHub, deployed Worker, workflow, or production state was mutated. The workerd proof covers the `superseded` successor path; the shared-command `requeue`, mismatch, ambiguity, active-batch, bounded-limit, and acknowledgement-observed paths are covered by focused tests.
