### PR TITLE
fix(notify): report OpenClaw hook delivery outcomes

### DIFF
--- a/docs/openclaw-event-hooks.md
+++ b/docs/openclaw-event-hooks.md
@@ -4,7 +4,7 @@
 - Owner: ClawSweeper notification and activity-stream maintainers
 - Source of truth: `.github/workflows/github-activity.yml`,
   `.github/workflows/repair-publish-results.yml`, and `src/repair/*notify*`
-- Last verified: `openclaw/clawsweeper@647503ec44b8e777dd172adf974a945367da0d19`
+- Last verified: `openclaw/clawsweeper@42226a81c43c2c8ded17a684a706e58f3a58577a`
 - Update when: hook payloads, delivery policy, activity filtering, runtime setup,
   notification ledgers, or workflow ownership changes
 
@@ -31,8 +31,11 @@ The normal event flow is:
 5. OpenClaw starts an isolated agent turn for the requested `agentId`.
 6. The agent sends the final message to the configured delivery target, or
    replies `NO_REPLY` when the event is intentionally silent.
-7. ClawSweeper records successful sends in the ledger and publishes it to
-   `openclaw/clawsweeper-state`.
+7. ClawSweeper classifies the bounded completion as `delivered`, `suppressed`,
+   `failed`, `unknown`, or `not-requested`. Older admission-only OpenClaw
+   responses are recorded as `admitted`.
+8. ClawSweeper records only conclusive delivery outcomes in the ledger and
+   publishes it to `openclaw/clawsweeper-state`.
 
 The hook call is best-effort by default. A Discord outage or Gateway outage
 must not make an already-completed GitHub mutation roll back or fail the state
@@ -70,7 +73,8 @@ reverse proxy.
   "to": "channel:1499243561407741994",
   "idempotencyKey": "clawsweeper:merge:openclaw/openclaw:123:abc123",
   "thinking": "low",
