### PR TITLE
fix: unblock reviews of approved Signal fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Admit the two approved Signal URL-rejection fixtures through exact URI, source-line, path, and native decoder bindings while retaining all scanner and verification checks.
 - Admit the reviewed Crabbox PostgreSQL operations example through exact Postgres detector, observed `PLAIN`/`HTML` decoder, value-hash, source-line, path, mode, metadata, and committed base/head bindings.
 - Admit the reviewed OpenClaw logging redaction fixtures through exact detector, native decoder, role, value-hash, source-line, path, mode, and metadata bindings while preserving legacy URI fixture behavior.
 - Keep canonical OpenClaw locale refresh PRs open across apply and repair close paths so their publisher can reconcile and auto-merge them after normal checks.

--- a/README.md
+++ b/README.md
@@ -597,13 +597,15 @@ the [Mattermost slash-error sanitization fixtures](https://github.com/openclaw/o
 the [MCP Apps sandbox-origin rejection fixture](https://github.com/openclaw/openclaw/blob/f3971bbd56e4aadea0f8b0c1434f6860f953cbbd/src/config/config-misc.test.ts),
 the [Gateway config CDP-redaction fixture](https://github.com/openclaw/openclaw/blob/4b5987829d0f82ea44ae50f2f418ffe5ea445e7f/src/gateway/server.config-patch.test.ts),
 the [mocked marketplace telemetry-redaction fixture](https://github.com/openclaw/openclaw/blob/9c5ee4676d0732e72ee9a939ae4918dc89bcaab8/src/cli/plugins-cli.marketplace-refresh.test.ts),
+the Signal URL-rejection fixtures in [client tests](https://github.com/openclaw/openclaw/blob/75d633a7b97240280ebf13e121a1960eb2ec2765/extensions/signal/src/client.test.ts#L172)
+and [container tests](https://github.com/openclaw/openclaw/blob/41dd2e04897b9bdbde971cad8c6ff21ecccd38b7/extensions/signal/src/client-container.test.ts#L1461),
 and the OpenClaw config [URL-redaction](https://github.com/openclaw/openclaw/blob/5fe22a7d88919f260e7999fc775733feff3cb1fa/src/config/redact-snapshot.test.ts)
 and [restoration fixtures](https://github.com/openclaw/openclaw/blob/5fe22a7d88919f260e7999fc775733feff3cb1fa/src/config/redact-snapshot.restore.test.ts)
 after a complete scan. Static host policy associates each
 exact detector-matched URI SHA-256 with only its approved source paths and exact
 scanner `Raw` digest, including when `Raw` omits a path retained by `RawV2`. The
 matched value must be a literal in a host-staged Git blob from mode `100644`.
-The three guarded-CDP/MCP entries, Crabbox fixture, Mac dashboard entry, MCP Apps entry, marketplace telemetry entry, Gateway config entry, and four Mattermost entries also bind complete
+The three guarded-CDP/MCP entries, Crabbox fixture, Mac dashboard entry, MCP Apps entry, marketplace telemetry entry, Gateway config entry, two Signal entries, and four Mattermost entries also bind complete
 reviewed source lines, including surrounding query text that TruffleHog's URI
 detector does not match. Changes to those lines or additional literal occurrences
 refuse classification. These witnesses do not expand native query detection.

--- a/src/agent-input-scan-fixtures.ts
+++ b/src/agent-input-scan-fixtures.ts
@@ -25,6 +25,21 @@ export type ReviewedAttribution = readonly [
 // This is host policy, never an allowlist loaded from the reviewed checkout.
 const REVIEWED_FIXTURES: readonly ReviewedFixture[] = [
   {
+    // Approved Signal URL-rejection fixture; retain the complete source-line witness.
+    fixtureSha256: "c9c820a05b2d035eb65422d1a50e58c5fa52e4d7a087ad3791de23bdd4efeabd",
+    rawSha256: "c9c820a05b2d035eb65422d1a50e58c5fa52e4d7a087ad3791de23bdd4efeabd",
+    lineSha256s: ["f4646625b141392982b168ff4591bf66dd208316f1f21ad712efb4ee30a8a339"],
+    decoders: ["PLAIN", "HTML"],
+    sources: ["extensions/signal/src/client.test.ts"],
+  },
+  {
+    fixtureSha256: "7849c0ac39a4f42a5cd5cb1b029c7132193f270454865f2f4a49a83da3444665",
+    rawSha256: "7849c0ac39a4f42a5cd5cb1b029c7132193f270454865f2f4a49a83da3444665",
+    lineSha256s: ["281f664b2e7f36e82ef38d0a36bb791ec8a70b4a4afca470847d4699573b338d"],
+    decoders: ["PLAIN", "HTML"],
+    sources: ["extensions/signal/src/client-container.test.ts"],
+  },
+  {
     // Maintainer-reviewed malformed-config fixture introduced by d68b1861172120fc.
     fixtureSha256: "a728de5dbbef23b8aa5ef2d99060835f4f2fb5a0fa2abb9fe249d08aa09bd09e",
     sources: ["test/action-ledger-runtime.test.ts"],

--- a/test/agent-input-scan.test.ts
+++ b/test/agent-input-scan.test.ts
@@ -804,6 +804,7 @@ function classifyWithProductionPolicy(
   findings: readonly Record<string, unknown>[],
   inputs: ReadonlyMap<string, StagedScanInput>,
 ) {
+  const verifiedCount = findings.filter((finding) => finding.Verified === true).length;
   return classifyReviewedFixtureScan(
     183,
     Buffer.from(`${findings.map((finding) => JSON.stringify(finding)).join("\n")}\n`),
@@ -815,13 +816,96 @@ function classifyWithProductionPolicy(
         trufflehog_version: "3.97.1",
         chunks: 1,
         bytes: 1,
-        verified_secrets: 0,
-        unverified_secrets: findings.length,
+        verified_secrets: verifiedCount,
+        unverified_secrets: findings.length - verifiedCount,
       })}\n`,
     ),
     inputs,
   );
 }
+
+test("reviewed Signal fixtures preserve exact source, line, decoder, and verification bindings", () => {
+  const sources = [
+    "extensions/signal/src/client.test.ts",
+    "extensions/signal/src/client-container.test.ts",
+  ];
+  for (const [index, host] of ["127.0.0.1", "localhost"].entries()) {
+    const url = new URL(`http://${host}:8080`);
+    url.username = "user";
+    url.password = "pass";
+    const raw = url.href.slice(0, -1);
+    const line =
+      index === 0
+        ? `        baseUrl: "${raw}",`
+        : `    await expect(containerCheck("${raw}")).rejects.toThrow(`;
+    const file = `/private/scanner/${String(index).repeat(40)}`;
+    const input: StagedScanInput = {
+      kind: "blob",
+      id: String(index).repeat(40),
+      bytes: Buffer.from(`${line}\n`),
+      references: [
+        { source: sources[index]!, mode: "100644", revision: "a".repeat(40), role: "head" },
+      ],
+    };
+    const finding = {
+      SourceType: 15,
+      DetectorType: 17,
+      DetectorName: "URI",
+      DecoderName: "PLAIN",
+      Verified: false,
+      VerificationError: "synthetic verification error",
+      Raw: raw,
+      RawV2: raw,
+      SourceMetadata: { Data: { Filesystem: { file, line: 1 } } },
+      SecretParts: { host: url.host, username: url.username, password: url.password },
+      ExtraData: null,
+      StructuredData: null,
+    };
+    for (const decoder of ["PLAIN", "HTML"]) {
+      const result = classifyWithProductionPolicy(
+        [{ ...finding, DecoderName: decoder }],
+        new Map([[file, input]]),
+      );
+      assert.equal(result.kind, "classified", `${host}: ${decoder}`);
+      if (result.kind === "classified") {
+        assert.equal(result.notices.length, 1);
+        assert.equal(result.notices[0]!.source, sources[index]);
+        assert.equal(result.notices[0]!.findings[0]!.decoder, decoder);
+      }
+    }
+    const otherSource: StagedScanInput = {
+      ...input,
+      references: [{ ...input.references[0]!, source: sources[1 - index]! }],
+    };
+    for (const [name, changedFinding, changedInput, reason] of [
+      ["other approved path", finding, otherSource, "source_not_reviewed"],
+      [
+        "changed source line",
+        finding,
+        { ...input, bytes: Buffer.from(`${line} // changed\n`) },
+        "literal_mismatch",
+      ],
+      [
+        "duplicate literal",
+        finding,
+        { ...input, bytes: Buffer.from(`${line}\n${line}\n`) },
+        "literal_mismatch",
+      ],
+      ["unapproved decoder", { ...finding, DecoderName: "BASE64" }, input, "finding_not_reviewed"],
+      ["verified finding", { ...finding, Verified: true }, input, "finding_not_reviewed"],
+    ] as const) {
+      const result = classifyWithProductionPolicy(
+        [changedFinding],
+        new Map([[file, changedInput]]),
+      );
+      assert.equal(result.kind, "refused", `${host}: ${name}`);
+      if (result.kind === "refused") {
+        assert.equal(result.diagnostic.kind, "unclassified_finding", `${host}: ${name}`);
+        assert.equal(result.diagnostic.reason, reason, `${host}: ${name}`);
+      }
+    }
+  }
+});
 
 function crabboxPostgresDocsFixture() {
   const raw = ["postgresql://crabbox", ":password@db.example.com", ":5432"].join("");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the approved Signal Bun compatibility PRs could not receive a completed review because two existing synthetic URL-rejection fixtures were not qualified in the host's fixture registry.

Related: https://github.com/openclaw/openclaw/pull/140305 and https://github.com/openclaw/openclaw/pull/140318.

## Why This Change Was Made

The maintainer approved these two exact fixtures. Each new entry binds both native value digests, the full source-line digest, one source path, and the supported PLAIN/HTML decoders. Detector execution, verification status, source fencing, scan completeness, and all other findings retain their existing checks. No raw fixture values are included here.

## User Impact

The two unchanged synthetic fixtures can be classified as non-sensitive after a complete native scan. Signal PRs still require fresh completed reviews, their required checks, and the normal maintainer landing workflow.

## OpenClaw Bay Impact

Bay is unaffected. No review-publication, queue, status, telemetry, API, or UI contract changes; this is static host classification data.

## Documentation Impact

Updated the active scanner-policy documentation in README.md with immutable links to the qualified source lines, and recorded the operator-visible fix in CHANGELOG.md. The policy remains owned by the host registry and must be requalified if its exact witnesses or native scanner contract change.

## Evidence

The new regression fails on the original policy and passes with these entries. It covers both paths and decoders, plus refusal when the source association, complete line, literal count, decoder, or verification status changes. The full `pnpm run check` passed on Node 26.8.1: 5,125 tests passed, 13 existing skips, zero failures; the separate focused coverage lane also passed its 13 tests. Fresh local and committed-branch Codex reviews found no actionable P0–P2 findings. All process trees joined without hitting the memory cap. A first local check had three environment-only failures because GIT_CONFIG_GLOBAL pointed to read-only /dev/null; the corrected credential-free run lets the tests write their own temporary HOME config and passes unchanged assertions.

## Real Behavior Proof

Claim: the production classifier refuses the exact retained Signal fixtures before the registry change and classifies exactly those two source associations afterward.

Surface: the production `classifyReviewedFixtureScan` consuming unmodified stdout/stderr from the managed pinned TruffleHog 3.97.1 binary. The scanner used the production filesystem flags (`--results=verified,unknown --fail --fail-on-scan-errors --no-update --json --no-color`) over the exact Git blobs from the two held PR heads. The source was read, never executed. A macOS sandbox denied all network access; no provider, credentials, live service, inference, review dispatch, or GitHub mutation was used for this proof.

Environment: trusted task-owned ClawSweeper checkout based on bb8bd3eb7; candidate production policy is unchanged in commit c1c43135c55d83643072461a2cec87e48e2dc231, Node 26.8.1, pinned pnpm 11.10.0, managed TruffleHog 3.97.1, macOS arm64. Commands: `pnpm run build`, the isolated native scan harness, then the production classifier over the saved native results before and after the registry change. The native invocation was wrapped with `sandbox-exec -p '(version 1)(allow default)(deny network*)'`; flags and native results were not rewritten.

Observed trace:

```text
native scan: exit183, finished scanning, 8 chunks, 91940 bytes
verified findings: 0; unknown URI findings: 2
client.test.ts: PLAIN; complete source line172
client-container.test.ts: HTML; complete source line1461
both Raw and RawV2 hashes: exact matches to the approved policy proposal
baseline production classifier: refused / literal_not_reviewed
candidate production classifier: classified / exactly2 source notices
private scan input and native result files: removed after proof
```

The real native scan's HTML finding and earlier hosted PLAIN findings confirm the existing decoder variants. The fixture values, raw native records and source contents are omitted from public evidence. Hash-only artifacts, the native completion record, baseline/candidate classification records, test logs, and cleanup evidence are retained in the task's qualification report.

Limits: this is real native scanning and classification, not a completed Signal review or Signal runtime test. Those PRs remain unchanged and will get fresh hosted reviews only after this host-policy change lands. Unqualified or verified findings and changed witnesses remain blocking.
