### PR TITLE
fix(review): classify Firecrawl URL safety fixture

### DIFF
--- a/src/agent-input-scan-fixtures.ts
+++ b/src/agent-input-scan-fixtures.ts
@@ -67,6 +67,11 @@ const REVIEWED_FIXTURES: readonly ReviewedFixture[] = [
     sources: ["extensions/browser/src/browser-tool.test.ts"],
   },
   {
+    // OpenClaw Firecrawl blocked-host credential fixture introduced by d1b80794b651.
+    fixtureSha256: "fe30fb721f4e8b1d50f281ae338da254a0e34dba6804776c231b8666d5856055",
+    sources: ["extensions/firecrawl/src/firecrawl-client.test.ts"],
+  },
+  {
     // Decoding a neighboring Basic-auth token can label these unchanged CDP
     // literals BASE64. Each match still requires its exact original source line.
     fixtureSha256: "24bd2ee9856630ff773868d946a3b3159e1bb04b297adf4d42b916218a0195d7",

--- a/test/agent-input-scan.test.ts
+++ b/test/agent-input-scan.test.ts
@@ -625,6 +625,7 @@ const browserToolSource = "extensions/browser/src/browser-tool.test.ts";
 const browserCdpHelpersSource = "extensions/browser/src/browser/cdp.helpers.test.ts";
 const browserMcpSource = "extensions/browser/src/browser/chrome-mcp.test.ts";
 const browserProfilesSource = "extensions/browser/src/browser/server-context.list-profiles.test.ts";
+const firecrawlSource = "extensions/firecrawl/src/firecrawl-client.test.ts";
 const macDashboardSource = "apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift";
 const mcpAppsSource = "src/config/config-misc.test.ts";
 const marketplaceFeedSource = "src/cli/plugins-cli.marketplace-refresh.test.ts";
@@ -1370,6 +1371,7 @@ for (const scenarioName of [
   "browser local server mismatch",
   "browser docs fixture",
   "browser page URL fixture",
+  "firecrawl target URL fixture",
   "browser CDP relay fixture",
   "browser CDP relay shifted HTML without companion",
   "browser CDP encoded fixture",
@@ -1551,6 +1553,7 @@ for (const scenarioName of [
     const browserCdpFixture = scenario.startsWith("browser CDP ");
     const browserMcpFixture = scenario.startsWith("browser MCP ");
     const browserExactFixture = browserCdpFixture || browserMcpFixture;
+    const firecrawlFixture = scenario === "firecrawl target URL fixture";
     const encodedCdpFixture = browserCdpFixture && scenario.includes("encoded");
     // Preserve the literal witnesses captured from the native OpenClaw scan.
     const literalLine = gatewayConfigFixture
@@ -1622,6 +1625,12 @@ for (const scenarioName of [
       if (scenario === "mattermost changed host") url.hostname = "other.example.com";
       if (scenario === "mattermost changed path") url.pathname = "/changed";
       uri = url.href;
+    }
+    if (firecrawlFixture) {
+      const url = new URL("http://127.0.0.1");
+      url.username = "user";
+      url.password = "pass";
+      uri = url.href.slice(0, -1);
     }
     if (macDashboardFixture) {
       // Native 3.97.1 witness from OpenClaw 9ba01d6c7b1c, line 273.
@@ -1743,6 +1752,7 @@ for (const scenarioName of [
       files = [scenario === "other file" ? "other.test.ts" : gatewayConfigSource];
     if (browserProfilesFixture)
       files = [scenario === "other file" ? "other.test.ts" : browserProfilesSource];
+    if (firecrawlFixture) files = [firecrawlSource];
     const value =
       scenario === "decoded only" || scenario.endsWith("encoded-only")
         ? primaryDecoder === "BASE64"
@@ -1974,6 +1984,7 @@ process.exit(scenario === 'unexpected successful output' ? 0 : 183);
         "browser remote server fixture",
         "browser docs fixture",
         "browser page URL fixture",
+        "firecrawl target URL fixture",
         "browser CDP relay fixture",
         "browser CDP relay shifted HTML without companion",
         "browser CDP encoded fixture",


### PR DESCRIPTION
## Summary

- classify the existing OpenClaw Firecrawl blocked-host credential URL as a reviewed synthetic fixture
- bind admission to the exact URI digest and exact test source
- add focused admission coverage without duplicating the credential-shaped literal

## Behavior proof

- **Claim:** only the exact existing Firecrawl synthetic credential URL is classified non-sensitive; every other finding remains fail-closed.
- **Surface:** host-owned `REVIEWED_FIXTURES` and the existing exact classifier.
- **Scenario:** OpenClaw #137603 before/after committed blobs scanned with pinned TruffleHog 3.97.1.
- **Environment:** Node 24; exact head `b727cd39d868`.
- **Observable:** one exact classified notice, provider admission succeeds, and raw fixture bytes are never emitted.
- **Limits:** focused classifier and pinned-scanner proof are local; hosted CI is authoritative for the full suite because this macOS host intermittently reports impossible clock-driven test durations.
- **Bay impact:** none; this changes host scan policy only and does not alter dashboard, queue, or record contracts.

### Native scan trace

Command, run from this exact ClawSweeper head against a clean detached checkout of OpenClaw #137603:

```sh
git -C /private/tmp/openclaw-firecrawl-review.FnOmpR rev-parse HEAD
pnpm run review -- --local-only --item-number 137603 \
  --target-dir /private/tmp/openclaw-firecrawl-review.FnOmpR
```

Redacted observable trace (credential bytes and endpoint text omitted):

```text
target head: 2fbd6d115fc90cacae9c8f4f3eac993ee6d7fe52
target base: e09a265b11112623addd4de2167ee6b34cd82719
event: agent_input_scan_classified
fixtureSha256: fe30fb721f4e8b1d50f281ae338da254a0e34dba6804776c231b8666d5856055
source: extensions/firecrawl/src/firecrawl-client.test.ts
base blob: 9c8effc77740339d0bbde4881ffece2e472f8f73, scanner/literal line 44
head blob: 3f678e9244266fb320df209f49300f6e42fe1458, scanner/literal line 101
decoder: PLAIN; occurrences: 1 per blob
provider phase: started after admission
raw fixture bytes in trace: none
```

This command used `review --local-only`; it did not post comments, labels, merges, or apply commands.

## Validation

- `pnpm run build:all`
- `pnpm run check:static`
- `pnpm run lint`
- `pnpm run test:unit -- --test-name-pattern="firecrawl target"` (179/179 files)
- real pinned TruffleHog admission against #137603 exact before/after blobs
- committed Codex review: no actionable findings
