### PR TITLE
fix(repair): time out cluster selector OpenAI and gh api calls

### DIFF
--- a/docs/proof/cluster-selector-deadlines/README.md
+++ b/docs/proof/cluster-selector-deadlines/README.md
@@ -1,0 +1,28 @@
+# Cluster selector deadline proof
+
+Active executable proof owned by `src/repair/select-cluster-candidate.ts`.
+Run from the repository root after `pnpm run build:repair`:
+
+```sh
+node docs/proof/cluster-selector-deadlines/run-proof.mjs /opt/homebrew/bin/gh
+```
+
+Pass a different native gh path on another host. The compiled CLI runs against
+synthetic evidence in private temporary directories. Its existing fetch transport
+is redirected to a local HTTP peer while preserving the production request and
+AbortSignal. Separate requests stall before headers and during a partial JSON
+body, each using the actual two-minute budget. A default native gh evidence read
+stalls at a local CONNECT proxy and must stop at the configured 30-second floor.
+Failure must publish neither a selected-path file nor a selection report.
+
+Successful selected and rejected decisions also run through the compiled CLI and
+native fetch. The selected case must perform the final-open GitHub read before
+writing its normal durable output. These success cases use a synthetic gh adapter;
+the GitHub timeout case uses native gh. All authentication is synthetic. There are
+no live GitHub mutations or model calls.
+
+The command prints a redacted JSON trace and removes its private fixtures.
+Update the proof when selector I/O, its deadlines, or durable selection output
+changes. Verified with this repair on Node 24 and gh 2.100.0. This proves local
+transport behavior, not live model quality or GitHub availability. OpenClaw Bay
+is unaffected: no public observer or status schema changes.

