### PR TITLE
fix(review): reduce repeated Git startup during admission

### DIFF
--- a/scripts/e2e/scan-git-batching.mjs
+++ b/scripts/e2e/scan-git-batching.mjs
@@ -1,0 +1,506 @@
+import assert from "node:assert/strict";
+import childProcess from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
+import { tmpdir } from "node:os";
+import { basename, delimiter, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { parseArgs } from "node:util";
+
+// Run after building both revisions. All fixtures and receipts stay outside the checkout.
+const { values } = parseArgs({
+  options: {
+    "before-dist": { type: "string" },
+    output: { type: "string" },
+    scanner: { type: "string" },
+    rounds: { type: "string", default: "3" },
+    blobs: { type: "string", default: "160" },
+    section: { type: "string", default: "all" },
+  },
+});
+assert.ok(values["before-dist"] && values.output && values.scanner);
+const rounds = Number(values.rounds);
+const blobCount = Number(values.blobs);
+assert.ok(Number.isSafeInteger(rounds) && rounds >= 2 && rounds <= 10);
+assert.ok(Number.isSafeInteger(blobCount) && blobCount >= 2 && blobCount <= 1000);
+assert.ok(["darwin", "linux"].includes(process.platform));
+assert.ok(
+  ["all", "many", "mixed", "snapshot", "content-budget", "negatives"].includes(values.section),
+);
+const selected = (section) => values.section === "all" || values.section === section;
+const beforeDist = resolve(values["before-dist"]);
+const scanner = fs.realpathSync(values.scanner);
+const nativeSpawn = childProcess.spawnSync;
+const nativeMkdtemp = fs.mkdtempSync;
+const run = (executable, args, options = {}) => {
+  const result = nativeSpawn(executable, args, { encoding: "utf8", timeout: 120_000, ...options });
+  assert.equal(result.error, undefined, "fixture command failed");
+  assert.equal(result.status, 0, "fixture command failed");
+  return result.stdout.trim();
+};
+const scannerVersion = nativeSpawn(scanner, ["--version"], { encoding: "utf8" });
+assert.equal(scannerVersion.status, 0);
+assert.equal(`${scannerVersion.stdout}${scannerVersion.stderr}`.trim(), "trufflehog 3.97.1");
+const gitBinary = fs.realpathSync(run("which", ["git"]));
+const root = fs.mkdtempSync(join(tmpdir(), "scan-git-batching-proof-"));
+const originalPath = process.env.PATH;
+const originalHome = process.env.HOME;
+const originalXdg = process.env.XDG_CONFIG_HOME;
+const hash = (bytes) => createHash("sha256").update(bytes).digest("hex");
+let active;
+const results = [];
+const compare = (before, after) => {
+  assert.equal(after.outcome, before.outcome);
+  assert.deepEqual(after.scans, before.scans);
+};
+try {
+  const bin = join(root, "bin");
+  const home = join(root, "home");
+  fs.mkdirSync(bin);
+  fs.mkdirSync(home);
+  fs.symlinkSync(scanner, join(bin, "trufflehog"));
+  process.env.PATH = `${bin}${delimiter}${originalPath ?? ""}`;
+  process.env.HOME = home;
+  process.env.XDG_CONFIG_HOME = home;
+  // Observe actual native children and their inputs without adding production test hooks.
+  childProcess.spawnSync = (executable, args, options) => {
+    if (!active) return nativeSpawn(executable, args, options);
+    if (executable === gitBinary || executable === "git") {
+      const cat = args.indexOf("cat-file");
+      const mode = cat < 0 ? "other" : args[cat + 1];
+      const input = options.input?.toString() ?? "";
+      active.git.push({
+        mode,
+        command:
+          args.find((arg) =>
+            ["merge-base", "rev-parse", "diff-index", "diff", "cat-file"].includes(arg),
+          ) ?? "other",
+        objects: input ? input.trim().split("\n").length : cat < 0 ? 0 : 1,
+        maxBuffer: options.maxBuffer,
+      });
+      if (executable === gitBinary) {
+        assert.ok(args.includes("protocol.allow=never"));
+        assert.ok(args.includes("core.fsmonitor=false"));
+        assert.ok(args.some((arg) => arg.startsWith("core.hooksPath=")));
+        assert.ok(args.includes("diff.external="));
+        for (const name of ["GIT_NO_LAZY_FETCH", "GIT_NO_REPLACE_OBJECTS"])
+          assert.equal(options.env[name], "1");
+        assert.equal(options.env.GIT_OPTIONAL_LOCKS, "0");
+      }
+    }
+    if (executable === scanner) {
+      assert.deepEqual(args.slice(2), [
+        "--results=verified,unknown",
+        "--fail",
+        "--fail-on-scan-errors",
+        "--no-update",
+        "--json",
+        "--no-color",
+      ]);
+      const files = fs
+        .readdirSync(args[1])
+        .sort()
+        .map((name) => {
+          const file = join(args[1], name);
+          assert.ok(fs.lstatSync(file).isFile());
+          assert.equal(fs.statSync(file).mode & 0o777, 0o600);
+          const bytes = fs.readFileSync(file);
+          return { name, size: bytes.length, sha256: hash(bytes) };
+        });
+      active.scans.push(files);
+      const result = nativeSpawn(executable, args, options);
+      active.afterScanner?.();
+      return result;
+    }
+    return nativeSpawn(executable, args, options);
+  };
+  fs.mkdtempSync = (...args) => {
+    const path = nativeMkdtemp(...args);
+    if (active && basename(path).startsWith("clawsweeper-input-scan-")) active.roots.push(path);
+    return path;
+  };
+  syncBuiltinESMExports();
+  const before = await import(pathToFileURL(join(beforeDist, "agent-input-scan.js")).href);
+  const after = await import("../../dist/agent-input-scan.js");
+  const beforeRunner = await import(pathToFileURL(join(beforeDist, "agent-runner.js")).href);
+  const afterRunner = await import("../../dist/agent-runner.js");
+  const { captureTargetCheckoutBinding, withTargetReviewSnapshot } =
+    await import("../../dist/repair/target-validation.js");
+
+  function fixture(name) {
+    const cwd = join(root, name);
+    fs.mkdirSync(cwd);
+    const git = (...args) =>
+      run(gitBinary, args, {
+        cwd,
+        env: { PATH: originalPath, HOME: home, GIT_CONFIG_NOSYSTEM: "1" },
+      });
+    git("init", "-q");
+    git("config", "user.name", "Scanner proof");
+    git("config", "user.email", "scanner@example.invalid");
+    git("config", "commit.gpgsign", "false");
+    const commit = () => {
+      git("add", "-A");
+      git("commit", "-qm", "synthetic fixture");
+      return git("rev-parse", "HEAD");
+    };
+    return { cwd, git, commit };
+  }
+
+  function measure(label, revision, options, { runner, afterScanner } = {}) {
+    active = { git: [], scans: [], roots: [], afterScanner };
+    const start = performance.now();
+    let outcome = "admitted";
+    try {
+      if (runner) runner();
+      else
+        revision.scanAgentInput({
+          prompt: "Review synthetic changes.",
+          timeoutMs: 120_000,
+          ...options,
+        });
+    } catch (error) {
+      assert.equal(error.name, "AgentInputScanError");
+      outcome = error.reason;
+    }
+    const elapsedMs = performance.now() - start;
+    const observation = active;
+    active = undefined;
+    for (const path of observation.roots) assert.equal(fs.existsSync(path), false);
+    assert.ok(observation.roots.length <= 1);
+    const result = {
+      label,
+      outcome,
+      elapsedMs,
+      git: observation.git,
+      scans: observation.scans,
+      cleaned: true,
+    };
+    results.push(result);
+    fs.writeFileSync(
+      resolve(values.output),
+      JSON.stringify({ complete: false, results }, null, 2) + "\n",
+      { mode: 0o600 },
+    );
+    process.stdout.write(
+      `${label}: ${outcome}; Git=${result.git.length}; scanners=${result.scans.length}; ${Math.round(elapsedMs)}ms\n`,
+    );
+    return result;
+  }
+
+  if (selected("many")) {
+    const many = fixture("many");
+    fs.writeFileSync(join(many.cwd, "seed"), "unchanged\n");
+    const baseSha = many.commit();
+    for (let i = 0; i < blobCount; i++)
+      fs.writeFileSync(join(many.cwd, `file-${i}.txt`), `fixture ${i}\nline two\n`);
+    const headSha = many.commit();
+    const manyOptions = { cwd: many.cwd, source: { kind: "committed", baseSha, headSha } };
+    let reference;
+    for (let round = 0; round < rounds; round++) {
+      // Alternate AB then BA; each sample retains both admission boundaries.
+      for (const [name, revision] of round % 2
+        ? [
+            ["after", after],
+            ["before", before],
+          ]
+        : [
+            ["before", before],
+            ["after", after],
+          ]) {
+        for (let boundary = 0; boundary < 2; boundary++) {
+          const result = measure(`many/${round}/${name}/${boundary}`, revision, manyOptions);
+          assert.equal(result.outcome, "admitted");
+          assert.equal(result.scans.length, 1);
+          reference ??= result;
+          compare(reference, result);
+          const blobReads = result.git.filter(({ mode }) => mode !== "other");
+          assert.equal(
+            blobReads.length,
+            name === "before" ? 2 * blobCount : 2 * Math.ceil(blobCount / 160),
+          );
+        }
+      }
+    }
+    assert.equal(many.git("status", "--porcelain"), "");
+  }
+
+  if (selected("mixed")) {
+    const mixed = fixture("mixed");
+    const binary = Buffer.from([0, 255, 10, 13, 128, 0]);
+    fs.writeFileSync(join(mixed.cwd, ".gitattributes"), "*.txt text eol=lf\n");
+    fs.writeFileSync(join(mixed.cwd, "old"), "renamed\n");
+    fs.writeFileSync(join(mixed.cwd, "deleted"), "deleted\n");
+    fs.writeFileSync(join(mixed.cwd, "binary"), binary);
+    fs.writeFileSync(join(mixed.cwd, "empty"), "");
+    fs.writeFileSync(join(mixed.cwd, "normalized.txt"), "base\n");
+    const mixedBase = mixed.commit();
+    mixed.git("mv", "old", "renamed");
+    fs.rmSync(join(mixed.cwd, "deleted"));
+    fs.writeFileSync(join(mixed.cwd, "binary"), Buffer.concat([binary, Buffer.from("\nnext\n")]));
+    fs.writeFileSync(join(mixed.cwd, "empty"), "not empty\n");
+    fs.writeFileSync(join(mixed.cwd, "normalized.txt"), "head\n");
+    fs.symlinkSync("nonexistent-target", join(mixed.cwd, "link"));
+    for (const [name, mib] of [
+      ["large-a", 5],
+      ["large-b", 5],
+      ["large-c", 9],
+    ]) {
+      fs.writeFileSync(join(mixed.cwd, name), name);
+      fs.truncateSync(join(mixed.cwd, name), mib * 1024 * 1024);
+    }
+    const mixedHead = mixed.commit();
+    fs.writeFileSync(join(mixed.cwd, "normalized.txt"), "head\r\n");
+    const schemaPath = join(root, "schema.json");
+    fs.writeFileSync(schemaPath, '{"type":"object"}\n');
+    const mixedOptions = {
+      cwd: mixed.cwd,
+      source: { kind: "committed", baseSha: mixedBase, headSha: mixedHead },
+      additionalBytes: [Buffer.from("extra\ninput\0")],
+      schemaPath,
+    };
+    const mixedBefore = measure("mixed/before", before, mixedOptions);
+    const mixedAfter = measure("mixed/after", after, mixedOptions);
+    compare(mixedBefore, mixedAfter);
+    assert.equal(mixedAfter.outcome, "admitted");
+    const contentBatches = mixedAfter.git.filter(({ mode }) => mode === "--batch");
+    assert.ok(contentBatches.length > 1);
+    assert.ok(
+      contentBatches.some(({ maxBuffer, objects }) => maxBuffer > 9 * 1024 * 1024 && objects === 1),
+    );
+    for (const { maxBuffer, objects } of contentBatches)
+      assert.ok(maxBuffer <= 8 * 1024 * 1024 + 160 * 100 || objects === 1);
+    for (const bytes of [
+      binary,
+      Buffer.alloc(0),
+      Buffer.from("deleted\n"),
+      Buffer.from("renamed\n"),
+      Buffer.from("head\r\n"),
+      Buffer.from("nonexistent-target"),
+    ])
+      assert.ok(mixedAfter.scans[0].some(({ sha256 }) => sha256 === hash(bytes)));
+  }
+
+  if (selected("snapshot")) {
+    // The same blob participates at base, head, index and tree under distinct paths.
+    const snapshot = fixture("snapshot");
+    fs.writeFileSync(join(snapshot.cwd, "a"), "shared\n");
+    fs.writeFileSync(join(snapshot.cwd, "b"), "base\n");
+    const snapshotBase = snapshot.commit();
+    fs.writeFileSync(join(snapshot.cwd, "a"), "head\n");
+    fs.writeFileSync(join(snapshot.cwd, "b"), "shared\n");
+    snapshot.commit();
+    fs.writeFileSync(join(snapshot.cwd, "a"), "shared\n");
+    snapshot.git("add", "a");
+    fs.writeFileSync(join(snapshot.cwd, "a"), "tree\r\n");
+    fs.writeFileSync(join(snapshot.cwd, "c"), "shared\n");
+    const binding = captureTargetCheckoutBinding(snapshot.cwd);
+    withTargetReviewSnapshot(
+      { cwd: snapshot.cwd, baseSha: snapshotBase, expected: binding, timeoutMs: 120_000 },
+      (source) => {
+        const first = measure("snapshot/before", before, { cwd: snapshot.cwd, source });
+        const second = measure("snapshot/after", after, { cwd: snapshot.cwd, source });
+        compare(first, second);
+        assert.equal(second.outcome, "admitted");
+        assert.ok(second.scans[0].some(({ sha256 }) => sha256 === hash(Buffer.from("tree\r\n"))));
+      },
+    );
+  }
+
+  if (selected("content-budget")) {
+    const budget = fixture("content-budget");
+    fs.writeFileSync(join(budget.cwd, "seed"), "unchanged\n");
+    const budgetBase = budget.commit();
+    for (let index = 0; index < 32; index++)
+      fs.writeFileSync(join(budget.cwd, `binary-${index}`), Buffer.from([0, 255, index, 10]));
+    const budgetHead = budget.commit();
+    const diffArgs = [
+      "diff",
+      "--no-ext-diff",
+      "--no-textconv",
+      "--no-renames",
+      "--ignore-submodules=none",
+      budgetBase,
+      budgetHead,
+    ];
+    const diffSize = (flags) => {
+      const result = nativeSpawn(gitBinary, [...diffArgs, ...flags, "--"], { cwd: budget.cwd });
+      assert.equal(result.status, 0);
+      return result.stdout.length;
+    };
+    const prompt = "Review synthetic changes.";
+    const materialBytes =
+      Buffer.byteLength(prompt) +
+      32 * 4 +
+      diffSize(["--raw", "--no-abbrev", "-z"]) +
+      diffSize(["--patch", "--binary", "--full-index"]);
+    // Leave room for existing control reads, but less than the batch's framing.
+    const filler = Buffer.alloc(256 * 1024 * 1024 - 1024 - materialBytes);
+    const budgetOptions = {
+      cwd: budget.cwd,
+      prompt,
+      source: { kind: "committed", baseSha: budgetBase, headSha: budgetHead },
+      additionalBytes: [filler],
+    };
+    const budgetBefore = measure("content-budget/before", before, budgetOptions);
+    const budgetAfter = measure("content-budget/after", after, budgetOptions);
+    compare(budgetBefore, budgetAfter);
+    assert.equal(budgetAfter.outcome, "admitted");
+    assert.equal(
+      budgetAfter.scans[0].reduce((sum, file) => sum + file.size, 0),
+      256 * 1024 * 1024 - 1024,
+    );
+    assert.ok(budgetAfter.git.find(({ mode }) => mode === "--batch").maxBuffer > 1024 + 32 * 4);
+  }
+
+  if (selected("negatives")) {
+    for (const scenario of [
+      "missing",
+      "oversize",
+      "unsafe-path",
+      "HEAD-drift",
+      "index-drift",
+      "raw-drift",
+      "deadline",
+      "finding",
+    ]) {
+      let previous;
+      for (const [name, revision, runner] of [
+        ["before", before, beforeRunner],
+        ["after", after, afterRunner],
+      ]) {
+        const f = fixture(`${scenario}-${name}`);
+        fs.writeFileSync(join(f.cwd, "a"), "base\n");
+        if (scenario === "oversize") {
+          for (const file of ["large-a", "large-b"]) {
+            fs.writeFileSync(join(f.cwd, file), file);
+            fs.truncateSync(join(f.cwd, file), 129 * 1024 * 1024);
+          }
+        }
+        const base = f.commit();
+        if (scenario === "oversize") {
+          fs.rmSync(join(f.cwd, "large-a"));
+          fs.rmSync(join(f.cwd, "large-b"));
+        }
+        fs.writeFileSync(join(f.cwd, "a"), "head\n");
+        const head = f.commit();
+        const source = { kind: "committed", baseSha: base, headSha: head };
+        const calls = join(f.cwd, "..", `${scenario}-${name}-provider-calls`);
+        const provider = join(f.cwd, "..", `${scenario}-${name}-provider`);
+        fs.writeFileSync(
+          provider,
+          `#!${process.execPath}\nrequire('node:fs').writeFileSync(${JSON.stringify(calls)}, 'called');`,
+          { mode: 0o700 },
+        );
+        let timeoutMs = 120_000;
+        let prompt = "Review synthetic changes.";
+        const extra = [];
+        let afterScanner;
+        if (scenario === "missing") {
+          const oid = f.git("rev-parse", `${base}:a`);
+          fs.rmSync(join(f.cwd, ".git", "objects", oid.slice(0, 2), oid.slice(2)));
+          f.git("config", "extensions.partialClone", "origin");
+          f.git("config", "remote.origin.promisor", "true");
+          f.git("config", "remote.origin.url", "https://fixture.example.invalid/unavailable.git");
+        } else if (scenario === "unsafe-path") {
+          fs.writeFileSync(join(f.cwd, "unsafe\nname"), "unsafe\n");
+          source.headSha = f.commit();
+        } else if (scenario === "HEAD-drift") {
+          afterScanner = () => f.git("update-ref", "HEAD", base);
+        } else if (scenario === "index-drift") {
+          afterScanner = () => {
+            fs.writeFileSync(join(f.cwd, "a"), "index drift\n");
+            f.git("add", "a");
+            fs.writeFileSync(join(f.cwd, "a"), "head\n");
+          };
+        } else if (scenario === "raw-drift") {
+          afterScanner = () => fs.writeFileSync(join(f.cwd, "a"), "raw drift\n");
+        } else if (scenario === "deadline") {
+          timeoutMs = 0;
+        } else if (scenario === "finding") {
+          const uri = new URL("https://fixture.example.invalid/path");
+          uri.username = "fixture-user";
+          uri.password = "fixture-pass";
+          prompt = `Review ${uri.href}\n`;
+        }
+        const result = measure(
+          `${scenario}/${name}`,
+          revision,
+          {},
+          {
+            afterScanner,
+            runner: () =>
+              runner.runAgentProcess({
+                label: "synthetic-refusal",
+                cwd: f.cwd,
+                prompt,
+                scanSource: source,
+                model: "test",
+                timeoutMs,
+                env: { PATH: process.env.PATH, HOME: home, CODEX_BIN: provider },
+                codexExtraArgs: extra,
+              }),
+          },
+        );
+        assert.equal(fs.existsSync(calls), false, "refusal must precede provider launch");
+        const expected =
+          scenario === "missing"
+            ? "incomplete_source"
+            : scenario === "oversize"
+              ? "staging_limit"
+              : scenario === "unsafe-path"
+                ? "unsafe_path"
+                : scenario.endsWith("-drift")
+                  ? "source_drift"
+                  : scenario === "finding"
+                    ? "findings"
+                    : "deadline";
+        assert.equal(result.outcome, expected);
+        if (scenario === "oversize" && name === "after")
+          assert.equal(result.git.filter(({ mode }) => mode === "--batch").length, 0);
+        if (previous) compare(previous, result);
+        previous = result;
+      }
+    }
+  }
+  fs.writeFileSync(
+    resolve(values.output),
+    JSON.stringify(
+      {
+        complete: true,
+        section: values.section,
+        platform: process.platform,
+        arch: process.arch,
+        node: process.version,
+        git: run(gitBinary, ["--version"]),
+        scanner: "3.97.1",
+        sourceSha256: hash(
+          fs.readFileSync(new URL("../../src/agent-input-scan.ts", import.meta.url)),
+        ),
+        beforeModuleSha256: hash(fs.readFileSync(join(beforeDist, "agent-input-scan.js"))),
+        rounds,
+        blobCount,
+        results,
+        limits:
+          "Synthetic local scan admission only; no production latency, model, queue, publication or Bay claim.",
+      },
+      null,
+      2,
+    ) + "\n",
+    { mode: 0o600 },
+  );
+} finally {
+  active = undefined;
+  childProcess.spawnSync = nativeSpawn;
+  fs.mkdtempSync = nativeMkdtemp;
+  syncBuiltinESMExports();
+  for (const [name, value] of [
+    ["PATH", originalPath],
+    ["HOME", originalHome],
+    ["XDG_CONFIG_HOME", originalXdg],
+  ])
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  fs.rmSync(root, { recursive: true, force: true });
+}

--- a/src/agent-input-scan.ts
+++ b/src/agent-input-scan.ts
@@ -76,6 +76,8 @@ export function agentInputScanFailureExitCode(error: unknown): number | null {
 }
 
 export const MAX_SCAN_BYTES = 256 * 1024 * 1024;
+const MAX_BATCH_OBJECTS = 160;
+const MAX_BATCH_BYTES = 8 * 1024 * 1024;
 const OBJECT_ID = /^[0-9a-f]{40}(?:[0-9a-f]{24})?$/;
 const hostRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const REVIEW_TOOL_BOOTSTRAP_ENV = [
@@ -295,12 +297,14 @@ export function scanAgentInput(options: {
         args: string[],
         maxBytes = MAX_SCAN_BYTES - staged,
         configuration?: ReviewGitReadOptions["configuration"],
+        input?: Buffer,
       ) => {
         remaining();
         const bytes = readReviewGit(cwd, args, {
           ...readOptions,
           maxBytes: Math.max(1, maxBytes),
           ...(configuration ? { configuration } : {}),
+          ...(input ? { input } : {}),
         });
         if (bytes === null) throw new AgentInputScanError("incomplete_source");
         return bytes;
@@ -567,19 +571,73 @@ export function scanAgentInput(options: {
       // Only live committed checkouts need normalized raw files staged here;
       // snapshot objects were already captured and fenced before preparation.
       if (source.kind === "committed") assertCurrent();
-      for (const [oid, references] of blobs) {
-        const size = Number(git(["cat-file", "-s", oid], 100).toString().trim());
-        if (!Number.isSafeInteger(size) || size < 0)
+      const objects = [...blobs].map(([oid, references]) => ({ oid, references, size: 0 }));
+      let contentBytes = 0;
+      // Preflight the complete content budget before allocating any blob batch.
+      for (let offset = 0; offset < objects.length; offset += MAX_BATCH_OBJECTS) {
+        const batch = objects.slice(offset, offset + MAX_BATCH_OBJECTS);
+        const metadata = git(
+          ["cat-file", "--batch-check"],
+          batch.length * 100,
+          undefined,
+          Buffer.from(batch.map(({ oid }) => `${oid}\n`).join("")),
+        ).toString();
+        const lines = metadata.split("\n");
+        if (lines.pop() !== "" || lines.length !== batch.length)
           throw new AgentInputScanError("incomplete_source");
-        if (size > MAX_SCAN_BYTES - staged) throw new AgentInputScanError("staging_limit");
-        const bytes = git(["cat-file", "blob", oid], Math.max(1, size));
-        if (bytes.length !== size) throw new AgentInputScanError("incomplete_source");
-        if (
-          bytes.subarray(0, 128).toString().startsWith("version https://git-lfs.github.com/spec/v1")
-        )
-          throw new AgentInputScanError("unsupported_content");
-        // OID names preserve multiline bytes and make symlinks ordinary scan files.
-        stage(bytes, { kind: "blob", references }, oid);
+        for (const [index, object] of batch.entries()) {
+          const match = /^([0-9a-f]+) blob (0|[1-9][0-9]*)$/.exec(lines[index]!);
+          if (!match || match[1] !== object.oid) throw new AgentInputScanError("incomplete_source");
+          const size = Number(match[2]);
+          if (!Number.isSafeInteger(size)) throw new AgentInputScanError("incomplete_source");
+          if (size > MAX_SCAN_BYTES - staged - contentBytes)
+            throw new AgentInputScanError("staging_limit");
+          object.size = size;
+          contentBytes += size;
+        }
+      }
+      for (let offset = 0; offset < objects.length;) {
+        const batch = [];
+        let batchBytes = 0;
+        while (offset < objects.length && batch.length < MAX_BATCH_OBJECTS) {
+          const object = objects[offset]!;
+          if (batch.length && batchBytes + object.size > MAX_BATCH_BYTES) break;
+          batch.push(object);
+          batchBytes += object.size;
+          offset++;
+        }
+        // A larger individual blob retains the existing content allowance.
+        // Protocol headers/delimiters bound capture, but never consume that allowance.
+        const headers = batch.map(({ oid, size }) => Buffer.from(`${oid} blob ${size}\n`));
+        const framedBytes =
+          batchBytes + headers.reduce((sum, header) => sum + header.length + 1, 0);
+        const output = git(
+          ["cat-file", "--batch"],
+          framedBytes,
+          undefined,
+          Buffer.from(batch.map(({ oid }) => `${oid}\n`).join("")),
+        );
+        if (output.length !== framedBytes) throw new AgentInputScanError("incomplete_source");
+        let position = 0;
+        for (const [index, { oid, references, size }] of batch.entries()) {
+          const header = headers[index]!;
+          if (!output.subarray(position, position + header.length).equals(header))
+            throw new AgentInputScanError("incomplete_source");
+          position += header.length;
+          const bytes = output.subarray(position, position + size);
+          position += size;
+          if (bytes.length !== size || output[position++] !== 10)
+            throw new AgentInputScanError("incomplete_source");
+          if (
+            bytes
+              .subarray(0, 128)
+              .toString()
+              .startsWith("version https://git-lfs.github.com/spec/v1")
+          )
+            throw new AgentInputScanError("unsupported_content");
+          // OID names preserve multiline bytes and make symlinks ordinary scan files.
+          stage(bytes, { kind: "blob", references }, oid);
+        }
       }
     }
     const result = spawnSync(

--- a/test/agent-input-scan.test.ts
+++ b/test/agent-input-scan.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
+import childProcess, { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
   chmodSync,
@@ -15,6 +15,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
+import { syncBuiltinESMExports } from "node:module";
 import { dirname, join } from "node:path";
 import test from "node:test";
 import { runAgentProcess, runAgentCheckoutInspection } from "../dist/agent-runner.js";
@@ -122,6 +123,166 @@ function disableManagedScanner(t: test.TestContext) {
     else process.env.CLAWSWEEPER_REVIEW_TOOLS_DIR = previous;
   });
 }
+
+test("scanner bounds Git process growth while preserving complete binary inputs in both scans", (t) => {
+  const f = fixture(t);
+  const expected = new Map<string, string>();
+  const receipt = join(f.root, "staged-inputs");
+  useFakeScanner(
+    t,
+    `fs.appendFileSync(${JSON.stringify(receipt)}, JSON.stringify(inputs.map(({name, bytes}) => [name, bytes.toString('base64')])) + '\\n');`,
+  );
+  const content = (i: number, version: string) =>
+    i === 0 && version === "before"
+      ? Buffer.alloc(0)
+      : Buffer.concat([
+          Buffer.from(`${version} ${i}\n${"f".repeat(40)} blob 42\n`),
+          Buffer.from([0, 255, 10, 13, 128]),
+        ]);
+  for (let i = 0; i < 81; i++) {
+    writeFileSync(join(f.cwd, `${i}.bin`), content(i, "before"));
+  }
+  const baseSha = f.commit();
+  for (let i = 0; i < 81; i++) {
+    writeFileSync(join(f.cwd, `${i}.bin`), content(i, "after"));
+  }
+  const headSha = f.commit();
+  for (const [revision, version] of [
+    [baseSha, "before"],
+    [headSha, "after"],
+  ]) {
+    for (let i = 0; i < 81; i++)
+      expected.set(
+        f.git("rev-parse", `${revision}:${i}.bin`),
+        content(i, version!).toString("base64"),
+      );
+  }
+  const nativeSpawn = childProcess.spawnSync;
+  const commands: string[][] = [];
+  t.mock.method(childProcess, "spawnSync", (...args: Parameters<typeof nativeSpawn>) => {
+    if (args[1]?.includes("cat-file")) commands.push([...args[1]]);
+    return nativeSpawn(...args);
+  });
+  syncBuiltinESMExports();
+  t.after(() => {
+    t.mock.restoreAll();
+    syncBuiltinESMExports();
+  });
+  for (let scan = 0; scan < 2; scan++)
+    scanAgentInput({
+      cwd: f.cwd,
+      prompt: "Review binary changes.",
+      source: { kind: "committed", baseSha, headSha },
+      timeoutMs: 120_000,
+    });
+  const scans = readFileSync(receipt, "utf8")
+    .trim()
+    .split("\n")
+    .map((line) => new Map<string, string>(JSON.parse(line)));
+  assert.equal(scans.length, 2, "each admission boundary must scan independently");
+  assert.deepEqual(scans[0], scans[1]);
+  for (const [oid, bytes] of expected) assert.equal(scans[0]!.get(oid), bytes);
+  assert.equal(scans[0]!.size, expected.size + 3, "prompt, complete raw diff and binary patch");
+  assert.ok(
+    commands.length <= 8,
+    `162 unique blobs across two scans must use bounded batches, observed ${commands.length} Git children`,
+  );
+});
+
+test("scanner refuses malformed batch metadata and binary frames before provider dispatch", (t) => {
+  const f = fixture(t);
+  const receipt = join(f.root, "unexpected-scan");
+  useFakeScanner(t, `fs.writeFileSync(${JSON.stringify(receipt)}, 'called');`);
+  writeFileSync(join(f.cwd, "a"), Buffer.from([0, 10, 255]));
+  const baseSha = f.commit();
+  writeFileSync(join(f.cwd, "a"), Buffer.from([0, 10, 255, 13]));
+  const headSha = f.commit();
+  const source = { kind: "committed" as const, baseSha, headSha };
+  const nativeSpawn = childProcess.spawnSync;
+  let fault = "";
+  let contentReads = 0;
+  let injected = false;
+  t.mock.method(childProcess, "spawnSync", (...args: Parameters<typeof nativeSpawn>) => {
+    const result = nativeSpawn(...args);
+    const command = args[1] ?? [];
+    const metadata = command.includes("--batch-check");
+    const content = command.includes("--batch");
+    if (content) contentReads++;
+    if (!metadata && !content) return result;
+    const output = Buffer.from(result.stdout);
+    const headerEnd = output.indexOf(10);
+    let changed: Buffer | undefined;
+    if (metadata && fault.startsWith("metadata/")) {
+      const lines = output.toString().trimEnd().split("\n");
+      const fields = lines[0]!.split(" ");
+      if (fault === "metadata/missing") lines[0] = `${fields[0]} missing`;
+      if (fault === "metadata/type") fields[1] = "tree";
+      if (fault === "metadata/identity") fields[0] = "0".repeat(40);
+      if (fault === "metadata/negative") fields[2] = "-1";
+      if (fault === "metadata/nondecimal") fields[2] = "1e2";
+      if (fault === "metadata/unsafe-integer") fields[2] = "9007199254740992";
+      if (fault !== "metadata/missing") lines[0] = fields.join(" ");
+      if (fault === "metadata/count") lines.pop();
+      if (fault === "metadata/aggregate")
+        for (let i = 0; i < lines.length; i++)
+          lines[i] = lines[i]!.replace(/\d+$/, String(128 * 1024 * 1024));
+      changed = Buffer.from(lines.join("\n") + "\n");
+      if (fault === "metadata/unterminated") changed = changed.subarray(0, -1);
+    } else if (content && fault.startsWith("content/")) {
+      changed = Buffer.from(output);
+      if (fault === "content/identity") changed[0] = changed[0] === 97 ? 98 : 97;
+      if (fault === "content/size") changed[headerEnd - 1] = 57;
+      if (fault === "content/delimiter") changed[headerEnd + 1 + 3] = 0;
+      if (fault === "content/truncated") changed = changed.subarray(0, -1);
+      if (fault === "content/trailing") changed = Buffer.concat([changed, Buffer.from("\n")]);
+      if (fault === "content/header-newline") changed[headerEnd] = 0;
+    }
+    if (!changed) return result;
+    injected = true;
+    return { ...result, stdout: changed };
+  });
+  syncBuiltinESMExports();
+  t.after(() => {
+    t.mock.restoreAll();
+    syncBuiltinESMExports();
+  });
+  for (fault of [
+    "metadata/missing",
+    "metadata/type",
+    "metadata/identity",
+    "metadata/negative",
+    "metadata/nondecimal",
+    "metadata/unsafe-integer",
+    "metadata/count",
+    "metadata/aggregate",
+    "metadata/unterminated",
+    "content/identity",
+    "content/size",
+    "content/delimiter",
+    "content/truncated",
+    "content/trailing",
+    "content/header-newline",
+  ]) {
+    contentReads = 0;
+    injected = false;
+    assert.throws(
+      () => f.run(source),
+      (error) => {
+        assert.ok(error instanceof AgentInputScanError);
+        assert.equal(
+          error.reason,
+          fault === "metadata/aggregate" ? "staging_limit" : "incomplete_source",
+          fault,
+        );
+        return true;
+      },
+    );
+    assert.ok(injected, fault);
+    if (fault.startsWith("metadata/")) assert.equal(contentReads, 0, fault);
+    assert.equal(existsSync(receipt), false, fault);
+    assert.equal(existsSync(f.calls), false, fault);
+  }
+});
 
 for (const scenario of ["deletion", "multiline", "past-display-limits", "comment-only"]) {
   test(`raw admission catches ${scenario} input before dispatch`, (t) => {

--- a/test/local-range-review.test.ts
+++ b/test/local-range-review.test.ts
@@ -221,6 +221,10 @@ function writeMetadataGit(harness: string): string {
     `import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 const args = process.argv.slice(2);
+if (!args.includes("--numstat") && !args.includes("--name-status")) {
+  const result = spawnSync(${JSON.stringify(realGit)}, args, { stdio: "inherit", env: process.env });
+  process.exit(result.status ?? 1);
+}
 const result = spawnSync(${JSON.stringify(realGit)}, args, { encoding: "utf8", env: process.env });
 if (result.status !== 0) process.exit(result.status ?? 1);
 let output = result.stdout;


### PR DESCRIPTION
## What Problem This Solves

Resolves repeated Git process startup during scanner admission for reviews with
many changed blobs. Each admission previously spawned two Git children per unique
blob, and both independent admission boundaries paid that cost.

## Why This Change Was Made

Batch local blob metadata and binary content within each `scanAgentInput` call.
Preflight the complete aggregate content size, then read at most 160 objects and
8 MiB of content per batch; larger individual blobs remain eligible as singletons
under the existing 256 MiB allowance. Validate exact ordered headers, byte lengths,
delimiters, and total output length. Framing is additional capture overhead, not
charged to the content allowance.

Both scans remain independent. This changes no cache lifecycle, persistence,
configuration, scanner arguments, source attribution, normalization, hardened Git
environment, drift fence, provider gate, or cleanup policy.

The local-range fault-injection fixture now passes non-metadata Git commands
through inherited stdio, preserving batch stdin and binary stdout. Its existing
numstat/name-status mutations and assertions are unchanged. This is test support,
not a production fallback or an exec/signal transparency claim.

## User Impact

Fewer local Git subprocesses during admission. No production latency or weekly
savings claim is made. Admission still scans complete prompt/schema/additional
input, raw diffs, binary patches, canonical blobs, and applicable raw working bytes.

## OpenClaw Bay Impact

None. No review result, observer payload, lifecycle disposition, telemetry schema,
route, or public control changes.

## Documentation Impact

Reviewed the README safety model, `docs/commit-sweeper.md`, and
`docs/review-cache.md`. Their admission, 256 MiB, and no-fetch contracts remain
accurate. No documentation or release-owned changelog edits are needed.

## Evidence

- Base: `ff0156fb8628cbf9f22d00864810dea56e83122b`.
- Regression: 162 unique binary blobs, two complete scans. Base failed only the
  process-growth assertion after all byte checks passed: 648 blob-read children.
  Candidate passes the bounded-batch assertion and exact staged-byte checks.
- Fifteen malformed metadata/frame cases refuse before scanner/provider dispatch;
  aggregate metadata refusal performs no blob-content read.
- Native TypeScript build, targeted formatting/lint, and `git diff --check` pass.
- Fresh four-file P2 precommit autoreview against the pinned base: `scoped-clean`,
  no findings, confidence 0.96 (`autoreview-four-file-final.json`). Final source
  verification passed. An earlier invocation stopped before reviewer execution
  on an unrelated untracked binary capture; the coordinator relocated that
  archive outside the checkout without changing its SHA-256. No review inputs
  were edited during the completed review.
- Focused existing scanner/Git-boundary suite: 259 passed, zero failures, in
  addition to the two new regression tests.
- Coordinator-owned Linux real proof: complete, exit 0; exact artifact and
  observations below.
- First coordinator-owned Linux fullcheck (`run_8ff8e378a3f6`) failed: 5,140
  tests, 5,121 passed, one failed, 18 skipped. The sole failure was the
  local-range fixture dropping batch stdin, producing `incomplete_source`.
  The original failed log is retained; it is not a passing gate.
- After the approved fixture-only fix, native macOS Node 26.7.0 passes the exact
  failing scenario (1/1, 41.531 s) and complete local-range file (17/17, 71.449 s).
  Targeted format/lint and diff checks pass. Scanner and real-proof harness
  bytes remain identical to the passing Linux real scanner proof.
- Coordinator-owned Linux fullcheck rerun `run_de097ee5e16e`: exit 0 in
  223.405 s. All 13 preflight tests passed; aggregate suite: 5,140 tests,
  5,122 passed, 18 skipped, zero failures or cancellations. The command checked
  all four source hashes before and after `pnpm run check`.
- Committed candidate: `8c37f7957c23992e7f02d06c5a9310fda33352e4`.
  Fresh committed-branch P2 autoreview against the pinned base is `scoped-clean`,
  with no findings (`autoreview-committed.json`); final source verification passed.
  No duplicate fullcheck or real scanner proof was run.

## Real Behavior Proof

**Claim:** identical scanned material and admitted/refused outcomes, fewer Git
children, no reuse across admission calls.

**Surface and command:** actual `scanAgentInput` and refusal paths through
`runAgentProcess`, real isolated synthetic Git repositories, TruffleHog
3.97.1:

```sh
node scripts/e2e/scan-git-batching.mjs \
  --before-dist "$BASELINE/dist" --scanner "$PINNED_SCANNER" \
  --rounds 3 --blobs 160 --output "$PROOF/scan-git-batching.json"
```

**Scenarios:** repeated alternating before/after samples, with two independent
scans per sample; newline/NUL/invalid UTF-8 and empty content; full binary patches;
deletion, rename, symlink; CRLF normalization; quarantined snapshot objects and
shared OIDs across endpoint roles; bounded content chunks and a 9 MiB singleton;
256 MiB minus 1 KiB admitted material with framing outside the content budget;
missing promised objects; oversized aggregate blobs; unsafe paths; HEAD/index/raw
drift; expired deadline; an existing synthetic URI refusal.

**Artifact identity:** the production pin covers the Linux archive and TruffleHog
3.97.1 version. The local Darwin binary matches its archive, whose checksum comes
from the upstream release; this is not a production-pinned Darwin hash or proof
of the exact Linux artifact. The coordinator reports the approved install action
verified the production Linux archive SHA. The downloaded JSON records scanner
version 3.97.1; its checksum below identifies the proof JSON, not the scanner archive.

**Linux environment and provenance:** AWS provider, image `ami-0461d919be7deb53c`,
lease `cbx_b57744ae34e8`, hydration Actions run `34073445284`. Coordinator-owned
Crabbox run `run_d3707d2c41f1` completed with exit 0 in 75.127 s. The exact JSON
records Linux x64, Node 24.20.0, Git 2.53.0, TruffleHog 3.97.1, `complete: true`,
and `section: all`.

**Artifact:** `linux-scan-git-batching.json`

- SHA-256: `258227488487998c6b8a3554a10b461c1a09585ca8dbe2e22f1ad51488e4b373`
- Scanner source SHA-256: `ca24096d5c452a5bc947d6b255674098ae0ed0eedf982ba4856923a96799bbea`,
  matching the frozen reviewed candidate.

**Qualified files:** the production scanner and real-proof harness are
byte-identical to the passing Linux scanner proof. The subsequent local-range
fixture repair is covered by focused tests, both four-file reviews, and the
passing full Linux check.

```text
sha256 src/agent-input-scan.ts=ca24096d5c452a5bc947d6b255674098ae0ed0eedf982ba4856923a96799bbea
sha256 test/agent-input-scan.test.ts=bf81fbe3cc52836d95e79edd2df917f48063cbf57f053e905f94069f79a43bff
sha256 scripts/e2e/scan-git-batching.mjs=89748a09b772ce7bea4664e5921a09c40d44084ccd6c1464ab18063b31422c4a
sha256 test/local-range-review.test.ts=fe166773ff766020ac53fd7943f6d807c621fa97ca492245bd9de28140f98c7f
```

**Sanitized Linux evidence trace** (counts and timings read from that JSON):

```text
many: 3 alternating AB/BA/AB rounds; 2 independent scans per revision per round
many: 6 before + 6 after; all admitted; 163 staged files / 56,325 bytes per scan
many: staged names, lengths and SHA-256 hashes identical across all 12 scans
Git children per scan: 330 -> 12; blob metadata/content children: 320 -> 2
Git children for both scans: 660 -> 24; both scanner invocations retained
full-scan median, n=6/revision: 2721.317 ms -> 1985.385 ms
full-scan range: 2690.544..2743.070 ms -> 1981.745..1991.819 ms
mixed: admitted, hashes equal, 20,038,275 bytes; Git 39 -> 20
snapshot: admitted, hashes equal, 1,355 bytes; Git including fences 94 -> 88
content budget: admitted, hashes equal, 268,434,432 bytes; Git 74 -> 12
missing / oversize / unsafe-path: incomplete_source / staging_limit / unsafe_path
HEAD / index / raw drift: source_drift; expired deadline: deadline; URI: findings
all 8 negative pairs preserve outcomes and staged hashes; no provider launch
oversize candidate: no content batch; all 34 measurements cleaned private staging
```

Completed harness assertions also cover chunk splitting, the 9 MiB singleton,
and framing beyond the content allowance. The artifact contains 26 real scanner
invocations across the positive and negative scenarios. No provider-launch count
is stored as a separate JSON field; the completed harness asserts that negative
cases never create the provider marker.

**Supplemental macOS evidence:** Node 26.7.0, Apple Git 2.50.1, TruffleHog 3.97.1.
The same 160-blob process counts and staged-hash equivalence held; six observations
per revision had median full-scan times of 8.535 s before and 1.227 s after on a
shared host.

**Limits:** all timing measurements are synthetic admission observations. Neither
the Linux nor macOS results establish production latency, model latency, weekly
savings, or a production speedup. No model, GitHub publication, queue, or Bay
execution is covered. Fault-injected binary framing and native timeout cases
supplement the real scanner proof. Existing attribution tests cover
path/mode/revision/role eligibility. Refusal reasons are asserted for the named
scenarios, not precedence among multiple simultaneous invalid inputs. The first
fullcheck failed; its fixture repair has focused native proof, a clean
four-file P2 precommit review, a clean committed-branch review, and a passing
full Linux check.

<!-- Punchcard-Session: silver-workshop-valley-hd -->
