### PR TITLE
test(router): canonicalize loopback fixture ledger roots

### DIFF
--- a/scripts/e2e/comment-router-throttle-loopback.mjs
+++ b/scripts/e2e/comment-router-throttle-loopback.mjs
@@ -10,7 +10,10 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const sourceRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
-const temporary = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-router-throttle-"));
+// Ledger roots must be canonical even when macOS exposes tmpdir through /var.
+const temporary = fs.realpathSync.native(
+  fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-router-throttle-")),
+);
 const root = path.join(temporary, "runtime");
 fs.mkdirSync(path.join(root, "scripts"), { recursive: true });
 fs.cpSync(path.join(sourceRoot, "dist"), path.join(root, "dist"), { recursive: true });


### PR DESCRIPTION
On macOS, the comment-router throttle proof failed before ledger finalization because `os.tmpdir()` supplied `/var/folders/...`, while the filesystem resolved the same directory through `/private/var/folders/...`. The ledger correctly rejects noncanonical roots.

Canonicalize the fixture-owned temporary directory immediately after creating it, before deriving the runtime and ledger paths. Production path validation, symlink rejection, timeouts, and router behavior remain unchanged. This is test-support-only: production LOC delta 0; fixture delta +4/-1. OpenClaw Bay is unaffected because no observer data or controls change.

Validation and behavior proof:

- Independently built baseline `e4d0e8205` reproduces `refusing link-resolved action event spool root` on macOS with Node 24.20.0.
- The unchanged `node --test test/repair/comment-router-throttle-resilience.test.ts` passes all 3 tests after the fix.
- `node scripts/e2e/comment-router-throttle-loopback.mjs` exercises the compiled router through real loopback HTTP and actual local ledger finalization. All 12 receipt assertions pass: rate-limit/abuse/429 deferral, structured skip, partial routable progress, unchanged cursor, incremental resume, fatal non-throttle error, stale report retirement, undiscovered explicit-comment accounting, empty finalization, and partial receipt finalization.
- Scope and limits: synthetic GitHub responses over loopback HTTP; no live GitHub mutation. The producer spool and command finalization are real local filesystem operations.
- Managed Codex reviews before commit and on committed head `2797b33f9ab335df714c9bdeb09f1ed9da68b429`: both clean for P0–P2.
- Exact-head [full `pnpm check`](https://github.com/openclaw/clawsweeper/actions/runs/34010455640) and [production automerge flow](https://github.com/openclaw/clawsweeper/actions/runs/34010455635) passed. All required GitHub checks are green.
- Full local `pnpm run check` also passed on macOS: 5,103 tests, zero failures, with 86.06% line / 76.28% branch / 89.72% function coverage.
