### PR TITLE
fix(queue): dry runs mutate publication lifecycle and expired batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Keep publication reconciliation dry runs from recording terminal lifecycle state or reclaiming expired publication batches.
+
 - Reduce the review ceiling to 32, cap scheduled background reviews at eight, pace scheduled intake at 60 per hour with a six-item burst, and scan normal backlog hourly while retaining manual-review priority and existing leases.
 - Honor the configured Codex reasoning effort in sweep planning, event and shard reviews, assist answers, and close-coverage proofs instead of forcing high reasoning; assist uses the shared fast service tier.
 

--- a/dashboard/exact-review-publication-batches.ts
+++ b/dashboard/exact-review-publication-batches.ts
@@ -341,10 +341,10 @@ export class ExactReviewPublicationBatchStore {
     });
   }
 
-  activeLeaseSnapshot(now: number) {
+  activeLeaseSnapshot(now: number, options: { reclaimExpired?: boolean } = {}) {
     return this.storage.transactionSync(() => {
-      this.reclaimExpiredSync(now);
-      return this.activeLeaseSnapshotSync();
+      if (options.reclaimExpired !== false) this.reclaimExpiredSync(now);
+      return this.activeLeaseSnapshotSync(now);
     });
   }
 
@@ -569,7 +569,7 @@ export class ExactReviewPublicationBatchStore {
       );
       const counts = new Map(rows.map((row) => [String(row.state), Number(row.count)]));
       const leased = rows.find((row) => row.state === "leased");
-      const activeLease = this.activeLeaseSnapshotSync();
+      const activeLease = this.activeLeaseSnapshotSync(now);
       const reclaimedItemsRetained = Number(
         Array.from(
           this.storage.sql.exec(
@@ -628,15 +628,17 @@ export class ExactReviewPublicationBatchStore {
     }
   }
 
-  private activeLeaseSnapshotSync() {
+  private activeLeaseSnapshotSync(now: number) {
     const rows = Array.from(
       this.storage.sql.exec(
         `SELECT membership.item_key, membership.batch_id, batch.lease_expires_at
            FROM ${EXACT_REVIEW_PUBLICATION_BATCH_ITEM_TABLE} AS membership
            JOIN ${EXACT_REVIEW_PUBLICATION_BATCH_TABLE} AS batch
              ON batch.batch_id = membership.batch_id
-          WHERE batch.state = 'leased' AND membership.terminal_outcome IS NULL
+          WHERE batch.state = 'leased' AND batch.lease_expires_at > ?
+            AND membership.terminal_outcome IS NULL
           ORDER BY membership.item_key`,
+        now,
       ),
     );
     return {

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -5664,7 +5664,9 @@ export class ExactReviewQueue {
 
     const checkedAt = Date.now();
     const checkedState = this.readStateSync();
-    const batchOwnership = this.batchStore.activeLeaseSnapshot(checkedAt);
+    const batchOwnership = this.batchStore.activeLeaseSnapshot(checkedAt, {
+      reclaimExpired: options.apply !== false,
+    });
     const checkedBatchItemKeys = new Set<string>(batchOwnership.itemKeys);
     if (options.legacyReconciliation) {
       for (const candidate of liveStates) {
@@ -5713,7 +5715,7 @@ export class ExactReviewQueue {
       ) {
         continue;
       }
-      if (candidate.hostedAdmission?.outcome === "terminal") {
+      if (options.apply !== false && candidate.hostedAdmission?.outcome === "terminal") {
         this.recordHostedTargetTerminal(item, checkedAt);
       }
       delete checkedState.items[item.key];
@@ -6933,7 +6935,11 @@ export class ExactReviewQueue {
     }
 
     const now = Date.now();
-    let activeBatchItemKeys = new Set<string>(this.batchStore.activeLeaseSnapshot(now).itemKeys);
+    // Dry runs classify expiry without terminalizing batch membership. Only the
+    // apply path owns canonical queue, lifecycle, and batch changes.
+    let activeBatchItemKeys = new Set<string>(
+      this.batchStore.activeLeaseSnapshot(now, { reclaimExpired: apply }).itemKeys,
+    );
     let state = this.readStateSync();
     const reclaimed =
       limit > 1 &&

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -733,6 +733,14 @@ cancellation clears the lease and requeues the item. Finalizer success remains
 provisional because GitHub can still cancel the run or fail a post-action; only
 the signed terminal-run backstop removes the item after GitHub confirms the
 exact attempt succeeded. A newer revision can requeue immediately. A signed
+`POST /internal/exact-review/publications/reconcile` defaults to `apply:false`.
+It classifies stale and legacy publication candidates without reconciliation-driven
+queue, lifecycle, batch, or Bay mutations; expired batches are excluded from active
+ownership without reclaiming their rows. Existing admission-cache revocation,
+request cleanup, and cold-start initialization still run. `apply:true` retains
+normal expiry recovery and terminalization. This is an authenticated operator
+route, not a Bay action.
+
 `POST /internal/exact-review/reconcile` backstop accepts at most 32 exact run IDs
 and intersects them with currently claimed leases. The Worker checks those IDs
 and attempts with an Actions-read GitHub App token and reconciles only runs

--- a/test/dashboard-worker-queue-runtime.test.ts
+++ b/test/dashboard-worker-queue-runtime.test.ts
@@ -38,6 +38,7 @@ import {
 } from "../src/hosted-target-admission.ts";
 import { directReReviewIntake } from "../src/repair/direct-re-review-admission.ts";
 import { EXACT_REVIEW_SOURCE_AUTHORITY_RETRY_LIMIT } from "../dashboard/exact-review-decision.ts";
+import { ExactReviewPublicationBatchStore } from "../dashboard/exact-review-publication-batches.ts";
 
 function serializedConsoleCalls(calls: unknown[][]) {
   return calls
@@ -2292,6 +2293,182 @@ test("publication reconcile terminalizes a completed protocol-v1 publication aft
   });
 });
 
+test("publication reconciliation dry runs preserve canonical state after private transitions", async (t) => {
+  const now = Date.parse("2026-09-06T00:00:00Z");
+  t.mock.method(Date, "now", () => now);
+  for (const protocol of [1, 2]) {
+    let admission: HostedPublicTargetProbe = "public";
+    let targetTokens = 0;
+    let producerChecks = 0;
+    const harness = createExactReviewAdmissionHarness(
+      () => {
+        assert.fail("private targets must not be read");
+      },
+      {
+        hostedPublicTargetProbe: async () => admission,
+        targetAccessToken: (_installationId, init) => {
+          const body = JSON.parse(String(init?.body));
+          if (body.permissions?.issues || body.permissions?.pull_requests) targetTokens += 1;
+          return jsonResponse({ token: "queue-token" });
+        },
+        producerRun: (runId, _runAttempt, kind) => {
+          producerChecks += 1;
+          return jsonResponse({
+            id: runId,
+            run_attempt: 1,
+            status: "completed",
+            ...(kind === "attempt" ? { conclusion: "success" } : {}),
+          });
+        },
+      },
+    );
+    await withExactReviewAdmissionHarness(harness, async () => {
+      const itemNumber = 9380 + protocol;
+      const producerRunId = "30091560790";
+      const itemKey = `openclaw/gogcli#${itemNumber}@publish:${producerRunId}:1`;
+      const publication =
+        protocol === 1
+          ? legacyExactReviewPublicationOverrides(itemNumber, producerRunId)
+          : exactReviewPublicationOverrides(itemNumber, producerRunId);
+      assert.equal(
+        (
+          await harness.queue.fetch(
+            buildExactReviewQueueRequest(
+              `private-dry-run-v${protocol}`,
+              itemNumber,
+              "exact_review_artifact_publish",
+              "issue",
+              "openclaw/gogcli",
+              publication,
+            ),
+          )
+        ).status,
+        202,
+      );
+      const batches = new ExactReviewPublicationBatchStore(harness.storage);
+      batches.claim({
+        batchId: "expired-private-publication",
+        leaseOwner: "worker",
+        leaseExpiresAt: now,
+        now: now - 1,
+        maxItems: 1,
+        candidates: [{ itemKey, revision: 1 }],
+      });
+      const tables = Array.from(
+        harness.storage.sql.exec(
+          "SELECT name FROM sqlite_master WHERE type = 'table' AND name LIKE 'exact_review_%' ORDER BY name",
+        ),
+        (row) => String(row.name),
+      );
+      const snapshot = async () => ({
+        tables: Object.fromEntries(
+          tables.map((table) => [
+            table,
+            Array.from(harness.storage.sql.exec(`SELECT * FROM ${table} ORDER BY rowid`)),
+          ]),
+        ),
+        alarm: await harness.storage.getAlarm(),
+      });
+      const before = await snapshot();
+      admission = "terminal";
+      const reconcile = (apply?: boolean) =>
+        harness.queue.fetch(
+          new Request("https://clawsweeper-exact-review-queue/publications/reconcile", {
+            method: "POST",
+            body: JSON.stringify({ ...(apply === undefined ? {} : { apply }), max_items: 1 }),
+          }),
+        );
+      for (const apply of [false, undefined]) {
+        const response = await reconcile(apply);
+        assert.equal(response.status, 200);
+        const result = await response.json();
+        assert.equal(result.changed, 0);
+        assert.equal(
+          protocol === 1
+            ? result.legacy_terminal_eligible
+            : result.legacy_state_batch_terminal_eligible,
+          1,
+        );
+        assert.deepEqual(await snapshot(), before);
+        assert.equal(targetTokens, 0);
+      }
+      assert.equal(producerChecks, protocol === 2 ? 4 : 0);
+      const applied = await (await reconcile(true)).json();
+      assert.equal(applied.changed, 1);
+      assert.equal(
+        Array.from(
+          harness.storage.sql.exec(
+            "SELECT item_key FROM exact_review_queue_items WHERE item_key = ?",
+            itemKey,
+          ),
+        ).length,
+        0,
+      );
+      assert.equal(
+        new ExactReviewLifecycleProjectionStore(harness.storage).read(
+          `openclaw/gogcli#${itemNumber}`,
+          itemKey,
+          1,
+        )?.terminalDisposition?.kind,
+        "superseded",
+      );
+      assert.equal(
+        Array.from(
+          harness.storage.sql.exec(
+            "SELECT state FROM exact_review_publication_batches WHERE batch_id = 'expired-private-publication'",
+          ),
+        )[0]?.state,
+        "expired",
+      );
+      assert.equal(targetTokens, 0);
+    });
+  }
+});
+
+test("publication reconciliation dry runs preserve expired batches without legacy candidates", async (t) => {
+  const now = Date.parse("2026-09-06T00:00:00Z");
+  t.mock.method(Date, "now", () => now);
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  // Initialize once before taking the raw baseline; cold-start migrations are
+  // independent of the reconciliation operation.
+  await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/publications/reconcile", {
+      method: "POST",
+      body: JSON.stringify({ apply: false, max_items: 1 }),
+    }),
+  );
+  const batches = new ExactReviewPublicationBatchStore(storage);
+  batches.claim({
+    batchId: "expired-without-candidate",
+    leaseOwner: "worker",
+    leaseExpiresAt: now,
+    now: now - 1,
+    maxItems: 1,
+    candidates: [{ itemKey: "openclaw/gogcli#9390@publish:30091560791:1", revision: 1 }],
+  });
+  const snapshot = () =>
+    [
+      "exact_review_queue_items",
+      "exact_review_queue_meta",
+      "exact_review_publication_batches",
+      "exact_review_publication_batch_items",
+      "exact_review_publication_batch_generations",
+    ].map((table) => Array.from(storage.sql.exec(`SELECT * FROM ${table} ORDER BY rowid`)));
+  const before = snapshot();
+  const alarm = await storage.getAlarm();
+  const response = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/publications/reconcile", {
+      method: "POST",
+      body: JSON.stringify({ apply: false, max_items: 1 }),
+    }),
+  );
+  assert.equal(response.status, 200);
+  assert.equal((await response.json()).changed, 0);
+  assert.deepEqual(snapshot(), before);
+  assert.equal(await storage.getAlarm(), alarm);
+});
+
 test("publication reconcile dry runs verify terminal legacy rows without deleting them", async () => {
   let terminal = false;
   let liveChecks = 0;
@@ -2400,6 +2577,33 @@ test("publication reconcile terminalizes a closed legacy publication after its l
     });
     await harness.storage.put("exact-review-queue", stored);
 
+    const durableSnapshot = async () => ({
+      tables: [
+        "exact_review_queue_items",
+        "exact_review_queue_meta",
+        "exact_review_lifecycle_projection_v1",
+        "exact_review_publication_batches",
+        "exact_review_publication_batch_items",
+        "exact_review_publication_batch_generations",
+      ].map((table) =>
+        Array.from(harness.storage.sql.exec(`SELECT * FROM ${table} ORDER BY rowid`)),
+      ),
+      alarm: await harness.storage.getAlarm(),
+    });
+    const before = await durableSnapshot();
+    const dryRun = await (
+      await harness.queue.fetch(
+        new Request("https://clawsweeper-exact-review-queue/publications/reconcile", {
+          method: "POST",
+          body: JSON.stringify({ apply: false, max_items: 100 }),
+        }),
+      )
+    ).json();
+    assert.equal(dryRun.changed, 0);
+    assert.equal(dryRun.legacy_terminal_eligible, 1);
+    assert.equal(probeState, "leased");
+    assert.deepEqual(await durableSnapshot(), before);
+
     const reconciled = await (
       await harness.queue.fetch(
         new Request("https://clawsweeper-exact-review-queue/publications/reconcile", {
@@ -2409,7 +2613,7 @@ test("publication reconcile terminalizes a closed legacy publication after its l
       )
     ).json();
 
-    assert.equal(liveChecks, 1);
+    assert.equal(liveChecks, 2);
     assert.equal(probeState, "pending");
     assert.equal(reconciled.changed, 1);
     const after = (await harness.storage.get("exact-review-queue")) as {

--- a/test/exact-review-publication-batches.test.ts
+++ b/test/exact-review-publication-batches.test.ts
@@ -610,6 +610,54 @@ test("publication batches allow a bounded number of disjoint active owners", () 
   });
 });
 
+test("publication batch snapshots can exclude expired leases without reclaiming them", () => {
+  const storage = new TestStorage();
+  const batches = new ExactReviewPublicationBatchStore(storage);
+  batches.ensureSchemaSync();
+  for (const [index, leaseExpiresAt] of [1_999, 2_000, 2_001].entries()) {
+    batches.claim({
+      batchId: `boundary-${index}`,
+      leaseOwner: "worker",
+      leaseExpiresAt,
+      now: 1_000,
+      maxItems: 1,
+      maxConcurrentBatches: 3,
+      candidates: [candidates[index]],
+    });
+  }
+  const snapshot = () =>
+    [
+      "exact_review_publication_batches",
+      "exact_review_publication_batch_items",
+      "exact_review_publication_batch_generations",
+    ].map((table) => Array.from(storage.sql.exec(`SELECT * FROM ${table} ORDER BY rowid`)));
+  const before = snapshot();
+
+  const observed = batches.activeLeaseSnapshot(2_000, { reclaimExpired: false });
+
+  assert.deepEqual(observed, {
+    items: [{ itemKey: candidates[2].itemKey, batchId: "boundary-2" }],
+    itemKeys: [candidates[2].itemKey],
+    activeBatches: 1,
+    nextLeaseExpiresAt: 2_001,
+  });
+  assert.deepEqual(snapshot(), before);
+  assert.deepEqual(batches.activeLeaseSnapshot(2_000), observed);
+  assert.equal(
+    storage.scalar(
+      "SELECT COUNT(*) AS value FROM exact_review_publication_batches WHERE state = 'expired'",
+    ),
+    2,
+  );
+  assert.equal(
+    storage.scalar(
+      "SELECT COUNT(*) AS value FROM exact_review_publication_batch_items WHERE terminal_outcome = 'lease_expired'",
+    ),
+    2,
+  );
+  assert.deepEqual(snapshot()[2], before[2]);
+});
+
 test("batch schema migration derives a safe cap for an active legacy lease", () => {
   const storage = new TestStorage();
   storage.exec(


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where an operator's publication-reconciliation dry run could mark a private target's lifecycle terminal and reclaim expired publication batches while reporting `changed: 0`.

Related: https://github.com/openclaw/clawsweeper/pull/1452

## Why This Change Was Made

The terminalization owner now gates lifecycle recording on `apply`. The batch owner has an explicit non-reclaim snapshot option, and its shared query excludes expired leases using the same `lease_expires_at > now` boundary as normal expiry recovery. Only publication reconciliation opts out of reclamation for dry runs; all default callers and `apply:true` keep their previous behavior.

Scope: two production files, **+8 net production lines**. No schema, endpoint, capacity, retry, acknowledgement, successor-fence, or hosted-admission policy changes. This does not claim zero storage writes: existing admission-cache revocation, request cleanup, and cold initialization remain intact.

## User Impact

Publication diagnostics no longer change canonical queue, lifecycle, batch, or Bay state as a side effect. Operators still need an explicit apply action to change those records.

## OpenClaw Bay Impact

No Bay code or public contract change. Avoiding premature terminal lifecycle recording prevents dry-run-driven Bay projection updates. The runtime proof snapshots every `exact_review_*` SQL table, including Bay event, pending, scope, and metadata tables. Bay remains observer-only.

## Documentation Impact

Updated the active authenticated-route reference in `docs/live-dashboard.md`; it distinguishes reconciliation mutations from admission-cache revocation, cleanup, and cold initialization. The owning source remains `dashboard/exact-review-queue.ts` and `dashboard/exact-review-publication-batches.ts`; maintainers should refresh this description when the apply boundary changes. Added release-note context to this repository's changelog.

## Evidence

- Baseline regression reproduced lifecycle terminal recording, batch `leased -> expired`, and member `null -> lease_expired` while `changed` remained zero.
- `node --test test/exact-review-publication-batches.test.ts test/dashboard-worker-queue-runtime.test.ts test/dashboard-worker-publication-lifecycle.test.ts`: **397 passed**.
- Focused coverage includes expiry `< now`, `== now`, and `> now`; default snapshot reclamation; private transitions for protocols v1/v2; omitted apply; one-item dry runs with no legacy candidate; and a larger-limit expired item lease followed by apply.
- `pnpm run build:all`, targeted Oxfmt, `pnpm run check:docs`, and `git diff --check`: passed.
- Full `pnpm run check`: passed in [exact-head CI](https://github.com/openclaw/clawsweeper/actions/runs/34003976485/job/101407737900) and an isolated AWS Crabbox with hydration disabled (Node 24.18.1, run `run_880df6096611`, exit 0). The remote full suite passed 5,085 tests, skipped 18, and had zero failures or cancellations; its separate changed-file coverage suite passed all 13 tests.
- Fresh pre-commit Codex review and committed-base review against `03182ae34303203557df136e147297ad5be25099`: no actionable findings.

## Real Behavior Proof

**Claim:** `apply:false` and omitted apply perform no reconciliation-driven canonical queue, lifecycle, batch, or Bay mutation; security revocation and explicit apply behavior remain intact.

**Surface:** real HMAC-signed `POST /internal/exact-review/publications/reconcile`, production Worker and ExactReviewQueue handlers, disposable workerd SQLite Durable Object. No `/stats` calls are used before or after the measured operation.

**Scenarios:** same initialized object runs public admission -> private visibility -> dry run -> omitted-apply dry run -> apply, separately for protocol v1 and completed state-batch v2. Additional scenarios cover an expired batch with no candidate at `max_items:1`, and an expired item lease with `max_items:100`.

**Command and environment:** `node <local-proof-script> <fresh-output-directory> <installed-wrangler-prefix>`, Node 26.7.0, Miniflare 4.20260701.0, workerd 1.20260701.1. The baseline is frozen at `03182ae34303203557df136e147297ad5be25099`; the executed committed head is `22909492a141b3db9c837b85ff4e53c3db72c3a4`. GitHub responses and credentials are synthetic and intercepted; unexpected outbound routes fail.

**Observable result:** all canonical SQL tables and the alarm remain byte-equivalent through both dry-run calls for every patched scenario. Private-target admission cache entries are revoked as before, with zero target issue/PR tokens or item reads; state-batch Actions-read probes remain allowed. Explicit apply removes the eligible queue row, records its terminal lifecycle, and expires batch membership. Final canonical apply state is identical between baseline and patch.

```json
{
  "signed_production_handler": true,
  "scenarios": ["private-v1", "private-v2", "no-candidate", "expired-item"],
  "patched_dry_run_changed_tables": [[], [], [], []],
  "private_target_tokens": 0,
  "private_target_reads": 0,
  "alarm_unchanged": true,
  "admission_revocation_preserved": true,
  "final_apply_state_equivalent": true
}
```

**Artifact:** retained local `reconcile-dry-run-proof-raw/behavior-report.json` and its eight baseline/patched scenario snapshot files, including runtime versions, baseline identity, raw before/dry-run/apply state, changed-table sets, and fixture request counts. Owner SHA-256 hashes: queue `1518d05114bc0a450288b747f791acd2f2f1e6ca468abe1ea025fb28b14fd9ba`; batch store `45e15b20dfb53b6e7f0129de80792a194592f0e47ab05d3bc20e76b35fdfd22c`.

**Limits:** synthetic local workerd and GitHub fixtures; no production queue request, live GitHub mutation, deployment, real backlog cleanup, or claim about concurrent production alarms.