--- a/docs/proof/cluster-selector-deadlines/run-proof.mjs
+++ b/docs/proof/cluster-selector-deadlines/run-proof.mjs
@@ -1,0 +1,207 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createServer as httpServer } from "node:http";
+import { createServer as tcpServer } from "node:net";
+import { spawn, execFileSync } from "node:child_process";
+import { once } from "node:events";
+
+const repoRoot = process.cwd();
+const cli = path.join(repoRoot, "dist/repair/select-cluster-candidate.js");
+const gh = process.argv[2] || "/opt/homebrew/bin/gh";
+const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-selector-proof-"));
+const sockets = new Set();
+const requests = [];
+let proxyRequests = 0;
+const candidate = "jobs/openclaw/inbox/gitcrawl-42-candidate.md";
+const model = httpServer((request, response) => {
+  const scenario = request.url.slice(1);
+  requests.push(scenario);
+  request.resume();
+  if (scenario === "headers") return;
+  response.writeHead(200, { "content-type": "application/json" });
+  if (scenario === "body") return response.write("{");
+  const selected = scenario === "selected";
+  response.end(
+    JSON.stringify({
+      output_text: JSON.stringify({
+        selected_path: selected ? candidate : null,
+        rationale: selected ? "Synthetic actionable defect." : "Synthetic rejection.",
+        assessments: [
+          {
+            path: candidate,
+            decision: selected ? "selected" : "rejected",
+            rationale: "Synthetic fixture evidence.",
+          },
+        ],
+      }),
+    }),
+  );
+});
+model.on("connection", (socket) => {
+  sockets.add(socket);
+  socket.on("close", () => sockets.delete(socket));
+});
+const proxy = tcpServer((socket) => {
+  sockets.add(socket);
+  socket.once("data", () => proxyRequests++);
+  socket.on("close", () => sockets.delete(socket));
+});
+model.listen(0, "127.0.0.1");
+proxy.listen(0, "127.0.0.1");
+await Promise.all([once(model, "listening"), once(proxy, "listening")]);
+const origin = `http://127.0.0.1:${model.address().port}/`;
+const proxyUrl = `http://127.0.0.1:${proxy.address().port}`;
+const preload = path.join(root, "transport.mjs");
+fs.writeFileSync(
+  preload,
+  `import assert from 'node:assert/strict';
+const nativeFetch=globalThis.fetch;
+globalThis.fetch=(url,init)=>{assert.equal(url,'https://api.openai.com/v1/responses');return nativeFetch(new URL(process.env.MODEL_SCENARIO,process.env.PROOF_ORIGIN),init);};`,
+);
+const fixtureGh = path.join(root, "gh.cjs");
+fs.writeFileSync(
+  fixtureGh,
+  `const fs=require('node:fs');const args=process.argv.slice(2);
+if(args[0]!=='api'||args[1]!=='repos/openclaw/clawsweeper/issues/100') process.exit(99);
+fs.appendFileSync(process.env.GH_TRACE,'read issue 100\\n');
+console.log(JSON.stringify({number:100,state:'open',title:'Synthetic defect',body:'Synthetic reproducible issue.',html_url:'https://github.com/openclaw/clawsweeper/issues/100',labels:[]}));`,
+);
+const ghConfig = path.join(root, "gh-config");
+fs.mkdirSync(ghConfig);
+fs.writeFileSync(path.join(ghConfig, "config.yml"), "telemetry: disabled\n");
+const isolatedGhEnv = {
+  PATH: process.env.PATH,
+  TMPDIR: process.env.TMPDIR,
+  SystemRoot: process.env.SystemRoot,
+  HOME: root,
+  GH_CONFIG_DIR: ghConfig,
+  XDG_STATE_HOME: path.join(root, "gh-state"),
+  GH_TOKEN: "synthetic-proof-token",
+  GH_NO_UPDATE_NOTIFIER: "1",
+  HTTP_PROXY: proxyUrl,
+  HTTPS_PROXY: proxyUrl,
+  ALL_PROXY: proxyUrl,
+  NO_PROXY: "",
+};
+const children = new Set();
+async function run(scenario) {
+  const dir = path.join(root, scenario);
+  fs.mkdirSync(path.join(dir, path.dirname(candidate)), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, candidate),
+    `---\nrepo: openclaw/clawsweeper\ncluster_id: gitcrawl-42-candidate\ncandidates: ["#100"]\ncluster_refs: ["#100"]\n---\nSynthetic fixture.\n`,
+  );
+  fs.writeFileSync(path.join(dir, "paths.txt"), candidate + "\n");
+  const env = {
+    ...isolatedGhEnv,
+    PATH: process.env.PATH,
+    TMPDIR: process.env.TMPDIR,
+    SystemRoot: process.env.SystemRoot,
+    GH_BIN: scenario === "github" ? gh : process.execPath,
+    GH_BIN_ARGS: scenario === "github" ? "[]" : JSON.stringify([fixtureGh]),
+    GH_TOKEN: "synthetic-proof-token",
+    OPENAI_API_KEY: "synthetic-proof-key",
+    GH_CONFIG_DIR: ghConfig,
+    XDG_STATE_HOME: path.join(dir, "state"),
+    GH_NO_UPDATE_NOTIFIER: "1",
+    GH_PROMPT_DISABLED: "1",
+    HTTP_PROXY: proxyUrl,
+    HTTPS_PROXY: proxyUrl,
+    ALL_PROXY: proxyUrl,
+    NO_PROXY: "",
+    CLAWSWEEPER_GH_COMMAND_TIMEOUT_MS: "30000",
+    GH_TRACE: path.join(dir, "gh-trace.txt"),
+    MODEL_SCENARIO: scenario,
+    PROOF_ORIGIN: origin,
+  };
+  const start = performance.now();
+  const child = spawn(
+    process.execPath,
+    [
+      "--import",
+      preload,
+      cli,
+      "--repo",
+      "openclaw/clawsweeper",
+      "--paths-file",
+      "paths.txt",
+      "--out",
+      "selected.txt",
+      "--report",
+      "report.json",
+      "--model",
+      "gpt-5.4",
+    ],
+    { cwd: dir, env, stdio: ["ignore", "pipe", "pipe"] },
+  );
+  children.add(child);
+  let stderr = "",
+    stdout = "";
+  child.stderr.on("data", (chunk) => (stderr += chunk));
+  child.stdout.on("data", (chunk) => (stdout += chunk));
+  const timer = setTimeout(() => child.kill("SIGKILL"), 145_000);
+  try {
+    const [code, signal] = await once(child, "close");
+    const elapsedMs = Math.round(performance.now() - start);
+    assert.equal(signal, null, `${scenario} watchdog fired`);
+    if (["headers", "body", "github"].includes(scenario)) {
+      assert.equal(code, 1, stderr);
+      assert.match(stderr, scenario === "github" ? /ETIMEDOUT/ : /timeout|abort/i);
+      const budget = scenario === "github" ? 30_000 : 120_000;
+      assert.ok(
+        elapsedMs >= budget - 1_000 && elapsedMs < budget + 15_000,
+        `${scenario} elapsed ${elapsedMs}`,
+      );
+      assert.equal(fs.existsSync(path.join(dir, "selected.txt")), false);
+      assert.equal(fs.existsSync(path.join(dir, "report.json")), false);
+      return {
+        scenario,
+        elapsedMs,
+        result: "failed closed",
+        error: scenario === "github" ? "ETIMEDOUT" : "fetch timeout/abort",
+        publishedSelection: false,
+      };
+    }
+    assert.equal(code, 0, stderr);
+    const selected = fs.readFileSync(path.join(dir, "selected.txt"), "utf8");
+    const report = JSON.parse(fs.readFileSync(path.join(dir, "report.json"), "utf8"));
+    assert.equal(selected, scenario === "selected" ? candidate + "\n" : "");
+    assert.equal(report.selected, scenario === "selected" ? 1 : 0);
+    assert.equal(report.assessments.length, 1);
+    const reads = fs.readFileSync(path.join(dir, "gh-trace.txt"), "utf8").trim().split("\n").length;
+    assert.equal(reads, scenario === "selected" ? 2 : 1);
+    assert.match(stdout, /cluster selector chose|cluster selector rejected/);
+    return { scenario, elapsedMs, selected: report.selected, githubReads: reads };
+  } finally {
+    clearTimeout(timer);
+    children.delete(child);
+  }
+}
+try {
+  const results = await Promise.all(["headers", "body", "github", "selected", "rejected"].map(run));
+  assert.ok(proxyRequests > 0);
+  assert.deepEqual([...requests].sort(), ["body", "headers", "rejected", "selected"]);
+  console.log(
+    JSON.stringify(
+      {
+        node: process.version,
+        ghVersion: execFileSync(gh, ["--version"], {
+          encoding: "utf8",
+          env: isolatedGhEnv,
+          cwd: root,
+        }).split("\n")[0],
+        results,
+      },
+      null,
+      2,
+    ),
+  );
+} finally {
+  for (const child of children) child.kill("SIGKILL");
+  for (const socket of sockets) socket.destroy();
+  model.close();
+  proxy.close();
+  fs.rmSync(root, { recursive: true, force: true });
+}

