### PR TITLE
fix(workflows): honor reasoning settings and assist fast mode

### DIFF
--- a/.github/workflows/assist.yml
+++ b/.github/workflows/assist.yml
@@ -236,7 +236,7 @@ jobs:
           COMMENT_URL: ${{ github.event.client_payload.comment_url || inputs.comment_url || '' }}
           AUTHOR: ${{ github.event.client_payload.author || inputs.author || '' }}
           MODEL: internal
-          REASONING_EFFORT: high
+          REASONING_EFFORT: ${{ vars.CLAWSWEEPER_CODEX_REASONING_EFFORT || 'high' }}
           TIMEOUT_MS: ${{ github.event.client_payload.assist.timeout_ms || github.event.client_payload.timeout_ms || '120000' }}
         run: |
           set -euo pipefail
@@ -317,7 +317,7 @@ jobs:
           COMMENT_ID: ${{ github.event.client_payload.comment_id || inputs.comment_id || '' }}
           COMMENT_URL: ${{ github.event.client_payload.comment_url || inputs.comment_url || '' }}
           AUTHOR: ${{ github.event.client_payload.author || inputs.author || '' }}
-          REASONING_EFFORT: high
+          REASONING_EFFORT: ${{ vars.CLAWSWEEPER_CODEX_REASONING_EFFORT || 'high' }}
           GENERATION_ATTEMPT: ${{ needs.assist.outputs.generation_attempt }}
         run: |
           set -euo pipefail
@@ -357,7 +357,7 @@ jobs:
           COMMENT_ID: ${{ github.event.client_payload.comment_id || inputs.comment_id || '' }}
           COMMENT_URL: ${{ github.event.client_payload.comment_url || inputs.comment_url || '' }}
           AUTHOR: ${{ github.event.client_payload.author || inputs.author || '' }}
-          REASONING_EFFORT: high
+          REASONING_EFFORT: ${{ vars.CLAWSWEEPER_CODEX_REASONING_EFFORT || 'high' }}
           GENERATION_ATTEMPT: ${{ needs.assist.outputs.generation_attempt }}
         run: |
           set -euo pipefail

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -242,6 +242,7 @@ env:
   CLAWSWEEPER_IDEA_REVIVAL_REACTIONS: ${{ vars.CLAWSWEEPER_IDEA_REVIVAL_REACTIONS || '5' }}
   CLAWSWEEPER_APP_CLIENT_ID: Iv23liOECG0slfuhz093
   CLAWSWEEPER_MODEL: internal
+  CLAWSWEEPER_CODEX_REASONING_EFFORT: ${{ vars.CLAWSWEEPER_CODEX_REASONING_EFFORT || 'high' }}
   CLAWSWEEPER_RUNNER: ${{ vars.CLAWSWEEPER_RUNNER || 'codex' }}
   CLAWSWEEPER_OPENCLAW_MODEL: ${{ secrets.CLAWSWEEPER_OPENCLAW_MODEL }}
   CLAWSWEEPER_OPENCLAW_PROVIDERS_JSON: ${{ secrets.CLAWSWEEPER_OPENCLAW_PROVIDERS_JSON }}
@@ -1463,7 +1464,7 @@ jobs:
             --batch-size 1 \
             --max-pages 1 \
             --codex-model internal \
-            --codex-reasoning-effort high \
+            --codex-reasoning-effort "$CLAWSWEEPER_CODEX_REASONING_EFFORT" \
             --codex-sandbox read-only \
             --codex-timeout-ms "$codex_timeout_ms" \
             --item-numbers "${{ steps.target.outputs.item_number }}" \
@@ -4663,7 +4664,7 @@ jobs:
             --max-pages "$MAX_PAGES" \
             --shard-count "$SHARD_COUNT" \
             --codex-model internal \
-            --codex-reasoning-effort high \
+            --codex-reasoning-effort "$CLAWSWEEPER_CODEX_REASONING_EFFORT" \
             --codex-sandbox read-only \
             --min-active-shards "$MIN_ACTIVE_SHARDS" \
             --min-backfill-review-age-minutes "$MIN_BACKFILL_REVIEW_AGE_MINUTES" \
@@ -4954,7 +4955,7 @@ jobs:
             --batch-size ${{ needs.plan.outputs.batch_size }} \
             --max-pages ${{ needs.plan.outputs.max_pages }} \
             --codex-model internal \