-  "timeoutSeconds": 300
+  "timeoutSeconds": 300,
+  "waitForCompletion": true
 }
 ```
 
@@ -107,7 +111,9 @@ OpenClaw call itself:
   result, such as repo, PR number, action, and merge commit SHA;
 - check a durable ledger before sending;
 - write a report for attempted, skipped, sent, and failed notifications;
-- write the ledger only after OpenClaw accepted the request;
+- request completion for direct agent hooks and write its bounded delivery
+  classification to the report;
+- write the ledger only for `delivered`, `suppressed`, or `not-requested`;
 - publish the report and ledger with the normal result state.
 
 The message sent to OpenClaw should be explicit enough that the agent does not
@@ -131,11 +137,31 @@ Default behavior:
 - transient OpenClaw HTTP/network failure: retry with the same idempotency key;
 - persistent OpenClaw HTTP failure: record the failed attempt and keep the
   workflow green;
+- a valid legacy `{ok:true,runId}` admission without `completion`: classify as
+  terminal `admitted`, report that delivery observability is unavailable, and
+  preserve prior at-most-once ledger behavior;
+- a present but malformed completion: classify delivery as `unknown` and leave
+  the event retryable;
+- verified delivery: classify as `delivered` even when automatic hook delivery
+  was disabled and the agent used the message tool, or when later terminal
+  fields also report an execution or delivery error;
+- an exact silent reply without verified delivery: classify as `suppressed`,
+  preserving the reported reason or deriving `silent`;
+- a visible reply without verified delivery: classify as `failed` or `unknown`,
+  never intentional suppression;
+- no automatic delivery, message-tool delivery, or model reply evidence:
+  classify as `not-requested`;
+- `status: "skipped"` without explicit silent-reply or suppression evidence:
+  classify as `unknown`;
 - rerun after failure: retry because no success ledger entry exists;
 - rerun after success: skip because the ledger contains the event key.
 
 Set `CLAWSWEEPER_OPENCLAW_HOOK_RETRY_ATTEMPTS` to override the default retry
 count for hook posts.
+
+Deploy OpenClaw first when possible so completion observability is available as
+soon as ClawSweeper requests it. Deploying ClawSweeper first remains safe:
+admission-only responses are terminal `admitted` outcomes and are not retried.
 
 Strict mode is allowed for events whose notification is the product of the
 workflow. Strict mode should fail on OpenClaw delivery errors, but it still
@@ -200,6 +226,10 @@ The GitHub activity notifier posts to `/hooks/agent` with `deliver: false` by
 default. The agent receives the Discord target in the prompt and should use the
 message tool only when the event is surprising, actionable, risky, or otherwise
 operationally useful. For routine events it replies exactly `NO_REPLY`.
+The completion distinguishes verified message-tool delivery from a silent or
+private visible final reply without exposing reply text. The notifier writes
+that classification, plus a bounded suppression reason when present, to its
+report and a concise GitHub step summary.
 
 The workflow skips native and forwarded pull request synchronize events plus
 successful workflow-run events before checkout because the notifier always

--- a/docs/repair/operations.md
+++ b/docs/repair/operations.md
@@ -4,7 +4,7 @@
 - Owner: ClawSweeper maintainers and the authorized repair operator
 - Source of truth: repair workflows/source, current gates, focused tests, and
   live read-only GitHub state where needed
-- Last verified: `openclaw/clawsweeper@647503ec44b8e777dd172adf974a945367da0d19`
+- Last verified: `openclaw/clawsweeper@42226a81c43c2c8ded17a684a706e58f3a58577a`
 - Update when: commands, trust checks, gates, tokens, runners, routing,
   publication, recovery, or promotion rules change
 
@@ -208,6 +208,21 @@ Successful event notifications are recorded in
 `openclaw/clawsweeper-state`, keyed by event type, repo, target, action, status,
 and stable mutation evidence. This prevents duplicate Discord posts when the
 publish workflow reruns.
+
+The notifier waits for the direct OpenClaw hook completion and records a
+bounded delivery classification in its report. `delivered`, `suppressed`, and
+`not-requested` are terminal and may enter the notification ledger. A valid
+admission-only response from an older OpenClaw is terminal `admitted`: its
+report states that delivery observability is unavailable, and ledgered
+notifiers preserve their prior at-most-once behavior. `failed` and `unknown`
+remain non-ledgered so the existing rerun path can retry them.
+Verified message-tool delivery wins even when automatic hook delivery was
+disabled or later completion fields report an error. Exact silent replies and
+explicit suppression evidence become `suppressed`; bare `skipped` and visible
+replies without verified delivery remain nonconclusive. Deploy OpenClaw first
+when possible so ClawSweeper receives completion observability immediately.
+OpenClaw Bay is unaffected because its public status and event contracts do not
+consume notification reports or ledgers.
 
 ## Autonomous Flow
 

--- a/src/repair/notify-events.ts
+++ b/src/repair/notify-events.ts
@@ -7,12 +7,17 @@ import { asJsonObject } from "./json-types.js";
 import { parseArgs, repoRoot } from "./lib.js";
 import { readJsonFile, writeJsonFile } from "./json-file.js";
 import {
+  describeHookDelivery,
   errorText,
+  hookDeliveryFromError,
+  hookDeliveryReport,
+  isConclusiveHookDelivery,
   postOpenClawAgentHook,
   resolveOpenClawHookConfig,
   stringArg,
   stringOrNull,
 } from "./openclaw-hook.js";
+import type { OpenClawHookDelivery } from "./openclaw-hook.js";
 
 type EventSeverity = "info" | "warning" | "error";
 type EventStatus = "sent" | "planned" | "failed" | "skipped";
@@ -388,8 +393,24 @@ export async function runClawSweeperEventNotifier(
         } catch (error) {
           dashboardDelivered = false;
           dashboardStatus = `status dashboard failed: ${errorText(error)}`;
-          reportActions.push(reportRow(event, "failed", dashboardStatus, result.runId));
+          reportActions.push(
+            reportRow(event, "failed", dashboardStatus, result.runId, result.delivery),
+          );
         }
+      }
+      if (!isConclusiveHookDelivery(result.delivery)) {
+        if (dashboardDelivered) {
+          reportActions.push(
+            reportRow(
+              event,
+              "failed",
+              describeHookDelivery(result.delivery),
+              result.runId,
+              result.delivery,
+            ),
+          );
+        }
+        continue;
       }
       if (dashboardDelivered) {
         const notifiedAt = now().toISOString();
@@ -400,10 +421,19 @@ export async function runClawSweeperEventNotifier(
         });
       }
       reportActions.push(
-        reportRow(event, "sent", `sent to OpenClaw hook; ${dashboardStatus}`, result.runId),
+        reportRow(
+          event,
+          "sent",
+          `${describeHookDelivery(result.delivery)}; ${dashboardStatus}`,
+          result.runId,
+          result.delivery,
+        ),
       );
     } catch (error) {
-      reportActions.push(reportRow(event, "failed", errorText(error)));
+      const delivery = hookDeliveryFromError(error);
+      reportActions.push(
+        reportRow(event, "failed", describeHookDelivery(delivery), null, delivery),
+      );
     }
   }
 
@@ -684,6 +714,7 @@ function reportRow(
   status: EventStatus,
   reason: string,
   hookRunId: string | null = null,
+  delivery: OpenClawHookDelivery | null = null,
 ): JsonObject {
   return {
     key: event.key,
@@ -699,6 +730,7 @@ function reportRow(
     run_id: event.runId,
     cluster_id: event.clusterId,
     hook_run_id: hookRunId,
+    delivery: delivery ? hookDeliveryReport(delivery) : null,
     url: event.url,
   };
 }

--- a/src/repair/notify-github-activity.ts
+++ b/src/repair/notify-github-activity.ts
@@ -9,12 +9,17 @@ import { writeJsonFile } from "./json-file.js";
 import { parseArgs, repoRoot } from "./lib.js";
 import {
   boolEnv,
+  describeHookDelivery,
   errorText,
+  hookDeliveryFromError,
+  hookDeliveryReport,
+  isConclusiveHookDelivery,
   postOpenClawAgentHook,
   resolveOpenClawHookConfig,
   stringArg,
   stringOrNull,
 } from "./openclaw-hook.js";
+import type { OpenClawHookDelivery } from "./openclaw-hook.js";
 
 export type GithubActivity = {
   type: string;
@@ -344,6 +349,7 @@ export async function runGithubActivityNotifier(
   }
 
   let hookRunId: string | null = null;
+  let delivery: OpenClawHookDelivery | null = null;
   let failed = 0;
   let reason: string | null = null;
   if (!dryRun) {
@@ -362,9 +368,15 @@ export async function runGithubActivityNotifier(
         },
       });
       hookRunId = result.runId;
+      delivery = result.delivery;
+      if (!isConclusiveHookDelivery(delivery)) {
+        failed = 1;
+        reason = describeHookDelivery(delivery);
+      }
     } catch (error) {
+      delivery = hookDeliveryFromError(error);
       failed = 1;
-      reason = errorText(error);
+      reason = describeHookDelivery(delivery);
     }
   }
 
@@ -377,10 +389,14 @@ export async function runGithubActivityNotifier(
       dry_run: dryRun,
       deliver,
       hook_run_id: hookRunId,
+      delivery: delivery ? hookDeliveryReport(delivery) : null,
       failed,
       reason,
       activity,
     });
+  }
+  if (delivery && env.GITHUB_STEP_SUMMARY) {
+    appendGithubStepSummary(env.GITHUB_STEP_SUMMARY, delivery);
   }
 
   const summary = summaryRow("ok", failed ? 0 : 1, failed, reason);
@@ -688,6 +704,16 @@ function summaryRow(
   reason: string | null,
 ): GithubActivityNotifierSummary {
   return { status, sent, failed, exitCode: 0, reason };
+}
+
+function appendGithubStepSummary(summaryPath: string, delivery: OpenClawHookDelivery): void {
+  const suppression = delivery.suppressionReason
+    ? ` (${delivery.suppressionReason.replaceAll("`", "'")})`
+    : "";
+  fs.appendFileSync(
+    summaryPath,
+    `### OpenClaw notification\n\n- Delivery: \`${delivery.status}\`${suppression}\n`,
+  );
 }
 
 async function main() {

--- a/src/repair/notify-maintainer-report.ts
+++ b/src/repair/notify-maintainer-report.ts
@@ -8,12 +8,17 @@ import { writeJsonFile } from "./json-file.js";
 import { parseArgs, repoRoot } from "./lib.js";
 import {
   boolEnv,
+  describeHookDelivery,
   errorText,
+  hookDeliveryFromError,
+  hookDeliveryReport,
+  isConclusiveHookDelivery,
   postOpenClawAgentHook,
   resolveOpenClawHookConfig,
   stringArg,
   stringOrNull,
 } from "./openclaw-hook.js";
+import type { OpenClawHookDelivery } from "./openclaw-hook.js";
 
 export type MaintainerReportPointer = {
   date: string;
@@ -159,6 +164,7 @@ export async function runMaintainerReportNotifier(
   }
 
   let hookRunId: string | null = null;
+  let delivery: OpenClawHookDelivery | null = null;
   let failed = 0;
   let reason: string | null = null;
   if (!dryRun) {
@@ -174,9 +180,15 @@ export async function runMaintainerReportNotifier(
         },
       });
       hookRunId = result.runId;
+      delivery = result.delivery;
+      if (!isConclusiveHookDelivery(delivery)) {
+        failed = 1;
+        reason = describeHookDelivery(delivery);
+      }
     } catch (error) {
+      delivery = hookDeliveryFromError(error);
       failed = 1;
-      reason = errorText(error);
+      reason = describeHookDelivery(delivery);
     }
   }
 