--- a/docs/repair/README.md
+++ b/docs/repair/README.md
@@ -431,6 +431,10 @@ The workflow needs:
   clones default to three minutes. Both honor the same environment overrides
   and report child-process timeout failures. A timed-out dispatch keeps its
   durable claim for observation/recovery rather than immediately dispatching again.
+  Cluster-selector evidence and final-open checks use these shared GitHub CLI
+  budgets. Its Responses API request has a two-minute deadline covering both
+  response headers and body delivery; a timeout fails selection without publishing
+  a selected candidate.
 - optional `CLAWSWEEPER_CODEX_REVIEW_ATTEMPTS` and `CLAWSWEEPER_RESOLVE_REVIEW_THREADS` variables for agentic merge-prep review loops; the review attempt default is `4`, with the last failed internal review converted into one final Codex review-fix pass when changed-surface validation can still prove the branch safe to push for exact-head review
 - optional `CLAWSWEEPER_MAX_REPAIRS_PER_PR` and
   `CLAWSWEEPER_MAX_REPAIRS_PER_HEAD` variables for trusted

--- a/src/repair/select-cluster-candidate.ts
+++ b/src/repair/select-cluster-candidate.ts
@@ -1,11 +1,14 @@
 #!/usr/bin/env node
 import fs from "node:fs";
 import path from "node:path";
