### PR TITLE
fix(github): enforce deadlines through response body reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Keep GitHub request deadlines active through response-body reads so stalled responses cannot hold queue operations indefinitely, while preserving HTTP and rate-limit classification.
+
 - Bound GitHub activity hook prompts to one received event and filtered trusted self-authored review chatter before model intake.
 - Replay durable scheduled enqueue dispositions after transient response loss while preserving signed delivery identity, rejecting mismatched bytes, failing closed on legacy ambiguous receipts, and leaving publication post-effects single-attempt.
 - Use the producer Actions run URL in failed-review retry receipts so ledger validation no longer prevents dispatch and fails the retry command.

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -16483,8 +16483,13 @@ async function githubTokenJson({ env = {}, token, path, method = "GET", body, er
   };
   if (body !== undefined) init.body = JSON.stringify(body);
   let response: Response;
+  let text: string;
   try {
     response = await fetch(githubApiUrl(env, path), init);
+    text = await response.text().catch((error) => {
+      if (response.ok) throw error;
+      return "";
+    });
   } catch (error) {
     const timedOut =
       controller.signal.aborted ||
@@ -16498,7 +16503,6 @@ async function githubTokenJson({ env = {}, token, path, method = "GET", body, er
     clearTimeout(timeout);
   }
   if (!response.ok) {
-    const text = await response.text().catch(() => "");
     const rateLimited = githubResponseRateLimited(response, text);
     throw new GitHubRequestError(
       `${errorLabel || "GitHub"} ${response.status}`,
@@ -16510,7 +16514,6 @@ async function githubTokenJson({ env = {}, token, path, method = "GET", body, er
     );
   }
   if (response.status === 204) return {};
-  const text = await response.text();
   return text ? JSON.parse(text) : {};
 }
 

--- a/dashboard/github-api.ts
+++ b/dashboard/github-api.ts
@@ -141,6 +141,7 @@ export async function githubAppJson(
 ) {
   const signal = AbortSignal.timeout(GITHUB_APP_TIMEOUT_MS);
   let response: Response;
+  let text: string;
   try {
     response = await fetch(githubApiUrl(env, path), {
       method: options.method || "GET",
@@ -156,6 +157,10 @@ export async function githubAppJson(
       },
       ...(options.body === undefined ? {} : { body: options.body }),
     });
+    text = await response.text().catch((error) => {
+      if (response.ok) throw error;
+      return "";
+    });
   } catch (error) {
     const timedOut =
       signal.aborted ||
@@ -169,7 +174,6 @@ export async function githubAppJson(
     throw requestError;
   }
   if (!response.ok) {
-    const text = await response.text().catch(() => "");
     const rateLimited = githubResponseRateLimited(response, text);
     throw new GitHubRequestError(
       `${options.errorLabel || "GitHub App"} ${response.status}`,
@@ -180,7 +184,7 @@ export async function githubAppJson(
       rateLimited ? githubResponseRateLimitHint(response, Date.now()) : undefined,
     );
   }
-  return response.json();
+  return JSON.parse(text);
 }
 
 export async function createGithubAppTokenFor({

--- a/docs/proof/github-body-deadlines/README.md
+++ b/docs/proof/github-body-deadlines/README.md
@@ -1,0 +1,32 @@
+# GitHub response-body deadline proof
+
+The queue's GitHub deadline must cover response bodies as well as headers.
+Successful-body timeouts must retain typed retry classification in both queue
+and App-token calls. Existing HTTP/rate-limit errors and malformed JSON retain
+their meanings.
+
+[`proof-github-body-deadlines.mjs`](../../../scripts/proof-github-body-deadlines.mjs)
+bundles the baseline and candidate code into workerd. It invokes the actual
+terminal-run resolver and App JSON helper against a Node HTTP fixture that
+flushes headers before delaying or withholding its body. Native workerd egress
+is restricted to that loopback fixture. No provider or GitHub credential is used.
+
+Run through the repository's resolved Crabbox provider with its pinned Wrangler
+tooling installed outside the checkout:
+
+```sh
+npm install --prefix /tmp/clawsweeper-worker-proof-tools --no-save --no-audit --no-fund wrangler@4.107.0
+node scripts/proof-github-body-deadlines.mjs a9ed9b5ba7eb12357da7cc2360d87cc5397c3c36 /tmp/clawsweeper-worker-proof-tools .artifacts/github-body-deadlines
+```
+
+The receipt records source hashes, Git revisions, dirty state, Node/workerd
+versions, elapsed time, error classification, and upstream cancellation. Finite
+delayed bodies reproduce the baseline defects without hanging the proof.
+Candidate cases additionally cover bodies that never finish.
+Deadline cases must finish within six seconds after runtime readiness, allowing
+headroom around the existing 4.5-second deadline. Ordinary JSON,
+malformed JSON, empty 204, 503, and rate-limit responses guard existing contracts.
+
+This proves the Worker transport boundary; it does not establish that stalled
+bodies caused a particular production backlog. OpenClaw Bay is unaffected:
+existing timeout/backoff states and public data contracts remain unchanged.

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -170,6 +170,9 @@ scheduling runs even if the subsequent lifecycle update fails, so persisted
 retries retain their scheduled wake-up.
 
 Review publication and apply/comment sync use separate non-dropping queues.
+Queue and GitHub App requests retain their request deadline through response-body
+consumption. A stalled successful response becomes a typed timeout; an error
+response retains its HTTP status and rate-limit headers even if its body stalls.
 Apply treats a typed GitHub installation or abuse-rate-limit response as a
 bounded yield, not a failed scan. It checkpoints completed item work, records
 the interrupted item as `skipped_runtime_budget`, returns that item to the

--- a/scripts/proof-github-body-deadlines.mjs
+++ b/scripts/proof-github-body-deadlines.mjs
@@ -1,0 +1,202 @@
+// Run with repository-pinned Wrangler tooling installed outside the checkout.
+// node scripts/proof-github-body-deadlines.mjs BASE TOOL_PREFIX OUTPUT
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { copyFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+const [baseRef, toolPrefix, output] = process.argv.slice(2);
+assert.ok(baseRef && toolPrefix && output, "expected BASE TOOL_PREFIX OUTPUT");
+const require = createRequire(path.resolve(toolPrefix, "package.json"));
+const { Miniflare } = require("miniflare");
+const { build } = require("esbuild");
+const root = process.cwd();
+const out = path.resolve(output);
+mkdirSync(out, { recursive: true });
+const git = (...args) => execFileSync("git", args, { encoding: "utf8" }).trim();
+const base = git("rev-parse", `${baseRef}^{commit}`);
+const head = git("rev-parse", "HEAD");
+const sources = ["dashboard/exact-review-queue.ts", "dashboard/github-api.ts"];
+const scenarios = [
+  { name: "json", status: 200 },
+  { name: "malformed", status: 200, malformed: true },
+  { name: "empty", status: 204 },
+  { name: "delayed-success", status: 200, delay: 5400 },
+  { name: "delayed-error", status: 503, delay: 5400 },
+  { name: "delayed-rate-limit", status: 429, delay: 5400 },
+  { name: "stalled-success", status: 200, stalled: true },
+  { name: "stalled-error", status: 503, stalled: true },
+];
+const manifest = {
+  base,
+  head,
+  working_tree_dirty: Boolean(git("status", "--porcelain")),
+  runtime: process.version,
+  workerd: require("workerd/package.json").version,
+  sources: {},
+  results: {},
+  limits:
+    "Actual workerd handlers and native HTTP to a loopback fixture. Synthetic credential only; no live GitHub calls, inference, queue mutation, or deployment. Baseline uses finite delayed bodies; candidate also proves never-ending bodies are cancelled.",
+};
+
+for (const variant of ["baseline", "candidate"]) {
+  const dir = path.join(out, variant);
+  mkdirSync(dir);
+  execFileSync("tar", ["-x", "-C", dir], {
+    input: execFileSync("git", ["archive", variant === "baseline" ? base : head], {
+      maxBuffer: 128 * 1024 * 1024,
+    }),
+  });
+  if (variant === "candidate")
+    for (const file of sources) copyFileSync(path.join(root, file), path.join(dir, file));
+  manifest.sources[variant] = Object.fromEntries(
+    sources.map((file) => [
+      file,
+      createHash("sha256")
+        .update(readFileSync(path.join(dir, file)))
+        .digest("hex"),
+    ]),
+  );
+  const observations = new Map();
+  const timers = new Set();
+  const server = createServer((request, response) => {
+    const owner = request.url.startsWith("/fixture/") ? "app" : "queue";
+    const id = Number(request.url.split("/").at(-1));
+    const scenario = scenarios[id - 1];
+    assert.ok(scenario, "unexpected upstream path");
+    assert.equal(request.headers.authorization, "Bearer synthetic-fixture-token");
+    const observation = { cancelled: false };
+    observations.set(`${owner}/${id}`, observation);
+    response.on("close", () => {
+      observation.cancelled = !response.writableEnded;
+    });
+    response.writeHead(scenario.status, {
+      "content-type": "application/json",
+      ...(scenario.status === 429 ? { "retry-after": "7" } : {}),
+    });
+    response.flushHeaders();
+    const finish = () =>
+      response.end(
+        scenario.status === 204
+          ? ""
+          : scenario.malformed
+            ? "invalid JSON"
+            : JSON.stringify({ id, run_attempt: 1, status: "in_progress", fixture: true }),
+      );
+    if (scenario.delay) timers.add(setTimeout(finish, scenario.delay));
+    else if (!scenario.stalled) finish();
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = `127.0.0.1:${server.address().port}`;
+  const entry = path.join(dir, "proof-worker.ts");
+  writeFileSync(
+    entry,
+    `
+import { exactReviewTerminalRun } from "./dashboard/exact-review-queue.ts";
+import { githubAppJson } from "./dashboard/github-api.ts";
+export default { async fetch(request, env) {
+  const [owner, id] = new URL(request.url).pathname.slice(1).split("/");
+  try {
+    const value = owner === "queue"
+      ? await exactReviewTerminalRun("synthetic-fixture-token", { runId: id, runAttempt: 1, claimGeneration: 1 }, env)
+      : await githubAppJson("/fixture/" + id, "synthetic-fixture-token", {}, env);
+    return Response.json({ outcome: "resolved", value });
+  } catch (error) {
+    return Response.json({ outcome: "rejected", errorType: error.name,
+      timedOut: error.timedOut ?? null, status: error.status ?? null, rateLimited: error.rateLimited ?? null });
+  }
+} };
+`,
+  );
+  let mf;
+  try {
+    const bundle = await build({
+      entryPoints: [entry],
+      bundle: true,
+      write: false,
+      format: "esm",
+      platform: "browser",
+      target: "es2022",
+      external: ["node:*", "cloudflare:*"],
+    });
+    mf = new Miniflare({
+      modules: true,
+      script: bundle.outputFiles[0].text,
+      compatibilityDate: "2026-07-08",
+      compatibilityFlags: ["nodejs_compat"],
+      bindings: { GITHUB_API_URL: `http://${address}` },
+      outboundService: { external: { address, http: {} } },
+    });
+    await mf.ready;
+    manifest.results[variant] = await Promise.all(
+      ["queue", "app"]
+        .flatMap((owner) =>
+          scenarios.map((scenario, index) => ({ owner, scenario, id: index + 1 })),
+        )
+        .filter(({ scenario }) => variant === "candidate" || !scenario.stalled)
+        .map(async ({ owner, scenario, id }) => {
+          const started = performance.now();
+          const response = await mf.dispatchFetch(`http://proof/${owner}/${id}`, {
+            signal: AbortSignal.timeout(10000),
+          });
+          const result = await response.json();
+          const elapsedMs = Math.round(performance.now() - started);
+          if (variant === "candidate" && (scenario.delay || scenario.stalled)) {
+            assert.ok(
+              elapsedMs >= 4000 && elapsedMs < 6000,
+              `${owner}/${scenario.name} deadline: ${elapsedMs}ms`,
+            );
+          }
+          if (scenario.name === "json") assert.equal(result.outcome, "resolved");
+          else if (scenario.malformed || scenario.status === 204)
+            assert.equal(
+              result.errorType,
+              owner === "queue" && scenario.status === 204 ? "Error" : "SyntaxError",
+            );
+          else if (scenario.status >= 400) {
+            assert.equal(result.errorType, "GitHubRequestError");
+            assert.equal(result.status, scenario.status);
+            assert.equal(result.timedOut, false);
+            assert.equal(result.rateLimited, scenario.status === 429);
+          } else if (variant === "candidate") {
+            assert.equal(result.errorType, "GitHubRequestError");
+            assert.equal(result.timedOut, true);
+          } else if (owner === "queue") {
+            assert.equal(result.outcome, "resolved");
+            assert.ok(elapsedMs >= 5300);
+          } else assert.notEqual(result.errorType, "GitHubRequestError");
+          return {
+            owner,
+            scenario: scenario.name,
+            elapsedMs,
+            ...result,
+            observation: `${owner}/${id}`,
+          };
+        }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    for (const result of manifest.results[variant]) {
+      result.cancelled = observations.get(result.observation).cancelled;
+      delete result.observation;
+      if (variant === "candidate" && /^(delayed|stalled)-/.test(result.scenario))
+        assert.equal(
+          result.cancelled,
+          true,
+          `${result.owner}/${result.scenario} did not cancel upstream`,
+        );
+    }
+  } finally {
+    try {
+      await mf?.dispose();
+    } finally {
+      for (const timer of timers) clearTimeout(timer);
+      server.closeAllConnections();
+      await new Promise((resolve) => server.close(resolve));
+    }
+  }
+}
+writeFileSync(path.join(out, "result.json"), `${JSON.stringify(manifest, null, 2)}\n`);
+console.log(JSON.stringify(manifest));

--- a/test/github-response-deadlines.test.ts
+++ b/test/github-response-deadlines.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { setImmediate as nextTurn } from "node:timers/promises";
+import test from "node:test";
+
+import { exactReviewTerminalRun } from "../dashboard/exact-review-queue.ts";
+import { githubAppJson, GitHubRequestError } from "../dashboard/github-api.ts";
+
+const readers = {
+  queue: () => exactReviewTerminalRun("synthetic-token", { runId: "1", claimGeneration: 1 }),
+  app: () => githubAppJson("/fixture", "synthetic-token"),
+};
+
+for (const [name, read] of Object.entries(readers)) {
+  for (const status of [200, 503, 429]) {
+    test(`${name} bounds a stalled ${status} body and preserves its error class`, async (t) => {
+      t.mock.timers.enable({ apis: ["setTimeout"] });
+      t.mock.method(AbortSignal, "timeout", (milliseconds: number) => {
+        const controller = new AbortController();
+        setTimeout(() => controller.abort("timeout"), milliseconds);
+        return controller.signal;
+      });
+      let markStarted!: () => void;
+      const started = new Promise<void>((resolve) => {
+        markStarted = resolve;
+      });
+      let bodyController!: ReadableStreamDefaultController;
+      t.mock.method(globalThis, "fetch", async (_input, init: RequestInit) => {
+        const response = new Response(
+          new ReadableStream({
+            start(controller) {
+              bodyController = controller;
+              init.signal!.addEventListener(
+                "abort",
+                () => controller.error(new DOMException("body aborted", "AbortError")),
+                { once: true },
+              );
+            },
+          }),
+          { status, headers: status === 429 ? { "retry-after": "7" } : {} },
+        );
+        const text = response.text.bind(response);
+        response.text = () => {
+          markStarted();
+          return text();
+        };
+        return response;
+      });
+      const outcome = read().then(
+        (value) => ({ value }),
+        (error) => ({ error }),
+      );
+      t.after(() => bodyController.error(new Error("fixture cleanup")));
+      await started;
+      t.mock.timers.tick(4500);
+      const result = await Promise.race([outcome, nextTurn().then(() => null)]);
+      assert.notEqual(result, null, "body remained pending after the request deadline");
+      assert.ok(result && "error" in result);
+      assert.ok(result.error instanceof GitHubRequestError);
+      assert.equal(result.error.timedOut, status === 200);
+      assert.equal(result.error.status, status === 200 ? undefined : status);
+      assert.equal(result.error.rateLimited, status === 429);
+      if (status === 429) assert.ok(result.error.rateLimitHint);
+    });
+  }
+
+  test(`${name} preserves JSON parse failures after a successful body read`, async (t) => {
+    t.mock.method(globalThis, "fetch", async () => new Response("not JSON"));
+    await assert.rejects(read(), SyntaxError);
+  });
+}


### PR DESCRIPTION
## What Problem This Solves

GitHub fetches in the exact-review queue clear their 4.5-second deadline after headers arrive, leaving response-body reads unbounded. The shared App client already aborts body reads, but successful-response body errors escape its typed transport classification. A stalled body can hold queue work open or bypass timeout recovery.

## Why This Change Was Made

Read the body inside the existing timed transport scope. Successful-response body failures now become typed GitHub transport errors. If HTTP headers already establish an error or rate limit, retain that classification even when the body cannot be read. JSON parsing stays outside the transport catch, preserving malformed-JSON behavior. No new transport abstraction is introduced.

The current branch includes the already-landed intake fix and contributor-credit correction. The GitHub client source hashes are unchanged by that merge, and native HTTP proof was rerun on the clean current head.

## User Impact

Both clients enforce their existing deadline through body consumption. Known HTTP/rate-limit responses retain their status and retry hints; queue empty-body and malformed-JSON behavior remains unchanged. This defect has not been established as the cause of observed production backlog fluctuations.

## Evidence

- Focused regression coverage exercises both production clients with successful, failed, rate-limited and malformed responses.
- Full `pnpm run check`: 4,993 tests, 4,975 passed, 18 skipped, zero failures; static checks, lint, builds and coverage passed on AWS through Crabbox (`run_04d8bc1abcdd`).
- Fresh independent Codex reviews before commit, after resolving the main-branch merge, and on the committed branch: no P0–P2 findings.
- Scheduler documentation and changelog updated.

## Real Behavior Proof

**Claim and surface:** run the actual exported queue run-inspection operation and App JSON client inside workerd against a native loopback HTTP server. The server flushes headers before delaying the body for 5.4 seconds or leaving it unfinished.

**Environment:** AWS through Crabbox, lease `cbx_76a9ed6493af`, image `ami-0461d919be7deb53c` in `eu-west-1`, Node `v24.18.1`, pnpm `11.10.0`, workerd `1.20260701.1`; temporary Wrangler `4.107.0` supplies the native outbound fixture. The configured provider was preserved; unsupported Actions hydration was replaced by a frozen install in the same lease.

**Source and command:** clean head `9653bc3b7f2938025a32634872bcc9b17c830622`; run `node scripts/proof-github-body-deadlines.mjs a9ed9b5ba7eb12357da7cc2360d87cc5397c3c36 /tmp/clawsweeper-worker-proof-tools .artifacts/github-body-deadlines-clean-9653`.

**Observed result:** 12 baseline and 16 candidate cases passed their assertions. Baseline queue bodies continued for about 5.4 seconds; candidate delayed/stalled bodies ended around 4.5 seconds, with all 10 expected upstream cancellations. The App client's formerly untyped successful-body timeout is now a typed timeout. Normal JSON, malformed JSON, empty responses, HTTP 503, and HTTP 429 classifications remain intact.

**Artifact/trace:** run `run_2a52a023749a`; `.artifacts/github-body-deadlines-clean-9653/result.json` records revision, clean-tree state, source hashes, timing, classifications and upstream cancellation. The current command and receipt download succeeded with a clean tree. Earlier reruns found generated Crabbox capture manifests and a reused proof output directory; those harness artifacts were resolved without changing production source. Candidate queue SHA-256 `6d62008f3fe35f0df01e0114a463e7a63b938e85834f45166df8e6f4d59dea0b`; App client `96bb9f7726c97d786c1b17dc64462db5a38a066a6fffcee6bf8540950898c493`. Harness and reproduction instructions are committed.

**Limits:** synthetic credential and native local HTTP upstream; no live GitHub API, inference, production queue mutation, or deployment. Baseline uses finite delayed bodies; candidate additionally verifies never-ending-body cancellation.

**OpenClaw Bay:** no change required. Existing timeout/backoff states already represent this outcome; no public status fields or lifecycle contract change.