-            --codex-reasoning-effort high \
+            --codex-reasoning-effort "$CLAWSWEEPER_CODEX_REASONING_EFFORT" \
             --codex-sandbox read-only \
             --codex-timeout-ms ${{ needs.plan.outputs.codex_timeout_ms }} \
             --item-numbers "${{ matrix.item_numbers }}" \
@@ -6313,7 +6314,7 @@ jobs:
             --close-delay-ms 0 \
             --max-runtime-ms 2700000 \
             --codex-model internal \
-            --codex-reasoning-effort high \
+            --codex-reasoning-effort "$CLAWSWEEPER_CODEX_REASONING_EFFORT" \
             --artifact-dir .artifacts/apply-proof \
             --report-path .artifacts/apply-proof/apply-report.json \
             --progress-every 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Honor the configured Codex reasoning effort in sweep planning, event and shard reviews, assist answers, and close-coverage proofs instead of forcing high reasoning.
+
 - Publication reconciliation diagnostics now report the exact acknowledgement-unavailable reason while preserving fail-closed supersede behavior.
 
 - Admit the reviewed mocked marketplace telemetry-redaction and Gateway config CDP-redaction fixtures through exact URI, source-line, path, and decoder bindings without relaxing native scanner checks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
-- Honor the configured Codex reasoning effort in sweep planning, event and shard reviews, assist answers, and close-coverage proofs instead of forcing high reasoning.
+- Honor the configured Codex reasoning effort in sweep planning, event and shard reviews, assist answers, and close-coverage proofs instead of forcing high reasoning; assist uses the shared fast service tier.
 
 - Publication reconciliation diagnostics now report the exact acknowledgement-unavailable reason while preserving fail-closed supersede behavior.
 

--- a/README.md
+++ b/README.md
@@ -398,8 +398,9 @@ Review is proposal-only. It never closes items.
   dispatchers can use `shard_count` to bound parallel shards and `batch_size`
   to set the number of items assigned to each worker.
 - Each shard checks out the selected target repository at `main`.
-- Codex reviews with the internal model, high reasoning, the default service tier, and a
-  10-minute per-item timeout.
+- Codex reviews with the internal model and the configured service tier. Sweep planning,
+  reviews, assist answers, and close-coverage proofs honor `CLAWSWEEPER_CODEX_REASONING_EFFORT`
+  (default `high`), matching the repair lane. Reviews have a 10-minute per-item timeout.
 - Each item becomes a flat report under
   `records/<repo-slug>/items/<number>.md` with the decision, evidence,
   Codex `/review`-style PR findings, suggested comment, runtime metadata, and

--- a/src/clawsweeper-assist.ts
+++ b/src/clawsweeper-assist.ts
@@ -20,6 +20,7 @@ import {
   type AssistRequestBinding,
 } from "./assist-artifact.js";
 import { numberArg, stringArg, type Args } from "./clawsweeper-args.js";
