### PR TITLE
fix: avoid SQLite schema warnings for unrelated runtime edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Scoped unchanged SQLite table context to the changed column's diff hunk and stopped treating runtime property values as schema declarations.
 - Align generated evidence commands with the parser's single-line contract so multiline proof commands remain in evidence detail instead of failing completed reviews.
 - Retire stale comment-router reports before each invocation so early GitHub throttles do not claim prior commands or fail empty action-ledger finalization.
 

--- a/docs/pr-review-comments.md
+++ b/docs/pr-review-comments.md
@@ -232,6 +232,18 @@ generic metadata or identifier filenames. Known storage paths, explicit
 vector/embedding contracts, and same-hunk persistence
 evidence still require review; diagnostic logging does not exempt real storage
 changes in the same patch.
+
+SQLite table detection retains directly changed table DDL and `sqliteTable(...)`
+declarations. Unchanged SQL or ORM table context must share a diff hunk with a
+changed column declaration; context from another hunk cannot establish one.
+Raw SQL columns use whitespace-separated, case-insensitive type keywords,
+including `NULL` and `NUMERIC`. ORM properties require supported column-builder
+calls such as `text(...)` or `integer(...)`; plain `null`, `TEXT`, `INTEGER`, and
+primitive type annotations are not column declarations. Likely-schema path
+uncertainty and approval/compatibility-proof requirements remain unchanged.
+OpenClaw Bay needs no change: the producer's classification is corrected without
+changing observer fields, routes, or controls.
+
 Markdown beside source is still documentation: ordinary
 prose mentioning sessions or metadata is not a stored-format change. Explicit
 storage formats, SQL DDL, and structured storage keys (including frontmatter)

--- a/src/clawsweeper-change-detection.ts
+++ b/src/clawsweeper-change-detection.ts
@@ -242,15 +242,18 @@ function sqliteSchemaPatchChangesTables(patch: string, changedLines: readonly st
     return true;
   }
 
