### PR TITLE
fix: expose publication successor fence diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ checkpoint, and status-only commits are intentionally omitted.
 - Reduce the review ceiling to 32, cap scheduled background reviews at eight, pace scheduled intake at 60 per hour with a six-item burst, and scan normal backlog hourly while retaining manual-review priority and existing leases.
 - Honor the configured Codex reasoning effort in sweep planning, event and shard reviews, assist answers, and close-coverage proofs instead of forcing high reasoning; assist uses the shared fast service tier.
 
+- Authenticated publication reconciliation now diagnoses missing, ambiguous, and mismatched successor fences without changing supersede behavior.
 - Publication reconciliation diagnostics now report the exact acknowledgement-unavailable reason while preserving fail-closed supersede behavior.
 
 - Admit the reviewed mocked marketplace telemetry-redaction and Gateway config CDP-redaction fixtures through exact URI, source-line, path, and decoder bindings without relaxing native scanner checks.

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -6796,6 +6796,25 @@ export class ExactReviewQueue {
     return "routed_receipts_incomplete";
   }
 
+  private publicationSuccessorFenceState(successor: ExactReviewQueueItem | null | undefined) {
+    if (successor === undefined) return "missing" as const;
+    if (successor === null) return "ambiguous" as const;
+    const producer = successor.decision.publication!.producerDecision;
+    const admission = this.lifecycleProjectionStore.read(
+      `${producer.targetRepo}#${producer.itemNumber}`,
+      successor.key,
+      successor.revision,
+    )?.admission;
+    if (!admission) return "admission_missing" as const;
+    if (admission.commandOriginated !== exactReviewDecisionHasCommandContext(producer))
+      return "admission_command_mismatch" as const;
+    if (admission.statusMarker !== (producer.commandStatusMarker ?? null))
+      return "admission_marker_mismatch" as const;
+    if (admission.statusCommentId !== (producer.statusCommentId ?? null))
+      return "admission_comment_mismatch" as const;
+    return "verified" as const;
+  }
+
   private stalePublicationCandidatesSync(
     state: ExactReviewQueueState,
     activeBatchItemKeys: ReadonlySet<string>,
@@ -6874,22 +6893,11 @@ export class ExactReviewQueue {
         const successor = successors.get(currentRevision.targetKey);
         if (
           this.publicationSupersedeSafety(current).acknowledgement_unavailable_reason !==
-            "terminal_missing" ||
-          !successor
+          "terminal_missing"
         )
           continue;
+        if (this.publicationSuccessorFenceState(successor) !== "verified" || !successor) continue;
         const successorProducer = successor.decision.publication!.producerDecision;
-        const successorAdmission = this.lifecycleProjectionStore.read(
-          `${successorProducer.targetRepo}#${successorProducer.itemNumber}`,
-          successor.key,
-          successor.revision,
-        )?.admission;
-        if (
-          successorAdmission?.commandOriginated !== hasCommand(successorProducer) ||
-          successorAdmission.statusMarker !== (successorProducer.commandStatusMarker ?? null) ||
-          successorAdmission.statusCommentId !== (successorProducer.statusCommentId ?? null)
-        )
-          continue;
         const requeue = exactReviewCommandObligationSurvives(producer, successorProducer);
         terminalized.push(
           this.recordLifecycleTerminalDispositionSync(
@@ -6971,7 +6979,7 @@ export class ExactReviewQueue {
           exactReviewLegacyTerminalPublicationCandidate(item, legacyAuthorityByTarget),
       )
       .sort((left, right) => left.createdAt - right.createdAt || left.key.localeCompare(right.key));
-    const { versioned, newestByTarget, stale } = this.stalePublicationCandidatesSync(
+    const { versioned, newestByTarget, stale, successors } = this.stalePublicationCandidatesSync(
       state,
       activeBatchItemKeys,
     );
@@ -7280,17 +7288,25 @@ export class ExactReviewQueue {
         ...remainingLegacyStateBatchTerminal.map((item) => ({ item })),
       ]),
       sample: [
-        ...selected.map(({ item, revision, reason, lineage, retainedKey }) => ({
-          item_key: item.key,
-          queue_revision: item.revision,
-          reason,
-          target_key: revision.targetKey,
-          publication_revision: revision.sourceRevision,
-          superseded_by_revision: newestByTarget.get(revision.targetKey),
-          lineage_claim_generation: lineage?.claimGeneration ?? null,
-          retained_item_key: retainedKey ?? null,
-          ...this.publicationSupersedeSafety(item, true),
-        })),
+        ...selected.map(({ item, revision, reason, lineage, retainedKey }) => {
+          const safety = this.publicationSupersedeSafety(item, true);
+          return {
+            item_key: item.key,
+            queue_revision: item.revision,
+            reason,
+            target_key: revision.targetKey,
+            publication_revision: revision.sourceRevision,
+            superseded_by_revision: newestByTarget.get(revision.targetKey),
+            lineage_claim_generation: lineage?.claimGeneration ?? null,
+            retained_item_key: retainedKey ?? null,
+            successor_fence_state:
+              reason === "stale_revision" &&
+              safety.acknowledgement_unavailable_reason === "terminal_missing"
+                ? this.publicationSuccessorFenceState(successors.get(revision.targetKey))
+                : null,
+            ...safety,
+          };
+        }),
         ...legacyTerminalEligible.map((item) => ({
           item_key: item.key,
           queue_revision: item.revision,
@@ -7300,6 +7316,7 @@ export class ExactReviewQueue {
           superseded_by_revision: null,
           lineage_claim_generation: null,
           retained_item_key: null,
+          successor_fence_state: null,
           ...this.publicationSupersedeSafety(item),
         })),
         ...legacyStateBatchTerminalEligible.map((item) => ({
@@ -7313,6 +7330,7 @@ export class ExactReviewQueue {
           ),
           lineage_claim_generation: item.decision.publication!.claimGeneration,
           retained_item_key: null,
+          successor_fence_state: null,
           producer_run_id: item.decision.publication!.producerRunId,
           producer_run_attempt: item.decision.publication!.producerRunAttempt,
           ...this.publicationSupersedeSafety(item),

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -652,6 +652,10 @@ admission: the same marker and comment requeues without a finalizer, while a
 changed address or non-command successor records superseded with an acknowledgement
 driver. Missing, ambiguous, or mismatched successor state stays retained fail-closed;
 duplicate-lineage and legacy terminal cleanup remains operator-owned.
+Authenticated reconciliation samples report `successor_fence_state` only for
+`stale_revision` rows whose acknowledgement is unavailable because the terminal
+disposition is missing. `verified` is diagnostic evidence, never mutation
+permission; other rows report `null`.
 Successful queue handoff expires the workflow's review-start lease to permit
 another exact-head review; terminal publication still deletes the placeholder.
 

--- a/test/dashboard-worker-publication-lifecycle.test.ts
+++ b/test/dashboard-worker-publication-lifecycle.test.ts
@@ -3826,6 +3826,7 @@ test("signed Worker supersedes only an acknowledgement-safe exact stale publicat
     superseded_by_revision: 2,
     lineage_claim_generation: 1,
     retained_item_key: null,
+    successor_fence_state: null,
     command_context: true,
     acknowledgement_state: "pending",
     acknowledgement_unavailable_reason: null,
@@ -4212,6 +4213,7 @@ test("publication reconciliation derives every acknowledgement state from the ex
         commandContext: sample.command_context,
         acknowledgementState: sample.acknowledgement_state,
         acknowledgementUnavailableReason: sample.acknowledgement_unavailable_reason,
+        successorFenceState: sample.successor_fence_state,
         supersedeSafe: sample.supersede_safe,
       },
       {
@@ -4219,6 +4221,7 @@ test("publication reconciliation derives every acknowledgement state from the ex
         commandContext: entry.producerCommand,
         acknowledgementState: entry.acknowledgementState,
         acknowledgementUnavailableReason: entry.unavailableReason,
+        successorFenceState: entry.name === "terminal_missing" ? "admission_missing" : null,
         supersedeSafe: entry.supersedeSafe,
       },
     );
@@ -4302,17 +4305,21 @@ test("publication reconciliation preserves and does not transplant an unsafe com
   assert.ok(state.items[command.key]);
 });
 
-test("alarm stale command terminalization fails closed without exact successor ownership", async () => {
-  for (const scenario of [
-    "stale_projection_mismatch",
-    "existing_requeue",
-    "missing_successor",
-    "ambiguous_successor",
-    "successor_projection_missing",
-    "successor_projection_mismatch",
-  ] as const) {
+test("stale command successor diagnostics match the alarm ownership fence", async () => {
+  const scenarios = [
+    ["stale_projection_mismatch", null],
+    ["existing_requeue", null],
+    ["missing_successor", "missing"],
+    ["ambiguous_successor", "ambiguous"],
+    ["successor_projection_missing", "admission_missing"],
+    ["successor_command_mismatch", "admission_command_mismatch"],
+    ["successor_marker_mismatch", "admission_marker_mismatch"],
+    ["successor_comment_mismatch", "admission_comment_mismatch"],
+    ["verified", "verified"],
+  ] as const;
+  for (const [index, [scenario, expectedFenceState]] of scenarios.entries()) {
     const storage = new MemoryDurableStorage();
-    const number = 18030 + scenario.length;
+    const number = 18030 + index;
     const stale = leasedExactReviewPublicationItem(number, `${number}0`);
     const fresh = leasedExactReviewPublicationItem(number, `${number}1`);
     const marker = `<!-- clawsweeper-command-status:${number}:re_review:${"e".repeat(40)} -->`;
@@ -4378,31 +4385,42 @@ test("alarm stale command terminalization fails closed without exact successor o
           revision: successor.revision,
           deliveryId: `successor-${successor.key}`,
           sourceAction: producer.sourceAction,
-          commandOriginated: true,
-          statusMarker:
-            scenario === "successor_projection_mismatch" ? `${marker}:mismatch` : marker,
-          statusCommentId: number * 10,
+          commandOriginated: scenario !== "successor_command_mismatch",
+          statusMarker: scenario === "successor_marker_mismatch" ? `${marker}:mismatch` : marker,
+          statusCommentId:
+            scenario === "successor_comment_mismatch" ? number * 10 + 1 : number * 10,
           observedAt: 3,
         });
       }
     }
+    const reconciled = await (
+      await queue.fetch(
+        new Request("https://queue/publications/reconcile", {
+          method: "POST",
+          body: JSON.stringify({ max_items: 1 }),
+        }),
+      )
+    ).json();
+    assert.equal(reconciled.changed, 0);
+    assert.equal(reconciled.sample[0].successor_fence_state, expectedFenceState);
     await queue.alarm();
     const state = storage.sql.readNormalizedQueue() as {
       items: Record<string, ExactReviewQueueItem>;
     };
-    assert.ok(state.items[stale.key]);
+    if (scenario === "verified") assert.equal(state.items[stale.key], undefined);
+    else assert.ok(state.items[stale.key]);
     if (scenario !== "missing_successor") assert.ok(state.items[fresh.key]);
     assert.equal(
       lifecycle.read(identity.canonicalTargetKey, identity.fenceKey, identity.revision)
         ?.terminalDisposition?.kind,
-      scenario === "existing_requeue" ? "requeue" : undefined,
+      scenario === "existing_requeue" || scenario === "verified" ? "requeue" : undefined,
     );
     await queue.alarm();
-    assert.ok(
-      (storage.sql.readNormalizedQueue() as { items: Record<string, ExactReviewQueueItem> }).items[
-        stale.key
-      ],
-    );
+    const replayed = storage.sql.readNormalizedQueue() as {
+      items: Record<string, ExactReviewQueueItem>;
+    };
+    if (scenario === "verified") assert.equal(replayed.items[stale.key], undefined);
+    else assert.ok(replayed.items[stale.key]);
   }
 });
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the authenticated publication-reconciliation response could report a stale command row as `terminal_missing` without identifying which successor uniqueness or lifecycle-admission fence prevented terminal disposition.

## Why This Change Was Made

The exact-review queue now derives one nullable `successor_fence_state` from the same successor and lifecycle-admission predicates used by the alarm path. The field is diagnostic only: `verified` does not grant mutation permission, and no supersede, terminal-disposition, or acknowledgement policy changes.

This is the Worker-first half of a staged rollout. The existing maintenance client accepts the additive Worker field without throwing but intentionally does not expose it yet. A follow-up will add the strict client type/parser and enum/coherence tests only after this Worker contract is deployed, avoiding a new strict client running against an older Worker.

Root cause: the queue already owned the complete successor fence, but the authenticated reconcile response exposed only the aggregate `terminal_missing` result.

Architectural owner: `ExactReviewQueue` remains the uniqueness, admission, and mutation-policy owner.

Canonical fix: one private successor-fence helper is shared by alarm evaluation and reconciliation sampling. No scan, schema, workflow, endpoint, public projection, or client change is included.

Production TypeScript delta: +18 net lines, justified by the new authenticated diagnostic contract and shared owner-boundary helper. Tests are counted separately.

## User Impact

The authenticated Worker response can distinguish a missing or ambiguous successor from each lifecycle-admission mismatch. The existing maintenance client remains compatible during deployment and will expose the field in the staged follow-up.

## OpenClaw Bay Impact

No Bay change. The new value exists only in the authenticated internal reconciliation response; it is not added to any public Bay projection or browser surface.

## Documentation Impact

Updated the active `docs/live-dashboard.md` runbook. Role owner: ClawSweeper maintainers. Source of truth: the authenticated Worker reconcile response at `6b896bf88912f4135d9d61eea1236c6d1f0e3c44`. Update triggers: changes to reconciliation sample fields, successor-fence predicates, or authentication/visibility of the route.

## Evidence

- `pnpm run build:all`: passed on Node 24.
- `node --test test/dashboard-worker-publication-lifecycle.test.ts test/dashboard-worker-queue-runtime.test.ts test/exact-review-publication-batches.test.ts test/repair/exact-review-batch-queue-client.test.ts test/repair/exact-review-batch-coordinator.test.ts`: 426/426 passed.
- `pnpm run check`: passed from a git-backed PR checkout on Crabbox AWS Linux, Node 24.18.1, run `run_aded5cabb9a5`; 5,103 tests, 5,085 passed, 18 skipped, 0 failed. A prior raw-rsync run was discarded because that workspace omitted `.git`, causing two unrelated E2E fixtures that call `git rev-parse HEAD` to fail.
- `git diff --check`: passed.
- Pre-commit and committed-head Codex reviews confirmed that the classifier preserves the existing alarm fence. Both raised the expected staged-rollout limitation that the current maintenance client drops the additive diagnostic. Disposition: deferred to the strict-client follow-up after this Worker deploys; adding it here would recreate the old-Worker/new-client incompatibility that required the split.
- Signed commit: `6b896bf88912f4135d9d61eea1236c6d1f0e3c44`, parented on deployed dry-run repair `50487d1848196e17e8b74e3dd2e7921b1a201588`.

## Real Behavior Proof

**Claim**

The actual signed production reconciliation handler reports the exact successor-fence diagnostic without mutating the tested queue state, and the unchanged production client accepts the additive field.

**Surface**

`POST /internal/exact-review/publications/reconcile` through the production Worker route and production `ExactReviewQueue`, backed by disposable workerd SQLite.

**Scenario**

Two synthetic publication rows share a target: the oldest row is stale with `acknowledgement_unavailable_reason=terminal_missing`; its unique successor has an exact matching lifecycle-admission record.

**Invocation**

- authenticated HMAC request
- `apply=false`
- `max_items=1`
- one request, no retry

**Environment**

- queue source SHA-256: `d87de8a66d8466b3e9ae2425b329ea86ee98f2fcbbf886f6e84d077cfb0b586d`, matching the committed file
- unchanged client source SHA-256: `eaacb158c94c5ecbf3be3b874b36c9a417bab0c8eb15c5519feb05243b254d4a`
- Node 24.16.0
- Miniflare 4.20260701.0
- workerd 1.20260701.1
- report SHA-256: `baf72a479229ed359f8ecaea7d3c10e2b976db50bba100896592c1f94055ef6f`

**Observed**

```text
reason=stale_revision
acknowledgement_unavailable_reason=terminal_missing
successor_fence_state=verified
changed=0
item_count_after=2
terminal_dispositions_after=0
external_calls=0
unchanged_client_sample_count=1
unchanged_client_acknowledgement_unavailable_reason=terminal_missing
```

**Limits**

The proof uses synthetic local rows and disposable workerd SQLite. It does not call GitHub, the deployed Worker, the production queue, or a workflow, and it performs no external mutation.

The independent `apply=false` safety repair in https://github.com/openclaw/clawsweeper/pull/1459 is merged and deployed at `50487d1848196e17e8b74e3dd2e7921b1a201588`. No live reconcile request is dispatched from this PR before the successor diagnostic Worker itself deploys; the post-deploy redacted one-shot remains a separate rollout gate.
