### PR TITLE
fix(ci): avoid reinstalling valid cached Codex packages

### DIFF
--- a/.github/actions/setup-codex/action.yml
+++ b/.github/actions/setup-codex/action.yml
@@ -42,19 +42,33 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        npm config set prefix "$HOME/.clawsweeper-repair/codex"
-        npm config set cache "$HOME/.npm"
         echo "$HOME/.clawsweeper-repair/codex/bin" >> "$GITHUB_PATH"
         export PATH="$HOME/.clawsweeper-repair/codex/bin:$PATH"
 
         install_env=(env -u OPENAI_API_KEY -u CODEX_API_KEY -u PROXY_API_KEY -u CLAWSWEEPER_INTERNAL_MODEL -u CLAWSWEEPER_CLAWROUTER_CONFIG)
-        "${install_env[@]}" npm install -g "@openai/codex@${{ inputs['codex-version'] }}" \
-          --prefer-online --no-audit --no-fund --ignore-scripts
-        if [[ "${{ inputs['auth-mode'] }}" == "proxy" ]]; then
-          "${install_env[@]}" npm install -g "@openai/codex-responses-api-proxy@${{ inputs['proxy-version'] }}" \
+        npm_configured=false
+        ensure_installed() {
+          local name="$1" version="$2" status
+          if "${install_env[@]}" node "${{ github.action_path }}/validate-install.mjs" "$name" "$version"; then
+            return
+          else
+            status=$?
+          fi
+          # Only an absent or unusable contained installation may be repaired.
+          if [[ "$status" != 1 ]]; then return "$status"; fi
+          if [[ "$npm_configured" == false ]]; then
+            "${install_env[@]}" npm config set prefix "$HOME/.clawsweeper-repair/codex"
+            "${install_env[@]}" npm config set cache "$HOME/.npm"
+            npm_configured=true
+          fi
+          "${install_env[@]}" npm install -g "@openai/$name@$version" \
             --prefer-online --no-audit --no-fund --ignore-scripts
+          "${install_env[@]}" node "${{ github.action_path }}/validate-install.mjs" "$name" "$version"
+        }
+        ensure_installed codex "${{ inputs['codex-version'] }}"
+        if [[ "${{ inputs['auth-mode'] }}" == "proxy" ]]; then
+          ensure_installed codex-responses-api-proxy "${{ inputs['proxy-version'] }}"
         fi
-        codex --version
 
     - name: Enable Linux user namespaces for bubblewrap
       if: ${{ runner.os == 'Linux' && runner.environment == 'github-hosted' }}

--- a/.github/actions/setup-codex/action.yml
+++ b/.github/actions/setup-codex/action.yml
@@ -49,7 +49,7 @@ runs:
         npm_configured=false
         ensure_installed() {
           local name="$1" version="$2" status
-          if "${install_env[@]}" node "${{ github.action_path }}/validate-install.mjs" "$name" "$version"; then
+          if "${install_env[@]}" node "$GITHUB_ACTION_PATH/validate-install.mjs" "$name" "$version"; then
             return
           else
             status=$?
@@ -63,7 +63,7 @@ runs:
           fi
           "${install_env[@]}" npm install -g "@openai/$name@$version" \
             --prefer-online --no-audit --no-fund --ignore-scripts
-          "${install_env[@]}" node "${{ github.action_path }}/validate-install.mjs" "$name" "$version"
+          "${install_env[@]}" node "$GITHUB_ACTION_PATH/validate-install.mjs" "$name" "$version"
         }
         ensure_installed codex "${{ inputs['codex-version'] }}"
         if [[ "${{ inputs['auth-mode'] }}" == "proxy" ]]; then