-  const patchText = patch
-    .split("\n")
-    .filter((line) => !line.startsWith("@@") && !line.startsWith("+++") && !line.startsWith("---"))
-    .map((line) => line.replace(/^[ +-]/, ""))
-    .join("\n");
-  return (
-    /\b(?:CREATE|ALTER)\s+(?:VIRTUAL\s+)?TABLE\b|\bsqliteTable\s*\(/i.test(patchText) &&
-    changedLines.some(sqliteSchemaDeclarationLine)
-  );
+  // Unchanged table context only applies to declarations changed in its hunk.
+  return patch.split(/^@@.*$/m).some((hunk) => {
+    const hunkText = hunk
+      .split("\n")
+      .filter((line) => /^[ +-]/.test(line) && !/^(?:\+\+\+|---)/.test(line))
+      .map((line) => line.slice(1))
+      .join("\n");
+    return (
+      /\b(?:CREATE|ALTER)\s+(?:VIRTUAL\s+)?TABLE\b|\bsqliteTable\s*\(/i.test(hunkText) &&
+      changedPatchLines(hunk).some(sqliteSchemaDeclarationLine)
+    );
+  });
 }
 
 function sqliteSchemaDeclarationLine(line: string): boolean {
@@ -259,9 +262,8 @@ function sqliteSchemaDeclarationLine(line: string): boolean {
     /\b(?:CREATE|ALTER|DROP)\s+(?:VIRTUAL\s+)?TABLE\b|\bRENAME\s+TABLE\b|\bsqliteTable\s*\(/i.test(
       text,
     ) ||
-    /^(?:[`"']?[A-Za-z_][\w$]*[`"']?\s+|[A-Za-z_$][\w$]*\s*:\s*)(?:BLOB|INTEGER|NULL|REAL|TEXT|ANY|blob|integer|numeric|real|text)\b/i.test(
-      text,
-    )
+    /^[`"']?[A-Za-z_][\w$]*[`"']?\s+(?:BLOB|INTEGER|NULL|REAL|TEXT|ANY|NUMERIC)\b/i.test(text) ||
+    /^[A-Za-z_$][\w$]*\s*:\s*(?:blob|integer|numeric|real|text)\s*\(/i.test(text)
   );
 }
 

--- a/test/pr-surface-policy.test.ts
+++ b/test/pr-surface-policy.test.ts
@@ -1312,6 +1312,172 @@ test("SQLite schema detector finds production table changes and ignores non-sche
   });
 });
 
+for (const [name, patch] of [
+  [
+    "exact cross-hunk runtime null repro",
+    '@@ -1,2 +1,2 @@\n db.exec("CREATE TABLE sessions (id TEXT)");\n- refresh();\n+ refresh(true);\n@@ -40,3 +40,3 @@\n const diagnostic = {\n-  suffix: "none",\n+  suffix: null,\n };',
+  ],
+  ...[
+    "null",
+    "text",
+    "integer",
+    "TEXT",
+    "INTEGER",
+    "numeric",
+    "string",
+    "number",
+    "boolean",
+    "any",
+  ].map((value) => [
+    `same-hunk runtime property ${value}`,
+    `@@\n db.exec("CREATE TABLE sessions (id TEXT)");\n const diagnostic = {\n-  suffix: "none",\n+  suffix: ${value},\n };`,
+  ]),
+  [
+    "same-hunk primitive type annotations beside ORM context",
+    '@@\n const sessions = sqliteTable("sessions", { id: text("id") });\n type Diagnostic = {\n-  suffix: string;\n+  suffix: null;\n+  text: TEXT;\n+  integer: INTEGER;\n+  count: number;\n };',
+  ],
+  ...[
+    [' db.exec("CREATE TABLE sessions (id TEXT)");', "-  suffix TEXT,\n+  suffix INTEGER,"],
+    [
+      ' const sessions = sqliteTable("sessions", { id: text("id") });',
+      '-  suffix: text("old"),\n+  suffix: integer("new"),',
+    ],
+  ].flatMap(([context, declaration], index) =>
+    [false, true].flatMap((bare) =>
+      [false, true].map((reversed) => {
+        const hunks = [`${context}\n- refresh();\n+ refresh(true);`, declaration];
+        if (reversed) hunks.reverse();
+        return [
+          `cross-hunk ${index === 0 ? "SQL column" : "ORM builder"} (${bare ? "bare" : "numbered"}, context ${reversed ? "last" : "first"})`,
+          hunks
+            .map((hunk, i) => `${bare ? "@@" : `@@ -${i * 40 + 1},2 +${i * 40 + 1},2 @@`}\n${hunk}`)
+            .join("\n"),
+        ];
+      }),
+    ),
+  ),
+  [
+    "file and hunk headers cannot supply table context",
+    'diff --git a/controller.ts b/controller.ts\n--- a/CREATE TABLE sessions\n+++ b/sqliteTable("sessions")\n@@ -1 +1 @@ CREATE TABLE sessions\n-  suffix TEXT,\n+  suffix INTEGER,',
+  ],
+] as const) {
+  for (const normalized of [false, true]) {
+    test(`SQLite ignores ${name} (${normalized ? "production-normalized" : "full"} patch)`, () => {
+      const files = [{ filename: "src/runtime/controller.ts", patch }];
+      const pullFiles = normalized
+        ? hydratePrimaryBody("", "pull_request", { pullFiles: files }).context.pullFiles
+        : files;
+      const report = renderPersistenceReport(pullFiles, "a".repeat(40));
+      const comment = renderReviewCommentFromReport(report, "none");
+      assert.doesNotMatch(
+        comment,
+        /SQLite table change|Persistent data-model change detected|### Stored data model|Add data-model compatibility proof|Confirm migration/,
+      );
+      assert.match(report, /^sqlite_schema_change: false$/m);
+      assert.match(report, /^data_model_change: false$/m);
+      assert.match(comment, /clawsweeper-review-state:ready/);
+      const markers = reviewAutomationMarkersFromReport(report);
+      assert.match(markers, /clawsweeper-verdict:pass/);
+      assert.doesNotMatch(markers, /needs-human|fix-required/);
+      assert.deepEqual(sqliteSchemaChangeFromPullFilesForTest({ pullFiles }), {
+        change: false,
+        files: [],
+      });
+      assert.deepEqual(dataModelChangeFromPullFilesForTest({ pullFiles }), {
+        change: false,
+        surfaces: [],
+      });
+    });
+  }
+}
+
+for (const [name, context, declaration] of [
+  ...["blob", "integer", "NULL", "null", "real", "text", "any", "numeric(10, 2)"].map((type) => [
+    `added SQL ${type} column`,
+    " CREATE TABLE sessions (",
+    `+  suffix ${type},`,
+  ]),
+  ["changed SQL column", " create table sessions (", "-  suffix text,\n+  suffix integer,"],
+  ["removed quoted SQL column", " CREATE TABLE sessions (", '-  "suffix" TEXT,'],
+  ["ALTER TABLE column", " ALTER TABLE sessions", "+  suffix text,"],
+  ["virtual table column", " CREATE VIRTUAL TABLE sessions USING fts5 (", "+  suffix text,"],
+  ...["blob", "integer", "numeric", "real", "text"].map((builder) => [
+    `ORM ${builder} builder call`,
+    ' const sessions = sqliteTable("sessions", {',
+    `+  suffix: ${builder}("suffix"),`,
+  ]),
+  [
+    "changed ORM column",
+    ' const sessions = sqliteTable("sessions", {',
+    '-  suffix: text("suffix"),\n+  suffix: integer("suffix"),',
+  ],
+  [
+    "removed ORM column",
+    ' const sessions = sqliteTable("sessions", {',
+    '-  suffix: text("suffix"),',
+  ],
+] as const) {
+  test(`SQLite retains same-hunk ${name} and compatibility proof gates`, () => {
+    for (const header of ["", "@@\n", "@@ -1,3 +1,4 @@\n"]) {
+      for (const normalized of [false, true]) {
+        const files = [
+          { filename: "src/runtime/controller.ts", patch: `${header}${context}\n${declaration}` },
+        ];
+        const pullFiles = normalized
+          ? hydratePrimaryBody("", "pull_request", { pullFiles: files }).context.pullFiles
+          : files;
+        const report = renderPersistenceReport(pullFiles, "a".repeat(40));
+        const comment = renderReviewCommentFromReport(report, "none");
+        assert.match(comment, /SQLite table change/);
+        assert.match(comment, /- \[ \] \*\*Add data-model compatibility proof\*\*/);
+        assert.match(comment, /clawsweeper-review-state:blocked/);
+        assert.match(report, /^sqlite_schema_change: true$/m);
+        assert.match(report, /^data_model_change: true$/m);
+        const markers = reviewAutomationMarkersFromReport(report);
+        assert.match(markers, /clawsweeper-verdict:needs-human/);
+        assert.doesNotMatch(markers, /clawsweeper-verdict:pass|clawsweeper-action:fix-required/);
+        assert.deepEqual(sqliteSchemaChangeFromPullFilesForTest({ pullFiles }), {
+          change: true,
+          files: ["src/runtime/controller.ts"],
+        });
+        assert.deepEqual(dataModelChangeFromPullFilesForTest({ pullFiles }), {
+          change: true,
+          surfaces: ["database schema: src/runtime/controller.ts"],
+        });
+      }
+    }
+  });
+}
+
+test("SQLite retains directly changed table declarations in a separate hunk", () => {
+  for (const declaration of [
+    'db.exec("CREATE TABLE sessions (id TEXT)");',
+    'db.exec("ALTER TABLE sessions ADD COLUMN suffix TEXT");',
+    'db.exec("DROP TABLE sessions");',
+    'db.exec("RENAME TABLE sessions TO previous_sessions");',
+    'const sessions = sqliteTable("sessions", { id: text("id") });',
+  ]) {
+    for (const sign of ["+", "-"]) {
+      const pullFiles = hydratePrimaryBody("", "pull_request", {
+        pullFiles: [
+          {
+            filename: "src/runtime/controller.ts",
+            patch: `@@ -1 +1 @@\n- refresh();\n+ refresh(true);\n@@ -40 +40 @@\n${sign}${declaration}`,
+          },
+        ],
+      }).context.pullFiles;
+      assert.deepEqual(sqliteSchemaChangeFromPullFilesForTest({ pullFiles }), {
+        change: true,
+        files: ["src/runtime/controller.ts"],
+      });
+      assert.match(
+        renderReviewCommentFromReport(renderPersistenceReport(pullFiles, "a".repeat(40)), "none"),
+        /SQLite table change/,
+      );
+    }
+  }
+});
+
 test("production path classification preserves test segment and basename boundaries", () => {
   const cases = [
     ["test/schema.sql", false],


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where contributors receive a false **SQLite table change** warning when a runtime-only edit shares a file with unchanged table setup. The confirmed example changes `refresh()` to `refresh(true)` and a diagnostic `suffix` from a string to `null` in another diff hunk; the database schema does not change.

## Why This Change Was Made

The producer previously joined the whole patch when looking for unchanged table context and used one case-insensitive pattern for both raw SQL columns and JavaScript properties. This combined unrelated hunks and interpreted `suffix: null` as a SQL declaration.

Unchanged SQL/ORM table context now applies only within the changed declaration's hunk. Raw SQL columns remain case-insensitive; ORM properties require supported column-builder calls. Direct changed table DDL, genuine same-hunk columns, and conservative likely-schema uncertainty remain detectable. Approval and compatibility-proof gates are not weakened. Serialization and filename/path-ownership classification are outside this change.

## User Impact

Runtime-only changes no longer receive an invented SQLite schema warning. Genuine table changes continue to receive their warning and compatibility-proof requirements. The detector remains a bounded lexical heuristic, not a complete SQL/JavaScript parser.

## OpenClaw Bay Impact

Unaffected: no observer API, fields, routes, or controls change.

## Documentation Impact

Updated active implementation guidance in `docs/pr-review-comments.md` and added one Unreleased changelog entry. Reviewed `AGENTS.md`, `CONTRIBUTING.md`, `docs/README.md`, and the proposed material-SQLite-change policy; the proposal remains untouched and grants no new enforcement authority.

## Evidence

Reviewed head: `5f3f045d394bb7309eed889890062ead311f4ab6`.

The regression suite covers the supplied cross-hunk repro, same-hunk runtime values/type annotations, independently tested hunk locality, lowercase/NULL/NUMERIC SQL columns, ORM builder calls, added/changed/removed declarations, direct DDL, normalized input, and contributor-visible warnings/readiness/automation markers.

The new negative regressions failed before the source fix: 121 passed, 34 failed. The initial fixed run passed all 155 focused tests. A fresh pre-commit Codex review found no actionable P0–P2 findings.

At this head, `pnpm run build` and `node --test test/pr-surface-policy.test.ts` passed all 155 focused tests with no failures. The committed branch also passed a fresh isolated Codex review against current `main`, with no actionable P0–P2 findings. Required repository checks remain mandatory before merge.

## Real Behavior Proof

**Claim and surface:** the compiled SQLite/data-model producers reject the supplied runtime-only false positive while continuing to classify genuine table changes. Equivalent before/after programs are executed against real in-memory SQLite databases using Node's `DatabaseSync`; `sqlite_schema`, `PRAGMA table_info`, diagnostic values, and refresh calls provide the observable result.

**Environment:** local macOS, Node 24+, repository-pinned pnpm. All inputs are synthetic; no hosted workflow, production database, or live publication is used for this proof.

**Observed result at the reviewed head:** the baseline at `da713f68d3fd46a1e6b123da5d709062b412cd1b` reports a SQLite change for the supplied patch; this head reports neither a SQLite nor a data-model change. Actual SQLite schemas stay identical while diagnostics/refresh behavior change. Three positive controls change actual columns and remain detected: a normal SQL column, a raw SQL `NULL` column, and `ALTER TABLE`.

```json
{
  "outcome": "PASS",
  "head": "5f3f045d394bb7309eed889890062ead311f4ab6",
  "node": "v24.20.0",
  "platform": "darwin",
  "runtimeSchemaUnchanged": true,
  "baseline": {
    "sqlite": {
      "change": true,
      "files": [
        "src/runtime/controller.ts"
      ]
    },
    "dataModel": {
      "change": false,
      "surfaces": []
    }
  },
  "candidate": {
    "sqlite": {
      "change": false,
      "files": []
    },
    "dataModel": {
      "change": false,
      "surfaces": []
    }
  },
  "positiveControls": [
    {
      "name": "SQL column",
      "sqliteChange": true,
      "dataModelChange": true,
      "columns": [
        "revision",
        "id"
      ]
    },
    {
      "name": "SQL NULL column",
      "sqliteChange": true,
      "dataModelChange": true,
      "columns": [
        "suffix",
        "id"
      ]
    },
    {
      "name": "ALTER TABLE",
      "sqliteChange": true,
      "dataModelChange": true,
      "columns": [
        "id",
        "revision"
      ]
    }
  ]
}
```

**Reproduction:** run the following from the repository root on the reviewed head. The baseline commit must be available locally.

```bash
pnpm run build
```

```bash
node --input-type=module <<'NODE'
import assert from "node:assert/strict";
import { execFileSync } from "node:child_process";
import { stripTypeScriptTypes } from "node:module";
import { DatabaseSync } from "node:sqlite";
import { pathToFileURL } from "node:url";
import { resolve } from "node:path";
import { runInNewContext } from "node:vm";

const candidate = await import(pathToFileURL(resolve("dist/clawsweeper-change-detection.js")).href);
const baselineSource = execFileSync("git", ["show", "da713f68d3fd46a1e6b123da5d709062b412cd1b:src/clawsweeper-change-detection.ts"], { encoding: "utf8" });
const baselineJs = stripTypeScriptTypes(baselineSource).replace('"./openclaw-file-role.js"', JSON.stringify(pathToFileURL(resolve("dist/openclaw-file-role.js")).href));
const baseline = await import(`data:text/javascript;base64,${Buffer.from(baselineJs).toString("base64")}`);
const filename = "src/runtime/controller.ts";
function detect(module, patch) {
  const context = { issue: {}, comments: [], timeline: [], counts: { comments: 0, timeline: 0 }, pullFiles: [{ filename, patch }] };
  return {
    sqlite: module.sqliteSchemaChangeFromContext("openclaw/openclaw", context),
    dataModel: module.dataModelChangeFromContext("openclaw/openclaw", context),
  };
}
function execute(source) {
  const db = new DatabaseSync(":memory:");
  const refreshCalls = [];
  try {
    const diagnostic = runInNewContext(`${source}\n;typeof diagnostic === "undefined" ? null : diagnostic;`, { db, refresh: (...args) => refreshCalls.push(args) }, { timeout: 1000 });
    return JSON.parse(JSON.stringify({ diagnostic, refreshCalls, schema: db.prepare("SELECT name, sql FROM sqlite_schema WHERE type = 'table' ORDER BY name").all(), columns: db.prepare("PRAGMA table_info(sessions)").all() }));
  } finally { db.close(); }
}
const patch = '@@ -1,2 +1,2 @@\n db.exec("CREATE TABLE sessions (id TEXT)");\n- refresh();\n+ refresh(true);\n@@ -40,3 +40,3 @@\n const diagnostic = {\n-  suffix: "none",\n+  suffix: null,\n };';
const before = execute('db.exec("CREATE TABLE sessions (id TEXT)");\nrefresh();\nconst diagnostic = { suffix: "none" };');
const after = execute('db.exec("CREATE TABLE sessions (id TEXT)");\nrefresh(true);\nconst diagnostic = { suffix: null };');
assert.deepEqual(before.schema, after.schema);
assert.deepEqual(before.columns, after.columns);
assert.notDeepEqual(before.diagnostic, after.diagnostic);
assert.notDeepEqual(before.refreshCalls, after.refreshCalls);
const oldResult = detect(baseline, patch);
const fixedResult = detect(candidate, patch);
assert.deepEqual(oldResult, { sqlite: { change: true, files: [filename] }, dataModel: { change: false, surfaces: [] } });
assert.deepEqual(fixedResult, { sqlite: { change: false, files: [] }, dataModel: { change: false, surfaces: [] } });
const controls = [
  ["SQL column", 'db.exec(`CREATE TABLE sessions (\n  revision integer,\n  id TEXT\n);`);', '@@\n db.exec(`CREATE TABLE sessions (\n+  revision integer,\n   id TEXT\n );`);'],
  ["SQL NULL column", 'db.exec(`CREATE TABLE sessions (\n  suffix NULL,\n  id TEXT\n);`);', '@@\n db.exec(`CREATE TABLE sessions (\n+  suffix NULL,\n   id TEXT\n );`);'],
  ["ALTER TABLE", 'db.exec("CREATE TABLE sessions (id TEXT)");\ndb.exec("ALTER TABLE sessions ADD COLUMN revision INTEGER");', '@@\n db.exec("CREATE TABLE sessions (id TEXT)");\n+db.exec("ALTER TABLE sessions ADD COLUMN revision INTEGER");'],
].map(([name, program, changedPatch]) => {
  const actual = execute(program);
  assert.notDeepEqual(before.schema, actual.schema, name);
  assert.notDeepEqual(before.columns, actual.columns, name);
  const detection = detect(candidate, changedPatch);
  assert.equal(detection.sqlite.change, true, name);
  assert.equal(detection.dataModel.change, true, name);
  return { name, sqliteChange: true, dataModelChange: true, columns: actual.columns.map((column) => column.name) };
});
console.log(JSON.stringify({ outcome: "PASS", head: execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim(), node: process.version, platform: process.platform, runtimeSchemaUnchanged: true, baseline: oldResult, candidate: fixedResult, positiveControls: controls }, null, 2));
NODE
```

**Limits:** this proves the compiled classifier boundary and actual SQLite schema outcomes for these fixtures, not hosted review/publication or database migration safety. The focused regression suite separately verifies report generation, visible warnings, readiness, and compatibility-proof gates. No real-user data or agent transcript is included.
