### PR TITLE
fix(queue): redact maintenance identities and refuse signed redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 - Authenticated publication reconciliation now diagnoses missing, ambiguous, and mismatched successor fences without changing supersede behavior.
 - Exact-review maintenance clients now expose and strictly validate successor-fence diagnostics after the Worker-first rollout.
+- Redact publication identities in maintenance output with stable row fingerprints and refuse redirects for signed queue requests.
 - Publication reconciliation diagnostics now report the exact acknowledgement-unavailable reason while preserving fail-closed supersede behavior.
 
 - Admit the reviewed mocked marketplace telemetry-redaction and Gateway config CDP-redaction fixtures through exact URI, source-line, path, and decoder bindings without relaxing native scanner checks.

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -659,6 +659,10 @@ permission; other rows report `null`. The maintenance client exposes this field
 as `successorFenceState` and rejects missing, unknown, or incoherent values.
 If the Worker must roll back below `e4d0e82050300cafb9459a6d9cf8a2041f4e62cb`,
 roll back the strict client first so it never reads a response without this field.
+CLI samples omit target, item, retained-item, and producer identities. Their
+`identity_hash` is SHA-256 of the unmodified UTF-8 item key, without a newline,
+so operators can correlate a row without logging its key. A different hash or
+an empty sample does not establish what happened to a previously observed row.
 Successful queue handoff expires the workflow's review-start lease to permit
 another exact-head review; terminal publication still deletes the placeholder.
 