+import { DEFAULT_SERVICE_TIER } from "./clawsweeper-policy.js";
 import { safeOutputTail } from "./clawsweeper-text.js";
 import type {
   AssistSourceCommentSnapshot,
@@ -259,7 +260,11 @@ export function createAssistWorkflow({
       ...(options.mode === undefined ? {} : { mode: options.mode }),
       ...(options.lens === undefined ? {} : { lens: options.lens }),
     });
-    const codexConfig = [codexLoginConfig(), 'approval_policy="never"'];
+    const codexConfig = [
+      codexLoginConfig(),
+      'approval_policy="never"',
+      `service_tier=${JSON.stringify(DEFAULT_SERVICE_TIER)}`,
+    ];
     const emptyGitHubConfigDir = join(options.workDir, ".gh-empty");
     ensureDir(emptyGitHubConfigDir);
     const result = runAgentProcess({

--- a/test/assist-artifact.test.ts
+++ b/test/assist-artifact.test.ts
@@ -314,7 +314,12 @@ test("assist workflow isolates Codex generation from the fresh write-token publi
   );
   assert.equal(workflow.match(/uses: actions\/checkout@v7/g)?.length, 4);
   assert.equal(workflow.match(/persist-credentials: false/g)?.length, 4);
-  assert.equal(workflow.match(/REASONING_EFFORT: high/g)?.length, 3);
+  assert.equal(
+    workflow.match(
+      /REASONING_EFFORT: \$\{\{ vars\.CLAWSWEEPER_CODEX_REASONING_EFFORT \|\| 'high' \}\}/g,
+    )?.length,
+    3,
+  );
   assert.doesNotMatch(workflow, /inputs\.reasoning_effort|client_payload\.reasoning_effort/);
 
   assert.match(generation, /Create read-only GitHub App token/);

--- a/test/assist-artifact.test.ts
+++ b/test/assist-artifact.test.ts
@@ -35,6 +35,7 @@ for (const admission of ["clean", "invalid-output"]) {
     t.after(() => rmSync(root, { recursive: true, force: true }));
     const promptPath = join(root, "42.assist.prompt.md");
     const providerInput = join(root, "provider-input");
+    const providerArgs = join(root, "provider-args.json");
     const artifactPath = join(root, "assist-result.json");
     writeFileSync(promptPath, "stale unscanned prompt");
     useFakeScanner(
@@ -49,6 +50,7 @@ ${admission === "invalid-output" ? "process.exit(183);" : ""}
       binary,
       `#!${process.execPath}
 const fs = require('node:fs');
+fs.writeFileSync(${JSON.stringify(providerArgs)}, JSON.stringify(process.argv.slice(2)));
 fs.writeFileSync(${JSON.stringify(providerInput)}, fs.readFileSync(0));
 fs.writeFileSync(process.argv[process.argv.indexOf('--output-last-message') + 1], 'Useful assist answer.');
 `,
@@ -85,6 +87,7 @@ fs.writeFileSync(process.argv[process.argv.indexOf('--output-last-message') + 1]
       workflow.assistGenerateCommand({
         item_number: "42",
         question: "Explain this change.",
+        codex_reasoning_effort: "medium",
         run_id: "123",
         run_attempt: "1",
         artifact: artifactPath,
@@ -97,6 +100,9 @@ fs.writeFileSync(process.argv[process.argv.indexOf('--output-last-message') + 1]
     } else {
       run();
       assert.match(readFileSync(providerInput, "utf8"), /Explain this change\./);
+      const args = JSON.parse(readFileSync(providerArgs, "utf8"));
+      assert.ok(args.includes('service_tier="fast"'));
+      assert.ok(args.includes('model_reasoning_effort="medium"'));
       assert.equal(
         JSON.parse(readFileSync(artifactPath, "utf8")).output.answer,
         "Useful assist answer.",

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -4003,7 +4003,10 @@ test("assist workflow preserves flat field fallbacks after nested dispatch field
     workflow,
     /CLAWSWEEPER_INTERNAL_MODEL: \$\{\{ vars\.CLAWSWEEPER_CODEX_AUTH_MODE != 'clawrouter' && secrets\.CLAWSWEEPER_MODEL \|\| '' \}\}/,
   );
-  assert.match(workflow, /REASONING_EFFORT: high/);
+  assert.match(
+    workflow,
+    /REASONING_EFFORT: \$\{\{ vars\.CLAWSWEEPER_CODEX_REASONING_EFFORT \|\| 'high' \}\}/,
+  );
   assert.doesNotMatch(workflow, /client_payload\.(?:assist\.)?reasoning_effort/);
   assert.match(
     workflow,

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -51,6 +51,37 @@ function runCommentSyncShell(root: string, commands: string[]): string {
   );
 }
 
+test("sweep commands honor configured reasoning effort with the shared high default", () => {
+  const workflow = YAML.parse(readText(".github/workflows/sweep.yml"));
+  const commands = Object.values(workflow.jobs).flatMap((job: any) =>
+    (job.steps ?? []).flatMap((step: any) =>
+      (step.run ?? "")
+        .split("\n")
+        .filter((line: string) => line.includes("--codex-reasoning-effort")),
+    ),
+  );
+  assert.equal(commands.length, 4);
+  assert.equal(
+    workflow.env.CLAWSWEEPER_CODEX_REASONING_EFFORT,
+    "${{ vars.CLAWSWEEPER_CODEX_REASONING_EFFORT || 'high' }}",
+  );
+  for (const effort of ["medium", "high"]) {
+    for (const command of commands) {
+      const argv = execFileSync(
+        "bash",
+        ["-c", `printf '%s\\n' ${command.trim().replace(/\\$/, "")}`],
+        {
+          encoding: "utf8",
+          env: { ...process.env, CLAWSWEEPER_CODEX_REASONING_EFFORT: effort },
+        },
+      )
+        .trim()
+        .split("\n");
+      assert.deepEqual(argv, ["--codex-reasoning-effort", effort]);
+    }
+  }
+});
+
 test("queued publication expires only its posted review lease after successful handoff", () => {
   const steps = YAML.parse(readText(".github/workflows/sweep.yml")).jobs["event-review-apply"]
     .steps;
@@ -2687,7 +2718,7 @@ test("apply workflow isolates proof Codex and keeps mutation free of Git recover
   assert.match(proofJob, /uses: \.\/\.github\/actions\/setup-codex/);
   assert.match(proofJob, /--dry-run/);
   assert.match(proofJob, /--codex-model internal/);
-  assert.match(proofJob, /--codex-reasoning-effort high/);
+  assert.match(proofJob, /--codex-reasoning-effort/);
   assert.match(proofJob, /write_coverage_proof_manifest/);
   assert.match(proofJob, /pr-close-coverage-proof\/\*/);
   assert.match(proofJob, /artifact_name: \$\{\{ steps\.proof-artifact\.outputs\.name \}\}/);


### PR DESCRIPTION
Sweep and assist forced high reasoning even when an operator configured another Codex reasoning effort. Assist also omitted the fast service tier used by review. Every sweep invocation and assist generation/publication step now reads the existing `CLAWSWEEPER_CODEX_REASONING_EFFORT` repository variable, retaining high when unset. Assist also passes the shared fast tier. Repair already reads the reasoning variable and retains its separate issue-implementation override.

Real behavior proof passed at `d7623f014c344b99119aea06a2fcf91339be757c` with Node 24.20.0 and the actual pinned Codex CLI 0.153.3 on macOS, using an isolated API-key-authenticated Codex home and the complete native catalog. The credential-free driver extends `scripts/hosted-review-scan-smoke.mjs`: the existing scanner refusal gates execute first, then production `runCodexForTest` reviews a synthetic committed diff through the real provider, and production `createAssistWorkflow().assistGenerateCommand` generates an answer from synthetic context. GitHub callbacks throw and publication is never invoked. The driver observes only medium/Fast booleans in the actual provider argv; API credentials and model identity are withheld.

Observed result: all four scanner refusal scenarios launched zero provider processes. The admitted review completed the real checkout challenge, executed exactly one successful shell diff command, observed the unpredictable fixture marker, returned the matching structured decision, passed the complete decision-schema and native tool-trace checks, and left the checkout unchanged. Assist received medium reasoning and Fast and returned its expected response marker. The proof artifact is booleans/counts only. Driver SHA-256: `50c651538de559a938b87b9c4f5ec0507d17acfa7bdecd6ec9100c9fa3ef7bbe`; result SHA-256: `f4ec00bff6125eb35256e63367793853048893198a1d66b853fcda76572e118a`. An earlier attempt returned the correct review but failed the strict tool-trace assertion; the successful rerun retained the original gates, with private diagnostic capture added. This proves configured provider execution; external repositories, publication, queue lifecycle, and full-window compaction are outside this canary.

```json
{"reviewMediumFastVerified":true,"assistMediumFastVerified":true,"productionReviewPath":true,"productionAssistPath":true,"assistResponseVerified":true,"refusalScenarioCount":4,"refusalCodexLaunchCount":0,"reviewCodexLaunchCount":2,"decisionSchemaValid":true,"toolAttemptCount":1,"completedToolCount":1,"fixtureToolCount":1,"reviewAfterToolCount":1,"terminalTurnCount":1,"checkoutUnchanged":true}
```

Validation: all three focused workflow tests and seven assist tests pass. The sweep regression executes all four actual shell argument lines and proves medium propagation plus the high fallback; the assist Fast assertion failed before the runtime fix. Static checks, builds, lint, and changed-file coverage pass. Exact-head hosted CI is green, including full `pnpm check`, Windows launcher, sparse builds, and CodeQL. The local full coverage run failed across unrelated timing/stream/lifecycle tests and was stopped; it is not claimed green. Its CrabFleet fairness failure passed in isolation in 9.7 seconds. Native precommit and final committed-branch reviews, plus structured reviews, found no actionable findings through P2.

Workflow production delta is +1 line; assist runtime is +5 lines to use the existing shared tier. README and the Unreleased changelog are updated. OpenClaw Bay is unaffected because lifecycle, queue, publication, and dashboard data contracts are unchanged.
