### PR TITLE
refactor(test): deduplicate target validation helpers

### DIFF
--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -3872,25 +3872,18 @@ if (args[0] === "enable") {
     setupTimeoutMs: FAKE_TOOLCHAIN_TIMEOUT_MS,
   };
 
-  withCommandOverridesUnset(["corepack", "pnpm"], () =>
-    withPathOnlyPrefix(hostBin, () => {
-      prepareTargetToolchain(cwd, options);
-      assert.deepEqual(runAllowedValidationCommands(["pnpm verify"], cwd, options), [
-        "pnpm verify",
-      ]);
+  withPreparedPnpmToolchain(cwd, hostBin, options, () => {
+    assert.deepEqual(runAllowedValidationCommands(["pnpm verify"], cwd, options), ["pnpm verify"]);
 
-      fs.writeFileSync(path.join(cwd, "check.js"), "process.exit(1);\n");
-      assert.throws(
-        () => runAllowedValidationCommands(["pnpm verify"], cwd, options),
-        /prepared target pnpm toolchain is stale/,
-      );
+    fs.writeFileSync(path.join(cwd, "check.js"), "process.exit(1);\n");
+    assert.throws(
+      () => runAllowedValidationCommands(["pnpm verify"], cwd, options),
+      /prepared target pnpm toolchain is stale/,
+    );
 
-      prepareTargetToolchain(cwd, options);
-      assert.deepEqual(runAllowedValidationCommands(["pnpm verify"], cwd, options), [
-        "pnpm verify",
-      ]);
-    }),
-  );
+    prepareTargetToolchain(cwd, options);
+    assert.deepEqual(runAllowedValidationCommands(["pnpm verify"], cwd, options), ["pnpm verify"]);
+  });
 
   assert.equal(fs.existsSync(hostLog), false, "host pnpm must never run");
   const corepackInvocations = fs.readFileSync(corepackLog, "utf8").trim().split(/\r?\n/);
@@ -4015,14 +4008,17 @@ if (args[0] === "enable") {
       setupTimeoutMs: FAKE_TOOLCHAIN_TIMEOUT_MS,
     };
 
-    withCommandOverridesUnset(["corepack", "pnpm"], () =>
-      withPathOnlyPrefix(hostBin, () => {
-        prepareTargetToolchain(cwd, options, ["pnpm check:changed"]);
+    withPreparedPnpmToolchain(
+      cwd,
+      hostBin,
+      options,
+      () => {
         assert.deepEqual(
           runAllowedValidationCommands(["pnpm first", "pnpm second"], cwd, options),
           ["pnpm first", "pnpm second"],
         );
-      }),
+      },
+      ["pnpm check:changed"],
     );
 
     const invocations = fs
@@ -4306,9 +4302,7 @@ if (args[0] === "enable") {
     setupTimeoutMs: FAKE_TOOLCHAIN_TIMEOUT_MS,
   };
 
-  withCommandOverridesUnset(["corepack", "pnpm"], () =>
-    withPathOnlyPrefix(hostBin, () => prepareTargetToolchain(cwd, options)),
-  );
+  withPreparedPnpmToolchain(cwd, hostBin, options, () => undefined);
 
   assert.equal(fs.existsSync(maliciousMarker), false);
 });
@@ -4893,23 +4887,7 @@ test("OpenClaw changed-gate rebuilds are disposable and restore existing runtime
       ].join("\n"),
     );
 