--- a/.github/actions/setup-codex/validate-install.mjs
+++ b/.github/actions/setup-codex/validate-install.mjs
@@ -1,0 +1,251 @@
+import { spawn } from "node:child_process";
+import {
+  accessSync,
+  constants,
+  lstatSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  realpathSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+
+class UnsafePath extends Error {}
+
+function inside(root, path) {
+  const rel = relative(root, path);
+  if (rel === ".." || rel.startsWith(`..${sep}`) || isAbsolute(rel)) {
+    throw new UnsafePath("managed installation path escapes its owner");
+  }
+}
+
+// Check even dangling links before deciding whether npm may repair a partial cache.
+function contained(root, path, depth = 0) {
+  inside(root, path);
+  if (depth > 32) throw new UnsafePath("managed installation has a symlink cycle");
+  let current = root;
+  const parts = relative(root, path).split(sep).filter(Boolean);
+  for (let index = 0; index < parts.length; index++) {
+    current = join(current, parts[index]);
+    let info;
+    try {
+      info = lstatSync(current);
+    } catch (error) {
+      if (error.code === "ENOENT" || error.code === "ENOTDIR")
+        return join(current, ...parts.slice(index + 1));
+      throw error;
+    }
+    if (info.isSymbolicLink()) {
+      const target = resolve(dirname(current), readlinkSync(current));
+      current = contained(root, target, depth + 1);
+    }
+  }
+  return current;
+}
+
+// A dangling search-directory link is visited invalid state, not an absent alias.
+function aliasPresent(root, path) {
+  let current = path;
+  for (;;) {
+    let info;
+    try {
+      info = lstatSync(current);
+    } catch (error) {
+      if (error.code === "ENOENT") {
+        current = dirname(current);
+        continue;
+      }
+      throw error;
+    }
+    if (info.isSymbolicLink()) statSync(contained(root, current));
+    return current === path;
+  }
+}
+
+function metadata(path) {
+  const info = statSync(path);
+  if (!info.isFile() || info.size > 64 * 1024) throw new Error("invalid package metadata file");
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function executable(path) {
+  if (!statSync(path).isFile()) throw new Error("missing executable");
+  accessSync(path, constants.X_OK);
+}
+
+async function probe(command, args, home) {
+  return new Promise((resolveProbe, reject) => {
+    const child = spawn(command, args, {
+      cwd: home,
+      detached: true,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: {
+        HOME: home,
+        CODEX_HOME: home,
+        PATH: `${dirname(process.execPath)}:/usr/bin:/bin`,
+        LANG: "C",
+      },
+    });
+    let output = "";
+    let size = 0;
+    let invalid = false;
+    let stopped = false;
+    const stop = () => {
+      if (stopped) return;
+      stopped = true;
+      if (child.pid) {
+        try {
+          process.kill(-child.pid, "SIGKILL");
+        } catch (error) {
+          if (error.code !== "ESRCH") throw error;
+        }
+      }
+    };
+    const timeout = setTimeout(() => {
+      invalid = true;
+      stop();
+    }, 5_000);
+    for (const stream of [child.stdout, child.stderr]) {
+      stream.on("data", (data) => {
+        size += data.length;
+        if (size > 64 * 1024) {
+          invalid = true;
+          stop();
+        } else if (stream === child.stdout) {
+          output += data.toString("utf8");
+        }
+      });
+    }
+    child.on("error", () => {
+      invalid = true;
+    });
+    child.on("close", (code) => {
+      clearTimeout(timeout);
+      stop();
+      if (invalid || code !== 0) reject(new Error("executable probe failed"));
+      else resolveProbe(output.trim());
+    });
+  });
+}
+
+async function validate(name, version) {
+  if (
+    !["codex", "codex-responses-api-proxy"].includes(name) ||
+    !/^\d+\.\d+\.\d+(?:-[\w.-]+)?$/.test(version)
+  ) {
+    throw new UnsafePath("unsupported package or non-exact version");
+  }
+  const target = {
+    "linux-x64": "x86_64-unknown-linux-musl",
+    "linux-arm64": "aarch64-unknown-linux-musl",
+    "darwin-x64": "x86_64-apple-darwin",
+    "darwin-arm64": "aarch64-apple-darwin",
+  }[`${process.platform}-${process.arch}`];
+  if (!target) throw new UnsafePath("unsupported runner platform");
+  const home = realpathSync(process.env.HOME);
+  const prefix = join(home, ".clawsweeper-repair", "codex");
+  contained(home, prefix);
+  for (const path of [dirname(prefix), prefix]) {
+    try {
+      if (lstatSync(path).isSymbolicLink()) throw new UnsafePath("managed prefix is a symlink");
+    } catch (error) {
+      if (error.code !== "ENOENT") throw error;
+    }
+  }
+  const pkg = join(prefix, "lib/node_modules/@openai", name);
+  const launcher = join(pkg, "bin", `${name}.js`);
+  const bin = join(prefix, "bin", name);
+  const manifest = join(pkg, "package.json");
+  const nativeSuffix = join("vendor", target, name === "codex" ? "bin" : name, name);
+  let nativeRoot = pkg;
+  const alias = `@openai/codex-${process.platform}-${process.arch}`;
+  for (const path of [manifest, launcher, bin]) contained(prefix, path);
+  const canonicalLauncher = contained(prefix, launcher);
+  const resolver = createRequire(canonicalLauncher);
+  let selectedManifest;
+  if (name === "codex") {
+    // Stop at the first present package, even if its final manifest is missing.
+    // Lower aliases and local vendor are not part of this launcher's active lookup.
+    for (const directory of resolver.resolve.paths(alias)) {
+      if (directory.startsWith(`${prefix}${sep}`)) contained(prefix, directory);
+      if (!aliasPresent(prefix, directory)) continue;
+      const candidate = join(directory, alias);
+      if (!aliasPresent(prefix, candidate)) continue;
+      selectedManifest = contained(prefix, join(candidate, "package.json"));
+      nativeRoot = dirname(selectedManifest);
+      break;
+    }
+  }
+  const native = join(nativeRoot, nativeSuffix);
+  contained(prefix, native);
+
+  const data = metadata(manifest);
+  if (
+    data.name !== `@openai/${name}` ||
+    data.version !== version ||
+    data.bin?.[name] !== `bin/${name}.js`
+  ) {
+    throw new Error("package identity, version, or launcher mismatch");
+  }
+  if (realpathSync(launcher) !== join(realpathSync(pkg), "bin", `${name}.js`))
+    throw new Error("managed launcher mismatch");
+  const platformVersion = `${version}-${process.platform}-${process.arch}`;
+  if (name === "codex") {
+    if (data.optionalDependencies?.[alias] !== `npm:@openai/codex@${platformVersion}`)
+      throw new Error("platform alias identity or version mismatch");
+    if (selectedManifest) {
+      const platformData = metadata(selectedManifest);
+      // The published platform package is @openai/codex under a local npm alias.
+      if (platformData.name !== "@openai/codex" || platformData.version !== platformVersion)
+        throw new Error("platform package identity or version mismatch");
+    }
+    let resolved;
+    try {
+      // Match rust-v0.153.3's launcher: resolve the optional alias, else local vendor.
+      resolved = resolver.resolve(`${alias}/package.json`);
+    } catch (error) {
+      if (selectedManifest || error.code !== "MODULE_NOT_FOUND") throw error;
+    }
+    if (resolved) contained(prefix, resolved);
+    if (resolved !== selectedManifest) throw new Error("platform alias resolution mismatch");
+  }
+  if (realpathSync(bin) !== realpathSync(launcher)) throw new Error("managed launcher mismatch");
+  executable(bin);
+  executable(native);
+  const scratch = mkdtempSync(join(tmpdir(), "codex-install-probe-"));
+  try {
+    const args = [name === "codex" ? "--version" : "--help"];
+    for (const [command, commandArgs] of [
+      [native, args],
+      [bin, args],
+    ]) {
+      const output = await probe(command, commandArgs, scratch);
+      if (
+        name === "codex"
+          ? output !== `codex-cli ${version}`
+          : !/^Usage: codex-responses-api-proxy\b/m.test(output)
+      ) {
+        throw new Error("executable output mismatch");
+      }
+    }
+    console.log(name === "codex" ? `codex-cli ${version}` : `Validated ${name} ${version}`);
+  } finally {
+    rmSync(scratch, { recursive: true, force: true });
+  }
+}
+
+try {
+  await validate(process.argv[2], process.argv[3]);
+} catch (error) {
+  const unsafe = error instanceof UnsafePath;
+  console.error(
+    unsafe
+      ? "Unsafe managed Codex installation path; refusing automatic repair."
+      : "Managed Codex installation is missing, mismatched, or unusable.",
+  );
+  process.exitCode = unsafe ? 2 : 1;
+}

--- a/.github/actions/setup-codex/validate-install.mjs
+++ b/.github/actions/setup-codex/validate-install.mjs
@@ -94,6 +94,7 @@ function aliasPresent(root, path) {
         current = dirname(current);
         continue;
       }
+      contained(root, current);
       throw error;
     }
     if (info.isSymbolicLink()) {

--- a/.github/actions/setup-codex/validate-install.mjs
+++ b/.github/actions/setup-codex/validate-install.mjs
@@ -12,7 +12,7 @@ import {
 } from "node:fs";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
-import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { dirname, isAbsolute, join, relative, sep } from "node:path";
 
 class UnsafePath extends Error {}
 
@@ -25,26 +25,61 @@ function inside(root, path) {
 
 // Check even dangling links before deciding whether npm may repair a partial cache.
 function contained(root, path, depth = 0) {
-  inside(root, path);
-  if (depth > 32) throw new UnsafePath("managed installation has a symlink cycle");
+  if (path !== root && !path.startsWith(`${root}${sep}`))
+    throw new UnsafePath("managed installation path escapes its owner");
   let current = root;
-  const parts = relative(root, path).split(sep).filter(Boolean);
-  for (let index = 0; index < parts.length; index++) {
-    current = join(current, parts[index]);
-    let info;
-    try {
-      info = lstatSync(current);
-    } catch (error) {
-      if (error.code === "ENOENT" || error.code === "ENOTDIR")
-        return join(current, ...parts.slice(index + 1));
-      throw error;
+  let directory = true;
+  let anchored = true;
+  let unresolved;
+  function walk(raw, level) {
+    if (level > 32) throw new UnsafePath("managed installation has a symlink cycle");
+    if (isAbsolute(raw)) {
+      current = sep;
+      directory = true;
+      anchored = false;
+      raw = raw.slice(1);
     }
-    if (info.isSymbolicLink()) {
-      const target = resolve(dirname(current), readlinkSync(current));
-      current = contained(root, target, depth + 1);
+    for (const part of raw.split(sep)) {
+      // Missing or non-directory traversal stays failed, including across a link's caller suffix.
+      if (unresolved !== undefined) unresolved += `${sep}${part}`;
+      else if (!directory) unresolved = `${current}${sep}${part}`;
+      const next =
+        part === ".."
+          ? dirname(current)
+          : part === "." || part === ""
+            ? current
+            : join(current, part);
+      const owned = next === root || next.startsWith(`${root}${sep}`);
+      // Absolute targets may reanchor through owner ancestors, never unrelated outside branches.
+      if (!owned && (anchored || (next !== sep && !root.startsWith(`${next}${sep}`))))
+        throw new UnsafePath("managed installation path escapes its owner");
+      anchored ||= owned;
+      if (part === "." || part === "" || part === "..") {
+        current = next;
+        if (part === "..") directory = true;
+        continue;
+      }
+      let info;
+      if (unresolved === undefined) {
+        try {
+          info = lstatSync(next);
+        } catch (error) {
+          if (error.code !== "ENOENT" && error.code !== "ENOTDIR") throw error;
+          unresolved = next;
+        }
+      }
+      if (info?.isSymbolicLink()) {
+        // Expand relative targets from the resolved parent before consuming the caller suffix.
+        walk(readlinkSync(next), level + 1);
+        inside(root, current);
+      } else {
+        current = next;
+        directory = info?.isDirectory() ?? false;
+      }
     }
   }
-  return current;
+  walk(path.slice(root.length + 1), depth);
+  return unresolved ?? current;
 }
 
 // A dangling search-directory link is visited invalid state, not an absent alias.
@@ -61,7 +96,20 @@ function aliasPresent(root, path) {
       }
       throw error;
     }
-    if (info.isSymbolicLink()) statSync(contained(root, current));
+    if (info.isSymbolicLink()) {
+      if (current === root || current.startsWith(`${root}${sep}`)) {
+        statSync(contained(root, current));
+      } else {
+        // An unused outside directory may establish absence, not authorize a dependency.
+        try {
+          info = statSync(current);
+        } catch (error) {
+          throw new UnsafePath("unusable outside alias search directory", { cause: error });
+        }
+        if (!info.isDirectory())
+          throw new UnsafePath("outside alias search path is not a directory");
+      }
+    }
     return current === path;
   }
 }

--- a/scripts/e2e/codex-warm-install.mjs
+++ b/scripts/e2e/codex-warm-install.mjs
@@ -1,0 +1,492 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { execFileSync, spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { createServer } from "node:http";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { parseArgs } from "node:util";
+import { parse } from "yaml";
+
+const { values } = parseArgs({
+  options: {
+    output: { type: "string" },
+    base: { type: "string", default: "ff0156fb8628cbf9f22d00864810dea56e83122b" },
+    repetitions: { type: "string", default: "5" },
+    help: { type: "boolean" },
+  },
+});
+if (values.help) {
+  console.log(
+    "node scripts/e2e/codex-warm-install.mjs --output /outside/repo/proof [--base SHA] [--repetitions 5]",
+  );
+  process.exit(0);
+}
+assert.equal(
+  process.platform,
+  "linux",
+  "Run only in the coordinator's isolated Linux proof environment",
+);
+assert.ok(Number(process.versions.node.split(".")[0]) >= 24);
+assert.ok(values.output, "--output is required");
+const repetitions = Number(values.repetitions);
+assert.ok(Number.isInteger(repetitions) && repetitions >= 2 && repetitions <= 20);
+const repo = process.cwd();
+const output = resolve(values.output);
+const outputRelative = relative(repo, output);
+assert.ok(
+  outputRelative.startsWith("../") || isAbsolute(outputRelative),
+  "Evidence must be outside the checkout",
+);
+mkdirSync(output, { recursive: true });
+const root = mkdtempSync(join(tmpdir(), "codex-warm-proof-"));
+const actionRelative = ".github/actions/setup-codex/action.yml";
+const actionPath = join(repo, dirname(actionRelative));
+const after = parse(readFileSync(actionRelative, "utf8"));
+const before = parse(
+  execFileSync("git", ["show", `${values.base}:${actionRelative}`], { encoding: "utf8" }),
+);
+const version = after.inputs["codex-version"].default;
+const proxyVersion = after.inputs["proxy-version"].default;
+assert.equal(before.inputs["codex-version"].default, version);
+assert.equal(before.inputs["proxy-version"].default, proxyVersion);
+const realNpm = realpathSync(execFileSync("which", ["npm"], { encoding: "utf8" }).trim());
+const tools = join(root, "tools");
+mkdirSync(tools);
+mkdirSync(join(root, "downloads"));
+writeFileSync(
+  join(tools, "npm"),
+  `#!${process.execPath}
+const fs = require("node:fs");
+const { spawnSync } = require("node:child_process");
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.PROOF_NPM_TRACE, JSON.stringify(args) + "\\n");
+if (args[0] === "install") {
+  for (const key of ["OPENAI_API_KEY", "CODEX_API_KEY", "PROXY_API_KEY", "CLAWSWEEPER_INTERNAL_MODEL", "CLAWSWEEPER_CLAWROUTER_CONFIG"]) {
+    if (process.env[key]) process.exit(87);
+  }
+}
+const result = spawnSync(${JSON.stringify(process.execPath)}, [${JSON.stringify(realNpm)}, ...args], { stdio: "inherit" });
+if (args[0] === "install" && result.status === 0 && process.env.PROOF_CORRUPT_AFTER_INSTALL) {
+  fs.writeFileSync(process.env.PROOF_CORRUPT_AFTER_INSTALL, "invalid JavaScript");
+}
+process.exit(result.status ?? 1);
+`,
+  { mode: 0o755 },
+);
+
+const denied = [];
+const deny = createServer((request, response) => {
+  denied.push({ method: request.method, path: request.url });
+  response.writeHead(503);
+  response.end("registry deliberately denied\n");
+});
+await new Promise((ready) => deny.listen(0, "127.0.0.1", ready));
+const registry = `http://127.0.0.1:${deny.address().port}/`;
+const records = [];
+const timings = [];
+const files = [
+  actionRelative,
+  ".github/actions/setup-codex/validate-install.mjs",
+  "test/setup-codex-action.test.ts",
+  "scripts/e2e/codex-warm-install.mjs",
+];
+const sourceHashes = Object.fromEntries(
+  files.map((path) => [path, createHash("sha256").update(readFileSync(path)).digest("hex")]),
+);
+function scrub(value) {
+  return value
+    .replaceAll(root, "$FIXTURE")
+    .replaceAll(repo, "$CHECKOUT")
+    .replaceAll(dirname(realNpm), "$NPM")
+    .replaceAll(dirname(process.execPath), "$NODE");
+}
+function makeHome(label, copy) {
+  const home = join(root, label);
+  mkdirSync(home);
+  symlinkSync(join(root, "downloads"), join(home, ".npm"));
+  if (copy)
+    cpSync(join(copy, ".clawsweeper-repair"), join(home, ".clawsweeper-repair"), {
+      recursive: true,
+      verbatimSymlinks: true,
+    });
+  return home;
+}
+function environment(home, offline = false) {
+  const selectedRegistry = offline ? registry : "https://registry.npmjs.org/";
+  writeFileSync(
+    join(home, ".npmrc"),
+    `registry=${selectedRegistry}\n@openai:registry=${selectedRegistry}\n`,
+  );
+  return {
+    HOME: home,
+    PATH: `${tools}:${dirname(process.execPath)}:/usr/local/bin:/usr/bin:/bin`,
+    GITHUB_PATH: join(home, "github-path"),
+    PROOF_NPM_TRACE: join(home, "npm-trace.jsonl"),
+    npm_config_userconfig: join(home, ".npmrc"),
+    npm_config_globalconfig: join(root, "empty-npmrc"),
+    npm_config_registry: selectedRegistry,
+    npm_config_fetch_retries: "0",
+    npm_config_fetch_timeout: "15000",
+    OPENAI_API_KEY: "fixture-only",
+    CODEX_API_KEY: "fixture-only",
+    PROXY_API_KEY: "fixture-only",
+    CLAWSWEEPER_INTERNAL_MODEL: "fixture-only",
+    CLAWSWEEPER_CLAWROUTER_CONFIG: "fixture-only",
+  };
+}
+function killGroup(pid) {
+  if (!pid) return;
+  try {
+    process.kill(-pid, "SIGKILL");
+  } catch (error) {
+    if (error.code !== "ESRCH") throw error;
+  }
+}
+function run(command, args, env, timeout = 120_000) {
+  const started = performance.now();
+  return new Promise((done, reject) => {
+    const child = spawn(command, args, {
+      cwd: repo,
+      env,
+      detached: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let text = "";
+    let failed = false;
+    let stopped = false;
+    const kill = () => {
+      if (stopped) return;
+      stopped = true;
+      killGroup(child.pid);
+    };
+    const timer = setTimeout(() => {
+      failed = true;
+      kill();
+    }, timeout);
+    for (const stream of [child.stdout, child.stderr])
+      stream.on("data", (chunk) => {
+        if (text.length + chunk.length > 1024 * 1024) {
+          failed = true;
+          kill();
+        } else text += chunk.toString();
+      });
+    child.on("error", () => {
+      failed = true;
+    });
+    child.on("close", (status) => {
+      clearTimeout(timer);
+      kill();
+      if (failed) reject(new Error("proof child failed, exceeded output bound, or timed out"));
+      else done({ status, elapsedMs: performance.now() - started, output: scrub(text) });
+    });
+  });
+}
+function render(action, mode) {
+  const step = action.runs.steps.find((entry) => entry.name === "Install Codex CLI");
+  return step.run.replace(/\$\{\{\s*([^}]+?)\s*\}\}/g, (_, expression) => {
+    if (expression === "github.action_path") return actionPath;
+    const key = /^inputs\['([^']+)'\]$/.exec(expression)?.[1];
+    if (key === "auth-mode") return mode;
+    assert.ok(key && action.inputs[key], `unexpected expression ${expression}`);
+    return action.inputs[key].default;
+  });
+}
+async function install(
+  label,
+  home,
+  { action = after, mode = "proxy", offline = false, expected = 0, corruptAfterInstall } = {},
+) {
+  const trace = join(home, "npm-trace.jsonl");
+  writeFileSync(trace, "");
+  denied.length = 0;
+  const env = environment(home, offline);
+  if (corruptAfterInstall) env.PROOF_CORRUPT_AFTER_INSTALL = corruptAfterInstall;
+  const result = await run("bash", ["-c", render(action, mode)], env);
+  const calls = readFileSync(trace, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+  const record = {
+    label,
+    mode,
+    offline,
+    ...result,
+    calls: calls.map((args) => args.map(scrub)),
+    deniedRequests: [...denied],
+  };
+  records.push(record);
+  writeFileSync(join(output, `${label}.json`), `${JSON.stringify(record, null, 2)}\n`);
+  assert.equal(result.status, expected, `${label}: ${result.output}`);
+  return record;
+}
+function installs(record) {
+  return record.calls
+    .filter((args) => args[0] === "install")
+    .map((args) => {
+      assert.deepEqual(args.slice(3), [
+        "--prefer-online",
+        "--no-audit",
+        "--no-fund",
+        "--ignore-scripts",
+      ]);
+      return args[2];
+    });
+}
+function paths(home, name = "codex") {
+  const prefix = join(home, ".clawsweeper-repair/codex");
+  const pkg = join(prefix, "lib/node_modules/@openai", name);
+  const launcher = join(pkg, "bin", `${name}.js`);
+  const nativeRoot =
+    name === "codex"
+      ? dirname(createRequire(launcher).resolve(`@openai/codex-linux-${process.arch}/package.json`))
+      : pkg;
+  const triple = `${process.arch === "arm64" ? "aarch64" : "x86_64"}-unknown-linux-musl`;
+  return {
+    prefix,
+    pkg,
+    launcher,
+    nativeRoot,
+    native: join(nativeRoot, "vendor", triple, name === "codex" ? "bin" : name, name),
+  };
+}
+async function proxyLifecycle(home) {
+  const info = join(home, "server-info.json");
+  const child = spawn(
+    join(paths(home, "codex-responses-api-proxy").prefix, "bin/codex-responses-api-proxy"),
+    ["--http-shutdown", "--server-info", info, "--upstream-url", registry],
+    {
+      cwd: home,
+      env: { HOME: home, PATH: `${dirname(process.execPath)}:/usr/bin:/bin` },
+      detached: true,
+      stdio: ["pipe", "ignore", "ignore"],
+    },
+  );
+  const exited = new Promise((done, reject) => {
+    child.once("error", reject);
+    child.once("close", done);
+  });
+  child.stdin.end("fixture-only\n");
+  try {
+    for (let index = 0; index < 100 && !existsSync(info); index++) {
+      assert.equal(child.exitCode, null, "proxy exited before startup");
+      await delay(50);
+    }
+    assert.ok(existsSync(info), "proxy did not start");
+    const { port } = JSON.parse(readFileSync(info, "utf8"));
+    assert.ok(Number.isInteger(port) && port > 0);
+    denied.length = 0;
+    const response = await fetch(`http://127.0.0.1:${port}/shutdown`, {
+      signal: AbortSignal.timeout(5_000),
+    });
+    assert.equal(response.status, 200);
+    const status = await Promise.race([exited, delay(5_000).then(() => "timeout")]);
+    assert.equal(status, 0);
+    assert.equal(denied.length, 0);
+    return { startup: true, shutdownStatus: response.status, exitStatus: status, modelRequests: 0 };
+  } finally {
+    killGroup(child.pid);
+    await exited;
+  }
+}
+
+let passed = false;
+let lifecycle;
+let packageIdentity;
+try {
+  const cold = makeHome("cold");
+  assert.deepEqual(installs(await install("cold", cold)), [
+    `@openai/codex@${version}`,
+    `@openai/codex-responses-api-proxy@${proxyVersion}`,
+  ]);
+  packageIdentity = {
+    codex: JSON.parse(readFileSync(join(paths(cold).pkg, "package.json"), "utf8")).version,
+    alias: JSON.parse(readFileSync(join(paths(cold).nativeRoot, "package.json"), "utf8")).version,
+    proxy: JSON.parse(
+      readFileSync(join(paths(cold, "codex-responses-api-proxy").pkg, "package.json"), "utf8"),
+    ).version,
+  };
+  const control = makeHome("deny-control");
+  const refused = await run(
+    "npm",
+    ["view", `@openai/codex@${version}`, "version"],
+    environment(control, true),
+  );
+  assert.notEqual(refused.status, 0);
+  assert.ok(denied.length > 0, "registry deny must reject a real npm request");
+  writeFileSync(
+    join(output, "registry-deny-control.json"),
+    JSON.stringify({ ...refused, requests: [...denied] }, null, 2),
+  );
+  const warm = makeHome("warm", cold);
+  const warmResult = await install("warm-offline", warm, { offline: true });
+  assert.deepEqual(warmResult.calls, []);
+  assert.deepEqual(warmResult.deniedRequests, []);
+  for (const mutation of ["shadowed-malformed-alias", "unused-vendor-escape"]) {
+    const home = makeHome(mutation, cold);
+    const item = paths(home);
+    const alias = `@openai/codex-linux-${process.arch}`;
+    const nested = join(item.pkg, "node_modules", alias);
+    if (item.nativeRoot !== nested) {
+      mkdirSync(dirname(nested), { recursive: true });
+      cpSync(item.nativeRoot, nested, { recursive: true });
+    }
+    if (mutation === "shadowed-malformed-alias") {
+      const shadowed = join(item.prefix, "lib/node_modules", alias);
+      mkdirSync(shadowed, { recursive: true });
+      writeFileSync(join(shadowed, "package.json"), "{");
+    } else {
+      symlinkSync(join(home, "outside-missing"), join(item.pkg, "vendor"));
+    }
+    const record = await install(mutation, home, { offline: true });
+    assert.deepEqual(record.calls, []);
+    assert.deepEqual(record.deniedRequests, []);
+    rmSync(home, { recursive: true });
+  }
+  const old = await install("before-offline-control", makeHome("old", cold), {
+    action: before,
+    offline: true,
+    expected: 1,
+  });
+  assert.ok(installs(old).length > 0);
+  assert.ok(old.deniedRequests.length > 0);
+  lifecycle = await proxyLifecycle(warm);
+
+  const repairs = [
+    "partial",
+    "self-linked-alias",
+    "corrupt-metadata",
+    "wrong-version",
+    "missing-native",
+    "broken-launcher",
+    "broken-shebang",
+    "non-executable",
+  ].map((mutation) => ({ mutation, name: "codex", label: mutation }));
+  for (const mutation of ["missing-native", "wrong-version"])
+    repairs.push({ mutation, name: "codex-responses-api-proxy", label: `proxy-${mutation}` });
+  for (const { mutation, name, label } of repairs) {
+    const home = makeHome(label, cold);
+    const item = paths(home, name);
+    if (mutation === "partial") rmSync(item.nativeRoot, { recursive: true });
+    if (mutation === "self-linked-alias") {
+      renameSync(join(item.nativeRoot, "vendor"), join(item.pkg, "vendor"));
+      rmSync(item.nativeRoot, { recursive: true });
+      symlinkSync(relative(dirname(item.nativeRoot), item.pkg), item.nativeRoot);
+    }
+    if (mutation === "corrupt-metadata") writeFileSync(join(item.pkg, "package.json"), "{");
+    if (mutation === "wrong-version") {
+      const manifest = join(item.pkg, "package.json");
+      const data = JSON.parse(readFileSync(manifest, "utf8"));
+      writeFileSync(manifest, JSON.stringify({ ...data, version: "0.0.1" }));
+    }
+    if (mutation === "missing-native") rmSync(item.native);
+    if (mutation === "broken-launcher") writeFileSync(item.launcher, "invalid JavaScript");
+    if (mutation === "broken-shebang")
+      writeFileSync(
+        item.launcher,
+        readFileSync(item.launcher, "utf8").replace("#!/usr/bin/env node", "#!/nonexistent/node"),
+      );
+    if (mutation === "non-executable") chmodSync(item.native, 0o644);
+    assert.deepEqual(installs(await install(label, home)), [
+      `@openai/${name}@${name === "codex" ? version : proxyVersion}`,
+    ]);
+    rmSync(home, { recursive: true });
+  }
+  const login = makeHome("login");
+  assert.deepEqual(installs(await install("login-cold", login, { mode: "login" })), [
+    `@openai/codex@${version}`,
+  ]);
+  for (const mode of ["login", "clawrouter"]) {
+    const record = await install(`${mode}-offline`, login, { mode, offline: true });
+    assert.deepEqual(record.calls, []);
+    assert.deepEqual(record.deniedRequests, []);
+  }
+  assert.deepEqual(installs(await install("login-to-proxy", login)), [
+    `@openai/codex-responses-api-proxy@${proxyVersion}`,
+  ]);
+  const persistent = makeHome("persistent-invalid", cold);
+  const persistentPaths = paths(persistent);
+  rmSync(persistentPaths.native);
+  const stillBroken = await install("persistent-invalid", persistent, {
+    expected: 1,
+    corruptAfterInstall: persistentPaths.launcher,
+  });
+  assert.deepEqual(installs(stillBroken), [`@openai/codex@${version}`]);
+
+  const escape = makeHome("escape", cold);
+  const escapedNative = paths(escape).native;
+  rmSync(escapedNative);
+  const external = join(root, "outside-native");
+  const marker = join(root, "executed-unsafe");
+  writeFileSync(external, `#!/bin/sh\ntouch "${marker}"\nexit 0\n`, { mode: 0o755 });
+  symlinkSync(external, escapedNative);
+  const unsafe = await install("unsafe-escape", escape, { expected: 2 });
+  assert.deepEqual(unsafe.calls, []);
+  assert.equal(existsSync(marker), false);
+  assert.ok(existsSync(external));
+
+  for (let index = 0; index < repetitions; index++) {
+    const order = index % 2 === 0 ? ["before", "after"] : ["after", "before"];
+    for (const variant of order) {
+      const home = makeHome(`timing-${index}-${variant}`, cold);
+      const result = await install(`timing-${index}-${variant}`, home, {
+        action: variant === "before" ? before : after,
+      });
+      assert.equal(installs(result).length, variant === "before" ? 2 : 0);
+      timings.push({ pair: index, variant, elapsedMs: result.elapsedMs });
+      rmSync(home, { recursive: true });
+    }
+  }
+  passed = true;
+} finally {
+  const means = Object.fromEntries(
+    ["before", "after"].map((variant) => {
+      const samples = timings
+        .filter((entry) => entry.variant === variant)
+        .map((entry) => entry.elapsedMs);
+      return [
+        variant,
+        samples.length ? samples.reduce((sum, value) => sum + value, 0) / samples.length : null,
+      ];
+    }),
+  );
+  const summary = {
+    passed,
+    base: values.base,
+    head: execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim(),
+    sourceHashes,
+    node: process.version,
+    platform: process.platform,
+    arch: process.arch,
+    pins: { codex: version, proxy: proxyVersion },
+    packageIdentity,
+    lifecycle,
+    scenarios: records.map(({ label, status }) => ({ label, status })),
+    timings,
+    means,
+    measuredNetImprovementMs: passed ? means.before - means.after : null,
+    limits:
+      "Actual pinned npm packages and extracted install shell in isolated HOME/prefix; full-block alternating timings include validation. The persistent-invalid case injects launcher corruption after a real successful npm install. Loopback denies the configured registry, not arbitrary process egress. No real credentials, model calls, hosted cache restore, scanner bootstrap, or live job mutation. No Bay contracts change. Separate focused test executes unchanged sandbox-failure propagation.",
+  };
+  writeFileSync(join(output, "summary.json"), `${JSON.stringify(summary, null, 2)}\n`);
+  deny.closeAllConnections();
+  await new Promise((done) => deny.close(done));
+  rmSync(root, { recursive: true, force: true });
+}
+console.log(JSON.stringify({ passed, output }, null, 2));

--- a/scripts/e2e/codex-warm-install.mjs
+++ b/scripts/e2e/codex-warm-install.mjs
@@ -137,6 +137,7 @@ function environment(home, offline = false) {
     HOME: home,
     PATH: `${tools}:${dirname(process.execPath)}:/usr/local/bin:/usr/bin:/bin`,
     GITHUB_PATH: join(home, "github-path"),
+    GITHUB_ACTION_PATH: actionPath,
     PROOF_NPM_TRACE: join(home, "npm-trace.jsonl"),
     npm_config_userconfig: join(home, ".npmrc"),
     npm_config_globalconfig: join(root, "empty-npmrc"),
@@ -200,7 +201,6 @@ function run(command, args, env, timeout = 120_000) {
 function render(action, mode) {
   const step = action.runs.steps.find((entry) => entry.name === "Install Codex CLI");
   return step.run.replace(/\$\{\{\s*([^}]+?)\s*\}\}/g, (_, expression) => {
-    if (expression === "github.action_path") return actionPath;
     const key = /^inputs\['([^']+)'\]$/.exec(expression)?.[1];
     if (key === "auth-mode") return mode;
     assert.ok(key && action.inputs[key], `unexpected expression ${expression}`);
@@ -338,6 +338,36 @@ try {
   const warmResult = await install("warm-offline", warm, { offline: true });
   assert.deepEqual(warmResult.calls, []);
   assert.deepEqual(warmResult.deniedRequests, []);
+  const fallback = makeHome("outside-empty-link-fallback", cold);
+  const fallbackPaths = paths(fallback);
+  renameSync(join(fallbackPaths.nativeRoot, "vendor"), join(fallbackPaths.pkg, "vendor"));
+  rmSync(fallbackPaths.nativeRoot, { recursive: true });
+  const emptyDirectory = join(fallback, "empty-node-modules");
+  mkdirSync(emptyDirectory);
+  symlinkSync(emptyDirectory, join(fallback, "node_modules"));
+  const fallbackResolution = await run(
+    process.execPath,
+    [
+      "--input-type=module",
+      "-e",
+      `import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+assert.throws(() => createRequire(process.argv[1]).resolve(process.argv[2]), { code: "MODULE_NOT_FOUND" });`,
+      fallbackPaths.launcher,
+      `@openai/codex-linux-${process.arch}/package.json`,
+    ],
+    environment(fallback, true),
+    5_000,
+  );
+  assert.equal(fallbackResolution.status, 0, fallbackResolution.output);
+  const fallbackResult = await install("outside-empty-link-fallback", fallback, {
+    mode: "login",
+    offline: true,
+  });
+  assert.equal(fallbackResult.output.trim(), `codex-cli ${version}`);
+  assert.deepEqual(fallbackResult.calls, []);
+  assert.deepEqual(fallbackResult.deniedRequests, []);
+  rmSync(fallback, { recursive: true });
   for (const mutation of ["shadowed-malformed-alias", "unused-vendor-escape"]) {
     const home = makeHome(mutation, cold);
     const item = paths(home);
@@ -440,6 +470,37 @@ try {
   assert.deepEqual(unsafe.calls, []);
   assert.equal(existsSync(marker), false);
   assert.ok(existsSync(external));
+
+  for (const name of ["codex", "codex-responses-api-proxy"]) {
+    for (const variant of ["contained", "live-escape", "missing-escape"]) {
+      const label = `${name}-compound-${variant}`;
+      const home = makeHome(label, cold);
+      const item = paths(home, name);
+      const deep = join(item.prefix, "path-order-deep");
+      const flat = join(item.prefix, "path-order-flat");
+      const contained = variant === "contained";
+      const filename = `${name}-payload`;
+      const payload = join(contained ? item.prefix : dirname(item.prefix), filename);
+      const executed = join(home, "unexpected-payload");
+      const banner =
+        name === "codex" ? `codex-cli ${version}` : "Usage: codex-responses-api-proxy [OPTIONS]";
+      const decoy = `#!/bin/sh\ntouch ${JSON.stringify(executed)}\nprintf '%s\\n' ${JSON.stringify(banner)}\n`;
+      mkdirSync(deep);
+      mkdirSync(flat);
+      symlinkSync(contained ? flat : item.prefix, join(deep, "link"));
+      if (contained) renameSync(item.native, payload);
+      else rmSync(item.native);
+      if (variant === "live-escape") writeFileSync(payload, decoy, { mode: 0o755 });
+      writeFileSync(join(deep, filename), decoy, { mode: 0o755 });
+      symlinkSync(`${deep}/link/../${filename}`, item.native);
+      const record = await install(label, home, { offline: true, expected: contained ? 0 : 2 });
+      assert.deepEqual(record.calls, []);
+      assert.deepEqual(record.deniedRequests, []);
+      assert.equal(existsSync(executed), false);
+      assert.equal(existsSync(payload), variant !== "missing-escape");
+      rmSync(home, { recursive: true });
+    }
+  }
 
   for (let index = 0; index < repetitions; index++) {
     const order = index % 2 === 0 ? ["before", "after"] : ["after", "before"];

--- a/scripts/e2e/codex-warm-install.mjs
+++ b/scripts/e2e/codex-warm-install.mjs
@@ -367,6 +367,15 @@ assert.throws(() => createRequire(process.argv[1]).resolve(process.argv[2]), { c
   assert.equal(fallbackResult.output.trim(), `codex-cli ${version}`);
   assert.deepEqual(fallbackResult.calls, []);
   assert.deepEqual(fallbackResult.deniedRequests, []);
+  rmSync(join(fallback, "node_modules"));
+  writeFileSync(join(fallback, "node_modules"), "");
+  const outsideFile = await install("outside-file-refusal", fallback, {
+    mode: "login",
+    offline: true,
+    expected: 2,
+  });
+  assert.deepEqual(outsideFile.calls, []);
+  assert.deepEqual(outsideFile.deniedRequests, []);
   rmSync(fallback, { recursive: true });
   for (const mutation of ["shadowed-malformed-alias", "unused-vendor-escape"]) {
     const home = makeHome(mutation, cold);

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2286,15 +2286,12 @@ test("agent workflows install pinned CLI releases and keep runner models secret"
 
   assert.match(action, /codex-version:[\s\S]*default: "0\.153\.3"/);
   assert.match(action, /proxy-version:[\s\S]*default: "0\.139\.0"/);
-  assert.match(action, /@openai\/codex@\$\{\{ inputs\['codex-version'\] \}\}/);
-  assert.match(action, /@openai\/codex-responses-api-proxy@\$\{\{ inputs\['proxy-version'\] \}\}/);
   assert.doesNotMatch(action, /@latest/);
   assert.match(localCheck, /CLAWSWEEPER_LOCAL_CODEX_MODEL \?\? "gpt-5\.6-sol"/);
   assert.match(localCheck, /model_reasoning_effort="high"/);
   assert.doesNotMatch(localCheck, /CLAWSWEEPER_PREFER_WINDOWS_CODEX_APP/);
   assert.doesNotMatch(localCheck, /gpt-5\.5/);
   assert.match(action, /env -u OPENAI_API_KEY[\s\S]*-u CLAWSWEEPER_INTERNAL_MODEL/);
-  assert.equal(action.match(/--ignore-scripts/g)?.length, 2);
   assert.match(action, /runner\.os == 'Linux' && runner\.environment == 'github-hosted'/);
   assert.match(action, /kernel\.unprivileged_userns_clone=1/);
   assert.match(action, /kernel\.apparmor_restrict_unprivileged_userns=0/);

--- a/test/setup-codex-action.test.ts
+++ b/test/setup-codex-action.test.ts
@@ -1,15 +1,20 @@
 import assert from "node:assert/strict";
 import {
   existsSync,
+  chmodSync,
+  cpSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
   readdirSync,
+  realpathSync,
+  renameSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
 
@@ -66,10 +71,602 @@ test(
 );
 
 type CompositeAction = {
+  inputs: Record<string, { default: string }>;
   runs?: {
     steps?: Array<{ if?: string; name?: string; run?: string }>;
   };
 };
+
+const actionPath = resolve(".github/actions/setup-codex");
+const action = parse(readFileSync(join(actionPath, "action.yml"), "utf8")) as CompositeAction;
+const version = action.inputs["codex-version"].default;
+const proxyVersion = action.inputs["proxy-version"].default;
+const triple =
+  process.platform === "darwin"
+    ? `${process.arch === "arm64" ? "aarch64" : "x86_64"}-apple-darwin`
+    : `${process.arch === "arm64" ? "aarch64" : "x86_64"}-unknown-linux-musl`;
+
+function fixture(home: string, proxy = false) {
+  const name = proxy ? "codex-responses-api-proxy" : "codex";
+  const prefix = join(home, ".clawsweeper-repair/codex");
+  const pkg = join(prefix, "lib/node_modules/@openai", name);
+  const alias = `@openai/codex-${process.platform}-${process.arch}`;
+  const nativePackage = proxy ? pkg : join(pkg, "node_modules", alias);
+  const native = join(nativePackage, "vendor", triple, proxy ? name : "bin", name);
+  const launcher = join(pkg, "bin", `${name}.js`);
+  mkdirSync(dirname(native), { recursive: true });
+  mkdirSync(dirname(launcher), { recursive: true });
+  mkdirSync(join(prefix, "bin"), { recursive: true });
+  writeFileSync(
+    join(pkg, "package.json"),
+    JSON.stringify({
+      name: `@openai/${name}`,
+      version: proxy ? proxyVersion : version,
+      type: "module",
+      bin: { [name]: `bin/${name}.js` },
+      optionalDependencies: proxy
+        ? undefined
+        : { [alias]: `npm:@openai/codex@${version}-${process.platform}-${process.arch}` },
+    }),
+  );
+  if (!proxy)
+    writeFileSync(
+      join(nativePackage, "package.json"),
+      JSON.stringify({
+        name: "@openai/codex",
+        version: `${version}-${process.platform}-${process.arch}`,
+      }),
+    );
+  writeFileSync(
+    launcher,
+    `#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+let root = fileURLToPath(new URL("../", import.meta.url));
+if (${!proxy}) {
+  try {
+    root = dirname(createRequire(import.meta.url).resolve(${JSON.stringify(`${alias}/package.json`)}));
+  } catch {}
+}
+const native = join(root, "vendor", ${JSON.stringify(triple)}, ${JSON.stringify(proxy ? name : "bin")}, ${JSON.stringify(name)});
+const result = spawnSync(native, process.argv.slice(2), { stdio: "inherit" });
+process.exit(result.status ?? 1);
+`,
+    { mode: 0o755 },
+  );
+  writeFileSync(
+    native,
+    `#!/bin/sh
+test -z "\${OPENAI_API_KEY:-}\${CODEX_API_KEY:-}\${PROXY_API_KEY:-}\${CLAWSWEEPER_INTERNAL_MODEL:-}\${CLAWSWEEPER_CLAWROUTER_CONFIG:-}\${GITHUB_TOKEN:-}" || exit 87
+test "$1" = "${proxy ? "--help" : "--version"}" || exit 88
+echo "${proxy ? "Usage: codex-responses-api-proxy [OPTIONS]" : `codex-cli ${version}`}"
+`,
+    { mode: 0o755 },
+  );
+  symlinkSync(`../lib/node_modules/@openai/${name}/bin/${name}.js`, join(prefix, "bin", name));
+  return { pkg, native, launcher, nativePackage, prefix };
+}
+
+function installStep(home: string, mode: string, npmBody = "exit 89", source = action) {
+  const bin = join(home, "tools");
+  mkdirSync(bin, { recursive: true });
+  writeFileSync(
+    join(bin, "npm"),
+    `#!/bin/bash
+printf '%s\\n' "$*" >> "$HOME/npm-calls"
+if [ "$1" = "config" ]; then exit 0; fi
+test -z "\${OPENAI_API_KEY:-}\${CODEX_API_KEY:-}\${PROXY_API_KEY:-}\${CLAWSWEEPER_INTERNAL_MODEL:-}\${CLAWSWEEPER_CLAWROUTER_CONFIG:-}" || exit 87
+${npmBody}
+`,
+    { mode: 0o755 },
+  );
+  const script = source.runs?.steps?.find((step) => step.name === "Install Codex CLI")?.run;
+  assert.ok(script);
+  return spawnSync(
+    "/bin/bash",
+    [
+      "-c",
+      script.replace(/\$\{\{\s*([^}]+?)\s*\}\}/g, (_, key) => {
+        if (key === "github.action_path") return actionPath;
+        const input = /^inputs\['([^']+)'\]$/.exec(key)?.[1];
+        if (input === "auth-mode") return mode;
+        assert.ok(input && source.inputs[input], `unknown expression ${key}`);
+        return source.inputs[input].default;
+      }),
+    ],
+    {
+      encoding: "utf8",
+      timeout: 20_000,
+      env: {
+        HOME: home,
+        PATH: `${bin}:${dirname(process.execPath)}:/usr/bin:/bin`,
+        GITHUB_PATH: join(home, "github-path"),
+        OPENAI_API_KEY: "fixture-only",
+        CODEX_API_KEY: "fixture-only",
+        PROXY_API_KEY: "fixture-only",
+        CLAWSWEEPER_INTERNAL_MODEL: "fixture-only",
+        CLAWSWEEPER_CLAWROUTER_CONFIG: "fixture-only",
+        GITHUB_TOKEN: "fixture-only",
+      },
+    },
+  );
+}
+
+test(
+  "warm managed pins reuse working launchers without invoking npm",
+  { skip: process.platform === "win32" },
+  () => {
+    for (const mode of ["login", "clawrouter", "proxy"]) {
+      const home = mkdtempSync(join(tmpdir(), "codex-warm-test-"));
+      try {
+        fixture(home);
+        if (mode === "proxy") fixture(home, true);
+        const result = installStep(home, mode);
+        assert.equal(result.status, 0, result.stderr);
+        assert.match(result.stdout, new RegExp(`codex-cli ${version.replaceAll(".", "\\.")}`));
+        assert.equal(existsSync(join(home, "npm-calls")), false);
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    }
+  },
+);
+
+test(
+  "warm aliases ignore shadowed candidates and unused local vendor",
+  { skip: process.platform === "win32" },
+  () => {
+    for (const mutation of ["malformed", "fifo", "dangling escape", "outside", "unused vendor"]) {
+      const home = realpathSync(mkdtempSync(join(tmpdir(), "codex-shadowed-test-")));
+      try {
+        const { pkg, prefix } = fixture(home);
+        const alias = `@openai/codex-${process.platform}-${process.arch}`;
+        const shadowed = join(
+          mutation === "outside" ? home : join(prefix, "lib"),
+          "node_modules",
+          alias,
+        );
+        if (mutation === "unused vendor") {
+          symlinkSync(join(home, "outside-missing"), join(pkg, "vendor"));
+        } else {
+          mkdirSync(dirname(shadowed), { recursive: true });
+          if (mutation === "dangling escape") {
+            symlinkSync(join(home, "outside-missing"), shadowed);
+          } else {
+            mkdirSync(shadowed);
+            const manifest = join(shadowed, "package.json");
+            if (mutation === "fifo") assert.equal(spawnSync("mkfifo", [manifest]).status, 0);
+            else writeFileSync(manifest, "{");
+          }
+        }
+        const result = installStep(home, "login");
+        assert.equal(result.status, 0, `${mutation}: ${result.stderr}`);
+        assert.match(result.stdout, new RegExp(`codex-cli ${version.replaceAll(".", "\\.")}`));
+        assert.equal(existsSync(join(home, "npm-calls")), false, mutation);
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    }
+  },
+);
+
+test(
+  "present invalid aliases cannot be skipped for a healthy lower candidate",
+  { skip: process.platform === "win32" },
+  () => {
+    for (const mutation of [
+      "malformed",
+      "fifo",
+      "missing manifest",
+      "dangling manifest",
+      "dangling alias",
+      "dangling search directory",
+      "escaping search directory",
+      "escaping missing manifest",
+      "escaping manifest",
+      "escaping native",
+      "outside search directory",
+    ]) {
+      const home = realpathSync(mkdtempSync(join(tmpdir(), "codex-visited-test-")));
+      try {
+        const { pkg, nativePackage, native, prefix } = fixture(home);
+        const alias = `@openai/codex-${process.platform}-${process.arch}`;
+        const lower = join(prefix, "lib/node_modules", alias);
+        cpSync(nativePackage, lower, { recursive: true });
+        const marker = join(home, "native-executed");
+        for (const path of [native, join(lower, "vendor", triple, "bin/codex")])
+          writeFileSync(path, `${readFileSync(path, "utf8")}touch ${JSON.stringify(marker)}\n`);
+        const manifest = join(nativePackage, "package.json");
+        if (mutation === "malformed") writeFileSync(manifest, "{");
+        if (mutation === "fifo") {
+          rmSync(manifest);
+          assert.equal(spawnSync("mkfifo", [manifest]).status, 0);
+        }
+        if (mutation === "missing manifest") rmSync(manifest);
+        if (mutation === "dangling manifest" || mutation === "escaping manifest") {
+          rmSync(manifest);
+          symlinkSync(
+            join(mutation === "escaping manifest" ? home : prefix, "missing.json"),
+            manifest,
+          );
+        }
+        if (mutation === "dangling alias") {
+          rmSync(nativePackage, { recursive: true });
+          symlinkSync(join(prefix, "missing-alias"), nativePackage);
+        }
+        if (mutation === "escaping missing manifest") {
+          rmSync(nativePackage, { recursive: true });
+          const outside = join(home, "outside");
+          mkdirSync(outside);
+          symlinkSync(outside, nativePackage);
+        }
+        if (mutation.endsWith("search directory")) {
+          const directory =
+            mutation === "outside search directory"
+              ? join(home, "node_modules")
+              : join(pkg, "node_modules");
+          if (mutation === "outside search directory") {
+            renameSync(join(nativePackage, "vendor"), join(pkg, "vendor"));
+            rmSync(lower, { recursive: true });
+          }
+          rmSync(join(pkg, "node_modules"), { recursive: true });
+          symlinkSync(
+            join(mutation === "dangling search directory" ? prefix : home, "missing-search"),
+            directory,
+          );
+        }
+        if (mutation === "escaping native") {
+          rmSync(native);
+          symlinkSync(join(home, "outside-missing"), native);
+        }
+        const unsafe = mutation.startsWith("escaping") || mutation === "outside search directory";
+        if (unsafe) writeFileSync(join(pkg, "package.json"), "{");
+        const result = installStep(home, "login", "exit 0");
+        assert.equal(result.status, unsafe ? 2 : 1, `${mutation}: ${result.stderr}`);
+        assert.equal(existsSync(marker), false, mutation);
+        if (unsafe) {
+          assert.equal(existsSync(join(home, "npm-calls")), false, mutation);
+        } else {
+          const calls = readFileSync(join(home, "npm-calls"), "utf8").trim().split("\n");
+          assert.deepEqual(
+            calls.filter((line) => line.startsWith("install ")),
+            [
+              `install -g @openai/codex@${version} --prefer-online --no-audit --no-fund --ignore-scripts`,
+            ],
+            mutation,
+          );
+        }
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    }
+  },
+);
+
+test(
+  "invalid managed installs get one pinned repair and must pass revalidation",
+  { skip: process.platform === "win32" },
+  () => {
+    const mutations: Record<string, (paths: ReturnType<typeof fixture>) => void> = {
+      cold: ({ prefix }) => rmSync(prefix, { recursive: true }),
+      "invalid metadata": ({ pkg }) => writeFileSync(join(pkg, "package.json"), "{"),
+      "wrong identity": ({ pkg }) => {
+        const path = join(pkg, "package.json");
+        const data = JSON.parse(readFileSync(path, "utf8"));
+        data.name = "@example/codex";
+        writeFileSync(path, JSON.stringify(data));
+      },
+      "wrong version": ({ pkg }) => {
+        const path = join(pkg, "package.json");
+        const data = JSON.parse(readFileSync(path, "utf8"));
+        data.version = "0.0.1";
+        writeFileSync(path, JSON.stringify(data));
+      },
+      "wrong native version": ({ native }) =>
+        writeFileSync(native, "#!/bin/sh\necho 'codex-cli 0.0.1'\n"),
+      "missing native": ({ native }) => rmSync(native),
+      "non-executable native": ({ native }) => chmodSync(native, 0o644),
+      "broken launcher": ({ launcher }) => writeFileSync(launcher, "this is not JavaScript"),
+      "broken launcher shebang": ({ launcher }) =>
+        writeFileSync(
+          launcher,
+          readFileSync(launcher, "utf8").replace("#!/usr/bin/env node", "#!/nonexistent/node"),
+        ),
+      "wrong alias version": ({ nativePackage }) =>
+        writeFileSync(
+          join(nativePackage, "package.json"),
+          JSON.stringify({ name: "@openai/codex", version: `${version}-wrong-platform` }),
+        ),
+      "wrong launcher": ({ prefix }) => {
+        const path = join(prefix, "bin/codex");
+        rmSync(path);
+        writeFileSync(path, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+      },
+    };
+    for (const [label, mutate] of Object.entries(mutations)) {
+      const home = mkdtempSync(join(tmpdir(), "codex-repair-test-"));
+      const pristine = mkdtempSync(join(tmpdir(), "codex-pristine-test-"));
+      try {
+        const paths = fixture(home);
+        const source = fixture(pristine);
+        mutate(paths);
+        writeFileSync(
+          join(home, "repair.cjs"),
+          `
+const fs = require("node:fs");
+fs.rmSync(${JSON.stringify(paths.prefix)}, { recursive: true, force: true });
+fs.cpSync(${JSON.stringify(source.prefix)}, ${JSON.stringify(paths.prefix)}, { recursive: true, verbatimSymlinks: true });
+`,
+        );
+        const result = installStep(home, "login", `exec "${process.execPath}" "$HOME/repair.cjs"`);
+        assert.equal(result.status, 0, `${label}: ${result.stderr}`);
+        assert.ok(existsSync(join(home, "npm-calls")), `${label} must trigger repair`);
+        const calls = readFileSync(join(home, "npm-calls"), "utf8").trim().split("\n");
+        assert.deepEqual(
+          calls.filter((line) => line.startsWith("install ")),
+          [
+            `install -g @openai/codex@${version} --prefer-online --no-audit --no-fund --ignore-scripts`,
+          ],
+          label,
+        );
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+        rmSync(pristine, { recursive: true, force: true });
+      }
+    }
+  },
+);
+
+test(
+  "a successful npm exit cannot authorize a persistently broken installation",
+  { skip: process.platform === "win32" },
+  () => {
+    const home = mkdtempSync(join(tmpdir(), "codex-invalid-test-"));
+    try {
+      const { native } = fixture(home);
+      rmSync(native);
+      const result = installStep(home, "login", "exit 0");
+      assert.equal(result.status, 1, result.stderr);
+      assert.equal(
+        readFileSync(join(home, "npm-calls"), "utf8")
+          .split("\n")
+          .filter((line) => line.startsWith("install ")).length,
+        1,
+      );
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "proxy mode repairs only its missing proxy and never probes proxy --version",
+  { skip: process.platform === "win32" },
+  () => {
+    const home = mkdtempSync(join(tmpdir(), "codex-proxy-test-"));
+    const pristine = mkdtempSync(join(tmpdir(), "codex-proxy-pristine-"));
+    try {
+      fixture(home);
+      fixture(pristine);
+      const proxy = fixture(pristine, true);
+      cpSync(proxy.prefix, join(home, "proxy-restore"), {
+        recursive: true,
+        verbatimSymlinks: true,
+      });
+      writeFileSync(
+        join(home, "repair.cjs"),
+        `
+const fs = require("node:fs");
+const path = require("node:path");
+const prefix = path.join(process.env.HOME, ".clawsweeper-repair/codex");
+const name = "codex-responses-api-proxy";
+fs.cpSync(path.join(process.env.HOME, "proxy-restore/lib/node_modules/@openai", name), path.join(prefix, "lib/node_modules/@openai", name), { recursive: true });
+fs.symlinkSync("../lib/node_modules/@openai/" + name + "/bin/" + name + ".js", path.join(prefix, "bin", name));
+`,
+      );
+      const result = installStep(home, "proxy", `exec "${process.execPath}" "$HOME/repair.cjs"`);
+      assert.equal(result.status, 0, result.stderr);
+      assert.deepEqual(
+        readFileSync(join(home, "npm-calls"), "utf8")
+          .trim()
+          .split("\n")
+          .filter((line) => line.startsWith("install ")),
+        [
+          `install -g @openai/codex-responses-api-proxy@${proxyVersion} --prefer-online --no-audit --no-fund --ignore-scripts`,
+        ],
+      );
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+      rmSync(pristine, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "the launcher local-vendor fallback remains reusable",
+  { skip: process.platform === "win32" },
+  () => {
+    for (const aliasState of [
+      "valid",
+      "outside empty directory",
+      "missing",
+      "wrong",
+      "self-linked",
+    ]) {
+      const home = mkdtempSync(join(tmpdir(), "codex-vendor-test-"));
+      try {
+        const { pkg, nativePackage } = fixture(home);
+        renameSync(join(nativePackage, "vendor"), join(pkg, "vendor"));
+        rmSync(nativePackage, { recursive: true });
+        if (aliasState === "outside empty directory") mkdirSync(join(home, "node_modules"));
+        if (aliasState === "self-linked") symlinkSync("../..", nativePackage);
+        if (aliasState === "missing" || aliasState === "wrong") {
+          const manifest = join(pkg, "package.json");
+          const data = JSON.parse(readFileSync(manifest, "utf8"));
+          data.optionalDependencies =
+            aliasState === "missing"
+              ? {}
+              : {
+                  [`@openai/codex-${process.platform}-${process.arch}`]: "npm:@openai/codex@0.0.1",
+                };
+          writeFileSync(manifest, JSON.stringify(data));
+        }
+        const result = installStep(home, "login", "exit 0");
+        const valid = aliasState === "valid" || aliasState === "outside empty directory";
+        assert.equal(result.status, valid ? 0 : 1, result.stderr);
+        assert.equal(existsSync(join(home, "npm-calls")), !valid);
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    }
+  },
+);
+
+test(
+  "canonical launcher location owns native dependency resolution",
+  { skip: process.platform === "win32" },
+  () => {
+    for (const escaping of [false, true]) {
+      const home = realpathSync(mkdtempSync(join(tmpdir(), "codex-canonical-test-")));
+      try {
+        const { prefix, pkg } = fixture(home);
+        const alias = `@openai/codex-${process.platform}-${process.arch}`;
+        const relocated = join(prefix, "shared/codex");
+        mkdirSync(dirname(relocated), { recursive: true });
+        renameSync(pkg, relocated);
+        symlinkSync(relocated, pkg);
+        const hoisted = join(prefix, "lib/node_modules", alias);
+        renameSync(join(relocated, "node_modules", alias), hoisted);
+        const actual = join(prefix, "shared/node_modules", alias);
+        mkdirSync(dirname(actual), { recursive: true });
+        const payload = escaping ? join(home, "outside") : actual;
+        cpSync(hoisted, payload, { recursive: true });
+        writeFileSync(join(hoisted, "package.json"), "{");
+        if (escaping) symlinkSync(payload, actual);
+        const marker = join(home, "actual-native");
+        const native = join(payload, "vendor", triple, "bin/codex");
+        writeFileSync(native, `${readFileSync(native, "utf8")}touch ${JSON.stringify(marker)}\n`);
+        const result = installStep(home, "login");
+        assert.equal(result.status, escaping ? 2 : 0, result.stderr);
+        assert.equal(existsSync(marker), !escaping);
+        assert.equal(existsSync(join(home, "npm-calls")), false);
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    }
+  },
+);
+
+test(
+  "chained directory links cannot hide an escaping native target",
+  { skip: process.platform === "win32" },
+  () => {
+    for (const escaping of [false, true]) {
+      const home = realpathSync(mkdtempSync(join(tmpdir(), "codex-chain-test-")));
+      try {
+        const { native, prefix } = fixture(home);
+        const bytes = readFileSync(native);
+        rmSync(dirname(native), { recursive: true });
+        mkdirSync(join(prefix, "deep"));
+        mkdirSync(join(prefix, "flat"));
+        symlinkSync("../flat", join(prefix, "deep/link"));
+        symlinkSync(join(prefix, "deep/link"), dirname(native));
+        const target = join(escaping ? dirname(prefix) : prefix, "payload");
+        writeFileSync(target, bytes, { mode: 0o755 });
+        symlinkSync(escaping ? "../../payload" : "../payload", join(prefix, "flat/codex"));
+        const result = installStep(home, "login");
+        assert.equal(result.status, escaping ? 2 : 0, result.stderr);
+        assert.equal(existsSync(join(home, "npm-calls")), false);
+        assert.ok(existsSync(target));
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    }
+  },
+);
+
+test(
+  "non-regular package metadata fails before Node resolution can block",
+  { skip: process.platform === "win32" },
+  () => {
+    for (const field of ["pkg", "nativePackage"] as const) {
+      const home = mkdtempSync(join(tmpdir(), "codex-metadata-test-"));
+      try {
+        const paths = fixture(home);
+        const manifest = join(paths[field], "package.json");
+        rmSync(manifest);
+        assert.equal(spawnSync("mkfifo", [manifest]).status, 0);
+        const result = spawnSync(
+          process.execPath,
+          [join(actionPath, "validate-install.mjs"), "codex", version],
+          {
+            env: { HOME: home, PATH: "/usr/bin:/bin" },
+            encoding: "utf8",
+            timeout: 5_000,
+          },
+        );
+        assert.equal(result.status, 1, result.stderr);
+        assert.match(result.stderr, /missing, mismatched, or unusable/);
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    }
+  },
+);
+
+test(
+  "escaping managed paths refuse execution and automatic repair even with mismatched metadata",
+  { skip: process.platform === "win32" },
+  () => {
+    for (const field of ["native", "launcher", "pkg", "nativePackage", "prefix"] as const) {
+      const home = mkdtempSync(join(tmpdir(), "codex-escape-test-"));
+      try {
+        const paths = fixture(home);
+        writeFileSync(join(paths.pkg, "package.json"), '{"name":"wrong"}');
+        rmSync(paths[field], { recursive: true, force: true });
+        symlinkSync(join(home, "outside-missing"), paths[field]);
+        const result = installStep(home, "login");
+        assert.equal(result.status, 2, `${field}: ${result.stderr}`);
+        assert.match(result.stderr, /Unsafe managed/);
+        assert.equal(existsSync(join(home, "npm-calls")), false);
+        assert.equal(existsSync(join(home, "outside-missing")), false);
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    }
+  },
+);
+
+test(
+  "native probes bound hangs and excessive output",
+  { skip: process.platform === "win32" },
+  () => {
+    for (const body of ["sleep 60", "yes overflow"]) {
+      const home = mkdtempSync(join(tmpdir(), "codex-bounded-test-"));
+      try {
+        const { native } = fixture(home);
+        writeFileSync(native, `#!/bin/sh\n${body}\n`);
+        const started = Date.now();
+        const result = spawnSync(
+          process.execPath,
+          [join(actionPath, "validate-install.mjs"), "codex", version],
+          {
+            env: { HOME: home, PATH: "/usr/bin:/bin" },
+            timeout: 10_000,
+            encoding: "utf8",
+          },
+        );
+        assert.equal(result.status, 1, result.stderr);
+        assert.ok(Date.now() - started < 9_000);
+        assert.ok(result.stderr.length < 200);
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    }
+  },
+);
 
 test(
   "hosted Linux sandbox preflight propagates Codex startup failures",

--- a/test/setup-codex-action.test.ts
+++ b/test/setup-codex-action.test.ts
@@ -14,7 +14,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
 
@@ -149,7 +149,13 @@ echo "${proxy ? "Usage: codex-responses-api-proxy [OPTIONS]" : `codex-cli ${vers
   return { pkg, native, launcher, nativePackage, prefix };
 }
 
-function installStep(home: string, mode: string, npmBody = "exit 89", source = action) {
+function installStep(
+  home: string,
+  mode: string,
+  npmBody = "exit 89",
+  source = action,
+  sourcePath = actionPath,
+) {
   const bin = join(home, "tools");
   mkdirSync(bin, { recursive: true });
   writeFileSync(
@@ -169,7 +175,6 @@ ${npmBody}
     [
       "-c",
       script.replace(/\$\{\{\s*([^}]+?)\s*\}\}/g, (_, key) => {
-        if (key === "github.action_path") return actionPath;
         const input = /^inputs\['([^']+)'\]$/.exec(key)?.[1];
         if (input === "auth-mode") return mode;
         assert.ok(input && source.inputs[input], `unknown expression ${key}`);
@@ -183,6 +188,7 @@ ${npmBody}
         HOME: home,
         PATH: `${bin}:${dirname(process.execPath)}:/usr/bin:/bin`,
         GITHUB_PATH: join(home, "github-path"),
+        GITHUB_ACTION_PATH: sourcePath,
         OPENAI_API_KEY: "fixture-only",
         CODEX_API_KEY: "fixture-only",
         PROXY_API_KEY: "fixture-only",
@@ -193,6 +199,77 @@ ${npmBody}
     },
   );
 }
+
+test(
+  "install step preserves literal action paths in validator arguments",
+  { skip: process.platform === "win32" },
+  () => {
+    const home = mkdtempSync(join(tmpdir(), "codex-action-path-test-"));
+    try {
+      const bin = join(home, "tools");
+      const trace = join(home, "node-argv");
+      const marker = join(home, "marker");
+      mkdirSync(bin);
+      for (const folder of [
+        "checkout with spaces",
+        `checkout$(touch "${marker}")`,
+        "checkout \"double\" 'single'",
+      ]) {
+        for (const repair of [false, true]) {
+          const sourcePath = join(home, folder, ".github/actions/setup-codex");
+          const label = `${folder}, repair=${repair}`;
+          writeFileSync(trace, "");
+          rmSync(join(home, "npm-calls"), { force: true });
+          writeFileSync(
+            join(bin, "node"),
+            `#!${process.execPath}
+const fs = require("node:fs");
+const trace = process.env.HOME + "/node-argv";
+const args = process.argv.slice(2);
+const calls = fs.readFileSync(trace, "utf8").trim().split("\\n").filter(Boolean).map((line) => JSON.parse(line));
+fs.appendFileSync(trace, JSON.stringify(args) + "\\n");
+if (${repair} && !calls.some((call) => call[1] === args[1])) process.exit(1);
+`,
+            { mode: 0o755 },
+          );
+          const result = installStep(home, "proxy", "exit 0", action, sourcePath);
+          assert.equal(result.status, 0, `${label}: ${result.stderr}`);
+          assert.equal(existsSync(marker), false, label);
+          const codexArgs = [join(sourcePath, "validate-install.mjs"), "codex", version];
+          const proxyArgs = [
+            join(sourcePath, "validate-install.mjs"),
+            "codex-responses-api-proxy",
+            proxyVersion,
+          ];
+          assert.deepEqual(
+            readFileSync(trace, "utf8")
+              .trim()
+              .split("\n")
+              .map((line) => JSON.parse(line)),
+            repair ? [codexArgs, codexArgs, proxyArgs, proxyArgs] : [codexArgs, proxyArgs],
+            label,
+          );
+          assert.deepEqual(
+            existsSync(join(home, "npm-calls"))
+              ? readFileSync(join(home, "npm-calls"), "utf8").trim().split("\n")
+              : [],
+            repair
+              ? [
+                  `config set prefix ${join(home, ".clawsweeper-repair/codex")}`,
+                  `config set cache ${join(home, ".npm")}`,
+                  `install -g @openai/codex@${version} --prefer-online --no-audit --no-fund --ignore-scripts`,
+                  `install -g @openai/codex-responses-api-proxy@${proxyVersion} --prefer-online --no-audit --no-fund --ignore-scripts`,
+                ]
+              : [],
+            label,
+          );
+        }
+      }
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  },
+);
 
 test(
   "warm managed pins reuse working launchers without invoking npm",
@@ -491,16 +568,38 @@ test(
     for (const aliasState of [
       "valid",
       "outside empty directory",
+      "outside empty directory link",
+      "outside alias directory",
+      "outside alias directory link",
+      "outside non-directory link",
       "missing",
       "wrong",
       "self-linked",
     ]) {
       const home = mkdtempSync(join(tmpdir(), "codex-vendor-test-"));
       try {
-        const { pkg, nativePackage } = fixture(home);
+        const { pkg, nativePackage, native } = fixture(home);
+        const trace = join(home, "native-trace");
+        const bytes = readFileSync(native, "utf8");
+        writeFileSync(native, `${bytes}printf 'local-vendor\\n' >> ${JSON.stringify(trace)}\n`);
+        if (aliasState.startsWith("outside")) {
+          const linked = aliasState.endsWith("link");
+          const directory = join(home, linked ? "shared-node-modules" : "node_modules");
+          if (aliasState === "outside non-directory link") writeFileSync(directory, "");
+          else mkdirSync(directory);
+          if (aliasState.startsWith("outside alias")) {
+            const outside = join(directory, `@openai/codex-${process.platform}-${process.arch}`);
+            mkdirSync(dirname(outside));
+            cpSync(nativePackage, outside, { recursive: true });
+            writeFileSync(
+              join(outside, "vendor", triple, "bin/codex"),
+              `${bytes}printf 'outside-alias\\n' >> ${JSON.stringify(trace)}\n`,
+            );
+          }
+          if (linked) symlinkSync(directory, join(home, "node_modules"));
+        }
         renameSync(join(nativePackage, "vendor"), join(pkg, "vendor"));
         rmSync(nativePackage, { recursive: true });
-        if (aliasState === "outside empty directory") mkdirSync(join(home, "node_modules"));
         if (aliasState === "self-linked") symlinkSync("../..", nativePackage);
         if (aliasState === "missing" || aliasState === "wrong") {
           const manifest = join(pkg, "package.json");
@@ -514,9 +613,15 @@ test(
           writeFileSync(manifest, JSON.stringify(data));
         }
         const result = installStep(home, "login", "exit 0");
-        const valid = aliasState === "valid" || aliasState === "outside empty directory";
-        assert.equal(result.status, valid ? 0 : 1, result.stderr);
-        assert.equal(existsSync(join(home, "npm-calls")), !valid);
+        const valid = aliasState === "valid" || aliasState.startsWith("outside empty directory");
+        const status = valid ? 0 : aliasState.startsWith("outside") ? 2 : 1;
+        assert.equal(result.status, status, `${aliasState}: ${result.stderr}`);
+        assert.deepEqual(
+          existsSync(trace) ? readFileSync(trace, "utf8").trim().split("\n") : [],
+          valid ? ["local-vendor", "local-vendor"] : [],
+          aliasState,
+        );
+        assert.equal(existsSync(join(home, "npm-calls")), status === 1, aliasState);
       } finally {
         rmSync(home, { recursive: true, force: true });
       }
@@ -563,23 +668,121 @@ test(
   "chained directory links cannot hide an escaping native target",
   { skip: process.platform === "win32" },
   () => {
-    for (const escaping of [false, true]) {
+    const cases = [
+      { variant: "chained-contained", proxy: false, absolute: true, status: 0 },
+      { variant: "chained-escape", proxy: false, absolute: true, status: 2 },
+    ];
+    for (const proxy of [false, true])
+      for (const absolute of [false, true])
+        for (const variant of ["compound-contained", "compound-live", "compound-missing"])
+          cases.push({
+            variant,
+            proxy,
+            absolute,
+            status: variant === "compound-contained" ? 0 : 2,
+          });
+    for (const [variant, status] of [
+      ["missing-parent", 1],
+      ["missing-caller", 1],
+      ["missing-escape", 2],
+      ["missing-manifest-escape", 2],
+      ["file-parent", 1],
+      ["file-dot", 1],
+      ["file-slash", 1],
+      ["directory-suffix", 0],
+      ["depth-32", 0],
+      ["depth-33", 2],
+    ] as const)
+      cases.push({ variant, proxy: false, absolute: true, status });
+    for (const { variant, proxy, absolute, status } of cases) {
       const home = realpathSync(mkdtempSync(join(tmpdir(), "codex-chain-test-")));
       try {
-        const { native, prefix } = fixture(home);
-        const bytes = readFileSync(native);
-        rmSync(dirname(native), { recursive: true });
+        if (proxy) fixture(home);
+        const { native, prefix, pkg } = fixture(home, proxy);
+        const bytes = readFileSync(native, "utf8");
+        const trace = join(home, "payload-trace");
+        const payload = (path: string, label: string) =>
+          writeFileSync(path, `${bytes}printf '${label}\\n' >> ${JSON.stringify(trace)}\n`, {
+            mode: 0o755,
+          });
         mkdirSync(join(prefix, "deep"));
         mkdirSync(join(prefix, "flat"));
-        symlinkSync("../flat", join(prefix, "deep/link"));
-        symlinkSync(join(prefix, "deep/link"), dirname(native));
-        const target = join(escaping ? dirname(prefix) : prefix, "payload");
-        writeFileSync(target, bytes, { mode: 0o755 });
-        symlinkSync(escaping ? "../../payload" : "../payload", join(prefix, "flat/codex"));
-        const result = installStep(home, "login");
-        assert.equal(result.status, escaping ? 2 : 0, result.stderr);
-        assert.equal(existsSync(join(home, "npm-calls")), false);
-        assert.ok(existsSync(target));
+        if (variant.startsWith("chained-")) {
+          const escaping = variant === "chained-escape";
+          rmSync(dirname(native), { recursive: true });
+          symlinkSync("../flat", join(prefix, "deep/link"));
+          symlinkSync(join(prefix, "deep/link"), dirname(native));
+          const target = join(escaping ? dirname(prefix) : prefix, "payload");
+          payload(target, escaping ? "outside" : "intended");
+          symlinkSync(escaping ? "../../payload" : "../payload", join(prefix, "flat/codex"));
+        } else if (variant.startsWith("compound-") || variant === "missing-manifest-escape") {
+          const contained = variant === "compound-contained";
+          const anchor = contained ? join(prefix, "flat") : prefix;
+          symlinkSync(anchor, join(prefix, "deep/link"));
+          rmSync(native);
+          const start = absolute ? prefix : relative(dirname(native), prefix);
+          symlinkSync(`${start}/deep/link/../payload`, native);
+          payload(join(prefix, "deep/payload"), "decoy");
+          if (variant !== "compound-missing")
+            payload(
+              join(contained ? prefix : dirname(prefix), "payload"),
+              contained ? "intended" : "outside",
+            );
+          if (variant === "missing-manifest-escape") rmSync(join(pkg, "package.json"));
+        } else if (variant === "missing-caller" || variant === "directory-suffix") {
+          rmSync(dirname(native), { recursive: true });
+          symlinkSync(
+            `${prefix}/${variant === "missing-caller" ? "missing/.." : "flat/./"}`,
+            dirname(native),
+          );
+          if (variant === "missing-caller")
+            symlinkSync(join(home, "outside-missing"), join(prefix, "codex"));
+          else payload(join(prefix, "flat/codex"), "intended");
+        } else {
+          rmSync(native);
+          payload(join(prefix, "payload"), "intended");
+          if (variant.startsWith("depth-")) {
+            const count = Number(variant.slice(6));
+            for (let hop = 1; hop < count; hop++)
+              symlinkSync(
+                hop === count - 1 ? "payload" : `hop-${hop + 1}`,
+                join(prefix, `hop-${hop}`),
+              );
+            symlinkSync(join(prefix, "hop-1"), native);
+          } else {
+            writeFileSync(join(prefix, "file"), "");
+            const suffixes: Record<string, string> = {
+              "missing-parent": "missing/../payload",
+              "missing-escape": "missing/../../payload",
+              "file-parent": "file/../payload",
+              "file-dot": "file/.",
+              "file-slash": "file/",
+            };
+            const suffix = suffixes[variant];
+            assert.ok(suffix);
+            symlinkSync(`${prefix}/${suffix}`, native);
+          }
+        }
+        const label = `${variant}, proxy=${proxy}, absolute=${absolute}`;
+        const result = installStep(home, proxy ? "proxy" : "login", "exit 0");
+        assert.equal(result.status, status, `${label}: ${result.stderr}`);
+        assert.deepEqual(
+          existsSync(trace) ? readFileSync(trace, "utf8").trim().split("\n") : [],
+          status === 0 ? ["intended", "intended"] : [],
+          label,
+        );
+        const calls = existsSync(join(home, "npm-calls"))
+          ? readFileSync(join(home, "npm-calls"), "utf8").trim().split("\n")
+          : [];
+        if (status === 1)
+          assert.deepEqual(
+            calls.filter((line) => line.startsWith("install ")),
+            [
+              `install -g @openai/codex@${version} --prefer-online --no-audit --no-fund --ignore-scripts`,
+            ],
+            label,
+          );
+        else assert.deepEqual(calls, [], label);
       } finally {
         rmSync(home, { recursive: true, force: true });
       }

--- a/test/setup-codex-action.test.ts
+++ b/test/setup-codex-action.test.ts
@@ -572,6 +572,9 @@ test(
       "outside alias directory",
       "outside alias directory link",
       "outside non-directory link",
+      "outside regular file",
+      "contained regular file",
+      "contained scope link to outside file",
       "missing",
       "wrong",
       "self-linked",
@@ -585,7 +588,8 @@ test(
         if (aliasState.startsWith("outside")) {
           const linked = aliasState.endsWith("link");
           const directory = join(home, linked ? "shared-node-modules" : "node_modules");
-          if (aliasState === "outside non-directory link") writeFileSync(directory, "");
+          if (aliasState === "outside non-directory link" || aliasState === "outside regular file")
+            writeFileSync(directory, "");
           else mkdirSync(directory);
           if (aliasState.startsWith("outside alias")) {
             const outside = join(directory, `@openai/codex-${process.platform}-${process.arch}`);
@@ -600,6 +604,18 @@ test(
         }
         renameSync(join(nativePackage, "vendor"), join(pkg, "vendor"));
         rmSync(nativePackage, { recursive: true });
+        if (aliasState === "contained regular file") {
+          const directory = join(pkg, "node_modules");
+          rmSync(directory, { recursive: true });
+          writeFileSync(directory, "");
+        }
+        if (aliasState === "contained scope link to outside file") {
+          const scope = join(pkg, "node_modules/@openai");
+          const outside = join(home, "outside-file");
+          rmSync(scope, { recursive: true });
+          writeFileSync(outside, "");
+          symlinkSync(outside, scope);
+        }
         if (aliasState === "self-linked") symlinkSync("../..", nativePackage);
         if (aliasState === "missing" || aliasState === "wrong") {
           const manifest = join(pkg, "package.json");
@@ -614,7 +630,9 @@ test(
         }
         const result = installStep(home, "login", "exit 0");
         const valid = aliasState === "valid" || aliasState.startsWith("outside empty directory");
-        const status = valid ? 0 : aliasState.startsWith("outside") ? 2 : 1;
+        const unsafe =
+          aliasState.startsWith("outside") || aliasState === "contained scope link to outside file";
+        const status = valid ? 0 : unsafe ? 2 : 1;
         assert.equal(result.status, status, `${aliasState}: ${result.stderr}`);
         assert.deepEqual(
           existsSync(trace) ? readFileSync(trace, "utf8").trim().split("\n") : [],


### PR DESCRIPTION
<!-- Punchcard-Session: silver-workshop-valley-hd -->

## What Problem This Solves

Fixes repeated pinned npm installation during Codex setup even when the restored
managed installation already contains working packages at the requested versions.

## Why This Change Was Made

Validate the managed package, exact versions, active platform alias, launcher,
and native executable before reuse. Valid warm installations skip all npm work;
missing or unusable contained installations get one unchanged pinned install
and revalidation. Paths outside the managed installation refuse automatic repair.

Alias selection follows the pinned launcher's actual lookup order. Native and
launcher probes use bounded time/output and an isolated, secret-free environment.
The proxy uses its supported `--help` contract and is required only in proxy mode.

Package pins, cache keys and restore policy, install flags, authentication,
fresh CODEX_HOME, scanner bootstrap, sandbox checks, model selection, and
configuration remain unchanged. Three obsolete inline-command source assertions
are removed; complete executed npm-argv assertions and independent workflow
guards remain.

## User Impact

Valid warm caches avoid redundant package-manager work and do not require the
configured npm registry. The corrected candidate's controlled Linux before/after
measurement is **3,274.108 ms before versus 149.960 ms after**, a mean reduction
of 3,124.148 ms (95.4%) across five alternating pairs. This measures the complete
install block, including validation, not full-sweep or fleet-wide latency.

Release-note context: reduce redundant Codex setup work on valid warm caches
while retaining exact-pin validation and repair. No changelog edit.

## OpenClaw Bay Impact

None. CLI setup changes no Bay route, payload, counter, lifecycle disposition,
publication contract, or observer permission.

## Documentation Impact

Reviewed the setup/token-flow documentation in `README.md`, `docs/README.md`,
`CONTRIBUTING.md`, and the composite action. Existing operator contracts remain
accurate; no setting, command, or documentation page is added.

## Evidence

- All 15 installer owner tests pass locally, including six warm/repair
  action-path rows. Isolated Linux setup/authentication tests:
  22 passed, zero failed, cancelled, or skipped.
- Corrected candidate `pnpm run check`: passed in 216.110 seconds. Thirteen
  preflight tests passed; the full suite reported 5,151 tests, 5,133 passed,
  18 skipped, zero failed or cancelled.
- Targeted formatting, lint, and `git diff --check` pass.
- Fresh full-five-file precommit P2 review: scoped-clean, exit 0, no actionable
  findings; final source verification passed.
- Fresh committed-branch P2 review: scoped-clean, exit 0, no actionable
  findings; final source verification passed.
- Signed candidate commit: `4645a3af5fff41c0546d9a308b9889b6a3d40432`.
- Additional exact-head hosted integration gates are tracked in the
  [PR checks](https://github.com/openclaw/clawsweeper/pull/1474/checks) and must
  pass before landing.

### Review Findings

- CodeQL alerts [111](https://github.com/openclaw/clawsweeper/security/code-scanning/111)
  and [112](https://github.com/openclaw/clawsweeper/security/code-scanning/112):
  both production validator calls now use the native composite-action
  `GITHUB_ACTION_PATH`, and the harnesses pass that value through the child
  environment. Neither renderer substitutes a safer implementation for the
  production shell. The original raw-interpolation cases lost literal argv
  bytes or created a synthetic marker. All six current warm/repair path cases
  preserve exact validator argv and expected npm calls without a marker.
  Current exact-source physical-path proof passed in a physical checkout whose
  name contains spaces, single/double quotes, and literal substitution syntax.
  The marker remained absent and all five source hashes stayed unchanged.
- [Compound-path finding](https://github.com/openclaw/clawsweeper/pull/1474#issuecomment-5564796369):
  the validator expands symlink targets before caller suffixes instead of
  collapsing `link/..` lexically. Missing and non-directory traversal state
  remains unresolved while structural owner checks continue. The regression
  returned 0 instead of 2 on the original defect; all 24 traversal rows now
  pass. Current real-package compound-path proof passed for both Codex and the
  proxy: contained controls returned 0; live and missing outside targets
  returned 2 with zero npm calls and zero configured-registry requests.
- Empty outside resolver-directory symlinks: a healthy directory link can
  establish alias absence and permit the pinned launcher's local-vendor
  fallback. Failed stat, non-directory targets, and present outside aliases
  still refuse before probing or repair. The new regression returned 2
  instead of 0 before correction; all twelve fallback and eleven first-present
  rows now pass. Current real-package fallback is included in the Linux proof.
- Failed resolver lookups now check containment before becoming repairable.
  Direct outside `ENOTDIR`/`EACCES` and contained scope links to outside targets
  previously returned 1 and invoked npm; all four now return 2 without npm or
  probes. A nine-case non-root Node 24.19.0 audit passed with no skips, including
  genuine `EACCES`. Healthy outside absence still reuses vendor; genuinely
  contained failures retain exactly one pinned repair. Three added table rows
  and a real-package outside-file refusal cover the changed boundary.
- Earlier proxy-banner and alias-precedence findings remain addressed. The
  legacy workflow test cleanup removes only three obsolete source-shape
  assertions; literal pins, credentials, model, scanner, and sandbox guards
  remain covered.
- The fallback fixture's alias-absence assertion now runs in a fresh Node
  process after deletion, matching the validator's process lifetime. An
  independent reproduction showed same-process resolution returning the
  deleted path; higher aliases and malformed metadata still fail the fresh
  assertion. No production behavior or assertion strength changed.

## Real Behavior Proof

Status: passed on September 7, 2026, for the five committed source hashes below.

**Claim:** a healthy exact-version managed installation skips npm; unusable
contained installations get one pinned repair; paths outside the owner and
persistent invalidity stop setup before successful reuse.

**Surface and fixture:** the actual composite action's install shell, validator,
and pinned published Codex 0.153.3 and proxy 0.139.0 packages, including actual
native executables and JavaScript launchers. A physical checkout name containing
spaces, quotes, and literal substitution syntax exercises the harness path fix.
Controlled temporary homes isolate all package fixtures.

**Command and environment:** configured AWS Crabbox, Linux x64, Node 24.20.0,
c7a.8xlarge, task-owned lease `cbx_0ef377990ced`, run `run_ec631f1766d1`.
[Actions hydration](https://github.com/openclaw/clawsweeper/actions/runs/34121259365)
prepared the branch's locked dependencies; it is not the qualification run.
The proof ran
`node scripts/e2e/codex-warm-install.mjs --base ff0156fb8628cbf9f22d00864810dea56e83122b --repetitions 5 --output <proof-directory>`,
focused setup tests from the physical special-character checkout, and
`pnpm run check` from a normal checkout.

**Observed results:** all 39 install records, including ten timing samples,
matched their expected outcomes. Offline warm reuse and the corrected
outside-empty-link vendor fallback made zero npm calls and zero configured
registry requests. The outside-file refusal returned 2 with zero npm calls
and zero configured-registry requests. Healthy login, proxy, and ClawRouter
cases; selected/shadowed alias behavior; pinned repair;
persistent invalidity; direct and compound path refusals; configured-registry
denial controls; and five alternating timing pairs are recorded in the retained
proof summary. The actual proxy started, returned HTTP 200 for shutdown,
exited 0, and made zero model requests.

Recorded full-install-block timings, milliseconds:

| Pair | Before | After |
| --- | ---: | ---: |
| 1 | 3250.040 | 148.249 |
| 2 | 3274.595 | 150.952 |
| 3 | 3310.363 | 151.579 |
| 4 | 3259.525 | 151.807 |
| 5 | 3276.017 | 147.214 |
| Mean | 3274.108 | 149.960 |

**Source identity and artifacts:** the retained bundle
`alias-error-linux-proof.tar.gz` has SHA-256
`7c3f3a0f14eb386015f6e41a75b2eccfea783eb46052a32331faaabee5f3bf13`.
Its `summary.json` SHA-256 is
`a3ad8ed1bb273cf71c762e5e7e816422b6142baabdd0c8171f5c32ac753894a8`;
`qualification.json` SHA-256 is
`cedc90247f99449284bb1abad705360a861bc8a6358ae8bf7660b2d19f64f91c`.
The bundle contains the per-scenario records and all three phase logs; the
public result trace is above. Qualification is by these five source hashes,
checked before and after proof and against committed blobs at `4645a3a`.
The synced remote checkout recorded Git HEAD `5b50f8e` while executing the
current, hash-verified files. This is source-hash qualification, not a claim
that the remote Git metadata identified `4645a3a`.

```text
1c9e3665050a5ea467501fb746ede3dbe29cec37c28ce3693d09a54b8de94ee2  .github/actions/setup-codex/action.yml
ecb7c787a60425fd4c34f7280632645b8116c6f77b42268b1d773c6dbf279974  .github/actions/setup-codex/validate-install.mjs
affd7796ce3e82ec7ebd92c59026114535617a3e642c3e1b462f15e18a295864  test/setup-codex-action.test.ts
08469a28f6b33497b7a4f53ae1074ba22641134ad5cf6dcc7b3ca8eed9772d5a  scripts/e2e/codex-warm-install.mjs
fb9a1b80633a450c7bce52bd9a08aee733ba704d859f5894989c038ae057c4b8  test/clawsweeper.test.ts
```

**Limits:** configured loopback-registry denial is not a general network
firewall. This does not exercise hosted cache restoration, inference, complete
sweep throughput, or fleet-wide savings. Synthetic path fixtures demonstrate
local validation/repair behavior, not remote exploitability or race-free
filesystem access. Earlier successful measurements and failed attempts are
retained as history, not substituted for the corrected candidate's proof.