-import { execFileSync } from "node:child_process";
 
 import type { JsonValue, LooseRecord } from "./json-types.js";
+import { ghJson } from "./github-cli.js";
 import { parseArgs, parseJob, repoRoot } from "./lib.js";
 import { internalCodexModel, PUBLIC_CODEX_MODEL } from "../codex-env.js";
+
+// Same class of model call as spam-scanner: bound a stalled Responses API hang.
+const OPENAI_CLUSTER_SELECTION_TIMEOUT_MS = 120_000;
 
 type LiveItem = {
   number: number;
@@ -258,6 +261,7 @@ export async function selectClusterCandidateWithModel(options: {
       authorization: `Bearer ${apiKey}`,
       "content-type": "application/json",
     },
+    signal: AbortSignal.timeout(OPENAI_CLUSTER_SELECTION_TIMEOUT_MS),
     body: JSON.stringify({
       model: internalCodexModel(options.model),
       reasoning: { effort: "high" },
@@ -301,9 +305,7 @@ function outputText(data: LooseRecord): string {
 }
 
 function githubJson(endpoint: string): any {
-  return JSON.parse(
-    execFileSync("gh", ["api", endpoint], { encoding: "utf8", maxBuffer: 8 * 1024 * 1024 }),
-  );
+  return ghJson(["api", endpoint]);
 }
 
 function refs(values: JsonValue): number[] {

--- a/test/repair/select-cluster-candidate.test.ts
+++ b/test/repair/select-cluster-candidate.test.ts
@@ -250,6 +250,51 @@ test("model request uses structured comparative selection without scores", async
   }
 });
 
+test("model request passes a 120s AbortSignal to the OpenAI cluster-selection fetch", async (t) => {
+  const previousKey = process.env.OPENAI_API_KEY;
+  process.env.OPENAI_API_KEY = "test-key";
+  const previousTimeout = AbortSignal.timeout;
+  const seenTimeouts: number[] = [];
+  t.mock.method(AbortSignal, "timeout", (ms: number) => {
+    seenTimeouts.push(ms);
+    return previousTimeout(ms);
+  });
+  const candidate = {
+    path: "jobs/openclaw/inbox/gitcrawl-1-a.md",
+    cluster_id: "gitcrawl-1-a",
+    members: [],
+  };
+  let requestSignal: AbortSignal | undefined;
+  try {
+    await selectClusterCandidateWithModel({
+      repo: "openclaw/openclaw",
+      evidence: [candidate],
+      model: "internal",
+      request: async (_input, init) => {
+        requestSignal = init?.signal ?? undefined;
+        return new Response(
+          JSON.stringify({
+            output_text: JSON.stringify({
+              selected_path: null,
+              rationale: "The evidence does not establish useful work.",
+              assessments: [
+                { path: candidate.path, decision: "rejected", rationale: "Not actionable." },
+              ],
+            }),
+          }),
+          { status: 200 },
+        );
+      },
+    });
+    assert.ok(requestSignal instanceof AbortSignal);
+    assert.equal(requestSignal.aborted, false);
+    assert.deepEqual(seenTimeouts, [120_000]);
+  } finally {
+    if (previousKey === undefined) delete process.env.OPENAI_API_KEY;
+    else process.env.OPENAI_API_KEY = previousKey;
+  }
+});
+
 test("cluster selection source contains no semantic word lists, thresholds, or scoring", () => {
   const sources = [
     fs.readFileSync("src/repair/select-cluster-candidate.ts", "utf8"),
@@ -258,4 +303,12 @@ test("cluster selection source contains no semantic word lists, thresholds, or s
   assert.doesNotMatch(sources, /STOP_WORDS|BUG_WORDS|FEATURE_WORDS|DECISION_WORDS/);
   assert.doesNotMatch(sources, /DECISION_LABELS|FEATURE_LABELS|BUG_LABELS/);
   assert.doesNotMatch(sources, /selection score|title cohesion|closedPercent|maxAgeDays/);
+});
+
+test("cluster selection source times out OpenAI fetch and default GitHub reads", () => {
+  const src = fs.readFileSync("src/repair/select-cluster-candidate.ts", "utf8");
+  assert.match(src, /AbortSignal\.timeout\(/);
+  assert.match(src, /from "\.\/github-cli\.js"/);
+  assert.match(src, /ghJson\(/);
+  assert.doesNotMatch(src, /execFileSync\(\s*["']gh["']/);
 });

--- a/test/repair/select-cluster-candidate.test.ts
+++ b/test/repair/select-cluster-candidate.test.ts
@@ -1,4 +1,8 @@
 import assert from "node:assert/strict";
+import childProcess from "node:child_process";
+import { createServer } from "node:http";
+import { once } from "node:events";
+import { syncBuiltinESMExports } from "node:module";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -250,50 +254,50 @@ test("model request uses structured comparative selection without scores", async
   }
 });
 
-test("model request passes a 120s AbortSignal to the OpenAI cluster-selection fetch", async (t) => {
-  const previousKey = process.env.OPENAI_API_KEY;
-  process.env.OPENAI_API_KEY = "test-key";
-  const previousTimeout = AbortSignal.timeout;
-  const seenTimeouts: number[] = [];
-  t.mock.method(AbortSignal, "timeout", (ms: number) => {
-    seenTimeouts.push(ms);
-    return previousTimeout(ms);
-  });
-  const candidate = {
-    path: "jobs/openclaw/inbox/gitcrawl-1-a.md",
-    cluster_id: "gitcrawl-1-a",
-    members: [],
-  };
-  let requestSignal: AbortSignal | undefined;
-  try {
-    await selectClusterCandidateWithModel({
-      repo: "openclaw/openclaw",
-      evidence: [candidate],
-      model: "internal",
-      request: async (_input, init) => {
-        requestSignal = init?.signal ?? undefined;
-        return new Response(
-          JSON.stringify({
-            output_text: JSON.stringify({
-              selected_path: null,
-              rationale: "The evidence does not establish useful work.",
-              assessments: [
-                { path: candidate.path, decision: "rejected", rationale: "Not actionable." },
-              ],
-            }),
-          }),
-          { status: 200 },
-        );
-      },
+for (const stage of ["headers", "body"])
+  test(`model deadline aborts native fetch stalled at ${stage}`, async (t) => {
+    const previousKey = process.env.OPENAI_API_KEY;
+    process.env.OPENAI_API_KEY = "synthetic-selector-key";
+    const nativeTimeout = AbortSignal.timeout;
+    t.mock.method(AbortSignal, "timeout", (ms: number) => {
+      assert.equal(ms, 120_000);
+      return nativeTimeout(100);
     });
-    assert.ok(requestSignal instanceof AbortSignal);
-    assert.equal(requestSignal.aborted, false);
-    assert.deepEqual(seenTimeouts, [120_000]);
-  } finally {
-    if (previousKey === undefined) delete process.env.OPENAI_API_KEY;
-    else process.env.OPENAI_API_KEY = previousKey;
-  }
-});
+    let received = false;
+    const server = createServer((request, response) => {
+      received = true;
+      request.resume();
+      if (stage === "body") {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.write("{");
+      }
+    });
+    t.after(() => {
+      if (previousKey === undefined) delete process.env.OPENAI_API_KEY;
+      else process.env.OPENAI_API_KEY = previousKey;
+      server.closeAllConnections();
+      server.close();
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    assert(address && typeof address !== "string");
+    const candidate = {
+      path: "jobs/openclaw/inbox/gitcrawl-1-a.md",
+      cluster_id: "gitcrawl-1-a",
+      members: [],
+    };
+    await assert.rejects(
+      selectClusterCandidateWithModel({
+        repo: "openclaw/openclaw",
+        evidence: [candidate],
+        model: "gpt-5.4",
+        request: (_url, init) => fetch(`http://127.0.0.1:${address.port}`, init),
+      }),
+      /timeout|abort/i,
+    );
+    assert.equal(received, true);
+  });
 
 test("cluster selection source contains no semantic word lists, thresholds, or scoring", () => {
   const sources = [
@@ -305,10 +309,71 @@ test("cluster selection source contains no semantic word lists, thresholds, or s
   assert.doesNotMatch(sources, /selection score|title cohesion|closedPercent|maxAgeDays/);
 });
 
-test("cluster selection source times out OpenAI fetch and default GitHub reads", () => {
-  const src = fs.readFileSync("src/repair/select-cluster-candidate.ts", "utf8");
-  assert.match(src, /AbortSignal\.timeout\(/);
-  assert.match(src, /from "\.\/github-cli\.js"/);
-  assert.match(src, /ghJson\(/);
-  assert.doesNotMatch(src, /execFileSync\(\s*["']gh["']/);
+test("default selector issue, pull and final-open reads honor the shared gh deadline", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-selector-gh-"));
+  const relative = job(root, 42, [100]);
+  const script = path.join(root, "gh.cjs");
+  fs.writeFileSync(
+    script,
+    `if (process.env.SELECTOR_TEST_STALL) setInterval(()=>{},1000);
+else console.log(JSON.stringify(process.argv.at(-1).includes('/pulls/') ? {draft:false} : {number:100,state:'open',title:'synthetic report',pull_request:{}}));`,
+  );
+  const previous = { ...process.env };
+  const cwd = process.cwd();
+  Object.assign(process.env, {
+    GH_BIN: process.execPath,
+    GH_BIN_ARGS: JSON.stringify([script]),
+    CLAWSWEEPER_GH_COMMAND_TIMEOUT_MS: "90000",
+  });
+  delete process.env.SELECTOR_TEST_STALL;
+  process.chdir(root);
+  const nativeExec = childProcess.execFileSync;
+  const calls: string[] = [];
+  t.mock.method(childProcess, "execFileSync", (file, args, options) => {
+    assert.equal(options.timeout, 90_000);
+    calls.push(args.at(-1));
+    return nativeExec(file, args, { ...options, timeout: 250 });
+  });
+  syncBuiltinESMExports();
+  t.after(() => {
+    process.chdir(cwd);
+    for (const key of [
+      "GH_BIN",
+      "GH_BIN_ARGS",
+      "CLAWSWEEPER_GH_COMMAND_TIMEOUT_MS",
+      "SELECTOR_TEST_STALL",
+    ]) {
+      if (previous[key] === undefined) delete process.env[key];
+      else process.env[key] = previous[key];
+    }
+    t.mock.restoreAll();
+    syncBuiltinESMExports();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+  const evidence = collectClusterSelectionEvidence({
+    repo: "openclaw/openclaw",
+    paths: [relative],
+  });
+  assert.equal(evidence[0].members[0].pull_request?.draft, false);
+  assertSelectedCandidateStillOpen({ path: relative });
+  assert.deepEqual(calls, [
+    "repos/openclaw/openclaw/issues/100",
+    "repos/openclaw/openclaw/pulls/100",
+    "repos/openclaw/openclaw/issues/100",
+  ]);
+  process.env.SELECTOR_TEST_STALL = "1";
+  assert.throws(
+    () => collectClusterSelectionEvidence({ repo: "openclaw/openclaw", paths: [relative] }),
+    { code: "ETIMEDOUT" },
+  );
+  assert.throws(
+    () =>
+      collectClusterSelectionEvidence({
+        repo: "openclaw/openclaw",
+        paths: [relative],
+        readItem: () => ({ number: 100, state: "open", title: "report", pull_request: {} }),
+      }),
+    { code: "ETIMEDOUT" },
+  );
+  assert.throws(() => assertSelectedCandidateStillOpen({ path: relative }), { code: "ETIMEDOUT" });
 });


### PR DESCRIPTION
## What Problem This Solves

A stalled Responses API request or default GitHub evidence read could leave a cluster selector blocked indefinitely, delaying repair intake.

## Why This Change Was Made

Keep @SebTardif's focused fix: attach a native two-minute AbortSignal to the model request and use the shared `ghJson` owner for GitHub reads. The same model deadline covers response headers and body consumption. Default issue, pull-request and final-open reads inherit the existing GitHub/network timeout policy.

Replace signal-presence/source-pattern assertions with behavioral regressions. Document the failure behavior and add a compiled CLI proof with stalled native transports. No retry policy, model-selection policy or output schema changes.

## User Impact

Stalled model or GitHub calls fail selection with an error instead of holding the worker indefinitely. Successful selected and rejected decisions preserve their existing outputs and final-open check. Contributor credit is retained; the changelog line is in the final batch notes PR.

## Evidence

- `pnpm run build:repair` passed.
- `node --test test/repair/select-cluster-candidate.test.ts test/repair/github-cli.test.ts`: 17 passed.
- Native-fetch regression tests abort before headers and during a partial JSON body. Native child-process tests cover deadlines on default issue, pull and final-open reads.
- Static checks and lint passed.
- Rebased head: `ab3e4f47cf28ec39d91e5f3ef243309d9abe99d3`, on current main after PRs 1483, 1382 and 1499. All 17 focused tests pass, and local Codex autoreview is clean through P2. Current-head CI is available in this PR’s Checks; the prior head’s CI is not used to approve the rebased head.

## Real Behavior Proof

**Claim and surface:** the compiled selector CLI fails closed on stalled model and default GitHub transports, and preserves successful selection/rejection output.

**Scenario and environment:** Node 24 on macOS, native fetch redirected at the existing transport boundary to a local HTTP peer, and native gh routed through a local stalled CONNECT proxy. Private temporary jobs and all authentication are synthetic. No production key, live model call or GitHub mutation is used.

**Command:**

```sh
pnpm run build:repair
node docs/proof/cluster-selector-deadlines/run-proof.mjs /opt/homebrew/bin/gh
```

**Observed result:** model requests stalled before headers and during partial-body delivery failed after 120.092 and 120.089 seconds respectively at the actual two-minute budget. The native gh evidence read stopped after 30.056 seconds at the configured 30-second floor. Each failed CLI process returned nonzero and wrote neither a selected-path file nor a selection report in its fresh fixture directory. Selected and rejected success cases wrote the expected durable output; the selected case made its second GitHub read to recheck that the candidate was still open.

**Artifact:** `docs/proof/cluster-selector-deadlines/run-proof.mjs` and its README. The command emits a redacted JSON trace, with measured timings in the proof comment.

**Limits:** the model transport is local HTTP and successful evidence reads use a synthetic gh adapter; the stalled GitHub case uses native gh. This proves transport completion and fail-closed output behavior, not live model quality or GitHub availability. It does not claim to clear output files from previous runs.

## Finding Disposition

The previous proof observed only an un-aborted signal. The replacement executes the compiled CLI to actual native-fetch timeout completion, native gh termination and successful durable output. Fast tests exercise the same failure paths with shortened test clocks. No accepted finding is deferred to the contributor.

## OpenClaw Bay Impact

None. This bounds internal selector I/O without changing public status, telemetry or observer schemas.

## Rebase integration

Retained main’s exported shared GitHub timeout policy and the two-minute dispatch/three-minute clone defaults from https://github.com/openclaw/clawsweeper/pull/1483. The prior maintainer repair lived in a merge commit; its behavioral tests, proof driver and selector documentation are preserved in the rebased linear branch. The selector still uses the shared ghJson owner. Every native gh proof call, including version inspection, now uses disposable configuration/state with telemetry disabled.

The stalled-transport proof above was rerun on the rebased tree. https://github.com/openclaw/clawsweeper/pull/1501 still applies cleanly and lists exactly 1483, 1446, 1382 and 1499. No notes change or merge was performed.