-    assert.deepEqual(
-      withPathOnlyPrefix(binDir, () =>
-        runAllowedValidationCommands(
-          ["pnpm check:changed"],
-          cwd,
-          validationOptions("openclaw/openclaw", {
-            pinnedBaseRef: "origin/main",
-            toolchain: {
-              packageManager: "pnpm",
-              baseValidationCommands: [],
-              changedGate: { command: "pnpm check:changed", requiredScript: "check:changed" },
-            },
-          }),
-        ),
-      ),
-      ["pnpm check:changed"],
-    );
+    assert.deepEqual(runOpenClawChangedGate(cwd, binDir), ["pnpm check:changed"]);
     for (const output of ["dist", "packages/plugin-sdk/dist"]) {
       const generated = path.join(cwd, output, "runtime.js");
       if (existingOutputs) {
@@ -4947,21 +4925,7 @@ test("changed-gate output restoration still rejects unrelated ignored-input pois
   );
 
   assert.throws(
-    () =>
-      withPathOnlyPrefix(binDir, () =>
-        runAllowedValidationCommands(
-          ["pnpm check:changed"],
-          cwd,
-          validationOptions("openclaw/openclaw", {
-            pinnedBaseRef: "origin/main",
-            toolchain: {
-              packageManager: "pnpm",
-              baseValidationCommands: [],
-              changedGate: { command: "pnpm check:changed", requiredScript: "check:changed" },
-            },
-          }),
-        ),
-      ),
+    () => runOpenClawChangedGate(cwd, binDir),
     /runtimeInputsSha256; changed runtime roots: node_modules$/,
   );
   assert.equal(fs.readFileSync(path.join(dist, "runtime.js"), "utf8"), "trusted original\n");
@@ -4982,21 +4946,7 @@ test("changed-gate output preparation failures preserve the existing compiler ca
   writeNodeCommandShim(binDir, "pnpm", "");
 
   assert.throws(
-    () =>
-      withPathOnlyPrefix(binDir, () =>
-        runAllowedValidationCommands(
-          ["pnpm check:changed"],
-          cwd,
-          validationOptions("openclaw/openclaw", {
-            pinnedBaseRef: "origin/main",
-            toolchain: {
-              packageManager: "pnpm",
-              baseValidationCommands: [],
-              changedGate: { command: "pnpm check:changed", requiredScript: "check:changed" },
-            },
-          }),
-        ),
-      ),
+    () => runOpenClawChangedGate(cwd, binDir),
     /changed-gate validation has an unsafe existing output: dist/,
   );
   assert.equal(fs.readFileSync(cache, "utf8"), "trusted compiler state\n");
@@ -5030,21 +4980,7 @@ test(
     );
 
     assert.throws(
-      () =>
-        withPathOnlyPrefix(binDir, () =>
-          runAllowedValidationCommands(
-            ["pnpm check:changed"],
-            cwd,
-            validationOptions("openclaw/openclaw", {
-              pinnedBaseRef: "origin/main",
-              toolchain: {
-                packageManager: "pnpm",
-                baseValidationCommands: [],
-                changedGate: { command: "pnpm check:changed", requiredScript: "check:changed" },
-              },
-            }),
-          ),
-        ),
+      () => runOpenClawChangedGate(cwd, binDir),
       (error: Error) =>
         /validation command failed \(pnpm check:changed\)/.test(error.message) &&
         /changed-gate validation produced an unsafe output: dist/.test(
@@ -5090,23 +5026,7 @@ test("OpenClaw changed-gate compiler cache is disposable and preserves existing 
       ].join("\n"),
     );
 
-    assert.deepEqual(
-      withPathOnlyPrefix(binDir, () =>
-        runAllowedValidationCommands(
-          ["pnpm check:changed"],
-          cwd,
-          validationOptions("openclaw/openclaw", {
-            pinnedBaseRef: "origin/main",
-            toolchain: {
-              packageManager: "pnpm",
-              baseValidationCommands: [],
-              changedGate: { command: "pnpm check:changed", requiredScript: "check:changed" },
-            },
-          }),
-        ),
-      ),
-      ["pnpm check:changed"],
-    );
+    assert.deepEqual(runOpenClawChangedGate(cwd, binDir), ["pnpm check:changed"]);
     assert.equal(
       fs.readFileSync(path.join(artifacts, "stable.txt"), "utf8"),
       "existing artifact\n",
@@ -5163,21 +5083,7 @@ test("OpenClaw changed-gate caches are disposable without exempting sibling runt
           : []),
       ].join("\n"),
     );
-    const execute = () =>
-      withPathOnlyPrefix(binDir, () =>
-        runAllowedValidationCommands(
-          ["pnpm check:changed"],
-          cwd,
-          validationOptions("openclaw/openclaw", {
-            pinnedBaseRef: "origin/main",
-            toolchain: {
-              packageManager: "pnpm",
-              baseValidationCommands: [],
-              changedGate: { command: "pnpm check:changed", requiredScript: "check:changed" },
-            },
-          }),
-        ),
-      );
+    const execute = () => runOpenClawChangedGate(cwd, binDir);
 
     if (poisonedPath) {
       assert.throws(execute, /unsafe validation command mutated checkout identity/);
@@ -5220,23 +5126,7 @@ test("OpenClaw validation disables shard timing writes without weakening ignored
       ].join("\n"),
     );
 
-    assert.deepEqual(
-      withPathOnlyPrefix(binDir, () =>
-        runAllowedValidationCommands(
-          ["pnpm check:changed"],
-          cwd,
-          validationOptions("openclaw/openclaw", {
-            pinnedBaseRef: "origin/main",
-            toolchain: {
-              packageManager: "pnpm",
-              baseValidationCommands: [],
-              changedGate: { command: "pnpm check:changed", requiredScript: "check:changed" },
-            },
-          }),
-        ),
-      ),
-      ["pnpm check:changed"],
-    );
+    assert.deepEqual(runOpenClawChangedGate(cwd, binDir), ["pnpm check:changed"]);
     assert.equal(
       fs.readFileSync(path.join(artifacts, "stable.txt"), "utf8"),
       "existing artifact\n",
@@ -5272,21 +5162,7 @@ test("changed-gate compiler cache isolation still rejects unrelated ignored-inpu
   );
 
   assert.throws(
-    () =>
-      withPathOnlyPrefix(binDir, () =>
-        runAllowedValidationCommands(
-          ["pnpm check:changed"],
-          cwd,
-          validationOptions("openclaw/openclaw", {
-            pinnedBaseRef: "origin/main",
-            toolchain: {
-              packageManager: "pnpm",
-              baseValidationCommands: [],
-              changedGate: { command: "pnpm check:changed", requiredScript: "check:changed" },
-            },
-          }),
-        ),
-      ),
+    () => runOpenClawChangedGate(cwd, binDir),
     /unsafe validation command mutated checkout identity \(pnpm check:changed\): runtimeInputsSha256; changed runtime roots: \.artifacts/,
   );
   assert.equal(fs.existsSync(path.join(artifacts, "tsgo-cache")), false);
@@ -5318,16 +5194,7 @@ test("runtime root diagnostics identify same-size poisoning even when its timest
   );
 
   assert.throws(
-    () =>
-      withPathOnlyPrefix(binDir, () =>
-        runAllowedValidationCommands(
-          ["pnpm verify"],
-          cwd,
-          validationOptions("steipete/example", {
-            toolchain: { packageManager: "pnpm", baseValidationCommands: [], changedGate: null },
-          }),
-        ),
-      ),
+    () => runStandardPnpmVerify(cwd, binDir),
     /runtimeInputsSha256; changed runtime roots: node_modules/,
   );
 });
@@ -5358,16 +5225,7 @@ test("runtime root diagnostics identify every independently mutated ignored root
   );
 
   assert.throws(
-    () =>
-      withPathOnlyPrefix(binDir, () =>
-        runAllowedValidationCommands(
-          ["pnpm verify"],
-          cwd,
-          validationOptions("steipete/example", {
-            toolchain: { packageManager: "pnpm", baseValidationCommands: [], changedGate: null },
-          }),
-        ),
-      ),
+    () => runStandardPnpmVerify(cwd, binDir),
     /runtimeInputsSha256; changed runtime roots: alpha, node_modules$/,
   );
 });