--- a/src/repair/exact-review-batch-queue-client.ts
+++ b/src/repair/exact-review-batch-queue-client.ts
@@ -518,6 +518,7 @@ export class ExactReviewBatchQueueClient implements ExactReviewBatchQueue {
       try {
         response = await this.request(`${this.baseUrl}${path}`, {
           method: "POST",
+          redirect: "error",
           headers: {
             "content-type": "application/json",
             "x-clawsweeper-exact-review-signature": signature,

--- a/src/repair/exact-review-queue-maintenance.ts
+++ b/src/repair/exact-review-queue-maintenance.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { createHash } from "node:crypto";
 import { ExactReviewBatchQueueClient } from "./exact-review-batch-queue-client.js";
 
 const apply = process.argv.includes("--apply");
@@ -15,7 +16,27 @@ if (requestedPasses > 1) {
   );
 }
 const result = await client.reconcilePublications({ apply, maxItems });
-console.log(JSON.stringify({ ok: true, requestedPasses, effectivePasses: 1, ...result }));
+console.log(
+  JSON.stringify({
+    ok: true,
+    requestedPasses,
+    effectivePasses: 1,
+    ...result,
+    // Retain stable row correlation without logging target or producer identities.
+    sample: result.sample.map((sample) => ({
+      identity_hash: createHash("sha256").update(sample.itemKey).digest("hex"),
+      queueRevision: sample.queueRevision,
+      reason: sample.reason,
+      publicationRevision: sample.publicationRevision,
+      supersededByRevision: sample.supersededByRevision,
+      commandContext: sample.commandContext,
+      acknowledgementState: sample.acknowledgementState,
+      acknowledgementUnavailableReason: sample.acknowledgementUnavailableReason,
+      supersedeSafe: sample.supersedeSafe,
+      successorFenceState: sample.successorFenceState,
+    })),
+  }),
+);
 
 function integerArg(name: string, fallback: number, minimum: number, maximum: number): number {
   const index = process.argv.indexOf(name);

--- a/test/repair/exact-review-batch-queue-client.test.ts
+++ b/test/repair/exact-review-batch-queue-client.test.ts
@@ -34,6 +34,7 @@ function fixture(t, respond) {
     baseUrl: "https://queue.example.test",
     webhookSecret: "synthetic-test-secret",
     fetch: async (url, init) => {
+      assert.equal(init.redirect, "error");
       calls.push({ url, ...init, at: Date.now() });
       return respond(calls.length, init);
     },
@@ -375,6 +376,7 @@ test("publication reconciliation returns a bounded allowlisted sample", async (t
   assert.equal(result.apply, true);
   assert.equal(calls.length, 1);
   assert.deepEqual(JSON.parse(calls[0].body), { apply: true, max_items: 1 });
+  assert.equal(calls[0].redirect, "error");
   assert.equal(result.sample.length, 20);
   assert.deepEqual(result.sample[0], {
     itemKey: "openclaw/example#1@publish:2:1",

--- a/test/repair/exact-review-queue-maintenance-workflow.test.ts
+++ b/test/repair/exact-review-queue-maintenance-workflow.test.ts
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { execFile } from "node:child_process";
+import { createHmac } from "node:crypto";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:https";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
+import { promisify } from "node:util";
 import YAML from "yaml";
 
 const path = ".github/workflows/exact-review-queue-maintenance.yml";
@@ -49,4 +55,156 @@ test("queue maintenance is explicit, bounded, and non-cancelling", () => {
   assert.match(cliSource, /effectivePasses: 1/);
   assert.doesNotMatch(cliSource, /for \(let pass/);
   assert.doesNotMatch(source, /schedule:/);
+});
+
+test("maintenance CLI signs one HTTPS dry run, redacts identities, and refuses redirects", async (t) => {
+  const directory = mkdtempSync(join(tmpdir(), "clawsweeper-maintenance-tls-"));
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  const key = join(directory, "key.pem");
+  const cert = join(directory, "cert.pem");
+  const config = join(directory, "openssl.cnf");
+  writeFileSync(
+    config,
+    "[req]\ndistinguished_name=dn\n[dn]\n[extensions]\nsubjectAltName=IP:127.0.0.1\n",
+  );
+  await promisify(execFile)(
+    "openssl",
+    [
+      "req",
+      "-x509",
+      "-newkey",
+      "rsa:2048",
+      "-nodes",
+      "-days",
+      "1",
+      "-subj",
+      "/CN=127.0.0.1",
+      "-config",
+      config,
+      "-extensions",
+      "extensions",
+      "-keyout",
+      key,
+      "-out",
+      cert,
+    ],
+    { timeout: 10_000 },
+  );
+  const secret = "synthetic-maintenance-secret";
+  let calls = 0;
+  let redirectedCalls = 0;
+  let redirect = false;
+  const server = createServer(
+    { key: readFileSync(key), cert: readFileSync(cert) },
+    async (request, response) => {
+      if (request.url !== "/internal/exact-review/publications/reconcile") {
+        redirectedCalls += 1;
+        response.writeHead(500).end();
+        return;
+      }
+      let body = "";
+      for await (const chunk of request) body += chunk;
+      calls += 1;
+      assert.equal(request.method, "POST");
+      assert.deepEqual(JSON.parse(body), { apply: false, max_items: 1 });
+      assert.equal(
+        request.headers["x-clawsweeper-exact-review-signature"],
+        `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`,
+      );
+      if (redirect) {
+        response.writeHead(307, { location: "/private-redirect-sentinel" }).end();
+        return;
+      }
+      response.setHeader("content-type", "application/json");
+      response.end(
+        JSON.stringify({
+          apply: false,
+          scanned: 1,
+          eligible: 1,
+          changed: 0,
+          eligible_remaining: 1,
+          protected_batch_items: 0,
+          oldest_eligible_age_seconds: 60,
+          oldest_remaining_age_seconds: 60,
+          sample: [
+            {
+              item_key: "private-item-sentinel",
+              target_key: "private-target-sentinel",
+              retained_item_key: "private-retained-sentinel",
+              queue_revision: calls === 1 ? 8 : 9,
+              reason: "stale_revision",
+              publication_revision: 7,
+              superseded_by_revision: 11,
+              lineage_claim_generation: 99,
+              command_context: true,
+              acknowledgement_state: "unavailable",
+              acknowledgement_unavailable_reason: "terminal_missing",
+              supersede_safe: false,
+              successor_fence_state: "missing",
+              producer_run_id: "private-producer-sentinel",
+              producer_run_attempt: 1,
+              private_detail: "private-detail-sentinel",
+            },
+          ],
+        }),
+      );
+    },
+  );
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  t.after(() => new Promise<void>((resolve) => server.close(() => resolve())));
+  const endpoint = `https://127.0.0.1:${(server.address() as import("node:net").AddressInfo).port}`;
+  const run = () =>
+    promisify(execFile)(
+      process.execPath,
+      ["dist/repair/exact-review-queue-maintenance.js", "--max-items", "1", "--passes", "3"],
+      {
+        timeout: 10_000,
+        env: {
+          PATH: process.env.PATH,
+          NODE_EXTRA_CA_CERTS: cert,
+          EXACT_REVIEW_QUEUE_URL: endpoint,
+          CLAWSWEEPER_WEBHOOK_SECRET: secret,
+        },
+      },
+    );
+  const { stdout, stderr } = await run();
+  const output = JSON.parse(stdout);
+  assert.equal(calls, 1);
+  assert.equal(output.apply, false);
+  assert.equal(output.effectivePasses, 1);
+  assert.equal(output.changed, 0);
+  assert.deepEqual(output.sample, [
+    {
+      identity_hash: "17f815f7c65a7e226b2b54b539f43e170734d435a5068a4af3a9e15c64a9fb9c",
+      queueRevision: 8,
+      reason: "stale_revision",
+      publicationRevision: 7,
+      supersededByRevision: 11,
+      commandContext: true,
+      acknowledgementState: "unavailable",
+      acknowledgementUnavailableReason: "terminal_missing",
+      supersedeSafe: false,
+      successorFenceState: "missing",
+    },
+  ]);
+  assert.doesNotMatch(stdout + stderr, /private-.*-sentinel|synthetic-maintenance-secret/);
+  assert.match(stderr, /clamped to one observed pass/);
+  const repeated = await run();
+  const next = JSON.parse(repeated.stdout).sample[0];
+  assert.equal(calls, 2);
+  assert.equal(next.queueRevision, 9);
+  assert.equal(next.identity_hash, output.sample[0].identity_hash);
+  assert.doesNotMatch(
+    repeated.stdout + repeated.stderr,
+    /private-.*-sentinel|synthetic-maintenance-secret/,
+  );
+  redirect = true;
+  await assert.rejects(run(), (error: Error & { stdout: string; stderr: string }) => {
+    assert.equal(error.stdout, "");
+    assert.match(error.stderr, /failed \(network_error\)/);
+    assert.doesNotMatch(error.stderr, /private-.*-sentinel|synthetic-maintenance-secret/);
+    return true;
+  });
+  assert.equal(calls, 3);
+  assert.equal(redirectedCalls, 0);
 });


### PR DESCRIPTION
Refs https://github.com/openclaw/clawsweeper/issues/1396

Builds on https://github.com/openclaw/clawsweeper/pull/1467, already merged as `02de5c6936817036036ecbc8fc21ba3e5550344f`. Its canonical strict successor parser, types, coherence checks, tests, and rollback guidance are preserved without duplication.

## What Problem This Solves

Resolves a problem where the maintenance workflow printed raw publication identities and signed queue requests followed redirects. Operators need bounded diagnostic output that can correlate a historical row without exposing its identifiers.

This is the remaining client-side prerequisite for investigating the pinned row. It does not resolve or close issue 1396.

## Why This Change Was Made

The CLI emits an explicit sample allowlist and SHA-256 of the unmodified UTF-8 item key, without a newline. The shared signed POST transport refuses redirects so fixed internal API routes cannot forward signed request bytes to a different route. Existing retry budgets, stable request identity, acknowledgement checks, and mutation decisions are unchanged.

The owner is the maintenance CLI output boundary and shared signed transport. Raw sample serialization is removed. The canonical Worker diagnostic parser is already on main through the dependency above; this residual patch changes no Worker policy, capacity, cadence, schema, acknowledgement rule, or competing enum.

Production delta: +23 / -1 lines (net +22), justified by the explicit privacy-preserving output and signed-request boundaries. Tests: +161 / -1 lines. Documentation and release notes: +5 lines.

## User Impact

Operators can compare a stable row fingerprint, revisions, acknowledgement safety, and successor-fence state without logging target, item, retained-item, or producer identities. A different fingerprint or empty sample is not evidence about a previously observed row. `verified` remains diagnostic only, never permission to requeue, supersede, or delete.

## OpenClaw Bay Impact

Bay is unaffected. Only the authenticated maintenance client and CLI output change; the public Worker response, observer-only Bay projection, and browser behavior are unchanged.

## Documentation Impact

Updated the active maintenance contract in `docs/live-dashboard.md` and added the release note. The exact-review maintenance lane owns this contract; the deployed Worker response and maintenance client/CLI are its source of truth. The documented scope is verified at `0ca077fc6a11674a1fd513048c26c0f09b39c845`. Update it when the fingerprint algorithm, sample allowlist, transport, or maintenance behavior changes.

The existing observation boundary remains explicit: `apply=false` does not perform reconciliation mutations, but normal initialization, legacy cleanup, and admission cache/revocation maintenance are not universally write-free.

## Evidence

- Fresh six-file precommit and committed-range Codex reviews: no actionable findings.
- `git diff --check` and local `node scripts/check-docs.mjs`: passed.
- Current combined source: 52/52 focused client, actual compiled HTTPS CLI, and scheduled-enqueue sibling tests passed on AWS Linux.
- Full repository `pnpm run check`: passed; 5,119 tests passed, 18 skipped, zero failures or cancellations. Coverage gates passed (86.12% lines, 76.35% branches, 89.77% functions).
- No production maintenance request, queue mutation, or Worker deployment was used for this proof.

## Real Behavior Proof

Claim: the compiled maintenance CLI makes one bounded signed HTTPS reconciliation request, emits a redacted diagnostic with a stable identity hash across revision changes, and refuses a redirect without sending signed bytes to the redirect target.

Exercised surface: real `dist/repair/exact-review-queue-maintenance.js` subprocess, Node HTTPS/fetch transport and HMAC signing, canonical client parser, and stdout serialization. A controlled HTTPS server uses synthetic data and a temporary trusted certificate. Fetch and the CLI are not mocked.

Environment: configured AWS through Crabbox, lease `cbx_742fe4d5f0b8`, run `run_5a7b569dba39`, `c7a.8xlarge`, image `ami-0461d919be7deb53c`, Node `v24.18.1`, pinned pnpm `11.10.0`. The checkout was synced from `02de5c6936817036036ecbc8fc21ba3e5550344f` plus the residual patch. Its five recorded source hashes match `0ca077fc6a11674a1fd513048c26c0f09b39c845`; the only later addition is the one-line release note, separately checked locally and covered by exact-head CI.

Command:

```sh
corepack pnpm install --frozen-lockfile
corepack pnpm run build:all
node --test test/repair/exact-review-batch-queue-client.test.ts \
  test/repair/exact-review-queue-maintenance-workflow.test.ts \
  test/repair/scheduled-review-enqueue.test.ts
corepack pnpm run check
```

Observed trace and assertions:

```text
maintenance CLI signs one HTTPS dry run, redacts identities, and refuses redirects: PASS
request body: {"apply":false,"max_items":1}
HMAC: exact sha256 signature verified by the HTTPS server
requested passes=3; effective passes=1; exactly one request per invocation
revision 8 -> 9: identity_hash unchanged
identity_hash=17f815f7c65a7e226b2b54b539f43e170734d435a5068a4af3a9e15c64a9fb9c
acknowledgementState=unavailable; acknowledgementUnavailableReason=terminal_missing
successorFenceState=missing; supersedeSafe=false; changed=0
raw identity/producer/secret sentinels in stdout or stderr: none
307 redirect: nonzero CLI exit; no stdout; redirected requests=0
focused tests: 52 passed, 0 failed
full check: 5,119 passed, 18 skipped, 0 failed
PUBLICATION_SUCCESSOR_CLIENT_PROOF_PASS
run status=succeeded; exitCode=0; leaseStopped=true
```

Artifacts: the committed HTTPS fixture is reproducible at `test/repair/exact-review-queue-maintenance-workflow.test.ts`. Run `run_5a7b569dba39` has the source manifest, command, build/check logs, and lifecycle receipt retained by the operator. CLI source SHA-256: `ca2c66f8fa414ddb87fe901ba1cedaeaf1cbc4116d319e3ba322699e0f186924`; client source SHA-256: `c445c5ca999860eb4ab17b2db2d4b88f54581a6e5d75659dc1485ca2c9243a08`. Previous `f0616011` proof and review are historical, not claimed as current integration proof.

Limits: synthetic HTTPS responses prove the changed client/runtime path, not production queue storage, live acknowledgement authority, or the pinned row's successor. The approved post-land follow-up is one existing signed maintenance workflow with `execute=false`, `passes=1`, and `max_items=1`. An empty or different sample stops correlation; no widening or destructive follow-up is implied.