@@ -184,6 +196,7 @@ export async function runMaintainerReportNotifier(
     writeJsonFile(reportPath, {
       ...reportPayload({ now, dryRun, deliver, pointer, message }),
       hook_run_id: hookRunId,
+      delivery: delivery ? hookDeliveryReport(delivery) : null,
       failed,
       reason,
     });

--- a/src/repair/notify-merge.ts
+++ b/src/repair/notify-merge.ts
@@ -7,13 +7,18 @@ import { asJsonObject } from "./json-types.js";
 import { parseArgs, repoRoot } from "./lib.js";
 import { readJsonFile, writeJsonFile } from "./json-file.js";
 import {
+  describeHookDelivery,
   errorText,
+  hookDeliveryFromError,
+  hookDeliveryReport,
+  isConclusiveHookDelivery,
   normalizeString,
   postOpenClawAgentHook,
   resolveOpenClawHookConfig,
   stringArg,
   stringOrNull,
 } from "./openclaw-hook.js";
+import type { OpenClawHookDelivery } from "./openclaw-hook.js";
 import type {
   CollectionResult,
   MergeLedgerEntry,
@@ -227,15 +232,29 @@ export async function runMergeNotifier(
           deliver: true,
         },
       });
-      const notifiedAt = now().toISOString();
-      nextLedger = addLedgerEntry(nextLedger, notification, {
-        notifiedAt,
-        hookRunId: result.runId,
-        discordTarget: config.discordTarget,
-      });
-      reportActions.push(reportRow(notification, "sent", "sent to OpenClaw hook", result.runId));
+      const conclusive = isConclusiveHookDelivery(result.delivery);
+      if (conclusive) {
+        const notifiedAt = now().toISOString();
+        nextLedger = addLedgerEntry(nextLedger, notification, {
+          notifiedAt,
+          hookRunId: result.runId,
+          discordTarget: config.discordTarget,
+        });
+      }
+      reportActions.push(
+        reportRow(
+          notification,
+          conclusive ? "sent" : "failed",
+          describeHookDelivery(result.delivery),
+          result.runId,
+          result.delivery,
+        ),
+      );
     } catch (error) {
-      reportActions.push(reportRow(notification, "failed", errorText(error)));
+      const delivery = hookDeliveryFromError(error);
+      reportActions.push(
+        reportRow(notification, "failed", describeHookDelivery(delivery), null, delivery),
+      );
     }
   }
 
@@ -342,6 +361,7 @@ function reportRow(
   status: "failed" | "planned" | "sent",
   reason: string,
   hookRunId: string | null = null,
+  delivery: OpenClawHookDelivery | null = null,
 ): JsonObject {
   return {
     key: notification.key,
@@ -355,6 +375,7 @@ function reportRow(
     merged_at: notification.mergedAt,
     run_id: notification.runId,
     hook_run_id: hookRunId,
+    delivery: delivery ? hookDeliveryReport(delivery) : null,
     url: notification.prUrl,
   };
 }

--- a/src/repair/openclaw-hook.ts
+++ b/src/repair/openclaw-hook.ts
@@ -18,8 +18,23 @@ export type OpenClawHookPost = {
   deliver: boolean;
 };
 
+export type OpenClawHookDeliveryStatus =
+  | "delivered"
+  | "admitted"
+  | "suppressed"
+  | "failed"
+  | "unknown"
+  | "not-requested";
+
+export type OpenClawHookDelivery = {
+  status: OpenClawHookDeliveryStatus;
+  suppressionReason: string | null;
+  error: string | null;
+};
+
 export type OpenClawHookPostResult = {
   runId: string | null;
+  delivery: OpenClawHookDelivery;
 };
 
 const DEFAULT_AGENT_ID = "clawsweeper";
@@ -28,6 +43,8 @@ const DEFAULT_THINKING = "low";
 const DEFAULT_TIMEOUT_SECONDS = 60;
 const DEFAULT_RETRY_ATTEMPTS = 3;
 const DEFAULT_RETRY_DELAYS_MS = [1000, 4000];
+const MAX_DIAGNOSTIC_CHARS = 500;
+const MAX_SUPPRESSION_REASON_CHARS = 80;
 
 export function resolveOpenClawHookConfig(env: NodeJS.ProcessEnv): OpenClawHookConfig | null {
   const hookUrl = normalizeString(env.CLAWSWEEPER_OPENCLAW_HOOK_URL);
@@ -119,13 +136,25 @@ async function postOpenClawAgentHookOnce({
       thinking: config.thinking,
       timeoutSeconds: config.timeoutSeconds,
       message: post.message,
+      waitForCompletion: true,
     }),
   });
   const body = await response.text();
   if (!response.ok) {
-    throw new OpenClawHookHttpError(response.status, body);
+    throw new OpenClawHookHttpError(
+      response.status,
+      boundedText(body, MAX_DIAGNOSTIC_CHARS, [config.token]) ?? "",
+    );
   }
-  return { runId: readHookRunId(body) };
+  const parsed = parseHookBody(body);
+  const runId = boundedText(parsed.runId, 128) ?? boundedText(parsed.run_id, 128);
+  return {
+    runId,
+    delivery:
+      parsed.ok === true && runId && !Object.hasOwn(parsed, "completion")
+        ? hookDelivery("admitted")
+        : classifyHookDelivery(parsed.completion, post.deliver, config.token),
+  };
 }
 
 export class OpenClawHookHttpError extends Error {
@@ -148,14 +177,41 @@ export function isTransientOpenClawHookError(error: unknown): boolean {
   );
 }
 