@@ -5402,16 +5260,7 @@ test(
     );
 
     assert.throws(
-      () =>
-        withPathOnlyPrefix(binDir, () =>
-          runAllowedValidationCommands(
-            ["pnpm verify"],
-            cwd,
-            validationOptions("steipete/example", {
-              toolchain: { packageManager: "pnpm", baseValidationCommands: [], changedGate: null },
-            }),
-          ),
-        ),
+      () => runStandardPnpmVerify(cwd, binDir),
       /runtimeInputsSha256; changed runtime roots: node_modules, runtime-input$/,
     );
   },
@@ -5446,16 +5295,7 @@ test(
     );
 
     assert.throws(
-      () =>
-        withPathOnlyPrefix(binDir, () =>
-          runAllowedValidationCommands(
-            ["pnpm verify"],
-            cwd,
-            validationOptions("steipete/example", {
-              toolchain: { packageManager: "pnpm", baseValidationCommands: [], changedGate: null },
-            }),
-          ),
-        ),
+      () => runStandardPnpmVerify(cwd, binDir),
       /runtimeInputsSha256; changed runtime roots: alpha, node_modules$/,
     );
   },
@@ -5485,16 +5325,7 @@ test(
     writeNodeCommandShim(binDir, "pnpm", 'require("node:fs").unlinkSync("alpha/shared.js");');
 
     assert.throws(
-      () =>
-        withPathOnlyPrefix(binDir, () =>
-          runAllowedValidationCommands(
-            ["pnpm verify"],
-            cwd,
-            validationOptions("steipete/example", {
-              toolchain: { packageManager: "pnpm", baseValidationCommands: [], changedGate: null },
-            }),
-          ),
-        ),
+      () => runStandardPnpmVerify(cwd, binDir),
       /runtimeInputsSha256; changed runtime roots: alpha$/,
     );
   },
