### PR TITLE
fix(review): classify OpenClaw redaction fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Admit the reviewed OpenClaw logging redaction fixtures through exact detector, native decoder, role, value-hash, source-line, path, mode, and metadata bindings while preserving legacy URI fixture behavior.
+
 - Keep publication reconciliation dry runs from recording terminal lifecycle state or reclaiming expired publication batches.
 
 - Reduce the review ceiling to 32, cap scheduled background reviews at eight, pace scheduled intake at 60 per hour with a six-item burst, and scan normal backlog hourly while retaining manual-review priority and existing leases.

--- a/README.md
+++ b/README.md
@@ -621,13 +621,24 @@ The pinned Base64 decoder preserves the rest of a chunk after
 decoding another token, so an unchanged literal can acquire that decoder label
 and win cross-decoder deduplication. Those entries still require the literal in
 its exact original source line; encoded-only content remains blocking.
+
+The OpenClaw [logging redaction fixtures](https://github.com/openclaw/openclaw/blob/fe0367a07a23660ea35007ac69bdb8f54309fc21/src/logging/redact.test.ts)
+use a separate flat attribution table without changing the legacy URI policy
+above. Each row binds the exact detector ID and name, native `PLAIN` or
+`ESCAPED_UNICODE` decoder, base/head role, `Raw`, `RawV2`, and complete source-line
+SHA-256 digests, path, and mode. URI findings require one literal `RawV2` witness
+and derived host, username, and password fields. MongoDB and Postgres findings
+bind the scanner-reported line and their exact native metadata shape. Any emitted
+subset and order may qualify; duplicate exact findings, unknown variants, lossy
+decoder buckets, or an unqualified deduplicated blob reference refuse admission.
+
 One source path may contain multiple independently reviewed fixtures; each
 digest/path/mode tuple must match exactly, so source membership alone never
 qualifies a finding.
-Deduplicated blobs retain every scanned logical endpoint's path and Git mode,
-including mode-only transitions and shared-path aliases. Every captured reference
-must qualify under the same digest's exact path and mode `100644` policy before
-any source is eligible for classification or an audit notice.
+Deduplicated blobs retain every scanned logical endpoint's role, path, and Git
+mode, including mode-only transitions and shared-path aliases. Every captured
+reference must qualify under the same exact attribution policy before any source
+is eligible for classification or an audit notice.
 The policy does not trust checkout ignore rules, domain patterns, fixture words,
 test names, or unchanged-line inference; no nearby fixture is implicitly approved.
 When review evidence quotes an exact reviewed synthetic URI, prompt preparation
@@ -646,9 +657,10 @@ upgrades require requalification. See `src/agent-input-scan-fixtures.ts`.
 After successful cleanup and final source fences, each accepted fixture/source
 pair emits a host-side structured stderr notice with `event`, `fixtureSha256`,
 `source`, `detector`, and `findings` entries containing `blob`, `decoder`, and
-`occurrences`. Each finding retains its reported `scannerLine` and a `literalLine`
-for the first exact literal in the staged blob. This bounded witness establishes
-literal presence; it does not identify which occurrence produced a decoded hit.
+`occurrences`; role-bound findings also include `role`. Each finding retains its
+reported `scannerLine` and a `literalLine` for the first exact literal in the
+staged blob. This bounded witness establishes literal presence; it does not
+identify which occurrence produced a decoded hit.
 Counts are per source: a shared blob can appear in both source
 notices and those counts must not be summed across sources. A refused or drifted
 scan emits no success notice. Raw values and verification diagnostics never

--- a/src/agent-input-scan-fixtures.ts
+++ b/src/agent-input-scan-fixtures.ts
@@ -9,6 +9,20 @@ interface ReviewedFixture {
   sources: readonly string[];
 }
 
+export type ScanSourceRole = "base" | "head" | "index" | "tree" | "worktree";
+
+export type ReviewedAttribution = readonly [
+  detectorType: 17 | 895 | 968,
+  detectorName: "URI" | "MongoDB" | "Postgres",
+  decoder: "PLAIN" | "ESCAPED_UNICODE",
+  role: ScanSourceRole,
+  rawSha256: string,
+  rawV2Sha256: string,
+  lineSha256: string,
+  source: string,
+  mode: "100644",
+];
+
 // This is host policy, never an allowlist loaded from the reviewed checkout.
 const REVIEWED_FIXTURES: readonly ReviewedFixture[] = [
   {
@@ -156,6 +170,44 @@ const REVIEWED_FIXTURES: readonly ReviewedFixture[] = [
   },
 ];
 
+// oxfmt-ignore
+const REVIEWED_ATTRIBUTIONS: readonly ReviewedAttribution[] = [
+  [17, "URI", "ESCAPED_UNICODE", "base", "a460200b4a488bc178d0dac30bc5fe027ff86d9c7c94554f5c9d915580bc4239", "839b16fa1dd892daf47ab10d50f7c1957a16ace282fe9e6df67fefc40f7f06ff", "232cce5bf0c7b495e2f008fdc45cbd2bd9afc5394906576e4466411f6841d260", "src/logging/redact.test.ts", "100644"],
+  [17, "URI", "ESCAPED_UNICODE", "base", "de7dcbd8612764d80691e85407d899f6e3686afd9ab40964943c3874ffe9571c", "198d323e34c2a045b86adbc72b8cd54bb8f9582175c5c25e6c68b4e374d8873f", "8ff8c788b296b7eb81abaf7f2f48bb4be717f6e8bef76200e7c842dbeea8a15c", "src/logging/redact.test.ts", "100644"],
+  [17, "URI", "ESCAPED_UNICODE", "head", "31ff9f3ec446cbcc27e6fc08f3cd96b5d95d8b436b4144f3a098d7c524a863f7", "0d9e27039ed24044fe06ab5145d7b04569ced32d3ff6fe8eb9acf04a75663919", "47171b920ebd0800ac107a92ad80b7279677f0096fad5a367f82fe3b1955c790", "src/logging/redact.test.ts", "100644"],
+  [17, "URI", "ESCAPED_UNICODE", "head", "de7dcbd8612764d80691e85407d899f6e3686afd9ab40964943c3874ffe9571c", "198d323e34c2a045b86adbc72b8cd54bb8f9582175c5c25e6c68b4e374d8873f", "8ff8c788b296b7eb81abaf7f2f48bb4be717f6e8bef76200e7c842dbeea8a15c", "src/logging/redact.test.ts", "100644"],
+  [17, "URI", "PLAIN", "base", "31ff9f3ec446cbcc27e6fc08f3cd96b5d95d8b436b4144f3a098d7c524a863f7", "0d9e27039ed24044fe06ab5145d7b04569ced32d3ff6fe8eb9acf04a75663919", "47171b920ebd0800ac107a92ad80b7279677f0096fad5a367f82fe3b1955c790", "src/logging/redact.test.ts", "100644"],
+  [17, "URI", "PLAIN", "base", "a460200b4a488bc178d0dac30bc5fe027ff86d9c7c94554f5c9d915580bc4239", "839b16fa1dd892daf47ab10d50f7c1957a16ace282fe9e6df67fefc40f7f06ff", "232cce5bf0c7b495e2f008fdc45cbd2bd9afc5394906576e4466411f6841d260", "src/logging/redact.test.ts", "100644"],
+  [17, "URI", "PLAIN", "base", "de7dcbd8612764d80691e85407d899f6e3686afd9ab40964943c3874ffe9571c", "198d323e34c2a045b86adbc72b8cd54bb8f9582175c5c25e6c68b4e374d8873f", "8ff8c788b296b7eb81abaf7f2f48bb4be717f6e8bef76200e7c842dbeea8a15c", "src/logging/redact.test.ts", "100644"],
+  [17, "URI", "PLAIN", "head", "31ff9f3ec446cbcc27e6fc08f3cd96b5d95d8b436b4144f3a098d7c524a863f7", "0d9e27039ed24044fe06ab5145d7b04569ced32d3ff6fe8eb9acf04a75663919", "47171b920ebd0800ac107a92ad80b7279677f0096fad5a367f82fe3b1955c790", "src/logging/redact.test.ts", "100644"],
+  [17, "URI", "PLAIN", "head", "a460200b4a488bc178d0dac30bc5fe027ff86d9c7c94554f5c9d915580bc4239", "839b16fa1dd892daf47ab10d50f7c1957a16ace282fe9e6df67fefc40f7f06ff", "232cce5bf0c7b495e2f008fdc45cbd2bd9afc5394906576e4466411f6841d260", "src/logging/redact.test.ts", "100644"],
+  [17, "URI", "PLAIN", "head", "de7dcbd8612764d80691e85407d899f6e3686afd9ab40964943c3874ffe9571c", "198d323e34c2a045b86adbc72b8cd54bb8f9582175c5c25e6c68b4e374d8873f", "8ff8c788b296b7eb81abaf7f2f48bb4be717f6e8bef76200e7c842dbeea8a15c", "src/logging/redact.test.ts", "100644"],
+  [895, "MongoDB", "ESCAPED_UNICODE", "base", "087c10edd5d21290a4a8695083ff8c42554fc1d1a1becea9053b11c4790b859c", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "0aeba0d1b540784464c2a230b589a48d3f062d0dbbb2d9669450ff4ee2176218", "src/logging/redact.test.ts", "100644"],
+  [895, "MongoDB", "ESCAPED_UNICODE", "head", "087c10edd5d21290a4a8695083ff8c42554fc1d1a1becea9053b11c4790b859c", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "0aeba0d1b540784464c2a230b589a48d3f062d0dbbb2d9669450ff4ee2176218", "src/logging/redact.test.ts", "100644"],
+  [895, "MongoDB", "PLAIN", "base", "087c10edd5d21290a4a8695083ff8c42554fc1d1a1becea9053b11c4790b859c", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "0aeba0d1b540784464c2a230b589a48d3f062d0dbbb2d9669450ff4ee2176218", "src/logging/redact.test.ts", "100644"],
+  [895, "MongoDB", "PLAIN", "head", "087c10edd5d21290a4a8695083ff8c42554fc1d1a1becea9053b11c4790b859c", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "0aeba0d1b540784464c2a230b589a48d3f062d0dbbb2d9669450ff4ee2176218", "src/logging/redact.test.ts", "100644"],
+  [968, "Postgres", "ESCAPED_UNICODE", "base", "050c1ddf61dd8b806e1a75cbe572669f8fa546e4ba36d03454377ba7a2c05d66", "050c1ddf61dd8b806e1a75cbe572669f8fa546e4ba36d03454377ba7a2c05d66", "6dc3c292a8c87dd8c203af74bf1fa03f3eb64ae12bafc23dadfff9c3f63c23e6", "src/logging/redact.test.ts", "100644"],
+  [968, "Postgres", "ESCAPED_UNICODE", "base", "39a0315176e45802aaa3c5c40c2a717e2fde14e99567c38b5640fe16138710fa", "39a0315176e45802aaa3c5c40c2a717e2fde14e99567c38b5640fe16138710fa", "4b03f485ba97fd1aea07f64e978e9a961179dbbb766828f20fc8a2401812a858", "src/logging/redact.test.ts", "100644"],
+  [968, "Postgres", "ESCAPED_UNICODE", "base", "4734d8b7c6e9bf96ae464bfc45b1482e00caaedea951cb96b9e88a92ba37a00f", "4734d8b7c6e9bf96ae464bfc45b1482e00caaedea951cb96b9e88a92ba37a00f", "252d197820142c40bc8701a8b1400f28a3224f305f37fd65cd2e6bfbe48d9fb1", "src/logging/redact.test.ts", "100644"],
+  [968, "Postgres", "ESCAPED_UNICODE", "base", "8be6f6c2f1e50f070e97e4b46fce7e7ad499a6bc0c145e8bdd4fc0a6ee4b5565", "8be6f6c2f1e50f070e97e4b46fce7e7ad499a6bc0c145e8bdd4fc0a6ee4b5565", "6a9d1339c87f11af0ba4e7ef89a77ea8eb8e7f7ac48fdec0abb19d9138821d18", "src/logging/redact.test.ts", "100644"],
+  [968, "Postgres", "ESCAPED_UNICODE", "base", "f2e76a2fe75ea0d64265b2a61462f1d8026a2286e3030077b4f3972fc0df3b70", "f2e76a2fe75ea0d64265b2a61462f1d8026a2286e3030077b4f3972fc0df3b70", "2020783f7b14c74d2d6960efca4ca82727980494ddef883f15ae9980141662ec", "src/logging/redact.test.ts", "100644"],
+  [968, "Postgres", "ESCAPED_UNICODE", "head", "050c1ddf61dd8b806e1a75cbe572669f8fa546e4ba36d03454377ba7a2c05d66", "050c1ddf61dd8b806e1a75cbe572669f8fa546e4ba36d03454377ba7a2c05d66", "6dc3c292a8c87dd8c203af74bf1fa03f3eb64ae12bafc23dadfff9c3f63c23e6", "src/logging/redact.test.ts", "100644"],
+  [968, "Postgres", "ESCAPED_UNICODE", "head", "39a0315176e45802aaa3c5c40c2a717e2fde14e99567c38b5640fe16138710fa", "39a0315176e45802aaa3c5c40c2a717e2fde14e99567c38b5640fe16138710fa", "4b03f485ba97fd1aea07f64e978e9a961179dbbb766828f20fc8a2401812a858", "src/logging/redact.test.ts", "100644"],
+  [968, "Postgres", "ESCAPED_UNICODE", "head", "4734d8b7c6e9bf96ae464bfc45b1482e00caaedea951cb96b9e88a92ba37a00f", "4734d8b7c6e9bf96ae464bfc45b1482e00caaedea951cb96b9e88a92ba37a00f", "252d197820142c40bc8701a8b1400f28a3224f305f37fd65cd2e6bfbe48d9fb1", "src/logging/redact.test.ts", "100644"],
+  [968, "Postgres", "ESCAPED_UNICODE", "head", "8be6f6c2f1e50f070e97e4b46fce7e7ad499a6bc0c145e8bdd4fc0a6ee4b5565", "8be6f6c2f1e50f070e97e4b46fce7e7ad499a6bc0c145e8bdd4fc0a6ee4b5565", "6a9d1339c87f11af0ba4e7ef89a77ea8eb8e7f7ac48fdec0abb19d9138821d18", "src/logging/redact.test.ts", "100644"],
+  [968, "Postgres", "ESCAPED_UNICODE", "head", "f2e76a2fe75ea0d64265b2a61462f1d8026a2286e3030077b4f3972fc0df3b70", "f2e76a2fe75ea0d64265b2a61462f1d8026a2286e3030077b4f3972fc0df3b70", "2020783f7b14c74d2d6960efca4ca82727980494ddef883f15ae9980141662ec", "src/logging/redact.test.ts", "100644"],
+  [968, "Postgres", "PLAIN", "base", "050c1ddf61dd8b806e1a75cbe572669f8fa546e4ba36d03454377ba7a2c05d66", "050c1ddf61dd8b806e1a75cbe572669f8fa546e4ba36d03454377ba7a2c05d66", "6dc3c292a8c87dd8c203af74bf1fa03f3eb64ae12bafc23dadfff9c3f63c23e6", "src/logging/redact.test.ts", "100644"],
+  [968, "Postgres", "PLAIN", "base", "39a0315176e45802aaa3c5c40c2a717e2fde14e99567c38b5640fe16138710fa", "39a0315176e45802aaa3c5c40c2a717e2fde14e99567c38b5640fe16138710fa", "4b03f485ba97fd1aea07f64e978e9a961179dbbb766828f20fc8a2401812a858", "src/logging/redact.test.ts", "100644"],
+  [968, "Postgres", "PLAIN", "base", "4734d8b7c6e9bf96ae464bfc45b1482e00caaedea951cb96b9e88a92ba37a00f", "4734d8b7c6e9bf96ae464bfc45b1482e00caaedea951cb96b9e88a92ba37a00f", "252d197820142c40bc8701a8b1400f28a3224f305f37fd65cd2e6bfbe48d9fb1", "src/logging/redact.test.ts", "100644"],
+  [968, "Postgres", "PLAIN", "base", "8be6f6c2f1e50f070e97e4b46fce7e7ad499a6bc0c145e8bdd4fc0a6ee4b5565", "8be6f6c2f1e50f070e97e4b46fce7e7ad499a6bc0c145e8bdd4fc0a6ee4b5565", "6a9d1339c87f11af0ba4e7ef89a77ea8eb8e7f7ac48fdec0abb19d9138821d18", "src/logging/redact.test.ts", "100644"],
+  [968, "Postgres", "PLAIN", "base", "f2e76a2fe75ea0d64265b2a61462f1d8026a2286e3030077b4f3972fc0df3b70", "f2e76a2fe75ea0d64265b2a61462f1d8026a2286e3030077b4f3972fc0df3b70", "2020783f7b14c74d2d6960efca4ca82727980494ddef883f15ae9980141662ec", "src/logging/redact.test.ts", "100644"],
+  [968, "Postgres", "PLAIN", "head", "050c1ddf61dd8b806e1a75cbe572669f8fa546e4ba36d03454377ba7a2c05d66", "050c1ddf61dd8b806e1a75cbe572669f8fa546e4ba36d03454377ba7a2c05d66", "6dc3c292a8c87dd8c203af74bf1fa03f3eb64ae12bafc23dadfff9c3f63c23e6", "src/logging/redact.test.ts", "100644"],
+  [968, "Postgres", "PLAIN", "head", "39a0315176e45802aaa3c5c40c2a717e2fde14e99567c38b5640fe16138710fa", "39a0315176e45802aaa3c5c40c2a717e2fde14e99567c38b5640fe16138710fa", "4b03f485ba97fd1aea07f64e978e9a961179dbbb766828f20fc8a2401812a858", "src/logging/redact.test.ts", "100644"],
+  [968, "Postgres", "PLAIN", "head", "4734d8b7c6e9bf96ae464bfc45b1482e00caaedea951cb96b9e88a92ba37a00f", "4734d8b7c6e9bf96ae464bfc45b1482e00caaedea951cb96b9e88a92ba37a00f", "252d197820142c40bc8701a8b1400f28a3224f305f37fd65cd2e6bfbe48d9fb1", "src/logging/redact.test.ts", "100644"],
+  [968, "Postgres", "PLAIN", "head", "8be6f6c2f1e50f070e97e4b46fce7e7ad499a6bc0c145e8bdd4fc0a6ee4b5565", "8be6f6c2f1e50f070e97e4b46fce7e7ad499a6bc0c145e8bdd4fc0a6ee4b5565", "6a9d1339c87f11af0ba4e7ef89a77ea8eb8e7f7ac48fdec0abb19d9138821d18", "src/logging/redact.test.ts", "100644"],
+  [968, "Postgres", "PLAIN", "head", "f2e76a2fe75ea0d64265b2a61462f1d8026a2286e3030077b4f3972fc0df3b70", "f2e76a2fe75ea0d64265b2a61462f1d8026a2286e3030077b4f3972fc0df3b70", "2020783f7b14c74d2d6960efca4ca82727980494ddef883f15ae9980141662ec", "src/logging/redact.test.ts", "100644"],
+];
+
 export function serializeReviewContext(context: object): string {
   return JSON.stringify(
     context,
@@ -192,6 +244,7 @@ export interface ScanSourceReference {
   source: string;
   mode: string;
   revision: string;
+  role: ScanSourceRole;
 }
 
 export type ScanInputOrigin =
@@ -207,7 +260,7 @@ interface ScanMaterialDiagnostic {
   from?: string;
   to?: string;
   referenceCount?: number;
-  references?: { revision: string; pathSha256: string; mode: string }[];
+  references?: { revision: string; pathSha256: string; mode: string; role: ScanSourceRole }[];
 }
 
 export type ScanRefusalDiagnostic =
@@ -229,7 +282,8 @@ export type ScanRefusalDiagnostic =
         | "material_not_reviewed"
         | "source_not_reviewed"
         | "metadata_mismatch"
-        | "literal_mismatch";
+        | "literal_mismatch"
+        | "duplicate_finding";
       findingCount: number;
       findingIndex: number;
       detectorType: number | null;
@@ -258,6 +312,7 @@ interface ClassifiedFinding {
   literalLine: number;
   decoder: string;
   occurrences: number;
+  role?: ScanSourceRole;
 }
 
 function object(value: unknown): Record<string, unknown> | undefined {
@@ -285,6 +340,15 @@ function records(bytes: Buffer): Record<string, unknown>[] | undefined {
   }
 }
 
+function exactStringRecord(value: unknown, keys: readonly string[]): boolean {
+  const record = object(value);
+  return (
+    record !== undefined &&
+    Object.keys(record).sort().join("\0") === [...keys].sort().join("\0") &&
+    keys.every((key) => typeof record[key] === "string" && record[key].length > 0)
+  );
+}
+
 function materialDiagnostic(input: StagedScanInput): ScanMaterialDiagnostic {
   // Only host-staged identities leave the scanner boundary. Bound reference
   // fanout and hash paths; raw finding values and provider strings never leave.
@@ -295,10 +359,11 @@ function materialDiagnostic(input: StagedScanInput): ScanMaterialDiagnostic {
     ...("references" in input
       ? {
           referenceCount: input.references.length,
-          references: input.references.slice(0, 4).map(({ source, mode, revision }) => ({
+          references: input.references.slice(0, 4).map(({ source, mode, revision, role }) => ({
             revision,
             pathSha256: createHash("sha256").update(source).digest("hex"),
             mode,
+            role,
           })),
         }
       : {}),
@@ -311,6 +376,7 @@ export function classifyReviewedFixtureScan(
   stdout: Buffer,
   stderr: Buffer,
   inputs: ReadonlyMap<string, StagedScanInput>,
+  reviewedAttributions: readonly ReviewedAttribution[] = REVIEWED_ATTRIBUTIONS,
 ): { kind: "classified"; notices: ReviewedFixtureNotice[] } | RefusedScan {
   const nativeFailure = (
     reason: Extract<ScanRefusalDiagnostic, { kind: "native_contract" }>["reason"],
@@ -361,8 +427,14 @@ export function classifyReviewedFixtureScan(
   const literalLines = new Map<string, number>();
   const classified = new Map<
     string,
-    { fixtureSha256: string; source: string; findings: Map<string, ClassifiedFinding> }
+    {
+      fixtureSha256: string;
+      source: string;
+      detector: string;
+      findings: Map<string, ClassifiedFinding>;
+    }
   >();
+  const exactFindings = new Set<string>();
   for (const [findingIndex, finding] of findings.entries()) {
     const source = object(object(object(finding.SourceMetadata)?.Data)?.Filesystem);
     const file = source?.file;
@@ -397,6 +469,168 @@ export function classifyReviewedFixtureScan(
         ...(staged ? { material: materialDiagnostic(staged) } : {}),
       },
     });
+    const raw = typeof finding.Raw === "string" ? finding.Raw : undefined;
+    const rawV2 = typeof finding.RawV2 === "string" ? finding.RawV2 : undefined;
+    const rawDigest =
+      raw === undefined ? undefined : createHash("sha256").update(raw).digest("hex");
+    const rawV2Digest =
+      rawV2 === undefined ? undefined : createHash("sha256").update(rawV2).digest("hex");
+    const exactCandidates =
+      rawDigest === undefined || rawV2Digest === undefined
+        ? []
+        : reviewedAttributions.filter(
+            ([, , , , expectedRaw, expectedRawV2]) =>
+              expectedRaw === rawDigest && expectedRawV2 === rawV2Digest,
+          );
+    if (exactCandidates.length > 0) {
+      if (
+        raw === undefined ||
+        rawV2 === undefined ||
+        rawDigest === undefined ||
+        rawV2Digest === undefined
+      )
+        return refuse("finding_not_reviewed");
+      if (
+        finding.SourceType !== 15 ||
+        finding.Verified !== false ||
+        typeof finding.VerificationError !== "string" ||
+        !finding.VerificationError ||
+        finding.StructuredData !== null
+      )
+        return refuse("finding_not_reviewed");
+      const matchingMetadata = exactCandidates.filter(
+        ([detectorType, detectorName, decoder]) =>
+          detectorType === finding.DetectorType &&
+          detectorName === finding.DetectorName &&
+          decoder === finding.DecoderName,
+      );
+      if (matchingMetadata.length === 0) return refuse("finding_not_reviewed");
+      const [detectorType, detectorName, decoder] = matchingMetadata[0]!;
+      if (typeof file !== "string" || scannerLine === null) return refuse("metadata_mismatch");
+      if (staged?.kind !== "blob" || !staged.bytes) return refuse("material_not_reviewed");
+      const parts = object(finding.SecretParts);
+      if (detectorType === 17) {
+        let uri: URL;
+        try {
+          uri = new URL(rawV2);
+        } catch {
+          return refuse("metadata_mismatch");
+        }
+        if (
+          finding.ExtraData !== null ||
+          !parts ||
+          Object.keys(parts).sort().join("\0") !== "host\0password\0username" ||
+          parts.host !== uri.host ||
+          parts.username !== uri.username ||
+          parts.password !== uri.password
+        )
+          return refuse("metadata_mismatch");
+      } else if (detectorType === 895) {
+        if (
+          rawV2 !== "" ||
+          !parts ||
+          Object.keys(parts).join("\0") !== "key" ||
+          parts.key !== raw ||
+          !exactStringRecord(finding.ExtraData, ["database", "host", "rotation_guide", "username"])
+        )
+          return refuse("metadata_mismatch");
+      } else if (
+        raw !== rawV2 ||
+        !parts ||
+        Object.keys(parts).join("\0") !== "connection_string" ||
+        parts.connection_string !== raw ||
+        !exactStringRecord(finding.ExtraData, ["database", "host", "sslmode", "username"])
+      ) {
+        return refuse("metadata_mismatch");
+      }
+      let text: string;
+      try {
+        text = new TextDecoder("utf-8", { fatal: true }).decode(staged.bytes);
+      } catch {
+        return refuse("literal_mismatch");
+      }
+      let lineStart = 0;
+      let lineNumber = 1;
+      let witnessLine: string | undefined;
+      let witnessLineNumber: number | undefined;
+      let literalOccurrences = 0;
+      while (lineStart <= text.length) {
+        const newline = text.indexOf("\n", lineStart);
+        const lineEnd = newline === -1 ? text.length : newline;
+        const line = text.slice(lineStart, lineEnd);
+        if (detectorType === 17 && line.includes(rawV2)) {
+          let occurrence = line.indexOf(rawV2);
+          while (occurrence !== -1) {
+            literalOccurrences++;
+            occurrence = line.indexOf(rawV2, occurrence + rawV2.length);
+          }
+          witnessLine ??= line;
+          witnessLineNumber ??= lineNumber;
+        } else if (detectorType !== 17 && lineNumber === scannerLine) {
+          witnessLine = line;
+          witnessLineNumber = lineNumber;
+        }
+        if (newline === -1) break;
+        lineStart = newline + 1;
+        lineNumber++;
+      }
+      if (
+        witnessLine === undefined ||
+        witnessLineNumber === undefined ||
+        (detectorType === 17 && literalOccurrences !== 1)
+      )
+        return refuse("literal_mismatch");
+      const lineDigest = createHash("sha256").update(witnessLine).digest("hex");
+      if (!matchingMetadata.some(([, , , , , , expectedLine]) => expectedLine === lineDigest))
+        return refuse("literal_mismatch");
+      if (
+        !staged.references.length ||
+        staged.references.some(({ source, mode, role }) =>
+          matchingMetadata.every(
+            ([, , , expectedRole, , , expectedLine, expectedSource, expectedMode]) =>
+              expectedRole !== role ||
+              expectedLine !== lineDigest ||
+              expectedSource !== source ||
+              expectedMode !== mode,
+          ),
+        )
+      )
+        return refuse("source_not_reviewed");
+      const duplicateKey = [
+        file,
+        scannerLine,
+        detectorType,
+        detectorName,
+        decoder,
+        rawDigest,
+        rawV2Digest,
+      ].join("\0");
+      if (exactFindings.has(duplicateKey)) return refuse("duplicate_finding");
+      exactFindings.add(duplicateKey);
+      const fixtureSha256 = detectorType === 17 ? rawV2Digest : rawDigest;
+      const blob = basename(file);
+      for (const { source, role } of staged.references) {
+        const groupKey = `exact:${detectorType}:${fixtureSha256}:${source}`;
+        const group = classified.get(groupKey) ?? {
+          fixtureSha256,
+          source,
+          detector: detectorName,
+          findings: new Map<string, ClassifiedFinding>(),
+        };
+        const key = `${blob}:${scannerLine}:${decoder}:${role}`;
+        const previous = group.findings.get(key);
+        group.findings.set(key, {
+          blob,
+          scannerLine,
+          literalLine: witnessLineNumber,
+          decoder,
+          role,
+          occurrences: (previous?.occurrences ?? 0) + 1,
+        });
+        classified.set(groupKey, group);
+      }
+      continue;
+    }
     if (
       finding.DetectorType !== 17 ||
       finding.DetectorName !== "URI" ||
@@ -413,10 +647,11 @@ export function classifyReviewedFixtureScan(
       return refuse("finding_not_reviewed");
     // URI Raw omits the path; bind both native outputs to the reviewed match.
     const digest = createHash("sha256").update(finding.RawV2).digest("hex");
-    const rawDigest = createHash("sha256").update(finding.Raw).digest("hex");
+    const legacyRawDigest = createHash("sha256").update(finding.Raw).digest("hex");
     const fixture = REVIEWED_FIXTURES.find(
       (entry) =>
-        entry.fixtureSha256 === digest && (entry.rawSha256 ?? entry.fixtureSha256) === rawDigest,
+        entry.fixtureSha256 === digest &&
+        (entry.rawSha256 ?? entry.fixtureSha256) === legacyRawDigest,
     );
     if (!fixture) return refuse("literal_not_reviewed");
     if (!(fixture.decoders ?? ["PLAIN", "HTML"]).some((decoder) => decoder === finding.DecoderName))
@@ -491,6 +726,7 @@ export function classifyReviewedFixtureScan(
       const group = classified.get(groupKey) ?? {
         fixtureSha256: digest,
         source: path,
+        detector: "URI",
         findings: new Map<string, ClassifiedFinding>(),
       };
       const previous = group.findings.get(key);
@@ -511,7 +747,7 @@ export function classifyReviewedFixtureScan(
       .map(([, group]) => ({
         fixtureSha256: group.fixtureSha256,
         source: group.source,
-        detector: "URI",
+        detector: group.detector,
         findings: [...group.findings.entries()]
           .sort(([a], [b]) => a.localeCompare(b))
           .map(([, value]) => value),

--- a/src/agent-input-scan.ts
+++ b/src/agent-input-scan.ts
@@ -26,6 +26,7 @@ import {
   type ScanInputOrigin,
   type ScanRefusalDiagnostic,
   type ScanSourceReference,
+  type ScanSourceRole,
   type StagedScanInput,
 } from "./agent-input-scan-fixtures.js";
 
@@ -476,7 +477,14 @@ export function scanAgentInput(options: {
             if (oid !== entry.oid)
               stage(bytes, {
                 kind: "worktree",
-                references: [{ source: entry.path, mode: entry.mode, revision: source.headSha }],
+                references: [
+                  {
+                    source: entry.path,
+                    mode: entry.mode,
+                    revision: source.headSha,
+                    role: "worktree",
+                  },
+                ],
               });
           }
         };
@@ -487,9 +495,16 @@ export function scanAgentInput(options: {
         source.kind === "snapshot"
           ? [mergeBase.sha, source.headSha, source.indexTreeSha, source.treeSha]
           : [mergeBase.sha, source.headSha];
+      const endpointRoles =
+        source.kind === "snapshot"
+          ? (["base", "head", "index", "tree"] as const)
+          : (["base", "head"] as const);
       for (let endpoint = 1; endpoint < endpoints.length; endpoint++) {
         const from = endpoints[endpoint - 1]!;
         const to = endpoints[endpoint]!;
+        const fromRole = endpointRoles[endpoint - 1];
+        const toRole = endpointRoles[endpoint];
+        if (!fromRole || !toRole) throw new AgentInputScanError("incomplete_source");
         if (!OBJECT_ID.test(to)) throw new AgentInputScanError("incomplete_source");
         const args = [
           "diff",
@@ -519,17 +534,27 @@ export function scanAgentInput(options: {
           if (!match) throw new AgentInputScanError("incomplete_source");
           if (source.kind === "committed")
             currentFiles.push({ path, mode: match[2]!, oid: match[4]! });
-          for (const [mode, oid, revision] of [
-            [match[1]!, match[3]!, from],
-            [match[2]!, match[4]!, to],
-          ]) {
+          const changedReferences: readonly [string, string, string, ScanSourceRole][] = [
+            [match[1]!, match[3]!, from, fromRole],
+            [match[2]!, match[4]!, to, toRole],
+          ];
+          for (const [mode, oid, revision, role] of changedReferences) {
             if (mode === "000000") continue;
             if (!["100644", "100755", "120000"].includes(mode!))
               throw new AgentInputScanError("unsupported_content");
             if (!OBJECT_ID.test(oid!)) throw new AgentInputScanError("incomplete_source");
             // An OID identifies bytes, not each scanned endpoint's path/mode eligibility.
             const references = blobs.get(oid!) ?? [];
-            references.push({ source: path, mode: mode!, revision: revision! });
+            if (
+              !references.some(
+                (reference) =>
+                  reference.source === path &&
+                  reference.mode === mode &&
+                  reference.revision === revision &&
+                  reference.role === role,
+              )
+            )
+              references.push({ source: path, mode: mode!, revision: revision!, role });
             blobs.set(oid!, references);
           }
         }

--- a/test/agent-input-scan.test.ts
+++ b/test/agent-input-scan.test.ts
@@ -31,6 +31,12 @@ import {
   captureTargetCheckoutBinding,
   withTargetReviewSnapshot,
 } from "../dist/repair/target-validation.js";
+import {
+  classifyReviewedFixtureScan,
+  type ReviewedAttribution,
+  type ScanSourceRole,
+  type StagedScanInput,
+} from "../dist/agent-input-scan-fixtures.js";
 import { useFakeScanner } from "./agent-input-scan-helpers.ts";
 import { writeExactReviewFailureDiagnostics } from "../dist/clawsweeper-review-failure-diagnostics.js";
 
@@ -538,6 +544,74 @@ test("repair scan binds raw bytes even when normalization leaves the same canoni
   assert.equal(existsSync(f.calls), false);
 });
 
+for (const expectedRole of ["base", "head", "index", "tree"] as const) {
+  test(`scan staging preserves ${expectedRole} blob provenance before provider launch`, (t) => {
+    const f = fixture(t);
+    const markers = {
+      base: "base-role-marker",
+      head: "head-role-marker",
+      index: "index-role-marker",
+      tree: "tree-role-marker",
+    };
+    writeFileSync(join(f.cwd, "a.txt"), `${markers.base}\n`);
+    const baseSha = f.commit();
+    writeFileSync(join(f.cwd, "a.txt"), `${markers.head}\n`);
+    const headSha = f.commit();
+    if (expectedRole === "index" || expectedRole === "tree") {
+      writeFileSync(join(f.cwd, "a.txt"), `${markers.index}\n`);
+      f.git("add", "a.txt");
+      writeFileSync(join(f.cwd, "a.txt"), `${markers.tree}\n`);
+    }
+    const uri = new URL("https://fixture.example.invalid/path");
+    uri.username = "fixture-user";
+    uri.password = "fixture-pass";
+    useFakeScanner(
+      t,
+      String.raw`
+const marker = ${JSON.stringify(markers[expectedRole])};
+const uri = ${JSON.stringify(uri.href)};
+const parsed = new URL(uri);
+const input = inputs.find(({name, bytes}) => /^[a-f0-9]{40}$/.test(name) && bytes.includes(marker));
+assert.ok(input);
+process.stdout.write(JSON.stringify({
+  SourceType: 15, DetectorType: 17, DetectorName: 'URI', DecoderName: 'PLAIN',
+  Verified: false, VerificationError: 'synthetic verification error',
+  Raw: uri, RawV2: uri,
+  SourceMetadata: {Data: {Filesystem: {file: path.join(inputDir, input.name), line: 1}}},
+  SecretParts: {host: parsed.host, username: parsed.username, password: parsed.password},
+  ExtraData: null, StructuredData: null,
+}) + '\n');
+process.stderr.write(JSON.stringify({
+  level: 'info-0', logger: 'trufflehog', msg: 'finished scanning',
+  trufflehog_version: '3.97.1', chunks: 1, bytes: 1,
+  verified_secrets: 0, unverified_secrets: 1,
+}) + '\n');
+process.exit(183);
+`,
+    );
+    const run = () => {
+      if (expectedRole === "base" || expectedRole === "head")
+        return f.run({ kind: "committed", baseSha, headSha });
+      const expected = captureTargetCheckoutBinding(f.cwd);
+      return withTargetReviewSnapshot({ cwd: f.cwd, baseSha, expected, timeoutMs: 30_000 }, f.run);
+    };
+    assert.throws(run, (error) => {
+      assert.ok(error instanceof AgentInputScanError);
+      assert.equal(error.reason, "findings");
+      assert.equal(error.scanDiagnostic?.kind, "unclassified_finding");
+      if (error.scanDiagnostic?.kind === "unclassified_finding") {
+        assert.equal(error.scanDiagnostic.material?.kind, "blob");
+        assert.deepEqual(
+          error.scanDiagnostic.material?.references?.map((reference) => reference.role),
+          [expectedRole],
+        );
+      }
+      return true;
+    });
+    assert.equal(existsSync(f.calls), false);
+  });
+}
+
 const ledgerSource = "test/action-ledger-runtime.test.ts";
 const autoreviewSources = [
   "skills/autoreview/tests/test_autoreview_hardening.py",
@@ -573,6 +647,429 @@ const nativeContractFailures = new Map([
   ["malformed output", "invalid_stdout"],
   ["unexpected successful output", "unexpected_exit"],
 ]);
+
+type ExactDetector = "URI" | "MongoDB" | "Postgres";
+type ExactDecoder = "PLAIN" | "ESCAPED_UNICODE";
+
+interface ExactCase {
+  detectorType: 17 | 895 | 968;
+  detectorName: ExactDetector;
+  decoder: ExactDecoder;
+  role: ScanSourceRole;
+  raw: string;
+  rawV2: string;
+  line: string;
+  secretParts: Record<string, string>;
+  extraData: Record<string, string> | null;
+}
+
+const exactSource = "src/logging/redact.test.ts";
+
+function exactCase(
+  detectorName: ExactDetector,
+  decoder: ExactDecoder,
+  role: ScanSourceRole,
+): ExactCase {
+  if (detectorName === "URI") {
+    const uri = new URL(`https://${decoder.toLowerCase()}.${role}.example.invalid/path`);
+    uri.username = "fixture-user";
+    uri.password = "fixture-pass";
+    const rawV2 = uri.href;
+    const authority = new URL(rawV2);
+    authority.pathname = "";
+    return {
+      detectorType: 17,
+      detectorName,
+      decoder,
+      role,
+      raw: authority.href.slice(0, -1),
+      rawV2,
+      line: `const fixture = ${JSON.stringify(rawV2)};`,
+      secretParts: {
+        host: uri.host,
+        username: uri.username,
+        password: uri.password,
+      },
+      extraData: null,
+    };
+  }
+  const raw = `${detectorName.toLowerCase()}://${decoder.toLowerCase()}.${role}.example.invalid/db`;
+  if (detectorName === "MongoDB") {
+    return {
+      detectorType: 895,
+      detectorName,
+      decoder,
+      role,
+      raw,
+      rawV2: "",
+      line: `const fixture = ${JSON.stringify(raw)};`,
+      secretParts: { key: raw },
+      extraData: {
+        database: "db",
+        host: `${decoder.toLowerCase()}.${role}.example.invalid`,
+        rotation_guide: "reviewed synthetic guidance",
+        username: "fixture-user",
+      },
+    };
+  }
+  return {
+    detectorType: 968,
+    detectorName,
+    decoder,
+    role,
+    raw,
+    rawV2: raw,
+    line: `const fixture = ${JSON.stringify(raw)};`,
+    secretParts: { connection_string: raw },
+    extraData: {
+      database: "db",
+      host: `${decoder.toLowerCase()}.${role}.example.invalid`,
+      sslmode: "require",
+      username: "fixture-user",
+    },
+  };
+}
+
+function exactFixture(cases: readonly ExactCase[]) {
+  const inputs = new Map<string, StagedScanInput>();
+  const findings = cases.map((entry, index) => {
+    const file = `/private/scanner/${index.toString(16).padStart(40, "0")}`;
+    inputs.set(file, {
+      kind: "blob",
+      id: index.toString(16).padStart(40, "0"),
+      bytes: Buffer.from(`// context\n${entry.line}\n`),
+      references: [
+        {
+          source: exactSource,
+          mode: "100644",
+          revision: entry.role === "base" ? "a".repeat(40) : "b".repeat(40),
+          role: entry.role,
+        },
+      ],
+    });
+    return {
+      SourceType: 15,
+      DetectorType: entry.detectorType,
+      DetectorName: entry.detectorName,
+      DecoderName: entry.decoder,
+      Verified: false,
+      VerificationError: "synthetic verification error",
+      Raw: entry.raw,
+      RawV2: entry.rawV2,
+      SourceMetadata: { Data: { Filesystem: { file, line: 2 } } },
+      SecretParts: entry.secretParts,
+      ExtraData: entry.extraData,
+      StructuredData: null,
+    };
+  });
+  const policy = cases.map(
+    (entry): ReviewedAttribution => [
+      entry.detectorType,
+      entry.detectorName,
+      entry.decoder,
+      entry.role,
+      createHash("sha256").update(entry.raw).digest("hex"),
+      createHash("sha256").update(entry.rawV2).digest("hex"),
+      createHash("sha256").update(entry.line).digest("hex"),
+      exactSource,
+      "100644",
+    ],
+  );
+  return { findings, inputs, policy };
+}
+
+function classifyExact(
+  findings: readonly Record<string, unknown>[],
+  inputs: ReadonlyMap<string, StagedScanInput>,
+  policy: readonly ReviewedAttribution[],
+) {
+  return classifyReviewedFixtureScan(
+    183,
+    Buffer.from(`${findings.map((finding) => JSON.stringify(finding)).join("\n")}\n`),
+    Buffer.from(
+      `${JSON.stringify({
+        level: "info-0",
+        logger: "trufflehog",
+        msg: "finished scanning",
+        trufflehog_version: "3.97.1",
+        chunks: 1,
+        bytes: 1,
+        verified_secrets: 0,
+        unverified_secrets: findings.length,
+      })}\n`,
+    ),
+    inputs,
+    policy,
+  );
+}
+
+test("exact reviewed attributions accept emitted detector subsets in any order", () => {
+  const cases = (["base", "head"] as const).flatMap((role) =>
+    (["URI", "MongoDB", "Postgres"] as const).flatMap((detector) =>
+      (["PLAIN", "ESCAPED_UNICODE"] as const).map((decoder) => exactCase(detector, decoder, role)),
+    ),
+  );
+  const fixture = exactFixture(cases);
+  const selections = [
+    cases.map((_, index) => index),
+    cases.map((_, index) => index).reverse(),
+    cases.map((_, index) => index).filter((index) => index % 2 === 0),
+    cases.map((_, index) => index).filter((index) => index % 2 === 1),
+    ...cases.map((_, index) => [index]),
+  ];
+  for (const selection of selections) {
+    const result = classifyExact(
+      selection.map((index) => fixture.findings[index]!),
+      fixture.inputs,
+      fixture.policy,
+    );
+    assert.equal(result.kind, "classified");
+    if (result.kind === "classified" && selection.length === cases.length) {
+      assert.deepEqual([...new Set(result.notices.map((notice) => notice.detector))].sort(), [
+        "MongoDB",
+        "Postgres",
+        "URI",
+      ]);
+      assert.deepEqual(
+        [
+          ...new Set(
+            result.notices.flatMap((notice) => notice.findings.map((finding) => finding.role)),
+          ),
+        ].sort(),
+        ["base", "head"],
+      );
+    }
+  }
+});
+
+test("exact reviewed attributions reject drift, duplicates, and mixed unknown findings", () => {
+  const base = exactFixture([exactCase("URI", "PLAIN", "base")]);
+  const valid = base.findings[0]!;
+  const inputFile = String(
+    (valid.SourceMetadata as { Data: { Filesystem: { file: string } } }).Data.Filesystem.file,
+  );
+  const cases: Array<{
+    name: string;
+    expected: string;
+    mutate: (
+      finding: Record<string, unknown>,
+      inputs: Map<string, StagedScanInput>,
+      policy: ReviewedAttribution[],
+    ) => Record<string, unknown>[];
+  }> = [
+    {
+      name: "raw drift",
+      expected: "literal_not_reviewed",
+      mutate: (finding) => [{ ...finding, Raw: `${finding.Raw}changed` }],
+    },
+    {
+      name: "RawV2 drift",
+      expected: "literal_not_reviewed",
+      mutate: (finding) => [{ ...finding, RawV2: `${finding.RawV2}changed` }],
+    },
+    {
+      name: "wrong detector",
+      expected: "finding_not_reviewed",
+      mutate: (finding) => [{ ...finding, DetectorType: 895 }],
+    },
+    {
+      name: "wrong name",
+      expected: "finding_not_reviewed",
+      mutate: (finding) => [{ ...finding, DetectorName: "Postgres" }],
+    },
+    {
+      name: "wrong decoder",
+      expected: "finding_not_reviewed",
+      mutate: (finding) => [{ ...finding, DecoderName: "HTML" }],
+    },
+    {
+      name: "lossy OTHER decoder",
+      expected: "finding_not_reviewed",
+      mutate: (finding) => [{ ...finding, DecoderName: "OTHER" }],
+    },
+    {
+      name: "swapped hashes",
+      expected: "literal_not_reviewed",
+      mutate: (finding, _inputs, policy) => {
+        const row = policy[0]!;
+        policy[0] = [
+          row[0],
+          row[1],
+          row[2],
+          row[3],
+          row[5],
+          row[4],
+          ...row.slice(6),
+        ] as ReviewedAttribution;
+        return [finding];
+      },
+    },
+    {
+      name: "wrong line",
+      expected: "literal_mismatch",
+      mutate: (finding, inputs) => {
+        const staged = inputs.get(inputFile)!;
+        inputs.set(inputFile, {
+          ...staged,
+          bytes: Buffer.from(`// context changed\n${base.policy[0]![5]}\n`),
+        });
+        return [finding];
+      },
+    },
+    {
+      name: "wrong path",
+      expected: "source_not_reviewed",
+      mutate: (finding, inputs) => {
+        const staged = inputs.get(inputFile)!;
+        inputs.set(inputFile, {
+          ...staged,
+          references: [{ ...staged.references[0]!, source: "other.test.ts" }],
+        });
+        return [finding];
+      },
+    },
+    {
+      name: "wrong mode",
+      expected: "source_not_reviewed",
+      mutate: (finding, inputs) => {
+        const staged = inputs.get(inputFile)!;
+        inputs.set(inputFile, {
+          ...staged,
+          references: [{ ...staged.references[0]!, mode: "100755" }],
+        });
+        return [finding];
+      },
+    },
+    {
+      name: "wrong role",
+      expected: "source_not_reviewed",
+      mutate: (finding, inputs) => {
+        const staged = inputs.get(inputFile)!;
+        inputs.set(inputFile, {
+          ...staged,
+          references: [{ ...staged.references[0]!, role: "index" }],
+        });
+        return [finding];
+      },
+    },
+    {
+      name: "mixed authorized and unauthorized references",
+      expected: "source_not_reviewed",
+      mutate: (finding, inputs) => {
+        const staged = inputs.get(inputFile)!;
+        inputs.set(inputFile, {
+          ...staged,
+          references: [...staged.references, { ...staged.references[0]!, source: "other.test.ts" }],
+        });
+        return [finding];
+      },
+    },
+    {
+      name: "wrong metadata",
+      expected: "metadata_mismatch",
+      mutate: (finding) => [{ ...finding, SecretParts: { host: "mismatch" } }],
+    },
+    {
+      name: "duplicate",
+      expected: "duplicate_finding",
+      mutate: (finding) => [finding, { ...finding }],
+    },
+    {
+      name: "mixed unknown",
+      expected: "literal_not_reviewed",
+      mutate: (finding) => [finding, { ...finding, Raw: "unknown", RawV2: "unknown" }],
+    },
+  ];
+  for (const scenario of cases) {
+    const fixture = exactFixture([exactCase("URI", "PLAIN", "base")]);
+    const finding = structuredClone(fixture.findings[0]!);
+    const inputs = new Map(fixture.inputs);
+    const policy = [...fixture.policy];
+    const result = classifyExact(scenario.mutate(finding, inputs, policy), inputs, policy);
+    assert.equal(result.kind, "refused", scenario.name);
+    if (result.kind === "refused" && result.diagnostic.kind === "unclassified_finding")
+      assert.equal(result.diagnostic.reason, scenario.expected, scenario.name);
+  }
+});
+
+test("exact detector metadata contracts reject malformed MongoDB and Postgres findings", () => {
+  const cases: Array<{
+    detector: "MongoDB" | "Postgres";
+    name: string;
+    mutate: (finding: Record<string, unknown>, policy: ReviewedAttribution[]) => void;
+  }> = [
+    {
+      detector: "MongoDB",
+      name: "nonempty RawV2",
+      mutate: (finding, policy) => {
+        finding.RawV2 = String(finding.Raw);
+        const row = policy[0]!;
+        policy[0] = [
+          ...row.slice(0, 5),
+          createHash("sha256").update(String(finding.RawV2)).digest("hex"),
+          ...row.slice(6),
+        ] as ReviewedAttribution;
+      },
+    },
+    {
+      detector: "MongoDB",
+      name: "wrong key",
+      mutate: (finding) => {
+        finding.SecretParts = { key: `${finding.Raw}changed` };
+      },
+    },
+    {
+      detector: "MongoDB",
+      name: "wrong ExtraData shape",
+      mutate: (finding) => {
+        finding.ExtraData = {
+          ...(finding.ExtraData as Record<string, string>),
+          unexpected: "value",
+        };
+      },
+    },
+    {
+      detector: "Postgres",
+      name: "RawV2 differs",
+      mutate: (finding, policy) => {
+        finding.RawV2 = `${finding.Raw}changed`;
+        const row = policy[0]!;
+        policy[0] = [
+          ...row.slice(0, 5),
+          createHash("sha256").update(String(finding.RawV2)).digest("hex"),
+          ...row.slice(6),
+        ] as ReviewedAttribution;
+      },
+    },
+    {
+      detector: "Postgres",
+      name: "wrong connection string",
+      mutate: (finding) => {
+        finding.SecretParts = { connection_string: `${finding.Raw}changed` };
+      },
+    },
+    {
+      detector: "Postgres",
+      name: "wrong ExtraData shape",
+      mutate: (finding) => {
+        finding.ExtraData = {
+          ...(finding.ExtraData as Record<string, string>),
+          unexpected: "value",
+        };
+      },
+    },
+  ];
+  for (const testCase of cases) {
+    const fixture = exactFixture([exactCase(testCase.detector, "PLAIN", "base")]);
+    const finding = structuredClone(fixture.findings[0]!);
+    const policy = [...fixture.policy];
+    testCase.mutate(finding, policy);
+    const result = classifyExact([finding], fixture.inputs, policy);
+    assert.equal(result.kind, "refused", testCase.name);
+    if (result.kind === "refused" && result.diagnostic.kind === "unclassified_finding")
+      assert.equal(result.diagnostic.reason, "metadata_mismatch", testCase.name);
+  }
+});
 
 for (const scenarioName of [
   "reviewed fixture",
@@ -1363,8 +1860,13 @@ process.exit(scenario === 'unexpected successful output' ? 0 : 183);
                   createHash("sha256").update(files[0]!).digest("hex"),
                 );
                 assert.equal(diagnostic.material.references[0].mode, "100644");
+                assert.equal(
+                  diagnostic.material.references[0].role,
+                  diagnostic.material.references[0].revision === baseSha ? "base" : "head",
+                );
               } else if (kind === "worktree") {
                 assert.equal(diagnostic.material.references[0].revision, headSha);
+                assert.equal(diagnostic.material.references[0].role, "worktree");
                 assert.equal(
                   diagnostic.material.references[0].pathSha256,
                   createHash("sha256").update(files[0]!).digest("hex"),


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where ClawSweeper refuses review admission for OpenClaw pull requests whose unchanged logging tests contain credential-shaped synthetic redaction fixtures, even when every native scanner attribution is tied to the reviewed fixture bytes.

This is a prerequisite for reviewing https://github.com/openclaw/openclaw/pull/138829.

## Why This Change Was Made

The change adds a separate, flat exact-attribution policy for the reviewed OpenClaw logging fixture. Each accepted finding is bound to its detector, exact native decoder, base/head source role, Raw and RawV2 hashes, full source-line hash, path, mode, and detector-specific metadata. Existing URI fixture behavior is preserved; there is no broad allowlist, fixed finding-count requirement, or classifier control-flow bypass.

## User Impact

Maintainers can run ClawSweeper review on the affected OpenClaw change without disabling secret scanning or authorizing unrelated findings. Any unknown detector, decoder, metadata shape, source role, path, mode, hash, duplicate, or partially authorized deduplicated reference still refuses admission before provider/model launch.

## OpenClaw Bay Impact

OpenClaw Bay is unaffected. This changes only admission classification and refusal diagnostics; no observer dashboard, queue, lifecycle, telemetry, status, or public data contract changes.

## Documentation Impact

The active classifier contract in `README.md` is updated to document the exact role-bound OpenClaw logging-fixture policy, accepted native decoder names, subset/order behavior, metadata validation, and the unchanged legacy URI policy. `CHANGELOG.md` is updated for the operationally meaningful admission change.

## Evidence

- ClawSweeper head: `e7fe2e09c39b3be40bda94995eb06f34e6eda1e9`
- OpenClaw base: `b8731bc88a7c562f01d0d7bc3e9634b71047d3d3`
- OpenClaw head: `fe0367a07a23660ea35007ac69bdb8f54309fc21`
- Target fixture: [`src/logging/redact.test.ts` at the exact OpenClaw head](https://github.com/openclaw/openclaw/blob/fe0367a07a23660ea35007ac69bdb8f54309fc21/src/logging/redact.test.ts), Git blob `cb52c7c395b6e3243b83f0c9680ea16edd913e6b`
- TruffleHog: `v3.97.1`, commit `20652fbbdefffcdaa493a5bf57ab2ac6b1db715b`
- Focused command: `node --test test/agent-input-scan.test.ts test/exact-review-failure-diagnostics.test.ts`
- Focused result: `258/258` passed.
- Supporting checks passed: `pnpm run build`, `pnpm run build:repair`, `pnpm run lint:src`, focused `oxfmt` verification, and `git diff --check`.
- Precommit and postcommit autoreview both completed `scoped-clean` at P0-P2. The postcommit review exited `0` with no findings.

The pinned upstream contracts are:

- [`pkg/detectors/uri/uri.go`](https://github.com/trufflesecurity/trufflehog/blob/20652fbbdefffcdaa493a5bf57ab2ac6b1db715b/pkg/detectors/uri/uri.go)
- [`pkg/detectors/mongodb/mongodb.go`](https://github.com/trufflesecurity/trufflehog/blob/20652fbbdefffcdaa493a5bf57ab2ac6b1db715b/pkg/detectors/mongodb/mongodb.go)
- [`pkg/detectors/postgres/postgres.go`](https://github.com/trufflesecurity/trufflehog/blob/20652fbbdefffcdaa493a5bf57ab2ac6b1db715b/pkg/detectors/postgres/postgres.go)
- [`pkg/decoders/decoders.go`](https://github.com/trufflesecurity/trufflehog/blob/20652fbbdefffcdaa493a5bf57ab2ac6b1db715b/pkg/decoders/decoders.go)
- [`pkg/decoders/escaped_unicode.go`](https://github.com/trufflesecurity/trufflehog/blob/20652fbbdefffcdaa493a5bf57ab2ac6b1db715b/pkg/decoders/escaped_unicode.go)

At that pinned commit, the detector sources establish the relevant `Raw`, `RawV2`, `SecretParts`, and `ExtraData` contracts: URI separates its normalized and path-bearing values and derives host/username/password; MongoDB emits the connection string as `Raw`, a `key` secret part, and its defined metadata; Postgres emits equal normalized `Raw`/`RawV2`, a `connection_string` secret part, and its defined metadata. The decoder sources establish default decoder ordering with plain UTF-8 first for duplicate handling and `ESCAPED_UNICODE` as the exact escaped-Unicode decoder identity.

Local full gate:

`PATH="/opt/homebrew/opt/bash/bin:$PATH" pnpm run check` completed static checks, builds, linters, changed coverage, and coverage thresholds. It did not fully pass because four unrelated local-environment or baseline tests failed:

- the machine had no Bash 4 executable, so the workflow-intake fixture hit `/bin/bash` 3.2 without `mapfile`;
- the existing live-proof environment test observed the host profile instead of its expected temporary profile;
- an existing repair throttle test rejected the macOS `/var` versus `/private/var` canonical-root alias;
- an existing target-validation test failed its baseline ordinary Git-hook marker assertion before the changed classifier path ran.

The focused scanner and exact-review diagnostics suites are green.

Current exact-head hosted CI: all substantive checks are complete and green, with only intentionally skipped checks remaining. [`CI / pnpm check`](https://github.com/openclaw/clawsweeper/actions/runs/34008728351/job/101420606064), CodeQL, Windows launcher, sparse repair build smoke, notification, and hosted-target admission all succeeded.

## Real Behavior Proof

**Claim:** the production admission scanner refuses the unqualified baseline before provider/model launch and classifies every emitted subset/order of the exact reviewed OpenClaw fixture findings on this candidate without weakening unknown-finding refusal.

**Exercised surface:** the production `scanAgentInput` entry point and its exact fixture classifier, using committed/snapshot Git source staging and pinned native TruffleHog output.

**Scenario and environment:** proof ran on macOS arm64 from the trusted ClawSweeper checkout against the exact OpenClaw revisions and blob listed above. It used private temporary Node ESM harnesses outside both repositories; these were not repository scripts. The native capture reproduced production committed-source staging: prompt, raw diff, binary/full-index patch, and every deduplicated base/head blob. It then invoked the pinned binary with:

```text
trufflehog filesystem <private-staging-directory> --results=verified,unknown --fail --fail-on-scan-errors --no-update --json --no-color
```

The scanner process used an isolated private `HOME`/`TMPDIR`, a 120-second timeout, and required native finding exit status `183` plus completion metadata reporting TruffleHog `3.97.1`.

The production-entry proof imported the built `dist/agent-input-scan.js` and called:

```text
scanAgentInput({
  cwd: <trusted-openclaw-checkout>,
  prompt: "Review the exact OpenClaw pull request source.",
  source: {
    kind: "snapshot",
    baseSha: "b8731bc88a7c562f01d0d7bc3e9634b71047d3d3",
    headSha: "fe0367a07a23660ea35007ac69bdb8f54309fc21",
    treeSha: <tree-of-exact-head>,
    indexTreeSha: <tree-of-exact-head>,
    objectEnv: {},
    assertCurrent() {}
  },
  timeoutMs: 180000
})
```

The production scanner resolved the pinned managed TruffleHog `3.97.1` binary. No provider or model process was part of either harness.

**Bounded protocol:** at most 8 production-equivalent native scans, stopping early after 3 consecutive scans add no exact attribution tuple. Finding counts and emitted subsets were allowed to vary; the policy did not assert a fixed total.

**Observed result:** the baseline refused before provider/model launch. The candidate classified every emitted subset/order retained by the bounded scans. Refusal paths recorded zero provider/model launches. Only detector IDs/names `17 URI`, `895 MongoDB`, and `968 Postgres`, with exact native decoders `PLAIN` and `ESCAPED_UNICODE`, were observed. No unexpected detector, decoder, or metadata variant appeared.

**Sanitized native trace:** each `sorted_tuple_sha256` is SHA-256 over that run's deterministic sorted exact-attribution tuple serialization. These records were derived from all retained bounded native runs and contain no native secret value or source-line text.

```json
{"run":1,"finding_count":15,"detector_decoder_set":["17 URI/ESCAPED_UNICODE","17 URI/PLAIN","895 MongoDB/ESCAPED_UNICODE","968 Postgres/ESCAPED_UNICODE","968 Postgres/PLAIN"],"role_set":["base","head"],"exact_tuple_count":15,"sorted_tuple_sha256":"7b5b348d771cb9284ce3e2d7aea8d87cc8f1eb0f69607e351b63a4a08acd7f64","newly_observed_tuples":15,"baseline_classification":"refused:findings","candidate_classification":"classified","provider_model_launch_count":0}
{"run":2,"finding_count":18,"detector_decoder_set":["17 URI/PLAIN","895 MongoDB/PLAIN","968 Postgres/ESCAPED_UNICODE","968 Postgres/PLAIN"],"role_set":["base","head"],"exact_tuple_count":18,"sorted_tuple_sha256":"12287fc716b5d2861f7b93fa258463e71cea7a42529ef62e728469383930078c","newly_observed_tuples":8,"baseline_classification":"refused:findings","candidate_classification":"classified","provider_model_launch_count":0}
{"run":3,"finding_count":17,"detector_decoder_set":["17 URI/PLAIN","895 MongoDB/ESCAPED_UNICODE","895 MongoDB/PLAIN","968 Postgres/ESCAPED_UNICODE","968 Postgres/PLAIN"],"role_set":["base","head"],"exact_tuple_count":17,"sorted_tuple_sha256":"48961ed705e82d7d496a180413b9ec887c6e796bc39ccc3f9976aa91a536d16e","newly_observed_tuples":4,"baseline_classification":"refused:findings","candidate_classification":"classified","provider_model_launch_count":0}
{"run":4,"finding_count":16,"detector_decoder_set":["17 URI/ESCAPED_UNICODE","17 URI/PLAIN","895 MongoDB/ESCAPED_UNICODE","895 MongoDB/PLAIN","968 Postgres/ESCAPED_UNICODE","968 Postgres/PLAIN"],"role_set":["base","head"],"exact_tuple_count":16,"sorted_tuple_sha256":"cacf35914ea9888e3addafd6c18143f9685bc936353145d5159dc1d97e796c43","newly_observed_tuples":1,"baseline_classification":"refused:findings","candidate_classification":"classified","provider_model_launch_count":0}
{"run":5,"finding_count":16,"detector_decoder_set":["17 URI/PLAIN","895 MongoDB/PLAIN","968 Postgres/ESCAPED_UNICODE","968 Postgres/PLAIN"],"role_set":["base","head"],"exact_tuple_count":16,"sorted_tuple_sha256":"79291b7d7f84e40d46ea5f6f1a409e7e852c1aecab498a5ff49b3318230081cf","newly_observed_tuples":2,"baseline_classification":"refused:findings","candidate_classification":"classified","provider_model_launch_count":0}
{"run":6,"finding_count":19,"detector_decoder_set":["17 URI/ESCAPED_UNICODE","17 URI/PLAIN","895 MongoDB/ESCAPED_UNICODE","895 MongoDB/PLAIN","968 Postgres/ESCAPED_UNICODE","968 Postgres/PLAIN"],"role_set":["base","head"],"exact_tuple_count":19,"sorted_tuple_sha256":"4fb73ab00c193710b8d28bbff38bb45e9861d8d7ebf9e8ba7355dcc6693ad3af","newly_observed_tuples":1,"baseline_classification":"refused:findings","candidate_classification":"classified","provider_model_launch_count":0}
{"run":7,"finding_count":18,"detector_decoder_set":["17 URI/ESCAPED_UNICODE","17 URI/PLAIN","895 MongoDB/ESCAPED_UNICODE","895 MongoDB/PLAIN","968 Postgres/ESCAPED_UNICODE","968 Postgres/PLAIN"],"role_set":["base","head"],"exact_tuple_count":18,"sorted_tuple_sha256":"40e7abc6d3bb85c6fd0b5740c907c7eb962bef01abdaa711d41ccacdf2295c5e","newly_observed_tuples":1,"baseline_classification":"refused:findings","candidate_classification":"classified","provider_model_launch_count":0}
{"run":8,"finding_count":16,"detector_decoder_set":["17 URI/ESCAPED_UNICODE","17 URI/PLAIN","895 MongoDB/ESCAPED_UNICODE","895 MongoDB/PLAIN","968 Postgres/ESCAPED_UNICODE","968 Postgres/PLAIN"],"role_set":["base","head"],"exact_tuple_count":16,"sorted_tuple_sha256":"5749ae62ef61ef49f85d1c8e9c8baa8e0ac8913aafebe16d105b6295bc5bd974","newly_observed_tuples":2,"baseline_classification":"refused:findings","candidate_classification":"classified","provider_model_launch_count":0}
{"stabilization_stop":"max_runs_reached","run":8,"required_consecutive_no_new_runs":3,"observed_consecutive_no_new_runs":0}
```

The deterministic tuple serialization field order is:

```text
detectorType, detectorName, decoderName, role, rawSha256, rawV2Sha256, lineSha256, sourcePath, mode
```

Each tuple is encoded as a compact JSON array in that order. Duplicate-free tuple arrays are sorted lexicographically by their compact JSON encoding, then the outer array is serialized as compact UTF-8 JSON. The 34-tuple sorted union serialization has SHA-256 `10f6a42ccf96952d1c658addddbf674b8b0400f93202f9fad30390c23e05901b`. The public [`REVIEWED_ATTRIBUTIONS` rows](https://github.com/openclaw/clawsweeper/blob/e7fe2e09c39b3be40bda94995eb06f34e6eda1e9/src/agent-input-scan-fixtures.ts#L174) equal that retained union exactly under this serialization.

The exact hashes, roles, source path, and mode are already public in `REVIEWED_ATTRIBUTIONS`; only the credential-shaped native `Raw`/`RawV2`, source-line text, and detector metadata values remain private.

**Public replay recipe:** there is no committed replay script. The original proof used a temporary ESM harness with this reproducible contract:

1. Clone the public `openclaw/clawsweeper`, `openclaw/openclaw`, and `trufflesecurity/trufflehog` repositories. Check out ClawSweeper `e7fe2e09c39b3be40bda94995eb06f34e6eda1e9`, retain OpenClaw objects `b8731bc88a7c562f01d0d7bc3e9634b71047d3d3` and `fe0367a07a23660ea35007ac69bdb8f54309fc21`, and use TruffleHog commit `20652fbbdefffcdaa493a5bf57ab2ac6b1db715b` / version `3.97.1`.
2. Build ClawSweeper. In a private temporary directory, have an ESM harness stage the fixed public review prompt, the exact raw diff, the exact binary/full-index patch, and each deduplicated base/head blob using Git plumbing. Verify the linked target file resolves to blob `cb52c7c395b6e3243b83f0c9680ea16edd913e6b` at the exact head.
3. Run the pinned binary exactly as shown above with isolated `HOME`/`TMPDIR`, parse native JSON only in memory, validate the pinned detector/decoder/metadata contracts, and derive the nine-field tuple hashes without printing native values.
4. For every run, call `classifyReviewedFixtureScan(183, stdout, stderr, stagedInputs, [])` for the baseline and `classifyReviewedFixtureScan(183, stdout, stderr, stagedInputs)` for the candidate. No provider/model process is started.
5. Emit only the fields present in the sanitized trace above. Stop after 3 consecutive runs add no exact tuple or after the eighth run, whichever comes first. Delete the native JSON and private staging after deriving the sanitized records.

**Artifact/trace:** a retained sanitized native attribution manifest has SHA-256 `a287b27b110ecc29e455ba7f5bd7d329b0f9e3493fb593fba167a585ca50d3da`. It is retained privately because it is derived from credential-shaped test literals. It is not a public artifact; therefore the digest proves immutability only to a reviewer with access to the retained artifact and does not independently expose or reproduce its contents for public reviewers.

**Limits:** the proof is exact to the revisions, blob, native scanner version/commit, detector contracts, decoder identities, modes, roles, paths, hashes, and observed metadata variants listed above. It does not authorize different fixture bytes, future TruffleHog behavior, other paths or modes, lossy `OTHER` decoder classification, duplicates, mixed unknown findings, or any unobserved detector/decoder/metadata variant.
