### PR TITLE
fix(repair): accept compressed and empty cluster snapshots

### DIFF
--- a/.github/workflows/repair-cluster-intake.yml
+++ b/.github/workflows/repair-cluster-intake.yml
@@ -217,17 +217,11 @@ jobs:
           db_name="${TARGET_REPO,,}"
           db_name="${db_name//\//__}.sync.db"
           manifest_path="gitcrawl-store/data/${db_name}.manifest.json"
-          db_path="gitcrawl-store/data/${db_name}"
           ledger_path="results/cluster-repair-intake/${repo_slug}.json"
           if [ ! -f "$manifest_path" ]; then
             echo "::error::Missing gitcrawl-store manifest: ${manifest_path}"
             exit 1
           fi
-          if [ ! -f "$db_path" ]; then
-            echo "::error::Missing gitcrawl-store DB: ${db_path}"
-            exit 1
-          fi
-
           store_sha="$(node -e "const fs=require('fs'); const m=JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); console.log(m.sha256 || '')" "$manifest_path")"
           exported_at="$(node -e "const fs=require('fs'); const m=JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); console.log(m.exportedAt || '')" "$manifest_path")"
           previous_sha=""
@@ -238,7 +232,6 @@ jobs:
           {
             echo "target_repo=${TARGET_REPO}"
             echo "repo_slug=${repo_slug}"
-            echo "db_path=${db_path}"
             echo "manifest_path=${manifest_path}"
             echo "ledger_path=${ledger_path}"
             echo "store_sha=${store_sha}"
@@ -250,7 +243,15 @@ jobs:
             echo "Already processed gitcrawl-store SHA ${store_sha}; skipping intake."
             exit 0
           fi
-          echo "should_import=true" >> "$GITHUB_OUTPUT"
+          db_path="$(mktemp -d "${RUNNER_TEMP}/cluster-repair-intake.XXXXXX")/${db_name}"
+          (
+            cd gitcrawl-store
+            node scripts/portable-artifact.mjs "data/${db_name}" "$db_path"
+          )
+          {
+            echo "db_path=${db_path}"
+            echo "should_import=true"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Prepare unprocessed cluster candidates
         if: ${{ steps.prepare.outputs.should_import == 'true' }}

--- a/.github/workflows/repair-cluster-intake.yml
+++ b/.github/workflows/repair-cluster-intake.yml
@@ -243,10 +243,18 @@ jobs:
             echo "Already processed gitcrawl-store SHA ${store_sha}; skipping intake."
             exit 0
           fi
-          db_path="$(mktemp -d "${RUNNER_TEMP}/cluster-repair-intake.XXXXXX")/${db_name}"
+          intake_dir="$(mktemp -d "${RUNNER_TEMP}/cluster-repair-intake.XXXXXX")"
+          db_path="${intake_dir}/${db_name}"
+          materializer="${intake_dir}/portable-artifact.mjs"
+          # Snapshot publishing must not authorize new code on the runner.
+          install -m 600 gitcrawl-store/scripts/portable-artifact.mjs "$materializer"
+          if ! printf '%s  %s\n' 'd3e7678faa48554e091ea51666692643e97cfab437bb23c44f59c139b7e0ebfa' "$materializer" | sha256sum --check --status; then
+            echo "::error::gitcrawl-store materializer does not match the reviewed digest" >&2
+            exit 1
+          fi
           (
             cd gitcrawl-store
-            node scripts/portable-artifact.mjs "data/${db_name}" "$db_path"
+            node "$materializer" "data/${db_name}" "$db_path"
           )
           {
             echo "db_path=${db_path}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Accept compressed Gitcrawl store snapshots in cluster intake and treat empty portable cluster tables as a successful empty import.
+
 - Bound GitHub activity hook prompts to one received event and filtered trusted self-authored review chatter before model intake.
 - Replay durable scheduled enqueue dispositions after transient response loss while preserving signed delivery identity, rejecting mismatched bytes, failing closed on legacy ambiguous receipts, and leaving publication post-effects single-attempt.
 - Use the producer Actions run URL in failed-review retry receipts so ledger validation no longer prevents dispatch and fails the retry command.

--- a/docs/proof/cluster-intake-portable/README.md
+++ b/docs/proof/cluster-intake-portable/README.md
@@ -8,10 +8,13 @@ fail before the workflow admits an import.
 `run-proof.mjs` executes the actual `Prepare intake` shell from the workflow,
 then the built importer against synthetic SQLite files. Empty cases also run
 the real selector without credentials and assert that no candidate is selected.
-The upstream store owns decompression and archive verification; provide its
+The upstream store owns decompression and archive verification; intake copies its
+materializer into a private temporary directory and checks a reviewed SHA-256
+before execution. A changed publisher-supplied helper fails before import.
+Provide the store's
 `scripts/portable-artifact.mjs` to the proof rather than substituting a decoder.
 
-Run on Node 24+ with Bash 4+, gzip, and dependencies installed, using the
+Run on Node 24+ with Bash 4+, gzip, GNU coreutils, and dependencies installed, using the
 repository's resolved Crabbox provider:
 
 ```sh
@@ -26,7 +29,7 @@ state, workflow and importer hashes, materializer hash, runtime, and each
 scenario's observable outcome. The baseline rejects gzip-only input and fails
 on empty portable tables; the candidate accepts both, preserves raw input and
 forced reimports, skips processed snapshots before decompression, and rejects
-archive/decoded hash mismatches.
+unreviewed materializer code and archive/decoded hash mismatches.
 
 This is controlled runtime proof, not a production intake or inference call.
 It does not restore clusters omitted by an upstream export, verify raw database

--- a/docs/proof/cluster-intake-portable/README.md
+++ b/docs/proof/cluster-intake-portable/README.md
@@ -1,0 +1,34 @@
+# Portable cluster intake proof
+
+The claim is that cluster intake accepts the store's raw and gzip snapshot
+formats, treats empty portable cluster tables as an empty result, and preserves
+processed-snapshot deduplication. Invalid gzip archive or decoded hashes must
+fail before the workflow admits an import.
+
+`run-proof.mjs` executes the actual `Prepare intake` shell from the workflow,
+then the built importer against synthetic SQLite files. Empty cases also run
+the real selector without credentials and assert that no candidate is selected.
+The upstream store owns decompression and archive verification; provide its
+`scripts/portable-artifact.mjs` to the proof rather than substituting a decoder.
+
+Run on Node 24+ with Bash 4+, gzip, and dependencies installed, using the
+repository's resolved Crabbox provider:
+
+```sh
+pnpm run build:node
+node docs/proof/cluster-intake-portable/run-proof.mjs /tmp/portable-artifact.mjs .artifacts/cluster-intake-portable/candidate.json
+node docs/proof/cluster-intake-portable/run-proof.mjs /tmp/portable-artifact.mjs .artifacts/cluster-intake-portable/baseline.json a9ed9b5ba7eb12357da7cc2360d87cc5397c3c36
+```
+
+The baseline runs its original workflow and TypeScript importer alongside
+current compiled dependencies. Receipts include the source revision, dirty
+state, workflow and importer hashes, materializer hash, runtime, and each
+scenario's observable outcome. The baseline rejects gzip-only input and fails
+on empty portable tables; the candidate accepts both, preserves raw input and
+forced reimports, skips processed snapshots before decompression, and rejects
+archive/decoded hash mismatches.
+
+This is controlled runtime proof, not a production intake or inference call.
+It does not restore clusters omitted by an upstream export, verify raw database
+hashes beyond the store helper's contract, or exercise live GitHub publication.
+OpenClaw Bay is unaffected: its public status and data contracts do not change.

--- a/docs/proof/cluster-intake-portable/run-proof.mjs
+++ b/docs/proof/cluster-intake-portable/run-proof.mjs
@@ -1,0 +1,254 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { gzipSync } from "node:zlib";
+import { parse } from "yaml";
+
+const [materializerPath, outputPath, baselineRef] = process.argv.slice(2);
+assert.ok(
+  materializerPath && outputPath,
+  "usage: run-proof.mjs <materializer> <output> [baseline-ref]",
+);
+const root = process.cwd();
+const materializer = fs.readFileSync(materializerPath);
+const workflowPath = ".github/workflows/repair-cluster-intake.yml";
+const source = baselineRef
+  ? execFileSync("git", ["show", `${baselineRef}:${workflowPath}`], { encoding: "utf8" })
+  : fs.readFileSync(workflowPath, "utf8");
+const prepare = parse(source).jobs.intake.steps.find((step) => step.name === "Prepare intake").run;
+const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "cluster-intake-proof-"));
+const importer = path.join(
+  root,
+  "dist/repair",
+  baselineRef ? `intake-proof-${randomUUID()}.ts` : "import-gitcrawl-clusters.js",
+);
+const results = [];
+
+try {
+  if (baselineRef) {
+    fs.writeFileSync(
+      importer,
+      execFileSync("git", ["show", `${baselineRef}:src/repair/import-gitcrawl-clusters.ts`]),
+      { flag: "wx" },
+    );
+  }
+  scenario("raw", { compression: false });
+  scenario("compressed", { compression: true });
+  scenario("empty-portable", { compression: false, empty: true });
+  if (!baselineRef) {
+    scenario("empty-compressed", { compression: true, empty: true });
+    scenario("archive-hash-mismatch", { compression: true, corruptArchiveHash: true });
+    scenario("decoded-hash-mismatch", { compression: true, corruptDecodedHash: true });
+    scenario("already-processed", { compression: true, processed: true, corruptArchiveHash: true });
+    scenario("forced-reimport", { compression: true, processed: true, force: true });
+  }
+  const receipt = {
+    source: baselineRef ?? execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim(),
+    variant: baselineRef ? "baseline" : "candidate",
+    runtime: process.version,
+    working_tree_dirty: Boolean(
+      execFileSync("git", ["status", "--porcelain"], { encoding: "utf8" }).trim(),
+    ),
+    importer_sha256: sha256(fs.readFileSync(importer)),
+    importer_source_sha256: sha256(
+      baselineRef
+        ? execFileSync("git", ["show", `${baselineRef}:src/repair/import-gitcrawl-clusters.ts`])
+        : fs.readFileSync("src/repair/import-gitcrawl-clusters.ts"),
+    ),
+    materializer_sha256: sha256(materializer),
+    workflow_sha256: sha256(Buffer.from(source)),
+    results,
+    limits:
+      "Synthetic SQLite snapshots; actual preparation, importer and empty selector. Baseline entrypoint shares current compiled dependencies. No inference, GitHub mutation, or production state. Empty upstream cluster exports remain empty.",
+  };
+  fs.mkdirSync(path.dirname(path.resolve(outputPath)), { recursive: true });
+  fs.writeFileSync(outputPath, `${JSON.stringify(receipt, null, 2)}\n`);
+  console.log(JSON.stringify(receipt));
+} finally {
+  fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  if (baselineRef) fs.rmSync(importer, { force: true });
+}
+
+function scenario(name, options) {
+  const cwd = path.join(fixtureRoot, name);
+  const dataDir = path.join(cwd, "gitcrawl-store/data");
+  const scriptsDir = path.join(cwd, "gitcrawl-store/scripts");
+  const runnerTemp = path.join(cwd, "tmp");
+  for (const dir of [dataDir, scriptsDir, runnerTemp]) fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(scriptsDir, "portable-artifact.mjs"), materializer);
+  const dbName = "openclaw__fixture.sync.db";
+  const dbPath = path.join(dataDir, dbName);
+  const database = new DatabaseSync(dbPath);
+  database.exec(`
+    create table threads (id integer primary key, number integer, kind text, state text,
+      title text, body_excerpt text, labels_json text, updated_at text);
+    create table cluster_groups (id integer primary key, created_at text, closed_at text,
+      status text, representative_thread_id integer);
+    create table cluster_memberships (cluster_id integer, thread_id integer, state text);
+  `);
+  if (!options.empty)
+    database.exec(`
+    insert into threads values (1, 70001, 'issue', 'open', 'Synthetic intake fixture',
+      'Synthetic input only', '["bug"]', '2026-09-01T00:00:00Z');
+    insert into cluster_groups values (7, '2026-09-01T00:00:00Z', null, 'active', 1);
+    insert into cluster_memberships values (7, 1, 'active');
+  `);
+  database.close();
+  const bytes = fs.readFileSync(dbPath);
+  const manifest = {
+    sha256: sha256(bytes),
+    outputBytes: bytes.length,
+    exportedAt: "2026-09-01T00:00:00Z",
+  };
+  if (options.compression) {
+    const archive = gzipSync(bytes);
+    Object.assign(manifest, {
+      compression: "gzip",
+      archivePath: `${dbName}.gz`,
+      archiveBytes: archive.length,
+      archiveSha256: options.corruptArchiveHash ? "0".repeat(64) : sha256(archive),
+      maxArchiveBytes: 100000000,
+    });
+    fs.writeFileSync(`${dbPath}.gz`, archive);
+    fs.rmSync(dbPath);
+  }
+  if (options.corruptDecodedHash) manifest.sha256 = "0".repeat(64);
+  fs.writeFileSync(`${dbPath}.manifest.json`, JSON.stringify(manifest));
+  if (options.processed) {
+    const ledger = path.join(cwd, "results/cluster-repair-intake/openclaw-fixture.json");
+    fs.mkdirSync(path.dirname(ledger), { recursive: true });
+    fs.writeFileSync(ledger, JSON.stringify({ last_processed_store_sha256: manifest.sha256 }));
+  }
+  const githubOutput = path.join(cwd, "outputs");
+  const prepared = spawnSync("bash", ["-c", prepare], {
+    cwd,
+    encoding: "utf8",
+    timeout: 30000,
+    env: {
+      PATH: process.env.PATH,
+      ENABLED: "1",
+      SCHEDULE_ENABLED: "0",
+      TARGET_REPO: "openclaw/fixture",
+      FORCE_STORE: options.force ? "1" : "0",
+      GITHUB_EVENT_NAME: "workflow_dispatch",
+      GITHUB_OUTPUT: githubOutput,
+      RUNNER_TEMP: runnerTemp,
+    },
+  });
+  const outputs = fs.existsSync(githubOutput)
+    ? Object.fromEntries(
+        fs
+          .readFileSync(githubOutput, "utf8")
+          .trim()
+          .split("\n")
+          .filter(Boolean)
+          .map((line) => {
+            const split = line.indexOf("=");
+            return [line.slice(0, split), line.slice(split + 1)];
+          }),
+      )
+    : {};
+  const rejected = baselineRef
+    ? options.compression
+    : !options.processed && (options.corruptArchiveHash || options.corruptDecodedHash);
+  if (rejected) {
+    assert.notEqual(prepared.status, 0, name);
+    assert.notEqual(outputs.should_import, "true", name);
+    assert.equal(outputs.db_path, undefined, name);
+    assert.match(
+      prepared.stderr + prepared.stdout,
+      baselineRef ? /Missing gitcrawl-store DB/ : /manifest (?:archiveSha256|sha256) mismatch/,
+    );
+    results.push({ name, admission: "rejected", jobs: 0 });
+    return;
+  }
+  assert.equal(prepared.status, 0, `${name}: ${prepared.stderr}`);
+  if (options.processed && !options.force) {
+    assert.equal(outputs.should_import, "false");
+    assert.equal(fs.readdirSync(runnerTemp).length, 0, "skip must precede materialization");
+    results.push({ name, admission: "skipped", jobs: 0 });
+    return;
+  }
+  assert.equal(outputs.should_import, "true");
+  assert.equal(outputs.store_sha, manifest.sha256);
+  assert.equal(outputs.manifest_path, `gitcrawl-store/data/${dbName}.manifest.json`);
+  const materialized = path.resolve(cwd, outputs.db_path);
+  assert.equal(sha256(fs.readFileSync(materialized)), sha256(bytes));
+  const outDir = path.join(cwd, "jobs");
+  const imported = spawnSync(
+    process.execPath,
+    [
+      importer,
+      "--from-gitcrawl",
+      "--allow-empty",
+      "--repo",
+      "openclaw/fixture",
+      "--db",
+      materialized,
+      "--out",
+      outDir,
+      "--skip-existing",
+      "false",
+    ],
+    {
+      cwd,
+      encoding: "utf8",
+      timeout: 30000,
+      env: { PATH: process.env.PATH, NODE_NO_WARNINGS: "1" },
+    },
+  );
+  if (baselineRef && options.empty) {
+    assert.notEqual(imported.status, 0);
+    assert.match(imported.stderr, /no such table: clusters/);
+    results.push({ name, admission: "accepted", import: "legacy-table-error", jobs: 0 });
+    return;
+  }
+  assert.equal(imported.status, 0, `${name}: ${imported.stderr}`);
+  const jobs = fs.existsSync(outDir) ? fs.readdirSync(outDir).length : 0;
+  assert.equal(jobs, options.empty ? 0 : 1, name);
+  if (options.empty) {
+    const pathsFile = path.join(cwd, "generated-paths.txt");
+    const selectedFile = path.join(cwd, "selected.txt");
+    const reportFile = path.join(cwd, "selection.json");
+    fs.writeFileSync(pathsFile, "\n");
+    const selected = spawnSync(
+      process.execPath,
+      [
+        path.join(root, "dist/repair/select-cluster-candidate.js"),
+        "--repo",
+        "openclaw/fixture",
+        "--paths-file",
+        pathsFile,
+        "--out",
+        selectedFile,
+        "--report",
+        reportFile,
+      ],
+      {
+        cwd,
+        encoding: "utf8",
+        timeout: 30000,
+        env: { PATH: process.env.PATH, NODE_NO_WARNINGS: "1" },
+      },
+    );
+    assert.equal(selected.status, 0, selected.stderr);
+    assert.equal(fs.readFileSync(selectedFile, "utf8"), "");
+    const report = JSON.parse(fs.readFileSync(reportFile, "utf8"));
+    assert.equal(report.selected, 0);
+    assert.equal(report.evaluated, 0);
+    assert.equal(report.decision, null);
+  } else {
+    const job = fs.readFileSync(path.join(outDir, fs.readdirSync(outDir)[0]), "utf8");
+    assert.match(job, /repo: openclaw\/fixture/);
+    assert.match(job, /#70001/);
+  }
+  results.push({ name, admission: "accepted", import: "success", jobs });
+}
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}

--- a/docs/proof/cluster-intake-portable/run-proof.mjs
+++ b/docs/proof/cluster-intake-portable/run-proof.mjs
@@ -41,6 +41,7 @@ try {
   scenario("empty-portable", { compression: false, empty: true });
   if (!baselineRef) {
     scenario("empty-compressed", { compression: true, empty: true });
+    scenario("unreviewed-materializer", { compression: true, corruptMaterializer: true });
     scenario("archive-hash-mismatch", { compression: true, corruptArchiveHash: true });
     scenario("decoded-hash-mismatch", { compression: true, corruptDecodedHash: true });
     scenario("already-processed", { compression: true, processed: true, corruptArchiveHash: true });
@@ -79,7 +80,12 @@ function scenario(name, options) {
   const scriptsDir = path.join(cwd, "gitcrawl-store/scripts");
   const runnerTemp = path.join(cwd, "tmp");
   for (const dir of [dataDir, scriptsDir, runnerTemp]) fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(path.join(scriptsDir, "portable-artifact.mjs"), materializer);
+  fs.writeFileSync(
+    path.join(scriptsDir, "portable-artifact.mjs"),
+    options.corruptMaterializer
+      ? 'import fs from "node:fs"; fs.writeFileSync("unreviewed-code-ran", "");\n'
+      : materializer,
+  );
   const dbName = "openclaw__fixture.sync.db";
   const dbPath = path.join(dataDir, dbName);
   const database = new DatabaseSync(dbPath);
@@ -154,15 +160,21 @@ function scenario(name, options) {
     : {};
   const rejected = baselineRef
     ? options.compression
-    : !options.processed && (options.corruptArchiveHash || options.corruptDecodedHash);
+    : !options.processed &&
+      (options.corruptMaterializer || options.corruptArchiveHash || options.corruptDecodedHash);
   if (rejected) {
     assert.notEqual(prepared.status, 0, name);
     assert.notEqual(outputs.should_import, "true", name);
     assert.equal(outputs.db_path, undefined, name);
     assert.match(
       prepared.stderr + prepared.stdout,
-      baselineRef ? /Missing gitcrawl-store DB/ : /manifest (?:archiveSha256|sha256) mismatch/,
+      baselineRef
+        ? /Missing gitcrawl-store DB/
+        : options.corruptMaterializer
+          ? /materializer does not match the reviewed digest/
+          : /manifest (?:archiveSha256|sha256) mismatch/,
     );
+    assert.equal(fs.existsSync(path.join(cwd, "gitcrawl-store/unreviewed-code-ran")), false);
     results.push({ name, admission: "rejected", jobs: 0 });
     return;
   }

--- a/docs/repair/README.md
+++ b/docs/repair/README.md
@@ -245,7 +245,8 @@ pnpm run repair:import-gitcrawl -- --from-gitcrawl --limit 40 --mode autonomous 
 # intake runs daily, records the processed portable DB SHA in
 # results/cluster-repair-intake/<repo>.json, and skips repeated ticks for the
 # same store snapshot. New snapshots are materialized by the store's own
-# portable-artifact helper, supporting raw and verified gzip archives. Empty
+# portable-artifact helper pinned to a reviewed digest, supporting raw and
+# verified gzip archives. A helper update requires a reviewed digest change. Empty
 # portable cluster tables produce no candidates; intake does not reconstruct
 # clustering omitted by the upstream export. The selector model compares the candidate batch without
 # word lists, scores, or semantic thresholds, and dispatches at most one cluster

--- a/docs/repair/README.md
+++ b/docs/repair/README.md
@@ -244,7 +244,10 @@ pnpm run repair:import-gitcrawl -- --from-gitcrawl --limit 40 --mode autonomous 
 # gitcrawl-store refreshes openclaw/openclaw every 15 minutes; the ClawSweeper
 # intake runs daily, records the processed portable DB SHA in
 # results/cluster-repair-intake/<repo>.json, and skips repeated ticks for the
-# same store snapshot. The selector model compares the candidate batch without
+# same store snapshot. New snapshots are materialized by the store's own
+# portable-artifact helper, supporting raw and verified gzip archives. Empty
+# portable cluster tables produce no candidates; intake does not reconstruct
+# clustering omitted by the upstream export. The selector model compares the candidate batch without
 # word lists, scores, or semantic thresholds, and dispatches at most one cluster
 # through the two-worker cluster_repair lane. Clusters with one live candidate
 # and useful closed context remain eligible for model evaluation. Intake appends

--- a/src/repair/import-gitcrawl-clusters.ts
+++ b/src/repair/import-gitcrawl-clusters.ts
@@ -333,16 +333,13 @@ function detectClusterSource() {
       ? Number(sqliteScalar("select count(*) from clusters;"))
       : 0;
   if (legacyRows > 0) return "legacy";
-  const portableRows =
+  const hasPortableSchema =
     Number(
       sqliteScalar(
         "select count(*) from sqlite_master where type = 'table' and name = 'cluster_groups';",
       ),
-    ) > 0
-      ? Number(sqliteScalar("select count(*) from cluster_groups;"))
-      : 0;
-  if (portableRows > 0) return "portable";
-  return "legacy";
+    ) > 0;
+  return hasPortableSchema ? "portable" : "legacy";
 }
 
 function numberArg(name: string, fallback: JsonValue) {

--- a/test/repair/gitcrawl-sqlite.test.ts
+++ b/test/repair/gitcrawl-sqlite.test.ts
@@ -289,6 +289,33 @@ test("gitcrawl importer CLIs preserve empty-result and database failure outcomes
   }
 });
 
+test("cluster intake accepts empty portable and legacy stores", (t) => {
+  const tempDir = temporaryDirectory(t);
+  for (const schema of ["portable", "legacy"] as const) {
+    const dbPath = path.join(tempDir, `${schema}.db`);
+    const database = createGitcrawlStore(dbPath, schema);
+    database.exec(
+      schema === "portable"
+        ? "delete from cluster_memberships; delete from cluster_groups;"
+        : "delete from cluster_members; delete from clusters;",
+    );
+    database.close();
+    const outDir = path.join(tempDir, `${schema}-jobs`);
+    const result = runCli(CLUSTER_IMPORTER, [
+      "--from-gitcrawl",
+      "--allow-empty",
+      "--db",
+      dbPath,
+      "--out",
+      outDir,
+    ]);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout, "");
+    assert.match(result.stderr, /no unprocessed gitcrawl clusters found/);
+    assert.equal(fs.existsSync(outDir), false);
+  }
+});
+
 function temporaryDirectory(t: test.TestContext): string {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-sqlite-test-"));
   t.after(() => fs.rmSync(directory, { recursive: true, force: true }));


### PR DESCRIPTION
## What Problem This Solves

Cluster repair intake requires a raw SQLite file even when the store exports only a gzip archive. After materialization, an empty portable cluster schema is incorrectly treated as legacy, causing a query against a nonexistent `clusters` table. The missing-file failure is visible in https://github.com/openclaw/clawsweeper/actions/runs/33955163748.

## Why This Change Was Made

Copy the store's portable-artifact materializer into an owner-only temporary directory and verify a reviewed SHA-256 before executing it, after the processed-SHA check. Pass the materialized temporary database to the importer. Detect portable cluster schema by table presence while preserving nonempty legacy precedence. Compression handling stays with the store; ClawSweeper keeps import and deduplication policy.

## Review Disposition

The fail-closed digest dependency is deliberate and accepted in this implementation: snapshot publication does not authorize replacing executable code on the intake runner. A helper update requires a reviewed checksum update in this workflow; silently executing new bytes would undo that boundary. The repair documentation states this coordination requirement.

The pinned helper was inspected locally, and the actual helper bytes were used in the runtime proof. Its compressed branch checks archive basename, compressed size and SHA-256, decode budget, and decoded size and SHA-256. This PR does not claim stronger verification for the raw-file branch. The passing raw/gzip, hash-mismatch, and unreviewed-helper cases exercise the integration contract without depending on the reviewer having network access to the upstream checkout. No helper source is copied into this repository.

The current branch includes the publication cleanup already on main and preserves its human contributor credit in the changelog. The intake source and workflow hashes are unchanged after that merge; the clean-head nine-case proof was rerun, and the fresh committed-branch review reports no P0–P2 findings.

## User Impact

Raw and compressed snapshots can reach candidate import. Empty portable snapshots finish successfully with zero candidates. Repeated snapshots skip before materialization, forced reimports still work, and gzip archive/decoded hash mismatches stop before import admission.

## Evidence

- Focused SQLite, store, and intake-publication tests: 16 passed.
- Full `pnpm run check` on AWS through Crabbox: 4,986 tests, 4,968 passed, 18 skipped, zero failures; static checks, lint, builds and coverage gates passed.
- Independent Codex review before commit: no P0–P2 findings. The committed review identified execution of mutable publisher-supplied code; the digest pin, private copy, and passing tampering case resolve that finding.
- Changelog and repair documentation updated.

## Real Behavior Proof

**Claim and surface:** execute the actual workflow `Prepare intake` shell, built importer, and empty selector against synthetic SQLite snapshots. The proof does not substitute a decoder for the upstream materializer.

**Environment:** AWS through Crabbox, lease `cbx_76a9ed6493af`, image `ami-0461d919be7deb53c` in `eu-west-1`, Node `v24.18.1`, pnpm `11.10.0`. The hydration adapter did not support the pinned pnpm action, so the same lease used a frozen dependency install directly. No provider switch was made.

**Current source:** `7e9406ca78ad3ed1f4e690db6f83d65b9d3621c2`, clean tree. Current proof run: `run_e415ed055b8d`; full gate: `run_7f37c2f9d8f1`.

**Command:** after `pnpm run build:node`, run `node docs/proof/cluster-intake-portable/run-proof.mjs /tmp/portable-artifact.mjs .artifacts/cluster-intake-portable/candidate-synced.json`. Supply the store's existing materializer at the named temporary path. The same executable accepts a baseline ref as its third argument.

**Observed result:** all nine candidate cases pass: raw and gzip snapshots each produce one job; empty raw/gzip portable schemas produce no jobs and an empty selector decision; unreviewed materializer code is rejected before execution; archive and decoded hash mismatches reject admission; a processed SHA skips before decoding; forced reimport produces one job. Baseline `a9ed9b5ba7eb12357da7cc2360d87cc5397c3c36` accepts raw input, rejects gzip-only input, and fails on an empty portable schema with a legacy-table error.

**Artifact/trace:** reproducible harness and receipt format are in `docs/proof/cluster-intake-portable/`. Generated JSON records source/compiled hashes, dirty state, materializer hash, runtime and per-case outcomes. Candidate workflow SHA-256: `c42316d8a1214f5b7060c4ab3a43458a1a99afe99adb0e8393ee01e700ca6344`; importer source SHA-256: `0f694d4e80fc0bca10beb339451ba0a7866c828189c4619e310336908000d2c8`.

**Limits:** synthetic snapshots; no inference, live GitHub publication, or production intake was triggered. The baseline importer shares unchanged compiled dependencies. This does not add clustering to exports that omit it or strengthen the upstream helper's raw-file verification contract.

**OpenClaw Bay:** unaffected; this changes internal snapshot import behavior, with no public status or data-contract change.