@@ -5538,16 +5369,7 @@ test(
     writeNodeCommandShim(binDir, "pnpm", 'require("node:fs").unlinkSync("alpha/shared");');
 
     assert.throws(
-      () =>
-        withPathOnlyPrefix(binDir, () =>
-          runAllowedValidationCommands(
-            ["pnpm verify"],
-            cwd,
-            validationOptions("steipete/example", {
-              toolchain: { packageManager: "pnpm", baseValidationCommands: [], changedGate: null },
-            }),
-          ),
-        ),
+      () => runStandardPnpmVerify(cwd, binDir),
       /runtimeInputsSha256; changed runtime roots: alpha$/,
     );
   },
@@ -5735,16 +5557,7 @@ test("runtime root mutation diagnostics enforce their comparison deadline", () =
   };
   try {
     assert.throws(
-      () =>
-        withPathOnlyPrefix(binDir, () =>
-          runAllowedValidationCommands(
-            ["pnpm verify"],
-            cwd,
-            validationOptions("steipete/example", {
-              toolchain: { packageManager: "pnpm", baseValidationCommands: [], changedGate: null },
-            }),
-          ),
-        ),
+      () => runStandardPnpmVerify(cwd, binDir),
       (error: Error & { cause?: Error }) =>
         /unsafe validation command checkout identity could not be verified/.test(error.message) &&
         /validation identity deadline exhausted during runtime root comparison/.test(
@@ -5788,21 +5601,7 @@ test("runtime root diagnostics ignore safe cache-directory timestamp changes", (
   );
 
   assert.throws(
-    () =>
-      withPathOnlyPrefix(binDir, () =>
-        runAllowedValidationCommands(
-          ["pnpm check:changed"],
-          cwd,
-          validationOptions("openclaw/openclaw", {
-            pinnedBaseRef: "origin/main",
-            toolchain: {
-              packageManager: "pnpm",
-              baseValidationCommands: [],
-              changedGate: { command: "pnpm check:changed", requiredScript: "check:changed" },
-            },
-          }),
-        ),
-      ),
+    () => runOpenClawChangedGate(cwd, binDir),
     /runtimeInputsSha256; changed runtime roots: node_modules$/,
   );
   assert.equal(fs.readFileSync(path.join(artifacts, "stable.txt"), "utf8"), "trusted artifact\n");
@@ -5838,23 +5637,7 @@ test("changed-gate merge-base fallback also isolates its disposable compiler cac
     ].join("\n"),
   );
 
-  assert.deepEqual(
-    withPathOnlyPrefix(binDir, () =>
-      runAllowedValidationCommands(
-        ["pnpm check:changed"],
-        cwd,
-        validationOptions("openclaw/openclaw", {
-          pinnedBaseRef: "origin/main",
-          toolchain: {
-            packageManager: "pnpm",
-            baseValidationCommands: [],
-            changedGate: { command: "pnpm check:changed", requiredScript: "check:changed" },
-          },
-        }),
-      ),
-    ),
-    ["pnpm check:changed"],
-  );
+  assert.deepEqual(runOpenClawChangedGate(cwd, binDir), ["pnpm check:changed"]);
   assert.equal(fs.readFileSync(attemptPath, "utf8"), "2");
   assert.equal(fs.readFileSync(path.join(artifacts, "stable.txt"), "utf8"), "existing artifact\n");
   assert.equal(fs.existsSync(path.join(artifacts, "tsgo-cache")), false);
@@ -6324,10 +6107,7 @@ if (args[0] === "enable") {
     };
 
     assert.throws(
-      () =>
-        withCommandOverridesUnset(["corepack", "pnpm"], () =>
-          withPathOnlyPrefix(hostBin, () => prepareTargetToolchain(cwd, options)),
-        ),
+      () => withPreparedPnpmToolchain(cwd, hostBin, options, () => undefined),
       /prepared target pnpm symlink escapes runtime/,
     );
   },
@@ -6397,26 +6177,23 @@ if (args[0] === "enable") {
       setupTimeoutMs: FAKE_TOOLCHAIN_TIMEOUT_MS,
     };
 
-    withCommandOverridesUnset(["corepack", "pnpm"], () =>
-      withPathOnlyPrefix(hostBin, () => {
-        prepareTargetToolchain(cwd, options);
-        fs.writeFileSync(
-          corepackLib,
-          `require("node:fs").writeFileSync(${JSON.stringify(maliciousMarker)}, "ran");\n`,
-        );
-        fs.writeFileSync(
-          corepackPackageJson,
-          `${JSON.stringify({
-            name: "corepack",
-            version: "mutated-host-package",
-            exports: { "./package.json": "./package.json" },
-          })}\n`,
-        );
-        assert.deepEqual(runAllowedValidationCommands(["pnpm verify"], cwd, options), [
-          "pnpm verify",
-        ]);
-      }),
-    );
+    withPreparedPnpmToolchain(cwd, hostBin, options, () => {
+      fs.writeFileSync(
+        corepackLib,
+        `require("node:fs").writeFileSync(${JSON.stringify(maliciousMarker)}, "ran");\n`,
+      );
+      fs.writeFileSync(
+        corepackPackageJson,
+        `${JSON.stringify({
+          name: "corepack",
+          version: "mutated-host-package",
+          exports: { "./package.json": "./package.json" },
+        })}\n`,
+      );
+      assert.deepEqual(runAllowedValidationCommands(["pnpm verify"], cwd, options), [
+        "pnpm verify",
+      ]);
+    });
 
     assert.equal(fs.existsSync(maliciousMarker), false);
     assert.deepEqual(fs.readFileSync(logPath, "utf8").trim().split(/\r?\n/), [
@@ -9430,6 +9207,51 @@ function withVirtualDeadlineCommands(t, now, onCommand, callback) {
     clock.mock.restore();
     fs.rmSync(binDir, { recursive: true, force: true });
   }
+}
+
+function runOpenClawChangedGate(cwd: string, binDir: string): string[] {
+  return withPathOnlyPrefix(binDir, () =>
+    runAllowedValidationCommands(
+      ["pnpm check:changed"],
+      cwd,
+      validationOptions("openclaw/openclaw", {
+        pinnedBaseRef: "origin/main",
+        toolchain: {
+          packageManager: "pnpm",
+          baseValidationCommands: [],
+          changedGate: { command: "pnpm check:changed", requiredScript: "check:changed" },
+        },
+      }),
+    ),
+  );
+}
+
+function runStandardPnpmVerify(cwd: string, binDir: string): string[] {
+  return withPathOnlyPrefix(binDir, () =>
+    runAllowedValidationCommands(
+      ["pnpm verify"],
+      cwd,
+      validationOptions("steipete/example", {
+        toolchain: { packageManager: "pnpm", baseValidationCommands: [], changedGate: null },
+      }),
+    ),
+  );
+}
+
+function withPreparedPnpmToolchain<T>(
+  cwd: string,
+  hostBin: string,
+  options: Parameters<typeof prepareTargetToolchain>[1],
+  callback: () => T,
+  commands?: Parameters<typeof prepareTargetToolchain>[2],
+): T {
+  return withCommandOverridesUnset(["corepack", "pnpm"], () =>
+    withPathOnlyPrefix(hostBin, () => {
+      if (commands === undefined) prepareTargetToolchain(cwd, options);
+      else prepareTargetToolchain(cwd, options, commands);
+      return callback();
+    }),
+  );
 }
 
 function withPackageScriptPnpm(callback, { name = "check:changed", file = "check.js" } = {}) {


### PR DESCRIPTION
## What Problem This Solves

Resolves repeated target-validation test setup that made child-process fixtures
and environment isolation harder to audit and maintain consistently.

## Why This Change Was Made

Extracts three file-local typed helpers for the fixed OpenClaw changed gate, the
standard `pnpm verify` fixture, and prepared pnpm toolchain environment nesting.
Production code, validation policy, fixture inputs, assertions, expected
errors, and scenario names are unchanged.

## User Impact

No user-visible behavior changes. The target-validation suite is 178 lines
smaller, and repeated security-sensitive setup now has one auditable definition.

## OpenClaw Bay Impact

OpenClaw Bay is unaffected. This is a pure test refactor and does not change
lifecycle publication, queues, workflow state, telemetry, dashboard contracts,
or observer surfaces.

## Documentation Impact

No documentation changes are needed because production and contributor-facing
contracts are unchanged. No release note is required for this test-only
refactor.

## Evidence

- Diff: one test file, 98 insertions and 276 deletions, net -178 lines.
- Pre-edit baseline: 214 tests, 211 passed, 3 skipped, 0 failed.
- Static parity: 210 test declarations, 617 assertions in the same order with
  semantically identical expected arguments, and 383 fixture writes preserved.
- Exact-head reviews: uncommitted and committed Codex reviews found no
  actionable regression.
- Controlled AWS proof: base and candidate each produced 214 terminal records,
  211 passes, 3 skips, and 0 failures, cancellations, or todos. Their 216 stable
  records, including file and cumulative summaries, were byte-identical.
- Full validation: `pnpm run check` completed with 4,977 tests, 4,959 passed,
  18 skipped, 0 failed, and 0 cancelled.
- Both proof manifests verified, the exact-head checkout remained clean, and
  the proof process was inactive after artifact capture.

## Real Behavior Proof

**Claim:** The helper extraction preserves target-validation child-process
arguments, environment isolation and cleanup, fixture Git state, error
matching, and result ordering.

**Exercised surface:** The actual child CLI and toolchain fixture paths in
`test/repair/target-validation.test.ts`, including the fixed OpenClaw changed
gate, standard pnpm verification, and prepared pnpm toolchains.

**Scenario or fixture:** All 22 refactored scenarios and the complete 214-test
target-validation file, followed by the repository-wide check.

**Command and environment:** Repository-configured AWS Crabbox, direct managed
SSH transport, Node v24.18.1, pnpm v11.10.0, `CI=1`, image
`ami-0461d919be7deb53c`, lease `cbx_5d4e9a2c6ff4`, and no delegated run ID.
The proof ran frozen installs, `pnpm run build:node`, the focused Node test
process with raw and structured reporters, and `pnpm run check`.

**Observable result:** Base and candidate focused runs matched exactly at 214
tests / 211 pass / 3 skip, with strict 216-record semantic parity. Full
validation passed at 4,977 tests / 4,959 pass / 18 skip.

**Artifact or trace:** The sanitized proof archive has SHA-256
`927985f955526dcdf40db64a4c03aa11dce97e84077c9a0d90ef01e8a7fad326`.
Its outer and inner manifests both verify against the exact candidate
`ebafbf93bf0586f9b29a7b9d30644bdedb53b0d1` and tree
`a6b62c43a2a9fc343e3ddbece6da34be0874c6cf`.

**Limits:** This proves test behavior and fixture command/environment
equivalence; it does not change or separately requalify production repair
policy. Two preliminary proof attempts were inconclusive and are not counted as
passing evidence: the first used a timing-sensitive skip normalizer and its
exact differing remote record was unavailable, while the second placed
reporter flags after the positional test path and ran only the base process.
The corrected retry above is the qualifying proof.