-export function readHookRunId(body: string): string | null {
-  try {
-    const parsed = JSON.parse(body);
-    if (!isJsonObject(parsed)) return null;
-    return stringOrNull(parsed.runId) ?? stringOrNull(parsed.run_id);
-  } catch {
-    return null;
+export function isConclusiveHookDelivery(delivery: OpenClawHookDelivery): boolean {
+  return ["delivered", "admitted", "suppressed", "not-requested"].includes(delivery.status);
+}
+
+export function hookDeliveryReport(delivery: OpenClawHookDelivery): {
+  status: OpenClawHookDeliveryStatus;
+  suppression_reason: string | null;
+  error: string | null;
+} {
+  return {
+    status: delivery.status,
+    suppression_reason: delivery.suppressionReason,
+    error: delivery.error,
+  };
+}
+
+export function describeHookDelivery(delivery: OpenClawHookDelivery): string {
+  if (delivery.status === "admitted") {
+    return "OpenClaw delivery observability unavailable after legacy admission";
   }
+  if (delivery.status === "suppressed" && delivery.suppressionReason) {
+    return `OpenClaw delivery suppressed: ${delivery.suppressionReason}`;
+  }
+  if (delivery.status === "failed" && delivery.error) {
+    return `OpenClaw delivery failed: ${delivery.error}`;
+  }
+  return `OpenClaw delivery ${delivery.status}`;
+}
+
+export function hookDeliveryFromError(error: unknown): OpenClawHookDelivery {
+  return hookDelivery(
+    error instanceof OpenClawHookHttpError ? "failed" : "unknown",
+    null,
+    errorText(error),
+  );
 }
 
 export function positiveInt(value: string | undefined, fallback: number): number {
@@ -183,7 +239,97 @@ export function normalizeString(value: string | undefined): string | undefined {
 }
 
 export function errorText(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
+  return (
+    boundedText(error instanceof Error ? error.message : String(error), MAX_DIAGNOSTIC_CHARS) ?? ""
+  );
+}
+
+function classifyHookDelivery(
+  value: unknown,
+  deliveryRequested: boolean,
+  token: string,
+): OpenClawHookDelivery {
+  if (!isJsonObject(value)) {
+    return hookDelivery("unknown");
+  }
+  const status = value.status;
+  if (status !== "ok" && status !== "error" && status !== "skipped") {
+    return hookDelivery("unknown");
+  }
+
+  const error = boundedText(value.deliveryError, MAX_DIAGNOSTIC_CHARS, [token]);
+  const suppressionReason = boundedText(
+    value.deliverySuppressionReason,
+    MAX_SUPPRESSION_REASON_CHARS,
+  );
+  const replyDisposition =
+    value.replyDisposition === "visible" ||
+    value.replyDisposition === "silent" ||
+    value.replyDisposition === "empty"
+      ? value.replyDisposition
+      : null;
+  if (value.delivered === true) {
+    return hookDelivery("delivered");
+  }
+  if (replyDisposition === "silent") {
+    return hookDelivery("suppressed", suppressionReason ?? "silent");
+  }
+  if (status === "error" || error) {
+    return hookDelivery("failed", null, error);
+  }
+  if (replyDisposition === "visible") {
+    return hookDelivery(value.deliveryAttempted === true ? "failed" : "unknown");
+  }
+  if (suppressionReason) {
+    return hookDelivery("suppressed", suppressionReason);
+  }
+  if (
+    status === "ok" &&
+    !deliveryRequested &&
+    replyDisposition === "empty" &&
+    value.delivered !== true &&
+    value.deliveryAttempted !== true
+  ) {
+    return hookDelivery("not-requested");
+  }
+  if (value.delivered === false && value.deliveryAttempted === true) {
+    return hookDelivery("failed");
+  }
+  return hookDelivery("unknown");
+}
+
+function parseHookBody(body: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(body);
+    return isJsonObject(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function hookDelivery(
+  status: OpenClawHookDeliveryStatus,
+  suppressionReason: string | null = null,
+  error: string | null = null,
+): OpenClawHookDelivery {
+  return { status, suppressionReason, error };
+}
+
+function boundedText(
+  value: unknown,
+  limit: number,
+  redactions: readonly string[] = [],
+): string | null {
+  if (typeof value !== "string") return null;
+  let text = value
+    .replace(/\p{Cc}+/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  for (const redaction of redactions) {
+    if (redaction) text = text.replaceAll(redaction, "<redacted>");
+  }
+  if (!text) return null;
+  return text.length <= limit ? text : `${text.slice(0, limit - 3)}...`;
 }
 
 function delay(ms: number): Promise<void> {

--- a/test/repair/notify-events.test.ts
+++ b/test/repair/notify-events.test.ts
@@ -13,6 +13,34 @@ import {
   runClawSweeperEventNotifier,
 } from "../../dist/repair/notify-events.js";
 
+function createNotifierEventRoot(prefix: string): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  fs.writeFileSync(
+    path.join(root, "repair-apply-report.json"),
+    `${JSON.stringify([
+      {
+        repo: "openclaw/openclaw",
+        target: "#456",
+        action: "close_duplicate",
+        status: "executed",
+        run_id: "987",
+        published_at: "2026-05-02T10:00:00Z",
+      },
+    ])}\n`,
+  );
+  return root;
+}
+
+function notifierEnvironment(): NodeJS.ProcessEnv {
+  return {
+    CLAWSWEEPER_OPENCLAW_HOOK_URL: "https://claw.example/hooks",
+    CLAWSWEEPER_OPENCLAW_HOOK_TOKEN: "secret",
+    CLAWSWEEPER_DISCORD_TARGET: "channel:123",
+    CLAWSWEEPER_STATUS_INGEST_URL: "https://status.example/api/events",
+    CLAWSWEEPER_STATUS_INGEST_TOKEN: "status-secret",
+  };
+}
+
 test("buildApplyEvent maps ClawSweeper merge, close, and blocked events", () => {
   const merge = buildApplyEvent({
     repo: "openclaw/openclaw",
@@ -179,8 +207,15 @@ test("runClawSweeperEventNotifier posts hook payloads and records ledger", async
       body: JSON.parse(String(init?.body)),
       auth: new Headers(init?.headers).get("authorization"),
     });
-    return new Response(JSON.stringify({ ok: true, runId: `hook-${requests.length}` }), {
-      status: 200,
+    return Response.json({
+      ok: true,
+      runId: `hook-${requests.length}`,
+      completion: {
+        status: "ok",
+        replyDisposition: "visible",
+        delivered: true,
+        deliveryAttempted: true,
+      },
     });
   };
 
@@ -203,6 +238,7 @@ test("runClawSweeperEventNotifier posts hook payloads and records ledger", async
   assert.equal(requests.length, 2);
   assert.equal(requests[0]?.auth, "Bearer secret");
   assert.equal(requests[0]?.body.deliver, true);
+  assert.equal(requests[0]?.body.waitForCompletion, true);
   assert.match(String(requests[0]?.body.message), /clawsweeper.pr_merged/);
   assert.match(String(requests[1]?.body.message), /clawsweeper.fix_pr_opened/);
 
@@ -244,7 +280,15 @@ test("runClawSweeperEventNotifier mirrors events to the live status dashboard", 
       return new Response(JSON.stringify({ ok: true }), { status: 200 });
     }
     hookRequests.push(request);
-    return new Response(JSON.stringify({ ok: true, runId: "hook-1" }), { status: 200 });
+    return Response.json({
+      ok: true,
+      runId: "hook-1",
+      completion: {
+        status: "skipped",
+        replyDisposition: "silent",
+        deliverySuppressionReason: "silent",
+      },
+    });
   };
 
   const summary = await runClawSweeperEventNotifier(["--run-id", "987"], {
@@ -277,6 +321,136 @@ test("runClawSweeperEventNotifier mirrors events to the live status dashboard", 
     title: "Duplicate issue",
     note: "duplicate",
   });
+  const report = JSON.parse(
+    fs.readFileSync(path.join(root, "notifications/clawsweeper-event-report.json"), "utf8"),
+  );
+  assert.deepEqual(report.actions[0].delivery, {
+    status: "suppressed",
+    suppression_reason: "silent",
+    error: null,
+  });
+});
+
+for (const scenario of [
+  {
+    name: "failed",
+    completion: {
+      status: "error",
+      replyDisposition: "visible",
+      delivered: false,
+      deliveryAttempted: true,
+      deliveryError: "delivery-failed",
+    },
+    delivery: {
+      status: "failed",
+      suppression_reason: null,
+      error: "delivery-failed",
+    },
+  },
+  {
+    name: "unknown",
+    completion: {
+      status: "ok",
+      replyDisposition: "visible",
+      delivered: false,
+      deliveryAttempted: false,
+      privateDiagnostic: "not public",
+    },
+    delivery: {
+      status: "unknown",
+      suppression_reason: null,
+      error: null,
+    },
+  },
+] as const) {
+  test(`runClawSweeperEventNotifier publishes dashboard but retries ${scenario.name} completion`, async () => {
+    const root = createNotifierEventRoot(`clawsweeper-events-${scenario.name}-`);
+
+    let hookRequests = 0;
+    let dashboardRequests = 0;
+    const fetcher: typeof fetch = async (input) => {
+      if (String(input).startsWith("https://status.example/")) {
+        dashboardRequests += 1;
+        return Response.json({ ok: true });
+      }
+      hookRequests += 1;
+      return Response.json({
+        ok: true,
+        runId: `hook-${hookRequests}`,
+        completion: scenario.completion,
+      });
+    };
+    const runtime = {
+      root,
+      fetch: fetcher,
+      now: () => new Date("2026-05-02T11:00:00Z"),
+      log: () => undefined,
+      env: notifierEnvironment(),
+    };
+
+    const first = await runClawSweeperEventNotifier(["--run-id", "987"], runtime);
+    const second = await runClawSweeperEventNotifier(["--run-id", "987"], runtime);
+
+    assert.equal(first.sent, 0);
+    assert.equal(first.failed, 1);
+    assert.equal(second.sent, 0);
+    assert.equal(second.failed, 1);
+    assert.equal(hookRequests, 2);
+    assert.equal(dashboardRequests, 2);
+    assert.equal(
+      fs.existsSync(path.join(root, "notifications/clawsweeper-event-ledger.json")),
+      false,
+    );
+    const report = JSON.parse(
+      fs.readFileSync(path.join(root, "notifications/clawsweeper-event-report.json"), "utf8"),
+    );
+    assert.equal(report.actions.length, 1);
+    assert.equal(report.actions[0].status, "failed");
+    assert.equal(report.actions[0].hook_run_id, "hook-2");
+    assert.deepEqual(report.actions[0].delivery, scenario.delivery);
+    assert.doesNotMatch(JSON.stringify(report), /not public/);
+  });
+}
+
+test("runClawSweeperEventNotifier reports one failure when delivery and dashboard fail", async () => {
+  const root = createNotifierEventRoot("clawsweeper-events-double-fail-");
+
+  const summary = await runClawSweeperEventNotifier(["--run-id", "987"], {
+    root,
+    fetch: async (input) => {
+      if (String(input).startsWith("https://status.example/")) {
+        return new Response("bad token", { status: 401 });
+      }
+      return Response.json({
+        ok: true,
+        runId: "hook-1",
+        completion: {
+          status: "error",
+          replyDisposition: "visible",
+          delivered: false,
+          deliveryAttempted: true,
+          deliveryError: "delivery-failed",
+        },
+      });
+    },
+    now: () => new Date("2026-05-02T11:00:00Z"),
+    log: () => undefined,
+    env: notifierEnvironment(),
+  });
+
+  assert.equal(summary.sent, 0);
+  assert.equal(summary.failed, 1);
+  const report = JSON.parse(
+    fs.readFileSync(path.join(root, "notifications/clawsweeper-event-report.json"), "utf8"),
+  );
+  assert.equal(report.actions.length, 1);
+  assert.equal(report.actions[0].status, "failed");
+  assert.match(report.actions[0].reason, /dashboard ingest returned 401/);
+  assert.deepEqual(report.actions[0].delivery, {
+    status: "failed",
+    suppression_reason: null,
+    error: "delivery-failed",
+  });
 });
 
 test("runClawSweeperEventNotifier retries events after dashboard ingest failures", async () => {
@@ -301,7 +475,16 @@ test("runClawSweeperEventNotifier retries events after dashboard ingest failures
       if (String(input).startsWith("https://status.example/")) {
         return new Response("bad token", { status: 401 });
       }
-      return new Response(JSON.stringify({ ok: true, runId: "hook-1" }), { status: 200 });
+      return Response.json({
+        ok: true,
+        runId: "hook-1",
+        completion: {
+          status: "ok",
+          replyDisposition: "visible",
+          delivered: true,
+          deliveryAttempted: true,
+        },
+      });
     },
     now: () => new Date("2026-05-02T11:00:00Z"),
     log: () => undefined,

--- a/test/repair/notify-github-activity.test.ts
+++ b/test/repair/notify-github-activity.test.ts
@@ -285,10 +285,20 @@ test("runGithubActivityNotifier posts one bounded forwarded push event", async (
       body: JSON.parse(String(init?.body)),
       auth: new Headers(init?.headers).get("authorization"),
     });
-    return new Response(JSON.stringify({ ok: true, runId: "hook-run-1" }), { status: 200 });
+    return Response.json({
+      ok: true,
+      runId: "hook-run-1",
+      completion: {
+        status: "ok",
+        replyDisposition: "silent",
+        delivered: true,
+        deliveryAttempted: true,
+      },
+    });
   };
 
   const observedAt = new Date("2026-09-05T07:24:31.000Z");
+  const stepSummaryPath = path.join(root, "step-summary.md");
   const summary = await runGithubActivityNotifier(["--write-report"], {
     root,
     fetch: mockFetch,
@@ -301,6 +311,7 @@ test("runGithubActivityNotifier posts one bounded forwarded push event", async (
       CLAWSWEEPER_OPENCLAW_HOOK_URL: "https://claw.example/hooks",
       CLAWSWEEPER_OPENCLAW_HOOK_TOKEN: "secret",
       CLAWSWEEPER_DISCORD_TARGET: "channel:123",
+      GITHUB_STEP_SUMMARY: stepSummaryPath,
     },
   });
 
@@ -308,6 +319,7 @@ test("runGithubActivityNotifier posts one bounded forwarded push event", async (
   assert.equal(requests.length, 1);
   assert.equal(requests[0]?.auth, "Bearer secret");
   assert.equal(requests[0]?.body.deliver, false);
+  assert.equal(requests[0]?.body.waitForCompletion, true);
   assert.match(String(requests[0]?.body.message), /use the message tool/);
   assert.match(String(requests[0]?.body.message), /channel:123/);
   assert.match(String(requests[0]?.body.message), /one exact GitHub event/);
@@ -320,6 +332,12 @@ test("runGithubActivityNotifier posts one bounded forwarded push event", async (
     fs.readFileSync(path.join(root, "notifications/github-activity-report.json"), "utf8"),
   );
   assert.equal(report.generated_at, observedAt.toISOString());
+  assert.deepEqual(report.delivery, {
+    status: "delivered",
+    suppression_reason: null,
+    error: null,
+  });
+  assert.match(fs.readFileSync(stepSummaryPath, "utf8"), /Delivery: `delivered`/);
 });
 
 test("runGithubActivityNotifier skips routine noisy GitHub activity before posting hooks", async () => {

--- a/test/repair/notify-maintainer-report.test.ts
+++ b/test/repair/notify-maintainer-report.test.ts
@@ -110,7 +110,15 @@ test("runMaintainerReportNotifier fetches the live report and posts the hook", a
       body: JSON.parse(String(init?.body)),
       idempotency: new Headers(init?.headers).get("idempotency-key"),
     });
-    return Response.json({ runId: "hook-run-1" });
+    return Response.json({
+      runId: "hook-run-1",
+      completion: {
+        status: "ok",
+        replyDisposition: "visible",
+        delivered: true,
+        deliveryAttempted: true,
+      },
+    });
   };
 
   const summary = await runMaintainerReportNotifier(["--write-report"], {
@@ -133,6 +141,7 @@ test("runMaintainerReportNotifier fetches the live report and posts the hook", a
   assert.equal(requests[0]?.url, "https://claw.example/hooks/agent");
   assert.equal(requests[0]?.idempotency, "maintainer-report:2026-05-22");
   assert.equal(requests[0]?.body?.deliver, true);
+  assert.equal(requests[0]?.body?.waitForCompletion, true);
   assert.deepEqual(reportFetchHeaders, ["access-id", "access-id"]);
   assert.match(
     String(requests[0]?.body?.message),
@@ -143,6 +152,11 @@ test("runMaintainerReportNotifier fetches the live report and posts the hook", a
     fs.readFileSync(path.join(root, "notifications/maintainer-report-discord.json"), "utf8"),
   );
   assert.equal(notification.hook_run_id, "hook-run-1");
+  assert.deepEqual(notification.delivery, {
+    status: "delivered",
+    suppression_reason: null,
+    error: null,
+  });
   assert.equal(notification.report_url, "https://reports.openclaw.ai/day/2026-05-22/");
 });
 

--- a/test/repair/notify-merge.test.ts
+++ b/test/repair/notify-merge.test.ts
@@ -214,7 +214,16 @@ test("runMergeNotifier posts hook payloads and records sent ledger", async () =>
       body: JSON.parse(String(init?.body)),
       auth: new Headers(init?.headers).get("authorization"),
     });
-    return new Response(JSON.stringify({ ok: true, runId: "hook-run-1" }), { status: 200 });
+    return Response.json({
+      ok: true,
+      runId: "hook-run-1",
+      completion: {
+        status: "ok",
+        replyDisposition: "visible",
+        delivered: true,
+        deliveryAttempted: true,
+      },
+    });
   };
 
   const summary = await runMergeNotifier(["--run-id", "987"], {
@@ -235,6 +244,7 @@ test("runMergeNotifier posts hook payloads and records sent ledger", async () =>
   assert.equal(requests[0]?.auth, "Bearer secret");
   assert.equal(requests[0]?.body.agentId, "clawsweeper");
   assert.equal(requests[0]?.body.to, "channel:123");
+  assert.equal(requests[0]?.body.waitForCompletion, true);
   assert.match(String(requests[0]?.body.message), /Fix config parsing/);
 
   const ledger = JSON.parse(
@@ -242,6 +252,14 @@ test("runMergeNotifier posts hook payloads and records sent ledger", async () =>
   );
   assert.equal(ledger.notifications[0].hookRunId, "hook-run-1");
   assert.equal(ledger.notifications[0].discordTarget, "channel:123");
+  const report = JSON.parse(
+    fs.readFileSync(path.join(root, "notifications/clawsweeper-merge-report.json"), "utf8"),
+  );
+  assert.deepEqual(report.actions[0].delivery, {
+    status: "delivered",
+    suppression_reason: null,
+    error: null,
+  });
 
   const rerun = await runMergeNotifier(["--run-id", "987"], {
     root,
@@ -256,6 +274,90 @@ test("runMergeNotifier posts hook payloads and records sent ledger", async () =>
   assert.equal(rerun.sent, 0);
   assert.equal(rerun.skipped, 1);
   assert.equal(requests.length, 1);
+});
+
+test("runMergeNotifier keeps unknown completion retryable and out of the ledger", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-notify-unknown-"));
+  fs.writeFileSync(
+    path.join(root, "repair-apply-report.json"),
+    `${JSON.stringify([
+      {
+        repo: "openclaw/openclaw",
+        target: "#123",
+        action: "merge_candidate",
+        status: "executed",
+        merge_commit_sha: "abc123",
+        run_id: "987",
+      },
+    ])}\n`,
+  );
+
+  const summary = await runMergeNotifier(["--run-id", "987", "--write-report"], {
+    root,
+    fetch: async () =>
+      Response.json({ ok: true, runId: "hook-run-1", completion: { status: "skipped" } }),
+    log: () => undefined,
+    env: {
+      CLAWSWEEPER_OPENCLAW_HOOK_URL: "https://claw.example/hooks",
+      CLAWSWEEPER_OPENCLAW_HOOK_TOKEN: "secret",
+      CLAWSWEEPER_DISCORD_TARGET: "channel:123",
+    },
+  });
+
+  assert.equal(summary.sent, 0);
+  assert.equal(summary.failed, 1);
+  assert.equal(
+    fs.existsSync(path.join(root, "notifications/clawsweeper-merge-ledger.json")),
+    false,
+  );
+  const report = JSON.parse(
+    fs.readFileSync(path.join(root, "notifications/clawsweeper-merge-report.json"), "utf8"),
+  );
+  assert.equal(report.actions[0].delivery.status, "unknown");
+});
+
+test("runMergeNotifier ledgers legacy admission to preserve at-most-once delivery", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-notify-admitted-"));
+  fs.writeFileSync(
+    path.join(root, "repair-apply-report.json"),
+    `${JSON.stringify([
+      {
+        repo: "openclaw/openclaw",
+        target: "#123",
+        action: "merge_candidate",
+        status: "executed",
+        merge_commit_sha: "abc123",
+        run_id: "987",
+      },
+    ])}\n`,
+  );
+
+  let calls = 0;
+  const summary = await runMergeNotifier(["--run-id", "987", "--write-report"], {
+    root,
+    fetch: async () => {
+      calls += 1;
+      return Response.json({ ok: true, runId: "legacy-run" });
+    },
+    log: () => undefined,
+    env: {
+      CLAWSWEEPER_OPENCLAW_HOOK_URL: "https://claw.example/hooks",
+      CLAWSWEEPER_OPENCLAW_HOOK_TOKEN: "secret",
+      CLAWSWEEPER_DISCORD_TARGET: "channel:123",
+    },
+  });
+
+  assert.equal(summary.sent, 1);
+  assert.equal(calls, 1);
+  const ledger = JSON.parse(
+    fs.readFileSync(path.join(root, "notifications/clawsweeper-merge-ledger.json"), "utf8"),
+  );
+  assert.equal(ledger.notifications[0].hookRunId, "legacy-run");
+  const report = JSON.parse(
+    fs.readFileSync(path.join(root, "notifications/clawsweeper-merge-report.json"), "utf8"),
+  );
+  assert.equal(report.actions[0].delivery.status, "admitted");
+  assert.match(report.actions[0].reason, /observability unavailable/);
 });
 
 test("runMergeNotifier returns a strict failure when the hook rejects", async () => {

--- a/test/repair/openclaw-hook.test.ts
+++ b/test/repair/openclaw-hook.test.ts
@@ -28,11 +28,25 @@ const post = {
 
 test("postOpenClawAgentHook retries transient hook failures with the same idempotency key", async () => {
   const calls: string[] = [];
+  const bodies: Record<string, unknown>[] = [];
   const fetcher: typeof fetch = async (_input, init) => {
     calls.push(new Headers(init?.headers).get("idempotency-key") ?? "");
+    bodies.push(JSON.parse(String(init?.body)));
     if (calls.length === 1) return new Response("bad gateway", { status: 502 });
     if (calls.length === 2) throw new Error("read ECONNRESET");
-    return new Response(JSON.stringify({ runId: "run-123" }), { status: 200 });
+    return new Response(
+      JSON.stringify({
+        runId: "run-123",
+        completion: {
+          status: "skipped",
+          replyDisposition: "silent",
+          delivered: false,
+          deliveryAttempted: false,
+          deliverySuppressionReason: "silent",
+        },
+      }),
+      { status: 200 },
+    );
   };
 
   const result = await postOpenClawAgentHook({
@@ -43,7 +57,16 @@ test("postOpenClawAgentHook retries transient hook failures with the same idempo
   });
 
   assert.equal(result.runId, "run-123");
+  assert.deepEqual(result.delivery, {
+    status: "suppressed",
+    suppressionReason: "silent",
+    error: null,
+  });
   assert.deepEqual(calls, ["github-activity:test", "github-activity:test", "github-activity:test"]);
+  assert.equal(
+    bodies.every((body) => body.waitForCompletion === true),
+    true,
+  );
 });
 
 test("postOpenClawAgentHook does not retry non-transient hook failures", async () => {
@@ -61,6 +84,170 @@ test("postOpenClawAgentHook does not retry non-transient hook failures", async (
     /OpenClaw hook returned 401/,
   );
   assert.equal(calls, 1);
+});
+
+test("postOpenClawAgentHook accepts legacy admission without retrying", async () => {
+  let calls = 0;
+  const result = await postOpenClawAgentHook({
+    config,
+    fetcher: async () => {
+      calls += 1;
+      return Response.json({ ok: true, runId: "legacy-run" });
+    },
+    post,
+    retryDelaysMs: [0, 0],
+  });
+
+  assert.equal(calls, 1);
+  assert.equal(result.runId, "legacy-run");
+  assert.deepEqual(result.delivery, {
+    status: "admitted",
+    suppressionReason: null,
+    error: null,
+  });
+});
+
+test("postOpenClawAgentHook classifies bounded completion results", async () => {
+  const cases = [
+    {
+      name: "deliver false with verified message-tool delivery",
+      deliver: false,
+      completion: {
+        status: "ok",
+        replyDisposition: "silent",
+        delivered: true,
+        deliveryAttempted: true,
+      },
+      expected: { status: "delivered", suppressionReason: null, error: null },
+    },
+    {
+      name: "deliver false with exact silent reply",
+      deliver: false,
+      completion: {
+        status: "ok",
+        replyDisposition: "silent",
+        delivered: false,
+        deliveryAttempted: false,
+      },
+      expected: { status: "suppressed", suppressionReason: "silent", error: null },
+    },
+    {
+      name: "exact silent reply wins over later error fields",
+      deliver: false,
+      completion: {
+        status: "error",
+        replyDisposition: "silent",
+        delivered: false,
+        deliveryAttempted: true,
+        deliveryError: "delivery-failed",
+      },
+      expected: { status: "suppressed", suppressionReason: "silent", error: null },
+    },
+    {
+      name: "deliver false with private visible reply",
+      deliver: false,
+      completion: {
+        status: "ok",
+        replyDisposition: "visible",
+        delivered: false,
+        deliveryAttempted: false,
+      },
+      expected: { status: "unknown", suppressionReason: null, error: null },
+    },
+    {
+      name: "deliver false with no delivery or model reply",
+      deliver: false,
+      completion: {
+        status: "ok",
+        replyDisposition: "empty",
+        delivered: false,
+        deliveryAttempted: false,
+      },
+      expected: { status: "not-requested", suppressionReason: null, error: null },
+    },
+    {
+      name: "automatic delivery with explicit suppression",
+      deliver: true,
+      completion: {
+        status: "skipped",
+        replyDisposition: "empty",
+        delivered: false,
+        deliveryAttempted: false,
+        deliverySuppressionReason: "heartbeat",
+      },
+      expected: { status: "suppressed", suppressionReason: "heartbeat", error: null },
+    },
+    {
+      name: "verified delivery wins over terminal errors",
+      deliver: true,
+      completion: {
+        status: "error",
+        replyDisposition: "visible",
+        delivered: true,
+        deliveryAttempted: true,
+        deliveryError: "delivery-failed",
+      },
+      expected: { status: "delivered", suppressionReason: null, error: null },
+    },
+    {
+      name: "terminal delivery error",
+      deliver: true,
+      completion: {
+        status: "error",
+        replyDisposition: "empty",
+        deliveryError: `secret\n${"x".repeat(600)}`,
+      },
+      expectedStatus: "failed",
+    },
+    {
+      name: "deliver false skipped without explicit suppression evidence",
+      deliver: false,
+      completion: {
+        status: "skipped",
+        replyDisposition: "empty",
+        delivered: false,
+        deliveryAttempted: false,
+      },
+      expected: { status: "unknown", suppressionReason: null, error: null },
+    },
+    {
+      name: "missing reply disposition",
+      deliver: false,
+      completion: { status: "ok", deliveryAttempted: false },
+      expected: { status: "unknown", suppressionReason: null, error: null },
+    },
+  ] as const;
+
+  for (const fixture of cases) {
+    const result = await postOpenClawAgentHook({
+      config,
+      fetcher: async () => Response.json({ runId: "run-123", completion: fixture.completion }),
+      post: { ...post, deliver: fixture.deliver },
+    });
+    if ("expected" in fixture) {
+      assert.deepEqual(result.delivery, fixture.expected);
+      continue;
+    }
+    assert.equal(result.delivery.status, fixture.expectedStatus);
+    assert.equal(result.delivery.error?.includes("\n"), false);
+    assert.equal(result.delivery.error?.includes("secret"), false);
+    assert.equal(result.delivery.error?.length, 500);
+  }
+});
+
+test("postOpenClawAgentHook rejects malformed completion as unknown", async () => {
+  const result = await postOpenClawAgentHook({
+    config,
+    fetcher: async () =>
+      Response.json({ ok: true, runId: "run-123", completion: { status: "skipped" } }),
+    post,
+  });
+
+  assert.deepEqual(result.delivery, {
+    status: "unknown",
+    suppressionReason: null,
+    error: null,
+  });
 });
 
 test("resolveOpenClawHookConfig supports explicit retry attempts", () => {


### PR DESCRIPTION
Fixes #1450

Depends on https://github.com/openclaw/openclaw/pull/139155. Land and deploy OpenClaw first.

## What Problem This Solves

Fixes an issue where ClawSweeper could observe only OpenClaw hook admission, so reports and notification ledgers could not distinguish a verified Discord send, exact `NO_REPLY`, an undelivered private reply, or a post-admission failure.

## Why This Change Was Made

All four notifier surfaces now request the additive direct-hook completion response and classify bounded outcomes as `delivered`, `suppressed`, `failed`, `unknown`, `not-requested`, or legacy `admitted`.

Verified delivery has highest precedence, exact silence is terminal suppression, bare skipped/malformed outcomes remain retryable unknowns, and older admission-only OpenClaw responses preserve the previous at-most-once ledger behavior.

## User Impact

Operators get a structured delivery result in notifier reports, plus a concise GitHub activity step summary. Missing Discord posts no longer get explained through unrelated filesystem or pagination guesses when the Gateway has direct terminal evidence.

## OpenClaw Bay Impact

OpenClaw Bay is unaffected. Its public status, queue, and dashboard data contracts do not consume these notification reports or ledgers.

## Documentation Impact

Updated the active event-hook and repair-operations references. Their owners, source-of-truth surfaces, compatibility behavior, deployment order, and update triggers remain explicit.

## Evidence

- `pnpm run build:repair`: passed.
- Focused hook-client and notifier suites: passed.
- Format, lint, docs, and diff checks: passed.
- Mandatory committed-branch Codex review: no actionable P0-P2 findings.
- Production LOC: +259/-23, net +236. This centralizes one bounded hook result/classifier and threads the structured outcome through four existing notifier reports/ledgers.
- Tests: +362/-8. Docs: +51/-6.

## Real Behavior Proof

- Claim: the committed production client preserves verified message-tool delivery, intentional silence, legacy at-most-once admission, and retryable malformed completion as distinct outcomes.
- Surface: `dist/repair/openclaw-hook.js` over a real loopback HTTP socket.
- Scenario: four synthetic Gateway responses exercised `deliver:false + delivered:true`, `silent + status:error`, legacy `{ok:true,runId}`, and malformed completion.
- Command: `node temporary-fixture-harness.mjs` after `pnpm run build:repair`.
- Observed: `delivered`, `suppressed`, `admitted`, and `unknown`, respectively; 4/4 matched.
- Trace: sanitized local proof record from commit `0e52a89cfa44c9eee7ab9fc266d2d052ec1aeba9`.
- Limits: fixture Gateway responses and synthetic payloads; no live Discord or external delivery.
