### PR TITLE
fix(queue): older publication commands remain pending after successors complete

### DIFF
--- a/dashboard/exact-review-decision.ts
+++ b/dashboard/exact-review-decision.ts
@@ -721,13 +721,15 @@ export function mergePendingExactReviewDecision(
   return merged;
 }
 
-export function exactReviewDecisionHasCommandContext(decision: ExactReviewDecision) {
+export function exactReviewDecisionHasCommandContext(
+  decision: Pick<ExactReviewDecision, "commandStatusMarker" | "statusCommentId">,
+) {
   return Boolean(decision.commandStatusMarker || decision.statusCommentId);
 }
 
 export function exactReviewCommandObligationSurvives(
-  current: ExactReviewDecision,
-  incoming: ExactReviewDecision,
+  current: Pick<ExactReviewDecision, "commandStatusMarker" | "statusCommentId">,
+  incoming: Pick<ExactReviewDecision, "commandStatusMarker" | "statusCommentId">,
 ) {
   if (!exactReviewDecisionHasCommandContext(current)) return true;
   if (!exactReviewDecisionHasCommandContext(incoming)) return false;

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -276,6 +276,15 @@ type ExactReviewTerminalFinalization = {
    */
   projection?: ExactReviewLifecycleProjectionIdentity;
 };
+type PublicationSuccessorWitness = {
+  targetKey: string;
+  predecessorQueueRevision: number;
+  predecessorSourceRevision: number;
+  sourceHead: number;
+} & (
+  | { state: "verified"; successorItemKey: string; successorQueueRevision: number }
+  | { state: "blocked" }
+);
 export type ExactReviewQueueItem = {
   key: string;
   decision: ExactReviewDecision;
@@ -314,6 +323,7 @@ export type ExactReviewQueueItem = {
   lastFailureReason?: ExactReviewPublicationReasonCode;
   firstFailureAt?: number;
   publicationFailureAttempts?: number;
+  publicationSuccessorWitness?: PublicationSuccessorWitness;
   reviewFailureAttempts?: number;
   reviewRetryPolicyEpoch?: string;
   reviewRecoveryReason?: ExactReviewReviewRecoveryReason;
@@ -1567,6 +1577,9 @@ export class ExactReviewQueue {
           return { deduped: true as const, crossRoute: true as const, key, state };
         }
         let supersededPublications = 0;
+        const priorPublicationHead = incomingPublicationRevision
+          ? this.publicationHeadRevisionSync(incomingPublicationRevision.targetKey)
+          : 0;
         if (incomingPublicationRevision) {
           const incomingLineage = exactReviewPublicationLineage(decision);
           const matching = Object.values(state.items)
@@ -1701,6 +1714,10 @@ export class ExactReviewQueue {
                 retained.item.updatedAt = now;
               }
               if (semanticIngress) {
+                this.updatePublicationSuccessorWitnesses(
+                  state,
+                  new Set([incomingPublicationRevision.targetKey]),
+                );
                 this.writeStateSync(state);
                 this.incrementQueueMetricsSync({
                   publicationCompleted: semanticDuplicatesRemoved,
@@ -2092,6 +2109,13 @@ export class ExactReviewQueue {
         }
         if (ingressAdmitted && state.items[key]) {
           this.recordLifecycleAdmission(state.items[key], state.items[key].decision, now);
+        }
+        if (incomingPublicationRevision && state.items[key]) {
+          this.updatePublicationSuccessorWitnesses(
+            state,
+            new Set([incomingPublicationRevision.targetKey]),
+            ingressAdmitted ? { itemKey: key, priorHead: priorPublicationHead } : undefined,
+          );
         }
         if (semanticEdited) this.recordEditedSemanticInputSync(semanticEdited, now);
         this.writeStateSync(state);
@@ -3680,6 +3704,10 @@ export class ExactReviewQueue {
           };
           owned.decision = publicationDecision;
           owned.leaseDecision = publicationDecision;
+          this.updatePublicationSuccessorWitnesses(
+            state,
+            new Set([publication.itemKey.toLowerCase()]),
+          );
           // The canonical record is durable, but its router handoff and guarded
           // command-status edit are separate lifecycle post-effects. Keep this
           // converted publication lease recoverable until that finalizer reports
@@ -6815,6 +6843,179 @@ export class ExactReviewQueue {
     return "verified" as const;
   }
 
+  private publicationWitnessTarget(item: ExactReviewQueueItem) {
+    const revision = exactReviewPublicationRevision(item.decision);
+    const producer = item.decision.publication?.producerDecision;
+    const canonicalTargetKey = producer ? `${producer.targetRepo}#${producer.itemNumber}` : "";
+    return revision &&
+      producer &&
+      revision.targetKey ===
+        `${item.decision.targetRepo}#${item.decision.itemNumber}`.toLowerCase() &&
+      revision.targetKey === canonicalTargetKey.toLowerCase()
+      ? { ...revision, canonicalTargetKey }
+      : null;
+  }
+
+  private publicationWitness(item: ExactReviewQueueItem) {
+    if (item.publicationSuccessorWitness === undefined) return undefined;
+    const witness = item.publicationSuccessorWitness;
+    const revision = this.publicationWitnessTarget(item);
+    if (
+      !witness ||
+      !revision ||
+      typeof witness.targetKey !== "string" ||
+      witness.targetKey.toLowerCase() !== revision.targetKey ||
+      witness.predecessorQueueRevision !== item.revision ||
+      witness.predecessorSourceRevision !== revision.sourceRevision ||
+      !Number.isSafeInteger(witness.sourceHead) ||
+      witness.sourceHead <= revision.sourceRevision ||
+      (witness.state !== "blocked" && witness.state !== "verified") ||
+      Object.keys(witness).length !== (witness.state === "verified" ? 7 : 5) ||
+      (witness.state === "verified" &&
+        (typeof witness.successorItemKey !== "string" ||
+          !witness.successorItemKey.toLowerCase().startsWith(`${revision.targetKey}@publish:`) ||
+          !Number.isSafeInteger(witness.successorQueueRevision) ||
+          witness.successorQueueRevision < 1))
+    )
+      return null;
+    return witness;
+  }
+
+  private publicationSuccessorEvidence(
+    item: ExactReviewQueueItem,
+    successor: ExactReviewQueueItem | null | undefined,
+    sourceHead: number,
+  ) {
+    const witness = this.publicationWitness(item);
+    if (witness !== undefined) {
+      // Known ambiguity survives disappearance and redelivery. Never fall back
+      // to a remaining live row when retained authority is blocked or invalid.
+      if (!witness || witness.state === "blocked" || witness.sourceHead !== sourceHead)
+        return { state: "ambiguous" as const, admission: null };
+      const admission = this.lifecycleProjectionStore.read(
+        witness.targetKey,
+        witness.successorItemKey,
+        witness.successorQueueRevision,
+      )?.admission;
+      if (!admission) return { state: "admission_missing" as const, admission: null };
+      if (
+        successor !== undefined &&
+        (!successor ||
+          successor.key !== witness.successorItemKey ||
+          successor.revision !== witness.successorQueueRevision ||
+          this.publicationWitnessTarget(successor)?.canonicalTargetKey !== witness.targetKey)
+      )
+        return { state: "ambiguous" as const, admission: null };
+      if (successor) {
+        const state = this.publicationSuccessorFenceState(successor);
+        if (state !== "verified") return { state, admission: null };
+      }
+      return { state: "verified" as const, admission };
+    }
+    const state = this.publicationSuccessorFenceState(successor);
+    const producer = successor?.decision.publication?.producerDecision;
+    const admission =
+      state === "verified" && successor && producer && this.publicationWitnessTarget(successor)
+        ? (this.lifecycleProjectionStore.read(
+            `${producer.targetRepo}#${producer.itemNumber}`,
+            successor.key,
+            successor.revision,
+          )?.admission ?? null)
+        : null;
+    return {
+      state: state === "verified" && !admission ? ("admission_missing" as const) : state,
+      admission,
+    };
+  }
+
+  private updatePublicationSuccessorWitnesses(
+    state: ExactReviewQueueState,
+    targets: ReadonlySet<string>,
+    admitted?: { itemKey: string; priorHead: number },
+  ) {
+    const heads = new Map(this.publicationHeadsSync(state));
+    const entries = Object.values(state.items).flatMap((item) => {
+      const revision = exactReviewPublicationRevision(item.decision);
+      return !item.terminalFinalization && revision && targets.has(revision.targetKey)
+        ? [{ item, revision }]
+        : [];
+    });
+    const successors = new Map<string, ExactReviewQueueItem | null>();
+    for (const { revision } of entries)
+      heads.set(
+        revision.targetKey,
+        Math.max(heads.get(revision.targetKey) ?? 0, revision.sourceRevision),
+      );
+    for (const { item, revision } of entries) {
+      if (revision.sourceRevision === heads.get(revision.targetKey))
+        successors.set(revision.targetKey, successors.has(revision.targetKey) ? null : item);
+    }
+    for (const { item, revision } of entries) {
+      if (!exactReviewDecisionHasCommandContext(item.decision.publication!.producerDecision))
+        continue;
+      const prior = this.publicationWitness(item);
+      const retainedHead = Number.isSafeInteger(item.publicationSuccessorWitness?.sourceHead)
+        ? item.publicationSuccessorWitness!.sourceHead
+        : 0;
+      const sourceHead = Math.max(heads.get(revision.targetKey) ?? 0, retainedHead);
+      if (sourceHead <= revision.sourceRevision) continue;
+      const successor = successors.get(revision.targetKey);
+      const evidence = this.publicationSuccessorEvidence(item, successor, sourceHead);
+      const priorSuccessor =
+        prior?.state === "verified" ? state.items[prior.successorItemKey] : null;
+      const invalidPrior =
+        prior === null ||
+        (prior?.state === "verified" &&
+          (!this.lifecycleProjectionStore.read(
+            prior.targetKey,
+            prior.successorItemKey,
+            prior.successorQueueRevision,
+          ) ||
+            (priorSuccessor &&
+              priorSuccessor.revision === prior.successorQueueRevision &&
+              (this.publicationWitnessTarget(priorSuccessor)?.canonicalTargetKey !==
+                prior.targetKey ||
+                this.publicationSuccessorFenceState(priorSuccessor) !== "verified"))));
+      const advancing =
+        admitted &&
+        successor?.key === admitted.itemKey &&
+        sourceHead > admitted.priorHead &&
+        sourceHead > retainedHead;
+      const verified =
+        !invalidPrior &&
+        ((advancing &&
+          this.publicationWitnessTarget(successor!) &&
+          this.publicationSuccessorFenceState(successor) === "verified") ||
+          (prior?.state === "verified" && evidence.state === "verified"));
+      // Only a new unique admission may raise authority. Semantic refresh,
+      // direct conversion, and reconciliation can preserve or block it only.
+      const verifiedTuple =
+        verified &&
+        (advancing
+          ? successor
+          : prior?.state === "verified"
+            ? { key: prior.successorItemKey, revision: prior.successorQueueRevision }
+            : null);
+      item.publicationSuccessorWitness = {
+        targetKey: verifiedTuple
+          ? advancing
+            ? `${successor!.decision.publication!.producerDecision.targetRepo}#${successor!.decision.publication!.producerDecision.itemNumber}`
+            : prior!.targetKey
+          : revision.targetKey,
+        predecessorQueueRevision: item.revision,
+        predecessorSourceRevision: revision.sourceRevision,
+        sourceHead,
+        ...(verifiedTuple
+          ? {
+              state: "verified",
+              successorItemKey: verifiedTuple.key,
+              successorQueueRevision: verifiedTuple.revision,
+            }
+          : { state: "blocked" }),
+      };
+    }
+  }
+
   private stalePublicationCandidatesSync(
     state: ExactReviewQueueState,
     activeBatchItemKeys: ReadonlySet<string>,
@@ -6896,9 +7097,16 @@ export class ExactReviewQueue {
           "terminal_missing"
         )
           continue;
-        if (this.publicationSuccessorFenceState(successor) !== "verified" || !successor) continue;
-        const successorProducer = successor.decision.publication!.producerDecision;
-        const requeue = exactReviewCommandObligationSurvives(producer, successorProducer);
+        const evidence = this.publicationSuccessorEvidence(
+          current,
+          successor,
+          newestByTarget.get(currentRevision.targetKey)!,
+        );
+        if (evidence.state !== "verified" || !evidence.admission) continue;
+        const requeue = exactReviewCommandObligationSurvives(producer, {
+          commandStatusMarker: evidence.admission.statusMarker ?? undefined,
+          statusCommentId: evidence.admission.statusCommentId ?? undefined,
+        });
         terminalized.push(
           this.recordLifecycleTerminalDispositionSync(
             exactReviewTerminalFinalizationProjection(current, current.revision),
@@ -7102,6 +7310,7 @@ export class ExactReviewQueue {
     );
     const changedKeys = new Set<string>();
     const changedLineages = new Set<string>();
+    const changedLineageTargets = new Set<string>();
     let staleRevisionChanged = 0;
     let lineageDuplicateChanged = 0;
     let lineageRefreshed = 0;
@@ -7154,6 +7363,7 @@ export class ExactReviewQueue {
           else {
             lineageDuplicateChanged += 1;
             if (candidate.lineageKey) changedLineages.add(candidate.lineageKey);
+            changedLineageTargets.add(candidate.revision.targetKey);
           }
         }
 
@@ -7186,6 +7396,7 @@ export class ExactReviewQueue {
           lineageRefreshed += 1;
         }
         if (changedKeys.size) {
+          this.updatePublicationSuccessorWitnesses(state, changedLineageTargets);
           this.writeStateSync(state);
           this.incrementQueueMetricsSync({
             publicationCompleted: changedKeys.size,
@@ -7302,7 +7513,11 @@ export class ExactReviewQueue {
             successor_fence_state:
               reason === "stale_revision" &&
               safety.acknowledgement_unavailable_reason === "terminal_missing"
-                ? this.publicationSuccessorFenceState(successors.get(revision.targetKey))
+                ? this.publicationSuccessorEvidence(
+                    item,
+                    successors.get(revision.targetKey),
+                    newestByTarget.get(revision.targetKey)!,
+                  ).state
                 : null,
             ...safety,
           };

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -652,6 +652,15 @@ admission: the same marker and comment requeues without a finalizer, while a
 changed address or non-command successor records superseded with an acknowledgement
 driver. Missing, ambiguous, or mismatched successor state stays retained fail-closed;
 duplicate-lineage and legacy terminal cleanup remains operator-owned.
+New publication admissions retain one predecessor-bound successor witness, so
+the successor's normal completion cannot erase command ownership evidence.
+Same-source conflicts remain blocked through removal, restart, and redelivery;
+only a unique, verified admission beyond both the durable source head and the
+retained conflict can establish newer authority. Direct publication conversion
+can block authority but cannot establish it. Malformed or mismatched evidence
+fails closed. Historical rows whose successor disappeared before evidence was
+retained are not automatically repaired. This private queue state changes no
+Bay response or action contract.
 Authenticated reconciliation samples report `successor_fence_state` only for
 `stale_revision` rows whose acknowledgement is unavailable because the terminal
 disposition is missing. `verified` is diagnostic evidence, never mutation

--- a/test/exact-review-publication-batches.test.ts
+++ b/test/exact-review-publication-batches.test.ts
@@ -1916,6 +1916,652 @@ for (const [scenario, successorMarker, successorComment, terminal] of [
   });
 }
 
+test("alarm supersedes an expired command after its newer publication has completed routing", async (t) => {
+  const h = admissionQueue(t, {
+    EXACT_REVIEW_PUBLICATION_BATCH_MAX_CONCURRENT: "2",
+    EXACT_REVIEW_PUBLICATION_BATCH_LEASE_MS: "60000",
+  });
+  const number = 108740;
+  const canonicalTargetKey = `openclaw/openclaw#${number}`;
+  const lifecycle = new ExactReviewLifecycleProjectionStore(h.storage);
+  const batches = new ExactReviewPublicationBatchStore(h.storage);
+  const enqueue = async (sourceRevision: number, producerRunId: string, markerDigest: string) => {
+    const body = await publicationRequest(
+      `completed-successor-${sourceRevision}`,
+      number,
+      producerRunId,
+      "openclaw/openclaw",
+      sourceRevision,
+    ).json();
+    const command = {
+      commandStatusMarker: `<!-- clawsweeper-command-status:${number}:re_review:${markerDigest.repeat(40)} -->`,
+      statusCommentId: number * 10 + sourceRevision,
+    };
+    Object.assign(body.decision, command);
+    Object.assign(body.decision.publication.producerDecision, command);
+    const response = await h.queue.fetch(batchRequest("/enqueue", body));
+    assert.equal(response.status, 202, JSON.stringify(await response.clone().json()));
+    return response.json();
+  };
+  const claim = (suffix: string, runId: string, runAttempt: number) =>
+    h.claim({
+      claim_id: `completed-successor-${suffix}`,
+      lease_owner: `completed-successor-worker-${suffix}`,
+      max_items: 1,
+      runner_run_id: runId,
+      runner_run_attempt: runAttempt,
+      runner_started_at: new Date(h.now).toISOString(),
+    });
+
+  await enqueue(1, "27401", "a");
+  const claimA = await claim("a", "97401", 1);
+  assert.equal(claimA.claimed, true, JSON.stringify(claimA));
+  assert.equal(claimA.batch.items.length, 1);
+  const memberA = claimA.batch.items[0];
+  const expiryA = Date.parse(claimA.batch.lease_expires_at);
+  assert.ok(expiryA > h.now);
+  h.now += 1;
+  await enqueue(2, "27402", "b");
+  const claimB = await claim("b", "97402", 2);
+  assert.equal(claimB.claimed, true, JSON.stringify(claimB));
+  assert.equal(claimB.batch.items.length, 1);
+  const memberB = claimB.batch.items[0];
+  assert.notEqual(memberA.item_key, memberB.item_key);
+  assert.notEqual(claimA.batch.batch_id, claimB.batch.batch_id);
+  const identityA = () => lifecycle.read(canonicalTargetKey, memberA.item_key, memberA.revision);
+  const identityB = () => lifecycle.read(canonicalTargetKey, memberB.item_key, memberB.revision);
+  const activeA = batches.fetch(claimA.batch.batch_id, "completed-successor-worker-a", h.now);
+  assert.equal(activeA?.state, "leased");
+  assert.equal(activeA.items[0]?.terminalOutcome, null);
+  assert.equal(identityA()?.terminalDisposition, null);
+  assert.equal(identityA()?.admission.commandOriginated, true);
+  assert.equal(identityB()?.admission.commandOriginated, true);
+  assert.notEqual(identityA()?.admission.statusMarker, identityB()?.admission.statusMarker);
+  assert.notEqual(identityA()?.admission.statusCommentId, identityB()?.admission.statusCommentId);
+
+  const publishedResponse = await h.queue.fetch(
+    batchRequest(
+      "/publication-batch-results",
+      directPlan(canonicalTargetKey, memberB.revision, {
+        fenceKey: memberB.item_key,
+        claimGeneration: memberB.claim_generation,
+      }),
+    ),
+  );
+  const published = await publishedResponse.json();
+  assert.equal(publishedResponse.status, 202, JSON.stringify(published));
+  assert.equal(published.accepted, true, JSON.stringify(published));
+  const receiptId = "router-completed-successor:97402:2";
+  const routedResponse = await h.queue.fetch(
+    batchRequest("/lifecycle/router-receipt", {
+      canonical_target_key: canonicalTargetKey,
+      fence_key: memberB.item_key,
+      revision: memberB.revision,
+      receipt_id: receiptId,
+    }),
+  );
+  const routed = await routedResponse.json();
+  assert.equal(routedResponse.status, 200, JSON.stringify(routed));
+  const completedResponse = await h.queue.fetch(
+    batchRequest("/publication-batches/complete", {
+      batch_id: claimB.batch.batch_id,
+      lease_owner: "completed-successor-worker-b",
+      items: [
+        {
+          item_key: memberB.item_key,
+          revision: memberB.revision,
+          claim_generation: memberB.claim_generation,
+          terminal_outcome: "published",
+        },
+      ],
+    }),
+  );
+  const completed = await completedResponse.json();
+  assert.equal(completedResponse.status, 200, JSON.stringify(completed));
+  assert.equal(completed.accepted, 1, JSON.stringify(completed));
+  assert.equal(completed.batch.state, "completed");
+  assert.equal(completed.batch.items[0].terminal_outcome, "published");
+  assert.equal(identityB()?.canonicalReceipts[0]?.outcome, "accepted");
+  assert.equal(identityB()?.routerReceipts[0]?.receiptId, receiptId);
+  assert.equal(identityB()?.routerReceipts[0]?.outcome, "durable");
+  assert.equal(identityB()?.terminalDisposition?.kind, "review_completed_routed");
+  assert.equal((await h.storage.get("exact-review-queue")).items[memberB.item_key], undefined);
+  assert.ok(h.now < expiryA);
+
+  const snapshot = async () => ({
+    lifecycleA: identityA(),
+    metrics: await h.publicationStats(),
+  });
+  await h.queue.alarm();
+  assert.ok((await h.storage.get("exact-review-queue")).items[memberA.item_key]);
+  assert.equal(identityA()?.terminalDisposition, null);
+  assert.equal(
+    batches.fetch(claimA.batch.batch_id, "completed-successor-worker-a", h.now)?.items[0]
+      ?.terminalOutcome,
+    null,
+  );
+  h.now = expiryA + 1;
+  await h.queue.alarm();
+  const afterExpiry = await snapshot();
+  h.restart();
+  await h.queue.alarm();
+  const afterRestart = await snapshot();
+  const laterClaim = await claim("later", "97403", 1);
+  assert.equal(h.networkCalls, 0);
+  assert.equal(
+    (laterClaim.batch?.items ?? []).some(
+      (item: { item_key: string }) => item.item_key === memberA.item_key,
+    ),
+    false,
+  );
+  assert.deepEqual(afterRestart.lifecycleA, afterExpiry.lifecycleA);
+  assert.deepEqual(afterRestart.metrics, afterExpiry.metrics);
+  assert.equal(
+    identityA()?.terminalDisposition?.kind,
+    "superseded",
+    "the expired command must terminalize after its admitted successor completes routing",
+  );
+  const finalState = await h.storage.get("exact-review-queue");
+  assert.equal(finalState.items[memberA.item_key], undefined);
+  const driverKey = `terminal-finalization:${memberA.item_key}:${memberA.revision}`;
+  assert.equal(finalState.items[driverKey]?.terminalFinalization?.disposition, "superseded");
+  assert.equal(
+    Object.keys(finalState.items).filter((key) =>
+      key.startsWith(`terminal-finalization:${memberA.item_key}:`),
+    ).length,
+    1,
+  );
+});
+
+for (const departure of ["after", "before"] as const) {
+  test(`alarm preserves same-source successor ambiguity when B leaves ${departure} C admission`, async (t) => {
+    const h = admissionQueue(t, {
+      EXACT_REVIEW_PUBLICATION_BATCH_MAX_CONCURRENT: "2",
+      EXACT_REVIEW_PUBLICATION_BATCH_LEASE_MS: "60000",
+    });
+    const number = departure === "after" ? 108741 : 108742;
+    const target = `openclaw/openclaw#${number}`;
+    const lifecycle = new ExactReviewLifecycleProjectionStore(h.storage);
+    const enqueue = async (
+      name: string,
+      sourceRevision: number,
+      generation: number,
+      replay = false,
+    ) => {
+      const index = "abcd".indexOf(name) + 1;
+      const body = await publicationRequest(
+        `ambiguous-${departure}-${name}${replay ? "-replay" : ""}`,
+        number,
+        String(number * 10 + index),
+        "openclaw/openclaw",
+        sourceRevision,
+      ).json();
+      const command = {
+        commandStatusMarker: `<!-- clawsweeper-command-status:${number}:re_review:${name.repeat(40)} -->`,
+        statusCommentId: number * 10 + index,
+      };
+      body.decision.publication.claimGeneration = generation;
+      Object.assign(body.decision, command);
+      Object.assign(body.decision.publication.producerDecision, command);
+      const response = await h.queue.fetch(batchRequest("/enqueue", body));
+      const result = await response.json();
+      assert.equal(response.status, 202, JSON.stringify(result));
+      assert.equal(result.queued, true, JSON.stringify(result));
+      const item = (await h.storage.get("exact-review-queue")).items[result.item_key];
+      assert.ok(item, JSON.stringify(result));
+      assert.equal(item.decision.publication.leaseRevision, sourceRevision);
+      assert.equal(item.decision.publication.claimGeneration, generation);
+      const admission = lifecycle.read(target, item.key, item.revision)?.admission;
+      assert.equal(admission?.commandOriginated, true);
+      assert.equal(admission.statusMarker, command.commandStatusMarker);
+      assert.equal(admission.statusCommentId, command.statusCommentId);
+      return { result, key: item.key, revision: item.revision };
+    };
+    const claim = async (name: string, runAttempt: number) => {
+      const result = await h.claim({
+        claim_id: `ambiguous-${departure}-${name}`,
+        lease_owner: `ambiguous-${departure}-worker-${name}`,
+        max_items: 1,
+        runner_run_id: String(number * 10 + runAttempt),
+        runner_run_attempt: runAttempt,
+        runner_started_at: new Date(h.now).toISOString(),
+      });
+      assert.equal(result.claimed, true, JSON.stringify(result));
+      assert.equal(result.batch.items.length, 1);
+      return result.batch;
+    };
+
+    const a = await enqueue("a", 1, 1);
+    const batchA = await claim("a", 1);
+    const memberA = batchA.items[0];
+    assert.equal(memberA.item_key, a.key);
+    assert.equal(memberA.revision, a.revision);
+    const expiryA = Date.parse(batchA.lease_expires_at);
+    h.now += 1;
+    const b = await enqueue("b", 2, 1);
+    const batchB = await claim("b", 2);
+    const memberB = batchB.items[0];
+    assert.equal(memberB.item_key, b.key);
+    assert.equal(memberB.revision, b.revision);
+    let c: Awaited<ReturnType<typeof enqueue>>;
+    if (departure === "after") c = await enqueue("c", 2, 2);
+
+    const publishedResponse = await h.queue.fetch(
+      batchRequest(
+        "/publication-batch-results",
+        directPlan(target, memberB.revision, {
+          fenceKey: memberB.item_key,
+          claimGeneration: memberB.claim_generation,
+        }),
+      ),
+    );
+    const published = await publishedResponse.json();
+    assert.equal(publishedResponse.status, 202, JSON.stringify(published));
+    assert.equal(published.accepted, true, JSON.stringify(published));
+    const receiptId = `router-ambiguous-${departure}-b`;
+    const routedResponse = await h.queue.fetch(
+      batchRequest("/lifecycle/router-receipt", {
+        canonical_target_key: target,
+        fence_key: memberB.item_key,
+        revision: memberB.revision,
+        receipt_id: receiptId,
+      }),
+    );
+    const routed = await routedResponse.json();
+    assert.equal(routedResponse.status, 200, JSON.stringify(routed));
+    const completedResponse = await h.queue.fetch(
+      batchRequest("/publication-batches/complete", {
+        batch_id: batchB.batch_id,
+        lease_owner: `ambiguous-${departure}-worker-b`,
+        items: [
+          {
+            item_key: memberB.item_key,
+            revision: memberB.revision,
+            claim_generation: memberB.claim_generation,
+            terminal_outcome: "published",
+          },
+        ],
+      }),
+    );
+    const completed = await completedResponse.json();
+    assert.equal(completedResponse.status, 200, JSON.stringify(completed));
+    assert.equal(completed.accepted, 1, JSON.stringify(completed));
+    assert.equal(completed.batch.state, "completed");
+    assert.equal(completed.batch.items[0].terminal_outcome, "published");
+    const projectionB = lifecycle.read(target, memberB.item_key, memberB.revision);
+    assert.equal(projectionB?.canonicalReceipts[0]?.outcome, "accepted");
+    assert.equal(projectionB?.routerReceipts[0]?.outcome, "durable");
+    assert.equal(projectionB?.routerReceipts[0]?.receiptId, receiptId);
+    assert.equal(projectionB?.terminalDisposition?.kind, "review_completed_routed");
+    assert.equal((await h.storage.get("exact-review-queue")).items[b.key], undefined);
+    if (departure === "before") c = await enqueue("c", 2, 2);
+    assert.notEqual(b.key, c!.key);
+
+    const snapshot = async () => ({
+      queue: await h.storage.get("exact-review-queue"),
+      lifecycleA: lifecycle.read(target, memberA.item_key, memberA.revision),
+    });
+    assert.ok(h.now < expiryA);
+    await h.queue.alarm();
+    assert.ok((await h.storage.get("exact-review-queue")).items[a.key]);
+    assert.equal(
+      lifecycle.read(target, memberA.item_key, memberA.revision)?.terminalDisposition,
+      null,
+    );
+    assert.equal(
+      new ExactReviewPublicationBatchStore(h.storage).fetch(
+        batchA.batch_id,
+        `ambiguous-${departure}-worker-a`,
+        h.now,
+      )?.items[0]?.terminalOutcome,
+      null,
+    );
+    h.now = expiryA + 1;
+    await h.queue.alarm();
+    const afterExpiry = await snapshot();
+    h.restart();
+    await h.queue.alarm();
+    const afterRestart = await snapshot();
+    await enqueue("c", 2, 2, true);
+    await h.queue.alarm();
+    const afterRedelivery = await snapshot();
+    await enqueue("d", 3, 1);
+    await h.queue.alarm();
+    const afterNewerD = await snapshot();
+    assert.equal(h.networkCalls, 0);
+    for (const [phase, state] of Object.entries({ afterExpiry, afterRestart, afterRedelivery })) {
+      assert.equal(
+        state.lifecycleA?.terminalDisposition,
+        null,
+        `${phase}: losing B must not make conflicting source-revision-2 C authoritative`,
+      );
+      assert.ok(state.queue.items[a.key], `${phase}: retain A while its successor is ambiguous`);
+      assert.equal(
+        Object.keys(state.queue.items).some((key) =>
+          key.startsWith(`terminal-finalization:${a.key}:`),
+        ),
+        false,
+      );
+    }
+    assert.equal(afterNewerD.lifecycleA?.terminalDisposition?.kind, "superseded");
+    assert.equal(afterNewerD.queue.items[a.key], undefined);
+    assert.equal(
+      Object.keys(afterNewerD.queue.items).filter((key) =>
+        key.startsWith(`terminal-finalization:${a.key}:`),
+      ).length,
+      1,
+    );
+  });
+}
+
+async function successorGuardFixture(
+  t: import("node:test").TestContext,
+  number: number,
+  directReview = false,
+  targetRepo = "openclaw/openclaw",
+) {
+  const h = admissionQueue(t, {
+    EXACT_REVIEW_PUBLICATION_BATCH_MAX_CONCURRENT: "2",
+    EXACT_REVIEW_PUBLICATION_BATCH_LEASE_MS: "60000",
+  });
+  const target = `${targetRepo}#${number}`;
+  const lifecycle = new ExactReviewLifecycleProjectionStore(h.storage);
+  const state = () => h.storage.get("exact-review-queue");
+  if (directReview) {
+    for (let revision = 1; revision <= 3; revision++)
+      assert.equal((await h.queue.fetch(reviewRequest(`direct-${revision}`, number))).status, 202);
+  }
+  const enqueue = async (
+    name: string,
+    sourceRevision: number,
+    {
+      address = name,
+      generation = 1,
+      delivery = name,
+    }: {
+      address?: string | null;
+      generation?: number;
+      delivery?: string;
+    } = {},
+  ) => {
+    const body = await publicationRequest(
+      `guard-${number}-${delivery}`,
+      number,
+      `${number}${"abcd".indexOf(name) + 1}`,
+      targetRepo,
+      sourceRevision,
+    ).json();
+    body.decision.publication.claimGeneration = generation;
+    if (address) {
+      const command = {
+        commandStatusMarker: `<!-- clawsweeper-command-status:${number}:re_review:${address.repeat(40)} -->`,
+        statusCommentId: number * 10 + "abcd".indexOf(address) + 1,
+      };
+      Object.assign(body.decision, command);
+      Object.assign(body.decision.publication.producerDecision, command);
+    }
+    const response = await h.queue.fetch(batchRequest("/enqueue", body));
+    const result = await response.json();
+    assert.equal(response.status, 202, JSON.stringify(result));
+    assert.ok(result.queued || result.deduped, JSON.stringify(result));
+    const item = (await state()).items[result.item_key];
+    assert.ok(item, JSON.stringify(result));
+    return item;
+  };
+  const a = await enqueue("a", 1);
+  const batchA = (await h.claim({ claim_id: `guard-${number}-a`, max_items: 1 })).batch;
+  assert.equal(batchA.items[0].item_key, a.key);
+  const expire = async () => {
+    h.now = Date.parse(batchA.lease_expires_at) + 1;
+    await h.queue.alarm();
+  };
+  const projectionA = () => lifecycle.read(target, a.key, a.revision);
+  const assertRetained = async () => {
+    assert.equal(projectionA()?.terminalDisposition, null);
+    assert.ok((await state()).items[a.key]);
+  };
+  const publish = async (item) => {
+    const claim = await h.claim({
+      claim_id: `guard-${number}-publish`,
+      lease_owner: "guard-publisher",
+      max_items: 1,
+      runner_run_id: String(number),
+      runner_run_attempt: 1,
+      runner_started_at: new Date(h.now).toISOString(),
+    });
+    assert.equal(claim.claimed, true);
+    const member = claim.batch.items[0];
+    assert.equal(member.item_key, item.key);
+    const published = await h.post(
+      "/publication-batch-results",
+      directPlan(target, member.revision, {
+        fenceKey: member.item_key,
+        claimGeneration: member.claim_generation,
+      }),
+    );
+    assert.equal(published.accepted, true, JSON.stringify(published));
+    const routed = await h.post("/lifecycle/router-receipt", {
+      canonical_target_key: target,
+      fence_key: member.item_key,
+      revision: member.revision,
+      receipt_id: `guard-router-${number}`,
+    });
+    assert.equal(routed.ok, true);
+    const completed = await h.post("/publication-batches/complete", {
+      batch_id: claim.batch.batch_id,
+      lease_owner: "guard-publisher",
+      items: [{ ...member, terminal_outcome: "published" }],
+    });
+    assert.equal(completed.accepted, 1);
+    assert.equal(completed.batch.items[0].terminal_outcome, "published");
+    assert.equal(
+      lifecycle.read(target, member.item_key, member.revision)?.terminalDisposition?.kind,
+      "review_completed_routed",
+    );
+    assert.equal((await state()).items[item.key], undefined);
+  };
+  t.after(() => assert.equal(h.networkCalls, 0));
+  return { h, target, lifecycle, state, enqueue, a, expire, projectionA, assertRetained, publish };
+}
+
+for (const [address, terminal] of [
+  [null, "superseded"],
+  ["a", "requeue"],
+] as const) {
+  test(`retained successor completion preserves ${address ? "the same command" : "a non-command successor"}`, async (t) => {
+    const f = await successorGuardFixture(t, address ? 108751 : 108750);
+    const b = await f.enqueue("b", 2, { address });
+    await f.publish(b);
+    await f.h.queue.alarm();
+    await f.assertRetained();
+    await f.expire();
+    assert.equal(f.projectionA()?.terminalDisposition?.kind, terminal);
+    assert.equal((await f.state()).items[f.a.key], undefined);
+    assert.equal(
+      Object.keys((await f.state()).items).filter((key) =>
+        key.startsWith(`terminal-finalization:${f.a.key}:`),
+      ).length,
+      terminal === "requeue" ? 0 : 1,
+    );
+  });
+}
+
+for (const corruption of [
+  "malformed",
+  "cross-target",
+  "queue-revision",
+  "source-revision",
+  "admission",
+] as const) {
+  test(`successor witness fails closed for ${corruption} drift before accepting newer authority`, async (t) => {
+    const f = await successorGuardFixture(t, 108760);
+    const b = await f.enqueue("b", 2);
+    const witness = (await f.state()).items[f.a.key].publicationSuccessorWitness;
+    assert.equal(witness.state, "verified");
+    if (corruption === "admission") {
+      const projection = f.lifecycle.read(f.target, b.key, b.revision)!;
+      projection.admission.statusMarker = "mismatched-admission";
+      f.h.storage.run(
+        `UPDATE ${EXACT_REVIEW_LIFECYCLE_PROJECTION_TABLE} SET projection_json = ?
+        WHERE canonical_target_key = ? AND fence_key = ? AND revision = ?`,
+        JSON.stringify(projection),
+        f.target,
+        b.key,
+        b.revision,
+      );
+    } else {
+      if (corruption === "malformed") witness.sourceHead = "2";
+      if (corruption === "cross-target") witness.targetKey = "openclaw/other#1";
+      if (corruption === "queue-revision") witness.predecessorQueueRevision += 1;
+      if (corruption === "source-revision") witness.predecessorSourceRevision += 1;
+      f.h.storage.run(
+        `UPDATE exact_review_queue_items
+        SET item_json = json_set(item_json, '$.publicationSuccessorWitness', json(?)) WHERE item_key = ?`,
+        JSON.stringify(witness),
+        f.a.key,
+      );
+    }
+    f.h.restart();
+    if (corruption === "admission") {
+      await f.expire();
+      const diagnostic = await f.h.post("/publications/reconcile", { max_items: 1 });
+      assert.equal(diagnostic.sample[0]?.item_key, f.a.key);
+      assert.equal(diagnostic.sample[0].successor_fence_state, "admission_marker_mismatch");
+    }
+    await f.enqueue("c", 3);
+    assert.equal((await f.state()).items[f.a.key].publicationSuccessorWitness.state, "blocked");
+    await f.expire();
+    await f.assertRetained();
+    await f.enqueue("d", 4);
+    await f.h.queue.alarm();
+    assert.equal(f.projectionA()?.terminalDisposition?.kind, "superseded");
+  });
+}
+
+test("historical missing successor evidence is not reconstructed after completion", async (t) => {
+  const f = await successorGuardFixture(t, 108761);
+  const b = await f.enqueue("b", 2);
+  const legacy = await f.state();
+  delete legacy.items[f.a.key].publicationSuccessorWitness;
+  await f.h.storage.put("exact-review-queue", legacy);
+  f.h.restart();
+  await f.publish(b);
+  await f.expire();
+  await f.assertRetained();
+  const result = await f.h.post("/publications/reconcile", { max_items: 1 });
+  assert.equal(result.sample[0].successor_fence_state, "missing");
+});
+
+test("retained successor resolves the exact mixed-case lifecycle admission target", async (t) => {
+  const f = await successorGuardFixture(t, 108764, false, "openclaw/OpenClaw");
+  const b = await f.enqueue("b", 2);
+  assert.equal((await f.state()).items[f.a.key].publicationSuccessorWitness.targetKey, f.target);
+  await f.publish(b);
+  f.h.restart();
+  await f.expire();
+  assert.equal(f.projectionA()?.terminalDisposition?.kind, "superseded");
+  assert.equal((await f.state()).items[f.a.key], undefined);
+});
+
+test("same-fence redelivery and semantic provenance cannot replace retained successor authority", async (t) => {
+  const f = await successorGuardFixture(t, 108762);
+  const b = await f.enqueue("b", 2);
+  const replay = await f.enqueue("b", 2, { delivery: "b-replay" });
+  assert.ok(replay.revision > b.revision);
+  assert.equal((await f.state()).items[f.a.key].publicationSuccessorWitness.state, "blocked");
+  const refreshed = await f.enqueue("c", 2);
+  assert.equal(refreshed.key, b.key);
+  await f.expire();
+  await f.assertRetained();
+  f.h.restart();
+  await f.h.post("/publications/reconcile", { apply: true, max_items: 10 });
+  await f.assertRetained();
+  assert.equal((await f.state()).items[f.a.key].publicationSuccessorWitness.state, "blocked");
+});
+
+test("same-fence admission at a strictly newer source revision can advance successor authority", async (t) => {
+  const f = await successorGuardFixture(t, 108765);
+  const b = await f.enqueue("b", 2);
+  const newer = await f.enqueue("b", 3, { delivery: "b-newer" });
+  assert.equal(newer.key, b.key);
+  assert.ok(newer.revision > b.revision);
+  const witness = (await f.state()).items[f.a.key].publicationSuccessorWitness;
+  assert.deepEqual(
+    [witness.state, witness.sourceHead, witness.successorQueueRevision],
+    ["verified", 3, newer.revision],
+  );
+  await f.expire();
+  assert.equal(f.projectionA()?.terminalDisposition?.kind, "superseded");
+});
+
+test("direct conversion blocks higher authority without advancing the artifact head", async (t) => {
+  const f = await successorGuardFixture(t, 108763, true);
+  await f.enqueue("b", 2);
+  const review = (await f.state()).items[f.target];
+  assert.equal(review.revision, 3);
+  // Model the already admitted review's live runner lease; only the real
+  // publication endpoint converts it into a successor publication.
+  Object.assign(review, {
+    state: "leased",
+    leaseDecision: review.decision,
+    leaseId: "direct-review",
+    leaseRevision: review.revision,
+    leaseExpiresAt: f.h.now + 60_000,
+    claimedRunId: "98763",
+    claimedRunAttempt: 1,
+    claimGeneration: 1,
+    claimProtocolVersion: 2,
+  });
+  f.h.storage.run(
+    "UPDATE exact_review_queue_items SET item_json = ? WHERE item_key = ?",
+    JSON.stringify(review),
+    review.key,
+  );
+  f.h.restart();
+  const direct = await f.h.post("/publication-results", {
+    ...directPlan(f.target, review.revision, {
+      fenceKey: review.key,
+      claimGeneration: review.claimGeneration,
+    }),
+    sourceSha: "a".repeat(40),
+    lifecycle: { kind: "router" },
+  });
+  assert.equal(direct.accepted, true, JSON.stringify(direct));
+  let witness = (await f.state()).items[f.a.key].publicationSuccessorWitness;
+  assert.deepEqual([witness.state, witness.sourceHead], ["blocked", 3]);
+  const routed = await f.h.post("/lifecycle/router-receipt", {
+    canonical_target_key: f.target,
+    fence_key: review.key,
+    revision: review.revision,
+    receipt_id: "direct-review-router",
+  });
+  assert.equal(routed.ok, true);
+  const completed = await f.h.post("/complete", {
+    lease_id: review.leaseId,
+    item_key: review.key,
+    lease_revision: review.leaseRevision,
+    claim_generation: review.claimGeneration,
+    run_id: review.claimedRunId,
+    run_attempt: review.claimedRunAttempt,
+    outcome: "success",
+    completion_kind: "published",
+    reason_code: "publication_applied",
+  });
+  assert.equal(completed.ok, true, JSON.stringify(completed));
+  assert.equal((await f.state()).items[review.key], undefined);
+  await f.enqueue("c", 2, { generation: 2 });
+  witness = (await f.state()).items[f.a.key].publicationSuccessorWitness;
+  assert.deepEqual([witness.state, witness.sourceHead], ["blocked", 3]);
+  await f.enqueue("d", 3);
+  witness = (await f.state()).items[f.a.key].publicationSuccessorWitness;
+  assert.deepEqual([witness.state, witness.sourceHead], ["blocked", 3]);
+  await f.expire();
+  await f.assertRetained();
+  await f.enqueue("d", 4, { delivery: "d-newer" });
+  await f.h.queue.alarm();
+  assert.equal(f.projectionA()?.terminalDisposition?.kind, "superseded");
+});
+
 test("semantic lineage dedupe cannot leave obsolete rows eligible for a batch", async (t) => {
   t.mock.method(Date, "now", () => 6_250_000);
   const queue = new ExactReviewQueue(


### PR DESCRIPTION
Related: https://github.com/openclaw/clawsweeper/issues/1396

## What Problem This Solves

Resolves a problem where an older publication command could remain without a
terminal outcome after its newer successor completed canonical publication and
router delivery. It also prevents a same-source conflict from appearing unique
merely because one of the conflicting successors has left the queue.

This is prevention for newly recorded admission evidence. Historical rows whose
successor disappeared before that evidence existed are not repaired, and the
related backlog issue remains open.

## Why This Change Was Made

The queue inferred command ownership from live successor rows, but normal
completion removes those rows. The admission owner now retains one bounded,
predecessor-bound `verified` or `blocked` witness instead of reconstructing
ownership after the evidence has disappeared.

Only an actual unique admission advancing both the pre-admission durable source
head and retained authority can establish a newer verified successor. Same-source
ambiguity remains blocked through disappearance, restart, redelivery, and
reconciliation. Malformed evidence and predecessor drift fail closed.

Four existing owner paths update the slot: normal admission, semantic dedupe,
duplicate-lineage reconciliation, and direct publication conversion. The latter
three can preserve or block authority, never establish it. Existing alarm,
terminal-disposition, finalizer, and metrics owners remain unchanged. Exact
lifecycle target casing and specific admission-mismatch diagnostics are preserved.

Production delta: **+217 lines**, including two type-only parameter narrowings
that reuse the existing command-address comparison. Tests: **+646 lines**.
Documentation: **+9 lines**. The growth records an authoritative fact at its
lifecycle owner; it adds no copied decisions, history arrays, side store,
completion/deletion interceptor, SQL/schema change, configuration, capacity,
cadence, or retry-policy change.

## User Impact

After its active lease expires, an older command can receive the existing
successor-aware terminal outcome even when the valid successor has already
completed. Same-command successors retain the existing requeue behavior;
distinct-command or non-command successors retain the existing superseded
acknowledgement behavior. Conflicting or unverifiable ownership stays retained.

Release-note context is kept here rather than editing the release-owned changelog.
No manual deployment or backlog reconciliation is performed by this PR. Merging
triggers the repository's existing dashboard deployment workflow.

## OpenClaw Bay Impact

No Bay response or action contract changes. The witness is private queue state;
existing lifecycle dispositions and metrics continue to supply the observer-only
status surface. No Bay UI, browser request, or mutation control is added.

## Documentation Impact

Updated the active `docs/live-dashboard.md` queue lifecycle documentation with
retained successor evidence, sticky ambiguity, direct-conversion limits, and the
historical-row limitation. Queue maintainers own this guidance; its source of
truth is `dashboard/exact-review-queue.ts`, verified at the commit below.
Admission, successor authority, or terminalization changes require reviewing it.

## Evidence

Reviewed commit: `fd58ec3c5c72a030bcb34e6f65766fcaef28c491`.
Base: `bb8bd3eb709b093a10ff1336227e89986dbcbb0c`.
Tree: `b5aa08ae53db7f5218bda5fabaa5630e323e30f5`.

Current `main` was inspected at `6cd409f54dbb8c6f97dd07c46aa8631d180dfa88`.
Its four commits since this base change scanner fixtures and batching, hot-only
claim reads, and publication-workspace record copying. None changes the queue,
lifecycle admission, retained successor authority, or decision contract exercised
by this proof. No branch rewrite was needed for publication.

- The completed-successor and both same-source ambiguity histories reproduced
  the original failures before the repair.
- Current-source focused coverage passed all 15 successor cases plus the existing
  nine-scenario diagnostic sibling test. Coverage includes ordinary and
  same-command successors, malformed/cross-target evidence, predecessor and
  admission drift, mixed-case identity, semantic redelivery, same-fence revision
  changes, and direct-conversion non-regression of a higher retained head.
- Scoped formatting, lint, dashboard types, documentation checks, and diff checks
  passed. Fresh precommit and committed-branch Codex reviews found no actionable
  findings. Independent implementation review's diagnostic correction was
  reproduced, applied, and revalidated before the signed commit.
- The full local `pnpm run check` **failed**: 5,152 tests, 5,085 passed,
  54 failed, 13 skipped. Failures span 17 unchanged test files and include
  process/readiness deadlines, native terminal cleanup/environment failures, and
  contained pnpm/rustup tool-fetch failures. These are not all proven flakes or
  baseline defects.
- A single serial retry of five failed local timing cases passed unchanged,
  including the batch-heartbeat safety-margin sibling. The other 49 failures
  were not resolved by that local retry. No timeout increases, registry/signature bypasses,
  unrelated source fixes, or broad local rerun were made.
- Local validation used Node 26.7.0, existing shared dependencies, cached
  pnpm 11.10.0, and Bash 5.3.12. Process-local dependency verification used
  pnpm's `warn` mode to prevent dependency reconciliation; repository checks
  and assertions were unchanged.

### Hosted Qualification and Review Disposition

[CI run 34099860543](https://github.com/openclaw/clawsweeper/actions/runs/34099860543)
passed for unchanged head `fd58ec3c5c72a030bcb34e6f65766fcaef28c491`.
The checkout log records GitHub's integration commit
`f2709876af073d5b975bc69b843a7b205912bf9b`, merging that head into inspected
main `6cd409f54dbb8c6f97dd07c46aa8631d180dfa88`.

- [Full Linux pnpm check](https://github.com/openclaw/clawsweeper/actions/runs/34099860543/job/101671562468)
  passed in 10m29s, including actionlint, static checks, builds, lint, changed
  coverage, and all-test coverage. The all-test result was **5,168 tests:
  5,150 passed, zero failed, 18 skipped**. The changed-coverage subset also
  passed all 13 tests.
- Windows launcher and sparse repair build checks passed in the same run.
  Both CodeQL analysis jobs and the aggregate CodeQL check passed.
- Every prior local failure was matched by test name to later evidence:
  **53 of 54 passed in this hosted run**. The sole Linux-skipped case is the
  macOS same-second process-identity test; it passed in the previously recorded
  native macOS serial retry at the unchanged head. There are no unmatched
  prior failures. This qualifies the branch without relabeling the failed
  local run as green or claiming every original failure was a proven flake.
- The [initial ClawSweeper review](https://github.com/openclaw/clawsweeper/pull/1475#issuecomment-5567616070)
  found no actionable code defect and accepted the runtime proof. Its sole
  merge risk and Rank-up move concerned the then-unresolved full-check failures.
  The completed hosted run and named-test reconciliation above address that
  request. No source change was required.

The head and real-runtime proof remain unchanged. This updated main body is the
review context for final readiness; the initial pending-CI review is not used as
a current-body merge verdict.

## Real Behavior Proof

**Claim:** retained admission authority survives successor completion, while
same-source ambiguity survives removal, persistent restart, and redelivery until
a genuinely newer unique admission arrives.

**Executed surface and environment:** the actual Worker and queue ran in local
workerd `1.20260701.1` through Miniflare `4.20260701.0`, with persistent SQLite
storage and Node 26.7.0. Each `node run-fixed.mjs --case=<case>` execution
verified all 51 production bundle inputs against the reviewed commit before
starting workerd and checked the immutable bundle hash again at completion.
Cases were `original`, `overlap`, and `nonoverlap`.

Executed Worker bundle SHA-256:
`ad93d7509616c563fe0c3b9fa9cc31169549f43187e09ce3ea43431e6971b750`.

Setup and publication used real signed local Worker endpoints:
`/enqueue`, batch claim, `/publication-batch-results`,
`/lifecycle/router-receipt`, and `/publication-batches/complete`.
There was no queue-row seeding or direct fixture mutation. Public-repository
admission used synthetic credentials and existing environment hooks.

| Scenario | Signed requests | Explicit alarms | Persistent restarts | Observed result |
| --- | ---: | ---: | ---: | --- |
| A/source1 active; B/source2 completes first | 7 | 3 | 1 | A remains protected while active, then supersedes once after expiry; exactly one A finalizer; completed/superseded counters each +1 and stable after restart alarm |
| B/source2 and C/source2 overlap before B leaves | 11 | 6 | 1 | A remains without terminal/finalizer through expiry, restart, and C replay; only unique D/source3 releases A; exactly one A finalizer |
| B completes before C/source2 is admitted | 11 | 6 | 1 | Same sticky ambiguity and D-only release; exactly one A finalizer and stable replay counters |

Aggregate: **29 signed local requests, 15 explicit production alarm calls,
three persistent SQLite restarts, zero attempted outbound HTTP requests**.
All three executions exited zero; all six owned workerd instances were disposed.

In both conflict histories, D also supersedes older C. Their cumulative
completed/superseded deltas are therefore two, not duplicate transitions for A.
Saved lifecycle projections independently confirm C's terminal outcome.
The following alarm leaves A's exact terminal projection, finalizer count, and
cumulative counters unchanged. Persisted witness snapshots remain identical
through expiry, restart, restart alarm, and same-key C redelivery.

**Limits:** leases use the supported 60,000 ms floor and captured wall-clock
expiry. The controlled fixture defers automatic callbacks and invokes the
production `super.alarm()` at recorded boundaries; this proves alarm behavior,
not Cloudflare scheduler-delivery timing. No Date/timer replacement is used.
Dispatcher timing metadata may refresh, so whole-store equality is not claimed.
Malformed-witness and direct-conversion monotonic-head cases are covered by
focused tests, not this three-case runtime package. No real GitHub acknowledgement
delivery, production deployment, health probe, or historical backlog repair is
claimed.
