### PR TITLE
fix(review): make fixture attributions role-neutral

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,8 +625,10 @@ its exact original source line; encoded-only content remains blocking.
 The OpenClaw [logging redaction fixtures](https://github.com/openclaw/openclaw/blob/fe0367a07a23660ea35007ac69bdb8f54309fc21/src/logging/redact.test.ts)
 use a separate flat attribution table without changing the legacy URI policy
 above. Each row binds the exact detector ID and name, native `PLAIN` or
-`ESCAPED_UNICODE` decoder, base/head role, `Raw`, `RawV2`, and complete source-line
-SHA-256 digests, path, and mode. URI findings require one literal `RawV2` witness
+`ESCAPED_UNICODE` decoder, `Raw`, `RawV2`, and complete source-line SHA-256
+digests, path, and mode. These exact attribution rows are role-neutral; every
+logical staged reference must independently match the row and have a committed
+`base` or `head` role. URI findings require one literal `RawV2` witness
 and derived host, username, and password fields. MongoDB and Postgres findings
 bind the scanner-reported line and their exact native metadata shape. Any emitted
 subset and order may qualify; duplicate exact findings, unknown variants, lossy

--- a/src/agent-input-scan-fixtures.ts
+++ b/src/agent-input-scan-fixtures.ts
@@ -15,7 +15,6 @@ export type ReviewedAttribution = readonly [
   detectorType: 17 | 895 | 968,
   detectorName: "URI" | "MongoDB" | "Postgres",
   decoder: "PLAIN" | "ESCAPED_UNICODE",
-  role: ScanSourceRole,
   rawSha256: string,
   rawV2Sha256: string,
   lineSha256: string,
@@ -172,41 +171,50 @@ const REVIEWED_FIXTURES: readonly ReviewedFixture[] = [
 
 // oxfmt-ignore
 const REVIEWED_ATTRIBUTIONS: readonly ReviewedAttribution[] = [
-  [17, "URI", "ESCAPED_UNICODE", "base", "a460200b4a488bc178d0dac30bc5fe027ff86d9c7c94554f5c9d915580bc4239", "839b16fa1dd892daf47ab10d50f7c1957a16ace282fe9e6df67fefc40f7f06ff", "232cce5bf0c7b495e2f008fdc45cbd2bd9afc5394906576e4466411f6841d260", "src/logging/redact.test.ts", "100644"],
-  [17, "URI", "ESCAPED_UNICODE", "base", "de7dcbd8612764d80691e85407d899f6e3686afd9ab40964943c3874ffe9571c", "198d323e34c2a045b86adbc72b8cd54bb8f9582175c5c25e6c68b4e374d8873f", "8ff8c788b296b7eb81abaf7f2f48bb4be717f6e8bef76200e7c842dbeea8a15c", "src/logging/redact.test.ts", "100644"],
-  [17, "URI", "ESCAPED_UNICODE", "head", "31ff9f3ec446cbcc27e6fc08f3cd96b5d95d8b436b4144f3a098d7c524a863f7", "0d9e27039ed24044fe06ab5145d7b04569ced32d3ff6fe8eb9acf04a75663919", "47171b920ebd0800ac107a92ad80b7279677f0096fad5a367f82fe3b1955c790", "src/logging/redact.test.ts", "100644"],
-  [17, "URI", "ESCAPED_UNICODE", "head", "de7dcbd8612764d80691e85407d899f6e3686afd9ab40964943c3874ffe9571c", "198d323e34c2a045b86adbc72b8cd54bb8f9582175c5c25e6c68b4e374d8873f", "8ff8c788b296b7eb81abaf7f2f48bb4be717f6e8bef76200e7c842dbeea8a15c", "src/logging/redact.test.ts", "100644"],
-  [17, "URI", "PLAIN", "base", "31ff9f3ec446cbcc27e6fc08f3cd96b5d95d8b436b4144f3a098d7c524a863f7", "0d9e27039ed24044fe06ab5145d7b04569ced32d3ff6fe8eb9acf04a75663919", "47171b920ebd0800ac107a92ad80b7279677f0096fad5a367f82fe3b1955c790", "src/logging/redact.test.ts", "100644"],
-  [17, "URI", "PLAIN", "base", "a460200b4a488bc178d0dac30bc5fe027ff86d9c7c94554f5c9d915580bc4239", "839b16fa1dd892daf47ab10d50f7c1957a16ace282fe9e6df67fefc40f7f06ff", "232cce5bf0c7b495e2f008fdc45cbd2bd9afc5394906576e4466411f6841d260", "src/logging/redact.test.ts", "100644"],
-  [17, "URI", "PLAIN", "base", "de7dcbd8612764d80691e85407d899f6e3686afd9ab40964943c3874ffe9571c", "198d323e34c2a045b86adbc72b8cd54bb8f9582175c5c25e6c68b4e374d8873f", "8ff8c788b296b7eb81abaf7f2f48bb4be717f6e8bef76200e7c842dbeea8a15c", "src/logging/redact.test.ts", "100644"],
-  [17, "URI", "PLAIN", "head", "31ff9f3ec446cbcc27e6fc08f3cd96b5d95d8b436b4144f3a098d7c524a863f7", "0d9e27039ed24044fe06ab5145d7b04569ced32d3ff6fe8eb9acf04a75663919", "47171b920ebd0800ac107a92ad80b7279677f0096fad5a367f82fe3b1955c790", "src/logging/redact.test.ts", "100644"],
-  [17, "URI", "PLAIN", "head", "a460200b4a488bc178d0dac30bc5fe027ff86d9c7c94554f5c9d915580bc4239", "839b16fa1dd892daf47ab10d50f7c1957a16ace282fe9e6df67fefc40f7f06ff", "232cce5bf0c7b495e2f008fdc45cbd2bd9afc5394906576e4466411f6841d260", "src/logging/redact.test.ts", "100644"],
-  [17, "URI", "PLAIN", "head", "de7dcbd8612764d80691e85407d899f6e3686afd9ab40964943c3874ffe9571c", "198d323e34c2a045b86adbc72b8cd54bb8f9582175c5c25e6c68b4e374d8873f", "8ff8c788b296b7eb81abaf7f2f48bb4be717f6e8bef76200e7c842dbeea8a15c", "src/logging/redact.test.ts", "100644"],
-  [895, "MongoDB", "ESCAPED_UNICODE", "base", "087c10edd5d21290a4a8695083ff8c42554fc1d1a1becea9053b11c4790b859c", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "0aeba0d1b540784464c2a230b589a48d3f062d0dbbb2d9669450ff4ee2176218", "src/logging/redact.test.ts", "100644"],
-  [895, "MongoDB", "ESCAPED_UNICODE", "head", "087c10edd5d21290a4a8695083ff8c42554fc1d1a1becea9053b11c4790b859c", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "0aeba0d1b540784464c2a230b589a48d3f062d0dbbb2d9669450ff4ee2176218", "src/logging/redact.test.ts", "100644"],
-  [895, "MongoDB", "PLAIN", "base", "087c10edd5d21290a4a8695083ff8c42554fc1d1a1becea9053b11c4790b859c", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "0aeba0d1b540784464c2a230b589a48d3f062d0dbbb2d9669450ff4ee2176218", "src/logging/redact.test.ts", "100644"],
-  [895, "MongoDB", "PLAIN", "head", "087c10edd5d21290a4a8695083ff8c42554fc1d1a1becea9053b11c4790b859c", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "0aeba0d1b540784464c2a230b589a48d3f062d0dbbb2d9669450ff4ee2176218", "src/logging/redact.test.ts", "100644"],
-  [968, "Postgres", "ESCAPED_UNICODE", "base", "050c1ddf61dd8b806e1a75cbe572669f8fa546e4ba36d03454377ba7a2c05d66", "050c1ddf61dd8b806e1a75cbe572669f8fa546e4ba36d03454377ba7a2c05d66", "6dc3c292a8c87dd8c203af74bf1fa03f3eb64ae12bafc23dadfff9c3f63c23e6", "src/logging/redact.test.ts", "100644"],
-  [968, "Postgres", "ESCAPED_UNICODE", "base", "39a0315176e45802aaa3c5c40c2a717e2fde14e99567c38b5640fe16138710fa", "39a0315176e45802aaa3c5c40c2a717e2fde14e99567c38b5640fe16138710fa", "4b03f485ba97fd1aea07f64e978e9a961179dbbb766828f20fc8a2401812a858", "src/logging/redact.test.ts", "100644"],
-  [968, "Postgres", "ESCAPED_UNICODE", "base", "4734d8b7c6e9bf96ae464bfc45b1482e00caaedea951cb96b9e88a92ba37a00f", "4734d8b7c6e9bf96ae464bfc45b1482e00caaedea951cb96b9e88a92ba37a00f", "252d197820142c40bc8701a8b1400f28a3224f305f37fd65cd2e6bfbe48d9fb1", "src/logging/redact.test.ts", "100644"],
-  [968, "Postgres", "ESCAPED_UNICODE", "base", "8be6f6c2f1e50f070e97e4b46fce7e7ad499a6bc0c145e8bdd4fc0a6ee4b5565", "8be6f6c2f1e50f070e97e4b46fce7e7ad499a6bc0c145e8bdd4fc0a6ee4b5565", "6a9d1339c87f11af0ba4e7ef89a77ea8eb8e7f7ac48fdec0abb19d9138821d18", "src/logging/redact.test.ts", "100644"],
-  [968, "Postgres", "ESCAPED_UNICODE", "base", "f2e76a2fe75ea0d64265b2a61462f1d8026a2286e3030077b4f3972fc0df3b70", "f2e76a2fe75ea0d64265b2a61462f1d8026a2286e3030077b4f3972fc0df3b70", "2020783f7b14c74d2d6960efca4ca82727980494ddef883f15ae9980141662ec", "src/logging/redact.test.ts", "100644"],
-  [968, "Postgres", "ESCAPED_UNICODE", "head", "050c1ddf61dd8b806e1a75cbe572669f8fa546e4ba36d03454377ba7a2c05d66", "050c1ddf61dd8b806e1a75cbe572669f8fa546e4ba36d03454377ba7a2c05d66", "6dc3c292a8c87dd8c203af74bf1fa03f3eb64ae12bafc23dadfff9c3f63c23e6", "src/logging/redact.test.ts", "100644"],
-  [968, "Postgres", "ESCAPED_UNICODE", "head", "39a0315176e45802aaa3c5c40c2a717e2fde14e99567c38b5640fe16138710fa", "39a0315176e45802aaa3c5c40c2a717e2fde14e99567c38b5640fe16138710fa", "4b03f485ba97fd1aea07f64e978e9a961179dbbb766828f20fc8a2401812a858", "src/logging/redact.test.ts", "100644"],
-  [968, "Postgres", "ESCAPED_UNICODE", "head", "4734d8b7c6e9bf96ae464bfc45b1482e00caaedea951cb96b9e88a92ba37a00f", "4734d8b7c6e9bf96ae464bfc45b1482e00caaedea951cb96b9e88a92ba37a00f", "252d197820142c40bc8701a8b1400f28a3224f305f37fd65cd2e6bfbe48d9fb1", "src/logging/redact.test.ts", "100644"],
-  [968, "Postgres", "ESCAPED_UNICODE", "head", "8be6f6c2f1e50f070e97e4b46fce7e7ad499a6bc0c145e8bdd4fc0a6ee4b5565", "8be6f6c2f1e50f070e97e4b46fce7e7ad499a6bc0c145e8bdd4fc0a6ee4b5565", "6a9d1339c87f11af0ba4e7ef89a77ea8eb8e7f7ac48fdec0abb19d9138821d18", "src/logging/redact.test.ts", "100644"],
-  [968, "Postgres", "ESCAPED_UNICODE", "head", "f2e76a2fe75ea0d64265b2a61462f1d8026a2286e3030077b4f3972fc0df3b70", "f2e76a2fe75ea0d64265b2a61462f1d8026a2286e3030077b4f3972fc0df3b70", "2020783f7b14c74d2d6960efca4ca82727980494ddef883f15ae9980141662ec", "src/logging/redact.test.ts", "100644"],
-  [968, "Postgres", "PLAIN", "base", "050c1ddf61dd8b806e1a75cbe572669f8fa546e4ba36d03454377ba7a2c05d66", "050c1ddf61dd8b806e1a75cbe572669f8fa546e4ba36d03454377ba7a2c05d66", "6dc3c292a8c87dd8c203af74bf1fa03f3eb64ae12bafc23dadfff9c3f63c23e6", "src/logging/redact.test.ts", "100644"],
-  [968, "Postgres", "PLAIN", "base", "39a0315176e45802aaa3c5c40c2a717e2fde14e99567c38b5640fe16138710fa", "39a0315176e45802aaa3c5c40c2a717e2fde14e99567c38b5640fe16138710fa", "4b03f485ba97fd1aea07f64e978e9a961179dbbb766828f20fc8a2401812a858", "src/logging/redact.test.ts", "100644"],
-  [968, "Postgres", "PLAIN", "base", "4734d8b7c6e9bf96ae464bfc45b1482e00caaedea951cb96b9e88a92ba37a00f", "4734d8b7c6e9bf96ae464bfc45b1482e00caaedea951cb96b9e88a92ba37a00f", "252d197820142c40bc8701a8b1400f28a3224f305f37fd65cd2e6bfbe48d9fb1", "src/logging/redact.test.ts", "100644"],
-  [968, "Postgres", "PLAIN", "base", "8be6f6c2f1e50f070e97e4b46fce7e7ad499a6bc0c145e8bdd4fc0a6ee4b5565", "8be6f6c2f1e50f070e97e4b46fce7e7ad499a6bc0c145e8bdd4fc0a6ee4b5565", "6a9d1339c87f11af0ba4e7ef89a77ea8eb8e7f7ac48fdec0abb19d9138821d18", "src/logging/redact.test.ts", "100644"],
-  [968, "Postgres", "PLAIN", "base", "f2e76a2fe75ea0d64265b2a61462f1d8026a2286e3030077b4f3972fc0df3b70", "f2e76a2fe75ea0d64265b2a61462f1d8026a2286e3030077b4f3972fc0df3b70", "2020783f7b14c74d2d6960efca4ca82727980494ddef883f15ae9980141662ec", "src/logging/redact.test.ts", "100644"],
-  [968, "Postgres", "PLAIN", "head", "050c1ddf61dd8b806e1a75cbe572669f8fa546e4ba36d03454377ba7a2c05d66", "050c1ddf61dd8b806e1a75cbe572669f8fa546e4ba36d03454377ba7a2c05d66", "6dc3c292a8c87dd8c203af74bf1fa03f3eb64ae12bafc23dadfff9c3f63c23e6", "src/logging/redact.test.ts", "100644"],
-  [968, "Postgres", "PLAIN", "head", "39a0315176e45802aaa3c5c40c2a717e2fde14e99567c38b5640fe16138710fa", "39a0315176e45802aaa3c5c40c2a717e2fde14e99567c38b5640fe16138710fa", "4b03f485ba97fd1aea07f64e978e9a961179dbbb766828f20fc8a2401812a858", "src/logging/redact.test.ts", "100644"],
-  [968, "Postgres", "PLAIN", "head", "4734d8b7c6e9bf96ae464bfc45b1482e00caaedea951cb96b9e88a92ba37a00f", "4734d8b7c6e9bf96ae464bfc45b1482e00caaedea951cb96b9e88a92ba37a00f", "252d197820142c40bc8701a8b1400f28a3224f305f37fd65cd2e6bfbe48d9fb1", "src/logging/redact.test.ts", "100644"],
-  [968, "Postgres", "PLAIN", "head", "8be6f6c2f1e50f070e97e4b46fce7e7ad499a6bc0c145e8bdd4fc0a6ee4b5565", "8be6f6c2f1e50f070e97e4b46fce7e7ad499a6bc0c145e8bdd4fc0a6ee4b5565", "6a9d1339c87f11af0ba4e7ef89a77ea8eb8e7f7ac48fdec0abb19d9138821d18", "src/logging/redact.test.ts", "100644"],
-  [968, "Postgres", "PLAIN", "head", "f2e76a2fe75ea0d64265b2a61462f1d8026a2286e3030077b4f3972fc0df3b70", "f2e76a2fe75ea0d64265b2a61462f1d8026a2286e3030077b4f3972fc0df3b70", "2020783f7b14c74d2d6960efca4ca82727980494ddef883f15ae9980141662ec", "src/logging/redact.test.ts", "100644"],
+  [17, "URI", "ESCAPED_UNICODE", "31ff9f3ec446cbcc27e6fc08f3cd96b5d95d8b436b4144f3a098d7c524a863f7", "0d9e27039ed24044fe06ab5145d7b04569ced32d3ff6fe8eb9acf04a75663919", "47171b920ebd0800ac107a92ad80b7279677f0096fad5a367f82fe3b1955c790", "src/logging/redact.test.ts", "100644"],
+  [17, "URI", "ESCAPED_UNICODE", "a460200b4a488bc178d0dac30bc5fe027ff86d9c7c94554f5c9d915580bc4239", "839b16fa1dd892daf47ab10d50f7c1957a16ace282fe9e6df67fefc40f7f06ff", "232cce5bf0c7b495e2f008fdc45cbd2bd9afc5394906576e4466411f6841d260", "src/logging/redact.test.ts", "100644"],
+  [17, "URI", "ESCAPED_UNICODE", "de7dcbd8612764d80691e85407d899f6e3686afd9ab40964943c3874ffe9571c", "198d323e34c2a045b86adbc72b8cd54bb8f9582175c5c25e6c68b4e374d8873f", "8ff8c788b296b7eb81abaf7f2f48bb4be717f6e8bef76200e7c842dbeea8a15c", "src/logging/redact.test.ts", "100644"],
+  [17, "URI", "PLAIN", "31ff9f3ec446cbcc27e6fc08f3cd96b5d95d8b436b4144f3a098d7c524a863f7", "0d9e27039ed24044fe06ab5145d7b04569ced32d3ff6fe8eb9acf04a75663919", "47171b920ebd0800ac107a92ad80b7279677f0096fad5a367f82fe3b1955c790", "src/logging/redact.test.ts", "100644"],
+  [17, "URI", "PLAIN", "a460200b4a488bc178d0dac30bc5fe027ff86d9c7c94554f5c9d915580bc4239", "839b16fa1dd892daf47ab10d50f7c1957a16ace282fe9e6df67fefc40f7f06ff", "232cce5bf0c7b495e2f008fdc45cbd2bd9afc5394906576e4466411f6841d260", "src/logging/redact.test.ts", "100644"],
+  [17, "URI", "PLAIN", "de7dcbd8612764d80691e85407d899f6e3686afd9ab40964943c3874ffe9571c", "198d323e34c2a045b86adbc72b8cd54bb8f9582175c5c25e6c68b4e374d8873f", "8ff8c788b296b7eb81abaf7f2f48bb4be717f6e8bef76200e7c842dbeea8a15c", "src/logging/redact.test.ts", "100644"],
+  [895, "MongoDB", "ESCAPED_UNICODE", "087c10edd5d21290a4a8695083ff8c42554fc1d1a1becea9053b11c4790b859c", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "0aeba0d1b540784464c2a230b589a48d3f062d0dbbb2d9669450ff4ee2176218", "src/logging/redact.test.ts", "100644"],
+  [895, "MongoDB", "PLAIN", "087c10edd5d21290a4a8695083ff8c42554fc1d1a1becea9053b11c4790b859c", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "0aeba0d1b540784464c2a230b589a48d3f062d0dbbb2d9669450ff4ee2176218", "src/logging/redact.test.ts", "100644"],
+  [968, "Postgres", "ESCAPED_UNICODE", "050c1ddf61dd8b806e1a75cbe572669f8fa546e4ba36d03454377ba7a2c05d66", "050c1ddf61dd8b806e1a75cbe572669f8fa546e4ba36d03454377ba7a2c05d66", "6dc3c292a8c87dd8c203af74bf1fa03f3eb64ae12bafc23dadfff9c3f63c23e6", "src/logging/redact.test.ts", "100644"],
+  [968, "Postgres", "ESCAPED_UNICODE", "39a0315176e45802aaa3c5c40c2a717e2fde14e99567c38b5640fe16138710fa", "39a0315176e45802aaa3c5c40c2a717e2fde14e99567c38b5640fe16138710fa", "4b03f485ba97fd1aea07f64e978e9a961179dbbb766828f20fc8a2401812a858", "src/logging/redact.test.ts", "100644"],
+  [968, "Postgres", "ESCAPED_UNICODE", "4734d8b7c6e9bf96ae464bfc45b1482e00caaedea951cb96b9e88a92ba37a00f", "4734d8b7c6e9bf96ae464bfc45b1482e00caaedea951cb96b9e88a92ba37a00f", "252d197820142c40bc8701a8b1400f28a3224f305f37fd65cd2e6bfbe48d9fb1", "src/logging/redact.test.ts", "100644"],
+  [968, "Postgres", "ESCAPED_UNICODE", "8be6f6c2f1e50f070e97e4b46fce7e7ad499a6bc0c145e8bdd4fc0a6ee4b5565", "8be6f6c2f1e50f070e97e4b46fce7e7ad499a6bc0c145e8bdd4fc0a6ee4b5565", "6a9d1339c87f11af0ba4e7ef89a77ea8eb8e7f7ac48fdec0abb19d9138821d18", "src/logging/redact.test.ts", "100644"],
+  [968, "Postgres", "ESCAPED_UNICODE", "f2e76a2fe75ea0d64265b2a61462f1d8026a2286e3030077b4f3972fc0df3b70", "f2e76a2fe75ea0d64265b2a61462f1d8026a2286e3030077b4f3972fc0df3b70", "2020783f7b14c74d2d6960efca4ca82727980494ddef883f15ae9980141662ec", "src/logging/redact.test.ts", "100644"],
+  [968, "Postgres", "PLAIN", "050c1ddf61dd8b806e1a75cbe572669f8fa546e4ba36d03454377ba7a2c05d66", "050c1ddf61dd8b806e1a75cbe572669f8fa546e4ba36d03454377ba7a2c05d66", "6dc3c292a8c87dd8c203af74bf1fa03f3eb64ae12bafc23dadfff9c3f63c23e6", "src/logging/redact.test.ts", "100644"],
+  [968, "Postgres", "PLAIN", "39a0315176e45802aaa3c5c40c2a717e2fde14e99567c38b5640fe16138710fa", "39a0315176e45802aaa3c5c40c2a717e2fde14e99567c38b5640fe16138710fa", "4b03f485ba97fd1aea07f64e978e9a961179dbbb766828f20fc8a2401812a858", "src/logging/redact.test.ts", "100644"],
+  [968, "Postgres", "PLAIN", "4734d8b7c6e9bf96ae464bfc45b1482e00caaedea951cb96b9e88a92ba37a00f", "4734d8b7c6e9bf96ae464bfc45b1482e00caaedea951cb96b9e88a92ba37a00f", "252d197820142c40bc8701a8b1400f28a3224f305f37fd65cd2e6bfbe48d9fb1", "src/logging/redact.test.ts", "100644"],
+  [968, "Postgres", "PLAIN", "8be6f6c2f1e50f070e97e4b46fce7e7ad499a6bc0c145e8bdd4fc0a6ee4b5565", "8be6f6c2f1e50f070e97e4b46fce7e7ad499a6bc0c145e8bdd4fc0a6ee4b5565", "6a9d1339c87f11af0ba4e7ef89a77ea8eb8e7f7ac48fdec0abb19d9138821d18", "src/logging/redact.test.ts", "100644"],
+  [968, "Postgres", "PLAIN", "f2e76a2fe75ea0d64265b2a61462f1d8026a2286e3030077b4f3972fc0df3b70", "f2e76a2fe75ea0d64265b2a61462f1d8026a2286e3030077b4f3972fc0df3b70", "2020783f7b14c74d2d6960efca4ca82727980494ddef883f15ae9980141662ec", "src/logging/redact.test.ts", "100644"],
 ];
+
+const sha256Pattern = /^[0-9a-f]{64}$/;
+const detectorNames = { 17: "URI", 895: "MongoDB", 968: "Postgres" } as const;
+
+function validateReviewedAttributions(rows: readonly ReviewedAttribution[]): void {
+  const seen = new Set<string>();
+  for (const row of rows) {
+    const [detectorType, detectorName, decoder, raw, rawV2, line, source, mode] = row;
+    if (
+      row.length !== 8 ||
+      detectorNames[detectorType] !== detectorName ||
+      (decoder !== "PLAIN" && decoder !== "ESCAPED_UNICODE") ||
+      ![raw, rawV2, line].every((digest) => sha256Pattern.test(digest)) ||
+      source !== "src/logging/redact.test.ts" ||
+      mode !== "100644"
+    ) {
+      throw new Error("invalid reviewed attribution policy");
+    }
+    const key = row.join("\0");
+    if (seen.has(key)) throw new Error("duplicate reviewed attribution policy");
+    seen.add(key);
+  }
+}
+
+validateReviewedAttributions(REVIEWED_ATTRIBUTIONS);
 
 export function serializeReviewContext(context: object): string {
   return JSON.stringify(
@@ -287,7 +295,7 @@ export type ScanRefusalDiagnostic =
       findingCount: number;
       findingIndex: number;
       detectorType: number | null;
-      decoder: "PLAIN" | "HTML" | "OTHER";
+      decoder: "PLAIN" | "HTML" | "ESCAPED_UNICODE" | "OTHER";
       verified: boolean | null;
       scannerLine: number | null;
       material?: ScanMaterialDiagnostic;
@@ -378,6 +386,7 @@ export function classifyReviewedFixtureScan(
   inputs: ReadonlyMap<string, StagedScanInput>,
   reviewedAttributions: readonly ReviewedAttribution[] = REVIEWED_ATTRIBUTIONS,
 ): { kind: "classified"; notices: ReviewedFixtureNotice[] } | RefusedScan {
+  validateReviewedAttributions(reviewedAttributions);
   const nativeFailure = (
     reason: Extract<ScanRefusalDiagnostic, { kind: "native_contract" }>["reason"],
   ): RefusedScan => ({
@@ -461,7 +470,9 @@ export function classifyReviewedFixtureScan(
             ? finding.DetectorType
             : null,
         decoder:
-          finding.DecoderName === "PLAIN" || finding.DecoderName === "HTML"
+          finding.DecoderName === "PLAIN" ||
+          finding.DecoderName === "HTML" ||
+          finding.DecoderName === "ESCAPED_UNICODE"
             ? finding.DecoderName
             : "OTHER",
         verified: typeof finding.Verified === "boolean" ? finding.Verified : null,
@@ -479,7 +490,7 @@ export function classifyReviewedFixtureScan(
       rawDigest === undefined || rawV2Digest === undefined
         ? []
         : reviewedAttributions.filter(
-            ([, , , , expectedRaw, expectedRawV2]) =>
+            ([, , , expectedRaw, expectedRawV2]) =>
               expectedRaw === rawDigest && expectedRawV2 === rawV2Digest,
           );
     if (exactCandidates.length > 0) {
@@ -581,18 +592,17 @@ export function classifyReviewedFixtureScan(
       )
         return refuse("literal_mismatch");
       const lineDigest = createHash("sha256").update(witnessLine).digest("hex");
-      if (!matchingMetadata.some(([, , , , , , expectedLine]) => expectedLine === lineDigest))
+      if (!matchingMetadata.some(([, , , , , expectedLine]) => expectedLine === lineDigest))
         return refuse("literal_mismatch");
       if (
         !staged.references.length ||
-        staged.references.some(({ source, mode, role }) =>
-          matchingMetadata.every(
-            ([, , , expectedRole, , , expectedLine, expectedSource, expectedMode]) =>
-              expectedRole !== role ||
-              expectedLine !== lineDigest ||
-              expectedSource !== source ||
-              expectedMode !== mode,
-          ),
+        staged.references.some(
+          ({ source, mode, role }) =>
+            (role !== "base" && role !== "head") ||
+            matchingMetadata.every(
+              ([, , , , , expectedLine, expectedSource, expectedMode]) =>
+                expectedLine !== lineDigest || expectedSource !== source || expectedMode !== mode,
+            ),
         )
       )
         return refuse("source_not_reviewed");

--- a/test/agent-input-scan.test.ts
+++ b/test/agent-input-scan.test.ts
@@ -655,7 +655,6 @@ interface ExactCase {
   detectorType: 17 | 895 | 968;
   detectorName: ExactDetector;
   decoder: ExactDecoder;
-  role: ScanSourceRole;
   raw: string;
   rawV2: string;
   line: string;
@@ -665,13 +664,9 @@ interface ExactCase {
 
 const exactSource = "src/logging/redact.test.ts";
 
-function exactCase(
-  detectorName: ExactDetector,
-  decoder: ExactDecoder,
-  role: ScanSourceRole,
-): ExactCase {
+function exactCase(detectorName: ExactDetector, decoder: ExactDecoder): ExactCase {
   if (detectorName === "URI") {
-    const uri = new URL(`https://${decoder.toLowerCase()}.${role}.example.invalid/path`);
+    const uri = new URL(`https://${decoder.toLowerCase()}.example.invalid/path`);
     uri.username = "fixture-user";
     uri.password = "fixture-pass";
     const rawV2 = uri.href;
@@ -681,7 +676,6 @@ function exactCase(
       detectorType: 17,
       detectorName,
       decoder,
-      role,
       raw: authority.href.slice(0, -1),
       rawV2,
       line: `const fixture = ${JSON.stringify(rawV2)};`,
@@ -693,20 +687,19 @@ function exactCase(
       extraData: null,
     };
   }
-  const raw = `${detectorName.toLowerCase()}://${decoder.toLowerCase()}.${role}.example.invalid/db`;
+  const raw = `${detectorName.toLowerCase()}://${decoder.toLowerCase()}.example.invalid/db`;
   if (detectorName === "MongoDB") {
     return {
       detectorType: 895,
       detectorName,
       decoder,
-      role,
       raw,
       rawV2: "",
       line: `const fixture = ${JSON.stringify(raw)};`,
       secretParts: { key: raw },
       extraData: {
         database: "db",
-        host: `${decoder.toLowerCase()}.${role}.example.invalid`,
+        host: `${decoder.toLowerCase()}.example.invalid`,
         rotation_guide: "reviewed synthetic guidance",
         username: "fixture-user",
       },
@@ -716,21 +709,23 @@ function exactCase(
     detectorType: 968,
     detectorName,
     decoder,
-    role,
     raw,
     rawV2: raw,
     line: `const fixture = ${JSON.stringify(raw)};`,
     secretParts: { connection_string: raw },
     extraData: {
       database: "db",
-      host: `${decoder.toLowerCase()}.${role}.example.invalid`,
+      host: `${decoder.toLowerCase()}.example.invalid`,
       sslmode: "require",
       username: "fixture-user",
     },
   };
 }
 
-function exactFixture(cases: readonly ExactCase[]) {
+function exactFixture(
+  cases: readonly ExactCase[],
+  roles: readonly (readonly ScanSourceRole[])[] = cases.map(() => ["base"]),
+) {
   const inputs = new Map<string, StagedScanInput>();
   const findings = cases.map((entry, index) => {
     const file = `/private/scanner/${index.toString(16).padStart(40, "0")}`;
@@ -738,14 +733,12 @@ function exactFixture(cases: readonly ExactCase[]) {
       kind: "blob",
       id: index.toString(16).padStart(40, "0"),
       bytes: Buffer.from(`// context\n${entry.line}\n`),
-      references: [
-        {
-          source: exactSource,
-          mode: "100644",
-          revision: entry.role === "base" ? "a".repeat(40) : "b".repeat(40),
-          role: entry.role,
-        },
-      ],
+      references: (roles[index] ?? ["base"]).map((role) => ({
+        source: exactSource,
+        mode: "100644",
+        revision: role === "base" ? "a".repeat(40) : "b".repeat(40),
+        role,
+      })),
     });
     return {
       SourceType: 15,
@@ -762,19 +755,23 @@ function exactFixture(cases: readonly ExactCase[]) {
       StructuredData: null,
     };
   });
-  const policy = cases.map(
-    (entry): ReviewedAttribution => [
-      entry.detectorType,
-      entry.detectorName,
-      entry.decoder,
-      entry.role,
-      createHash("sha256").update(entry.raw).digest("hex"),
-      createHash("sha256").update(entry.rawV2).digest("hex"),
-      createHash("sha256").update(entry.line).digest("hex"),
-      exactSource,
-      "100644",
-    ],
-  );
+  const policy = [
+    ...new Map(
+      cases.map((entry) => {
+        const row: ReviewedAttribution = [
+          entry.detectorType,
+          entry.detectorName,
+          entry.decoder,
+          createHash("sha256").update(entry.raw).digest("hex"),
+          createHash("sha256").update(entry.rawV2).digest("hex"),
+          createHash("sha256").update(entry.line).digest("hex"),
+          exactSource,
+          "100644",
+        ];
+        return [row.join("\0"), row] as const;
+      }),
+    ).values(),
+  ];
   return { findings, inputs, policy };
 }
 
@@ -804,12 +801,13 @@ function classifyExact(
 }
 
 test("exact reviewed attributions accept emitted detector subsets in any order", () => {
-  const cases = (["base", "head"] as const).flatMap((role) =>
-    (["URI", "MongoDB", "Postgres"] as const).flatMap((detector) =>
-      (["PLAIN", "ESCAPED_UNICODE"] as const).map((decoder) => exactCase(detector, decoder, role)),
-    ),
+  const cases = (["URI", "MongoDB", "Postgres"] as const).flatMap((detector) =>
+    (["PLAIN", "ESCAPED_UNICODE"] as const).map((decoder) => exactCase(detector, decoder)),
   );
-  const fixture = exactFixture(cases);
+  const fixture = exactFixture(
+    cases,
+    cases.map(() => ["base", "head"]),
+  );
   const selections = [
     cases.map((_, index) => index),
     cases.map((_, index) => index).reverse(),
@@ -842,8 +840,30 @@ test("exact reviewed attributions accept emitted detector subsets in any order",
   }
 });
 
+test("exact reviewed attributions accept role-neutral tuples from committed references", () => {
+  for (const decoder of ["PLAIN", "ESCAPED_UNICODE"] as const) {
+    const entry = exactCase("URI", decoder);
+    const separate = exactFixture([entry, entry], [["base"], ["head"]]);
+    assert.equal(
+      classifyExact(separate.findings, separate.inputs, separate.policy).kind,
+      "classified",
+    );
+
+    const deduplicated = exactFixture([entry], [["base", "head"]]);
+    const result = classifyExact(deduplicated.findings, deduplicated.inputs, deduplicated.policy);
+    assert.equal(result.kind, "classified");
+    if (result.kind === "classified") {
+      assert.deepEqual(
+        result.notices.flatMap((notice) => notice.findings.map((finding) => finding.role)).sort(),
+        ["base", "head"],
+      );
+    }
+  }
+});
+
 test("exact reviewed attributions reject drift, duplicates, and mixed unknown findings", () => {
-  const base = exactFixture([exactCase("URI", "PLAIN", "base")]);
+  const entry = exactCase("URI", "PLAIN");
+  const base = exactFixture([entry]);
   const valid = base.findings[0]!;
   const inputFile = String(
     (valid.SourceMetadata as { Data: { Filesystem: { file: string } } }).Data.Filesystem.file,
@@ -896,10 +916,9 @@ test("exact reviewed attributions reject drift, duplicates, and mixed unknown fi
           row[0],
           row[1],
           row[2],
-          row[3],
-          row[5],
           row[4],
-          ...row.slice(6),
+          row[3],
+          ...row.slice(5),
         ] as ReviewedAttribution;
         return [finding];
       },
@@ -911,7 +930,7 @@ test("exact reviewed attributions reject drift, duplicates, and mixed unknown fi
         const staged = inputs.get(inputFile)!;
         inputs.set(inputFile, {
           ...staged,
-          bytes: Buffer.from(`// context changed\n${base.policy[0]![5]}\n`),
+          bytes: Buffer.from(`// context\n${entry.line} // changed\n`),
         });
         return [finding];
       },
@@ -941,7 +960,7 @@ test("exact reviewed attributions reject drift, duplicates, and mixed unknown fi
       },
     },
     {
-      name: "wrong role",
+      name: "index reference",
       expected: "source_not_reviewed",
       mutate: (finding, inputs) => {
         const staged = inputs.get(inputFile)!;
@@ -953,13 +972,37 @@ test("exact reviewed attributions reject drift, duplicates, and mixed unknown fi
       },
     },
     {
+      name: "tree reference",
+      expected: "source_not_reviewed",
+      mutate: (finding, inputs) => {
+        const staged = inputs.get(inputFile)!;
+        inputs.set(inputFile, {
+          ...staged,
+          references: [{ ...staged.references[0]!, role: "tree" }],
+        });
+        return [finding];
+      },
+    },
+    {
+      name: "worktree reference",
+      expected: "source_not_reviewed",
+      mutate: (finding, inputs) => {
+        const staged = inputs.get(inputFile)!;
+        inputs.set(inputFile, {
+          ...staged,
+          references: [{ ...staged.references[0]!, role: "worktree" }],
+        });
+        return [finding];
+      },
+    },
+    {
       name: "mixed authorized and unauthorized references",
       expected: "source_not_reviewed",
       mutate: (finding, inputs) => {
         const staged = inputs.get(inputFile)!;
         inputs.set(inputFile, {
           ...staged,
-          references: [...staged.references, { ...staged.references[0]!, source: "other.test.ts" }],
+          references: [...staged.references, { ...staged.references[0]!, role: "index" }],
         });
         return [finding];
       },
@@ -981,7 +1024,7 @@ test("exact reviewed attributions reject drift, duplicates, and mixed unknown fi
     },
   ];
   for (const scenario of cases) {
-    const fixture = exactFixture([exactCase("URI", "PLAIN", "base")]);
+    const fixture = exactFixture([exactCase("URI", "PLAIN")]);
     const finding = structuredClone(fixture.findings[0]!);
     const inputs = new Map(fixture.inputs);
     const policy = [...fixture.policy];
@@ -990,6 +1033,42 @@ test("exact reviewed attributions reject drift, duplicates, and mixed unknown fi
     if (result.kind === "refused" && result.diagnostic.kind === "unclassified_finding")
       assert.equal(result.diagnostic.reason, scenario.expected, scenario.name);
   }
+});
+
+test("exact refusal diagnostics retain the escaped-unicode decoder", () => {
+  const fixture = exactFixture([exactCase("URI", "ESCAPED_UNICODE")], [["index"]]);
+  const result = classifyExact(fixture.findings, fixture.inputs, fixture.policy);
+  assert.equal(result.kind, "refused");
+  if (result.kind === "refused" && result.diagnostic.kind === "unclassified_finding") {
+    assert.equal(result.diagnostic.reason, "source_not_reviewed");
+    assert.equal(result.diagnostic.decoder, "ESCAPED_UNICODE");
+  }
+});
+
+test("exact attribution policy rejects duplicate and malformed rows", () => {
+  const fixture = exactFixture([exactCase("URI", "PLAIN")]);
+  const nativeFailure = classifyReviewedFixtureScan(0, Buffer.alloc(0), Buffer.alloc(0), new Map());
+  assert.deepEqual(nativeFailure, {
+    kind: "refused",
+    reason: "scanner_failed",
+    diagnostic: { kind: "native_contract", reason: "unexpected_exit" },
+  });
+  assert.throws(
+    () =>
+      classifyReviewedFixtureScan(0, Buffer.alloc(0), Buffer.alloc(0), new Map(), [
+        ...fixture.policy,
+        fixture.policy[0]!,
+      ]),
+    /duplicate reviewed attribution policy/,
+  );
+  const row = fixture.policy[0]!;
+  assert.throws(
+    () =>
+      classifyReviewedFixtureScan(0, Buffer.alloc(0), Buffer.alloc(0), new Map(), [
+        [895, row[1], row[2], ...row.slice(3)] as ReviewedAttribution,
+      ]),
+    /invalid reviewed attribution policy/,
+  );
 });
 
 test("exact detector metadata contracts reject malformed MongoDB and Postgres findings", () => {
@@ -1005,9 +1084,9 @@ test("exact detector metadata contracts reject malformed MongoDB and Postgres fi
         finding.RawV2 = String(finding.Raw);
         const row = policy[0]!;
         policy[0] = [
-          ...row.slice(0, 5),
+          ...row.slice(0, 4),
           createHash("sha256").update(String(finding.RawV2)).digest("hex"),
-          ...row.slice(6),
+          ...row.slice(5),
         ] as ReviewedAttribution;
       },
     },
@@ -1035,9 +1114,9 @@ test("exact detector metadata contracts reject malformed MongoDB and Postgres fi
         finding.RawV2 = `${finding.Raw}changed`;
         const row = policy[0]!;
         policy[0] = [
-          ...row.slice(0, 5),
+          ...row.slice(0, 4),
           createHash("sha256").update(String(finding.RawV2)).digest("hex"),
-          ...row.slice(6),
+          ...row.slice(5),
         ] as ReviewedAttribution;
       },
     },
@@ -1060,7 +1139,7 @@ test("exact detector metadata contracts reject malformed MongoDB and Postgres fi
     },
   ];
   for (const testCase of cases) {
-    const fixture = exactFixture([exactCase(testCase.detector, "PLAIN", "base")]);
+    const fixture = exactFixture([exactCase(testCase.detector, "PLAIN")]);
     const finding = structuredClone(fixture.findings[0]!);
     const policy = [...fixture.policy];
     testCase.mutate(finding, policy);


### PR DESCRIPTION
## What Problem This Solves

ClawSweeper's exact OpenClaw redaction-fixture policy encoded `base` and `head` roles inside each attribution row. Native decoder selection can vary independently by scan, so two asymmetric role rows caused a valid committed source finding to refuse before review.

Hosted run https://github.com/openclaw/clawsweeper/actions/runs/34009940964 reproduced the parent failure on ClawSweeper `c33896727985e6b729788dce9b05a2ebc0650cf3`. A local policy audit found 34 role-specific rows, 18 unique role-neutral tuples, and two asymmetric role gaps.

## Why This Change Was Made

Exact detector attribution and staged-source provenance are separate contracts. The policy now stores one row per exact detector/name/decoder/raw hash/rawV2 hash/line hash/source/mode tuple, while the classifier independently requires every logical staged reference to:

- match that exact source, mode, and line policy;
- carry a committed `base` or `head` role.

Any `index`, `tree`, or `worktree` reference, including one mixed into an otherwise valid deduplicated blob, refuses admission. Detector, decoder, value, metadata, literal-witness, duplicate-finding, and legacy URI checks remain unchanged. Static policy validation rejects duplicate or malformed exact rows.

## User Impact

Valid reviewed OpenClaw redaction fixtures no longer fail solely because TruffleHog selected a decoder/role combination that was absent from a duplicated role-specific table. Uncommitted or ambiguously attributed material remains fail-closed.

## OpenClaw Bay Impact

None. This changes admission classification and diagnostics only. No observer dashboard, queue, status, or publication contract changes.

## Documentation Impact

The active README safety contract now states that exact attribution rows are role-neutral and that every logical staged reference must independently be a committed base/head source. The existing changelog entry already owns this repair; no second entry was added.

## Evidence

- Signed commit: `b1c1807717ceaf7f8bcdd86f7b6cba038585ad43`
- Diff: 3 files, 193 insertions, 102 deletions
- Final policy audit: 18 rows, 18 unique rows, tuple width 8, no role field
- `pnpm run build`: passed
- `node --test test/agent-input-scan.test.ts test/exact-review-failure-diagnostics.test.ts`: 261/261 passed
- Exact-attribution focused rerun: 6/6 passed
- `git diff --check`: passed
- Precommit autoreview: `scoped-clean` at P0-P2
- Postcommit autoreview: `scoped-clean` at P0-P2

`PATH="/opt/homebrew/opt/bash/bin:$PATH" pnpm run check` completed formatting, static checks, all builds, lint, and 5,108 of 5,125 tests. It retained four unrelated parent/environment failures: an E2E script invoking a Bash without `mapfile`, a disposable-profile HOME assertion, a macOS temporary-root alias assertion, and an existing signing-callback assertion. The changed scanner and diagnostics tests passed inside the full run.

### Real Behavior Proof

The production `scanAgentInput` entry point was built from this branch and run against the exact committed OpenClaw revisions:

- base `b8731bc88a7c562f01d0d7bc3e9634b71047d3d3`
- head `fe0367a07a23660ea35007ac69bdb8f54309fc21`
- base source blob `27377297fde37750aa9a99dce76bccd2f8b35313`
- head source blob `cb52c7c395b6e3243b83f0c9680ea16edd913e6b`

The managed TruffleHog `3.97.1` binary was placed first in `PATH`; the production source was `{ kind: "committed", baseSha, headSha }`. The bounded replay allowed at most eight scans and stopped after three consecutive scans added no sanitized classification identity.

Five scans completed before stabilization. Their emitted finding counts were 15, 16, 16, 16, and 17. Every emitted subset/order classified successfully. Only detector names URI, MongoDB, and Postgres; native decoders `PLAIN` and `ESCAPED_UNICODE`; and source roles `base` and `head` appeared. No OpenClaw contributor code was executed and no provider/model process was launched by the replay.

The parent hosted failure refused at agent-input admission before provider/model launch. Focused integration coverage also proves a scanner refusal cannot launch the provider.
