### PR TITLE
fix(review): admit Crabbox Postgres docs fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Admit the reviewed Crabbox PostgreSQL operations example through exact Postgres detector, observed `PLAIN`/`HTML` decoder, value-hash, source-line, path, mode, metadata, and committed base/head bindings.
 - Admit the reviewed OpenClaw logging redaction fixtures through exact detector, native decoder, role, value-hash, source-line, path, mode, and metadata bindings while preserving legacy URI fixture behavior.
 - Keep canonical OpenClaw locale refresh PRs open across apply and repair close paths so their publisher can reconcile and auto-merge them after normal checks.
 

--- a/README.md
+++ b/README.md
@@ -623,16 +623,19 @@ and win cross-decoder deduplication. Those entries still require the literal in
 its exact original source line; encoded-only content remains blocking.
 
 The OpenClaw [logging redaction fixtures](https://github.com/openclaw/openclaw/blob/fe0367a07a23660ea35007ac69bdb8f54309fc21/src/logging/redact.test.ts)
-use a separate flat attribution table without changing the legacy URI policy
-above. Each row binds the exact detector ID and name, native `PLAIN` or
-`ESCAPED_UNICODE` decoder, `Raw`, `RawV2`, and complete source-line SHA-256
-digests, path, and mode. These exact attribution rows are role-neutral; every
-logical staged reference must independently match the row and have a committed
-`base` or `head` role. URI findings require one literal `RawV2` witness
-and derived host, username, and password fields. MongoDB and Postgres findings
-bind the scanner-reported line and their exact native metadata shape. Any emitted
-subset and order may qualify; duplicate exact findings, unknown variants, lossy
-decoder buckets, or an unqualified deduplicated blob reference refuse admission.
+and the reviewed Crabbox PostgreSQL operations example use a separate flat
+attribution table without changing the legacy URI policy above. Each row binds
+the exact detector ID and name, observed native decoder, `Raw`, `RawV2`, and
+complete source-line SHA-256 digests, path, and mode. The logging rows permit
+only their observed `PLAIN` or `ESCAPED_UNICODE` variants; the Crabbox
+documentation row permits only its observed `PLAIN` or `HTML` variants. These
+exact attribution rows are role-neutral; every logical staged reference must
+independently match the row and have a committed `base` or `head` role. URI
+findings require one literal `RawV2` witness and derived host, username, and
+password fields. MongoDB and Postgres findings bind the scanner-reported line
+and their exact native metadata shape. Any emitted subset and order may qualify;
+duplicate exact findings, unknown variants, lossy decoder buckets, or an
+unqualified deduplicated blob reference refuse admission.
 
 One source path may contain multiple independently reviewed fixtures; each
 digest/path/mode tuple must match exactly, so source membership alone never

--- a/src/agent-input-scan-fixtures.ts
+++ b/src/agent-input-scan-fixtures.ts
@@ -14,7 +14,7 @@ export type ScanSourceRole = "base" | "head" | "index" | "tree" | "worktree";
 export type ReviewedAttribution = readonly [
   detectorType: 17 | 895 | 968,
   detectorName: "URI" | "MongoDB" | "Postgres",
-  decoder: "PLAIN" | "ESCAPED_UNICODE",
+  decoder: "PLAIN" | "HTML" | "ESCAPED_UNICODE",
   rawSha256: string,
   rawV2Sha256: string,
   lineSha256: string,
@@ -169,6 +169,29 @@ const REVIEWED_FIXTURES: readonly ReviewedFixture[] = [
   },
 ];
 
+const CRABBOX_POSTGRES_DOC_ATTRIBUTIONS: readonly ReviewedAttribution[] = [
+  [
+    968,
+    "Postgres",
+    "HTML",
+    "b296b6d2d18690f50a8088d03ce813c6147aaf1642e9f774a88b7c10b4c1948b",
+    "b296b6d2d18690f50a8088d03ce813c6147aaf1642e9f774a88b7c10b4c1948b",
+    "222f928b39fd053a8a3b088b53f703bccbb7d3cd58ede6ae974e985cae4d6406",
+    "docs/operations.md",
+    "100644",
+  ],
+  [
+    968,
+    "Postgres",
+    "PLAIN",
+    "b296b6d2d18690f50a8088d03ce813c6147aaf1642e9f774a88b7c10b4c1948b",
+    "b296b6d2d18690f50a8088d03ce813c6147aaf1642e9f774a88b7c10b4c1948b",
+    "222f928b39fd053a8a3b088b53f703bccbb7d3cd58ede6ae974e985cae4d6406",
+    "docs/operations.md",
+    "100644",
+  ],
+];
+
 // oxfmt-ignore
 const REVIEWED_ATTRIBUTIONS: readonly ReviewedAttribution[] = [
   [17, "URI", "ESCAPED_UNICODE", "31ff9f3ec446cbcc27e6fc08f3cd96b5d95d8b436b4144f3a098d7c524a863f7", "0d9e27039ed24044fe06ab5145d7b04569ced32d3ff6fe8eb9acf04a75663919", "47171b920ebd0800ac107a92ad80b7279677f0096fad5a367f82fe3b1955c790", "src/logging/redact.test.ts", "100644"],
@@ -189,6 +212,7 @@ const REVIEWED_ATTRIBUTIONS: readonly ReviewedAttribution[] = [
   [968, "Postgres", "PLAIN", "4734d8b7c6e9bf96ae464bfc45b1482e00caaedea951cb96b9e88a92ba37a00f", "4734d8b7c6e9bf96ae464bfc45b1482e00caaedea951cb96b9e88a92ba37a00f", "252d197820142c40bc8701a8b1400f28a3224f305f37fd65cd2e6bfbe48d9fb1", "src/logging/redact.test.ts", "100644"],
   [968, "Postgres", "PLAIN", "8be6f6c2f1e50f070e97e4b46fce7e7ad499a6bc0c145e8bdd4fc0a6ee4b5565", "8be6f6c2f1e50f070e97e4b46fce7e7ad499a6bc0c145e8bdd4fc0a6ee4b5565", "6a9d1339c87f11af0ba4e7ef89a77ea8eb8e7f7ac48fdec0abb19d9138821d18", "src/logging/redact.test.ts", "100644"],
   [968, "Postgres", "PLAIN", "f2e76a2fe75ea0d64265b2a61462f1d8026a2286e3030077b4f3972fc0df3b70", "f2e76a2fe75ea0d64265b2a61462f1d8026a2286e3030077b4f3972fc0df3b70", "2020783f7b14c74d2d6960efca4ca82727980494ddef883f15ae9980141662ec", "src/logging/redact.test.ts", "100644"],
+  ...CRABBOX_POSTGRES_DOC_ATTRIBUTIONS,
 ];
 
 const sha256Pattern = /^[0-9a-f]{64}$/;
@@ -201,9 +225,15 @@ function validateReviewedAttributions(rows: readonly ReviewedAttribution[]): voi
     if (
       row.length !== 8 ||
       detectorNames[detectorType] !== detectorName ||
-      (decoder !== "PLAIN" && decoder !== "ESCAPED_UNICODE") ||
       ![raw, rawV2, line].every((digest) => sha256Pattern.test(digest)) ||
-      source !== "src/logging/redact.test.ts" ||
+      !(
+        (source === "src/logging/redact.test.ts" &&
+          (decoder === "PLAIN" || decoder === "ESCAPED_UNICODE")) ||
+        (source === "docs/operations.md" &&
+          detectorType === 968 &&
+          detectorName === "Postgres" &&
+          (decoder === "PLAIN" || decoder === "HTML"))
+      ) ||
       mode !== "100644"
     ) {
       throw new Error("invalid reviewed attribution policy");

--- a/test/agent-input-scan.test.ts
+++ b/test/agent-input-scan.test.ts
@@ -800,6 +800,218 @@ function classifyExact(
   );
 }
 
+function classifyWithProductionPolicy(
+  findings: readonly Record<string, unknown>[],
+  inputs: ReadonlyMap<string, StagedScanInput>,
+) {
+  return classifyReviewedFixtureScan(
+    183,
+    Buffer.from(`${findings.map((finding) => JSON.stringify(finding)).join("\n")}\n`),
+    Buffer.from(
+      `${JSON.stringify({
+        level: "info-0",
+        logger: "trufflehog",
+        msg: "finished scanning",
+        trufflehog_version: "3.97.1",
+        chunks: 1,
+        bytes: 1,
+        verified_secrets: 0,
+        unverified_secrets: findings.length,
+      })}\n`,
+    ),
+    inputs,
+  );
+}
+
+function crabboxPostgresDocsFixture() {
+  const raw = ["postgresql://crabbox", ":password@db.example.com", ":5432"].join("");
+  const sourceUri = [
+    "postgresql://crabbox",
+    ":password@db.example.com/crabbox",
+    "?sslmode=verify-full&sslrootcert=/run/secrets/postgres-ca.pem",
+  ].join("");
+  const line = ["DATABASE_URL='", sourceUri, "' \\"].join("");
+  const inputs = new Map<string, StagedScanInput>();
+  const blobs = [
+    {
+      id: "4fa440e5879379b16bcb570cc0adc46439f075fd",
+      revision: "b".repeat(40),
+      role: "head",
+    },
+    {
+      id: "75f9bd02e4948b6b214997ab7e3878718740b4d8",
+      revision: "a".repeat(40),
+      role: "base",
+    },
+  ] as const;
+  for (const blob of blobs) {
+    const file = `/private/scanner/${blob.id}`;
+    inputs.set(file, {
+      kind: "blob",
+      id: blob.id,
+      bytes: Buffer.from(`${"\n".repeat(352)}${line}\n`),
+      references: [
+        {
+          source: "docs/operations.md",
+          mode: "100644",
+          revision: blob.revision,
+          role: blob.role,
+        },
+      ],
+    });
+  }
+  const findings = blobs.flatMap((blob) =>
+    (["PLAIN", "HTML"] as const).map((decoder) => ({
+      SourceType: 15,
+      DetectorType: 968,
+      DetectorName: "Postgres",
+      DecoderName: decoder,
+      Verified: false,
+      VerificationError: "lookup db.example.com: no such host",
+      Raw: raw,
+      RawV2: raw,
+      SourceMetadata: {
+        Data: { Filesystem: { file: `/private/scanner/${blob.id}`, line: 353 } },
+      },
+      SecretParts: { connection_string: raw },
+      ExtraData: {
+        database: "crabbox",
+        host: "db.example.com:5432",
+        sslmode: "verify-full",
+        username: "crabbox",
+      },
+      StructuredData: null,
+    })),
+  );
+  return { findings, inputs, raw, line };
+}
+
+test("Crabbox Postgres docs attribution accepts only the observed committed variants", () => {
+  const accepted = crabboxPostgresDocsFixture();
+  assert.equal(
+    createHash("sha256").update(accepted.raw).digest("hex"),
+    "b296b6d2d18690f50a8088d03ce813c6147aaf1642e9f774a88b7c10b4c1948b",
+  );
+  assert.equal(
+    createHash("sha256").update(accepted.line).digest("hex"),
+    "222f928b39fd053a8a3b088b53f703bccbb7d3cd58ede6ae974e985cae4d6406",
+  );
+  for (let mask = 1; mask < 1 << accepted.findings.length; mask++) {
+    const subset = accepted.findings.filter((_, index) => mask & (1 << index));
+    assert.equal(classifyWithProductionPolicy(subset, accepted.inputs).kind, "classified");
+    assert.equal(
+      classifyWithProductionPolicy([...subset].reverse(), accepted.inputs).kind,
+      "classified",
+    );
+  }
+
+  const firstFile = String(
+    (accepted.findings[0]!.SourceMetadata as { Data: { Filesystem: { file: string } } }).Data
+      .Filesystem.file,
+  );
+  const cases: Array<{
+    name: string;
+    expected: string;
+    mutate: (findings: Record<string, unknown>[], inputs: Map<string, StagedScanInput>) => void;
+  }> = [
+    {
+      name: "value",
+      expected: "finding_not_reviewed",
+      mutate: (findings) => {
+        findings[0]!.Raw = `${findings[0]!.Raw}changed`;
+        findings[0]!.RawV2 = findings[0]!.Raw;
+      },
+    },
+    {
+      name: "line",
+      expected: "literal_mismatch",
+      mutate: (_findings, inputs) => {
+        const staged = inputs.get(firstFile)!;
+        inputs.set(firstFile, {
+          ...staged,
+          bytes: Buffer.from(`${staged.bytes!.toString().trimEnd()} # changed\n`),
+        });
+      },
+    },
+    {
+      name: "path",
+      expected: "source_not_reviewed",
+      mutate: (_findings, inputs) => {
+        const staged = inputs.get(firstFile)!;
+        inputs.set(firstFile, {
+          ...staged,
+          references: [{ ...staged.references[0]!, source: "docs/infrastructure.md" }],
+        });
+      },
+    },
+    {
+      name: "mode",
+      expected: "source_not_reviewed",
+      mutate: (_findings, inputs) => {
+        const staged = inputs.get(firstFile)!;
+        inputs.set(firstFile, {
+          ...staged,
+          references: [{ ...staged.references[0]!, mode: "100755" }],
+        });
+      },
+    },
+    {
+      name: "detector",
+      expected: "finding_not_reviewed",
+      mutate: (findings) => {
+        findings[0]!.DetectorType = 895;
+        findings[0]!.DetectorName = "MongoDB";
+      },
+    },
+    {
+      name: "decoder",
+      expected: "finding_not_reviewed",
+      mutate: (findings) => {
+        findings[0]!.DecoderName = "ESCAPED_UNICODE";
+      },
+    },
+    ...(["index", "tree", "worktree"] as const).map((role) => ({
+      name: `${role} role`,
+      expected: "source_not_reviewed",
+      mutate: (_findings: Record<string, unknown>[], inputs: Map<string, StagedScanInput>) => {
+        const staged = inputs.get(firstFile)!;
+        inputs.set(firstFile, {
+          ...staged,
+          references: [{ ...staged.references[0]!, role }],
+        });
+      },
+    })),
+    {
+      name: "duplicate",
+      expected: "duplicate_finding",
+      mutate: (findings) => {
+        findings.splice(1, findings.length - 1, structuredClone(findings[0]!));
+      },
+    },
+    {
+      name: "mixed unknown",
+      expected: "finding_not_reviewed",
+      mutate: (findings) => {
+        findings.push({
+          ...structuredClone(findings[0]!),
+          Raw: "unknown",
+          RawV2: "unknown",
+        });
+      },
+    },
+  ];
+  for (const scenario of cases) {
+    const fixture = crabboxPostgresDocsFixture();
+    const findings = structuredClone(fixture.findings) as Record<string, unknown>[];
+    const inputs = new Map(fixture.inputs);
+    scenario.mutate(findings, inputs);
+    const result = classifyWithProductionPolicy(findings, inputs);
+    assert.equal(result.kind, "refused", scenario.name);
+    if (result.kind === "refused" && result.diagnostic.kind === "unclassified_finding")
+      assert.equal(result.diagnostic.reason, scenario.expected, scenario.name);
+  }
+});
+
 test("exact reviewed attributions accept emitted detector subsets in any order", () => {
   const cases = (["URI", "MongoDB", "Postgres"] as const).flatMap((detector) =>
     (["PLAIN", "ESCAPED_UNICODE"] as const).map((decoder) => exactCase(detector, decoder)),


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where ClawSweeper refuses review admission for a Crabbox pull
request that changes `docs/operations.md`, because that file already contains a
public synthetic PostgreSQL connection example elsewhere in the document.

This is a prerequisite for reviewing
https://github.com/openclaw/crabbox/pull/1904.

## Why This Change Was Made

The change adds two exact host-owned attribution rows for the reviewed
PostgreSQL example. They bind the Postgres detector, the observed `PLAIN` and
`HTML` decoders, exact native value hashes, the complete source-line hash,
`docs/operations.md`, mode `100644`, detector metadata, and the existing
committed `base`/`head` role requirement.

There is no path-wide, detector-wide, repository-controlled, or runtime
override. Changed values, lines, paths, modes, metadata, decoders, duplicates,
mixed unknown findings, and non-committed roles still refuse admission.

## User Impact

Maintainers can review the affected Crabbox change without disabling input
scanning or authorizing unrelated findings. Genuine or changed credential-shaped
material remains blocking before a provider or model can launch.

## OpenClaw Bay Impact

OpenClaw Bay is unaffected. This changes only host-side review-input
classification; no queue, status, lifecycle, telemetry, dashboard, or public
data contract changes.

## Documentation Impact

The active scanner contract in `README.md` now documents the narrowly reviewed
Crabbox PostgreSQL example and its accepted native decoder variants.
`CHANGELOG.md` records the operational admission change.

## Evidence

- Exact head: `c95e0b18b49e6f975116947939bfda89afde837b`
- Target Crabbox base: `728a0d0837642ac84f3302fe6191f24087320e1a`
- Target Crabbox head: `0ac90de2ce3a5c1523c1885e81c7018a16b828b1`
- Original refusal:
  https://github.com/openclaw/clawsweeper/actions/runs/34014871213
- TruffleHog: `3.97.1`, binary SHA-256
  `f6899e5521ff060634a9599e02215195d29d330e9a902feb3f5322eedcb7ba21`
- Focused scanner suite: `256/256` passed.
- Static checks, build, lint, formatting, changed coverage, and diff checks
  passed.
- Exact committed-scope Codex review: scoped clean at P0-P2, correctness
  confidence `0.94`.
- Production code delta: `+33/-3`; tests: `+212`; docs/changelog: `+14/-10`.

The local full `pnpm run check` completed static checks, builds, lint, and
changed coverage, then retained two unrelated host-environment failures in
`test/live-proof-review-environment.test.ts`: one synthetic review-child
compound command and one nodenv lookup for a missing literal Node `24`
installation. The changed scanner suite and production replay are green;
hosted CI is the clean-environment gate.

## Real Behavior Proof

**Claim:** the production admission boundary classifies the exact four native
records from the affected Crabbox review input while preserving the existing
fail-closed launch boundary.

**Exercised surface:** the built production `scanAgentInput` entry point with
committed Git source staging and pinned native TruffleHog output.

**Scenario and environment:** a private temporary harness called the candidate
ClawSweeper build against the exact Crabbox base/head revisions above. It used
TruffleHog `3.97.1` with the production arguments, isolated temporary
directories, and no provider or model process.

**Observed result:**

```json
{
  "status": "classified",
  "nativeRecordCount": 4,
  "noticeCount": 2,
  "providerModelLaunchCount": 0,
  "records": [
    "Postgres docs head / PLAIN",
    "Postgres docs base / HTML",
    "existing Crabbox fleet URI / PLAIN",
    "existing Crabbox fleet URI / PLAIN"
  ]
}
```

The production boundary invoked trusted Git 58 times and pinned TruffleHog once.
It invoked no provider or model. The canonical compact trace, excluding its
self-digest field, has SHA-256
`a221a36a175b38921a592910d78fe02add22e457bbac03636c847cfe836b251e`;
the retained pretty-printed sanitized file has SHA-256
`8224d2c47b56f19825172fbb68a688a0caf543bb12c781de4223d707dcd38088`.
The trace contains only source paths, blob IDs, detector/decoder names, line
numbers, roles, and fixture hashes, not native matched values.

**Limits:** this proof is exact to the listed Crabbox revisions, source line,
path, mode, detector metadata, observed decoder identities, and TruffleHog
version. It does not authorize different bytes, future scanner behavior,
verified findings, other repositories or paths, other modes or roles,
duplicates, or mixed unknown findings.
