### PR TITLE
fix(queue): retire closed publications through reviewed maintenance plans

### DIFF
--- a/.github/workflows/exact-review-queue-maintenance.yml
+++ b/.github/workflows/exact-review-queue-maintenance.yml
@@ -3,6 +3,12 @@ name: Maintain exact review queue
 on:
   workflow_dispatch:
     inputs:
+      mode:
+        description: "Reconcile lineages or retire one verified closed publication"
+        required: true
+        type: choice
+        options: [reconcile, retire-closed-publication]
+        default: reconcile
       execute:
         description: "Apply one bounded pass (false runs a dry-run)"
         required: true
@@ -18,6 +24,21 @@ on:
         required: true
         type: number
         default: 1
+      producer_run_id:
+        description: "Retirement only: exact producer run ID"
+        type: string
+      artifact_id:
+        description: "Retirement only: exact producer artifact ID"
+        type: string
+      publication_key_sha256:
+        description: "Retirement only: approved publication-key SHA256"
+        type: string
+      queue_revision:
+        description: "Retirement only: approved publication queue revision"
+        type: string
+      reviewed_plan_sha256:
+        description: "Retirement execute requires the reviewed preview plan SHA256"
+        type: string
 
 concurrency:
   group: exact-review-queue-maintenance
@@ -28,11 +49,11 @@ permissions:
 
 jobs:
   reconcile:
+    if: ${{ inputs.mode == 'reconcile' || inputs.mode == '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
       EXACT_REVIEW_QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
-      CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -47,6 +68,7 @@ jobs:
 
       - name: Preview or reconcile historical publication lineages
         env:
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           EXECUTE: ${{ inputs.execute }}
           PASSES: ${{ inputs.passes }}
           MAX_ITEMS: ${{ inputs.max_items }}
@@ -57,3 +79,49 @@ jobs:
           fi
           args+=(--passes "$PASSES")
           pnpm run --silent repair:exact-review-queue-maintenance -- "${args[@]}"
+
+  retire-closed-publication:
+    if: ${{ inputs.mode == 'retire-closed-publication' && github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          filter: blob:none
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-pnpm
+        with:
+          build-script: build:repair
+
+      - name: Prepare closed publication retirement
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PRODUCER_RUN_ID: ${{ inputs.producer_run_id }}
+          ARTIFACT_ID: ${{ inputs.artifact_id }}
+          PUBLICATION_KEY_SHA256: ${{ inputs.publication_key_sha256 }}
+          QUEUE_REVISION: ${{ inputs.queue_revision }}
+        run: |
+          pnpm run --silent repair:exact-review-queue-maintenance retire-closed-publication \
+            --producer-run-id "$PRODUCER_RUN_ID" \
+            --artifact-id "$ARTIFACT_ID" \
+            --publication-key-sha256 "$PUBLICATION_KEY_SHA256" \
+            --queue-revision "$QUEUE_REVISION" \
+            --plan-file "$RUNNER_TEMP/closed-publication-retirement.json"
+
+      - name: Assert reviewed closed publication retirement
+        if: ${{ inputs.execute }}
+        env:
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          EXACT_REVIEW_QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          REVIEWED_PLAN_SHA256: ${{ inputs.reviewed_plan_sha256 }}
+        run: |
+          pnpm run --silent repair:exact-review-queue-maintenance retire-closed-publication \
+            --apply \
+            --reviewed-plan-sha256 "$REVIEWED_PLAN_SHA256" \
+            --plan-file "$RUNNER_TEMP/closed-publication-retirement.json"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Add reviewed-plan retirement of one merged-target publication through the existing maintenance workflow, keeping signing credentials confined to its execution step.
 - Admit the two approved Signal URL-rejection fixtures through exact URI, source-line, path, and native decoder bindings while retaining all scanner and verification checks.
 - Admit the reviewed Crabbox PostgreSQL operations example through exact Postgres detector, observed `PLAIN`/`HTML` decoder, value-hash, source-line, path, mode, metadata, and committed base/head bindings.
 - Admit the reviewed OpenClaw logging redaction fixtures through exact detector, native decoder, role, value-hash, source-line, path, mode, and metadata bindings while preserving legacy URI fixture behavior.

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -761,6 +761,52 @@ request cleanup, and cold-start initialization still run. `apply:true` retains
 normal expiry recovery and terminalization. This is an authenticated operator
 route, not a Bay action.
 
+### Retire One Closed-Target Publication
+
+Active operator runbook. Owner: exact-review maintainers. Owning sources:
+`.github/workflows/exact-review-queue-maintenance.yml`,
+`src/repair/closed-publication-retirement.ts`, and
+`dashboard/exact-review-queue.ts`. Last source verification: `ff0156fb` plus
+the retirement maintenance route. Update this section when artifact provenance,
+plan fields, terminal disposition, or acknowledgement ownership changes.
+
+Use **Maintain exact review queue** on `main`, mode
+`retire-closed-publication`, only for an explicitly approved publication whose
+public target PR is merged. Supply its exact producer run ID, artifact ID,
+publication-key SHA256, and publication queue revision. The source-review
+revision in the artifact is not the publication queue revision.
+
+1. Leave `execute` false. Preview fetches the exact artifact and attempt
+   metadata, verifies the archive digest, reads only its bounded root manifest,
+   and checks the public merged target. It neither constructs a Worker client
+   nor requests a Worker route. An expired artifact or absent GitHub archive
+   digest fails closed.
+2. Review the emitted plan SHA256 and numeric tuple against the approved
+   publication. The plan also binds the immutable workflow SHA, historical
+   producer source SHA, archive identity, and merged PR identity. Raw target
+   keys, command identities, artifact contents, and signed URLs stay private.
+3. Run the same inputs with `execute` true and `reviewed_plan_sha256` set to
+   that reviewed hash. Preparation remains secretless with respect to the
+   Worker signing credential. Only the final assertion step receives it.
+   A changed workflow SHA or evidence requires a new preview and review.
+
+Execution records one **new operator `target_closed` fact** through the existing
+terminal-disposition route. It is not a replay of a historical completion.
+This is deliberately not an ownership CAS: concurrent active or newer queue
+ownership does not reject the assertion. The normal owner removes only a
+matching pending or parked publication revision and uses the original
+admission's command marker for acknowledgement. It does not retire another
+publication, reject a concurrent owner, or publish a stale review verdict.
+
+The normal finalizer must observe the original command acknowledgement as
+`Complete`, with detail `The item is closed; no stale verdict was published.`,
+and record its verified receipt. HTTP success or `acknowledgementState: pending`
+is not completion proof. Check the exact original receipt, available matching
+queue cleanup evidence, and preservation of later commands. Do not force a
+driver dispatch. On timeout, redirect, malformed response, or error, stop and
+inspect the exact operation; never blindly retry or substitute a new operation
+ID. Bay remains observer-only and uses the unchanged lifecycle projections.
+
 `POST /internal/exact-review/reconcile` backstop accepts at most 32 exact run IDs
 and intersects them with currently claimed leases. The Worker checks those IDs
 and attempts with an Actions-read GitHub App token and reconciles only runs

--- a/package.json
+++ b/package.json
@@ -121,10 +121,12 @@
     "repair:pr-intake": "node dist/repair/pr-repair-intake.js"
   },
   "dependencies": {
-    "yaml": "^2.9.0"
+    "yaml": "^2.9.0",
+    "yauzl": "3.4.0"
   },
   "devDependencies": {
     "@types/node": "^24.13.3",
+    "@types/yauzl": "3.4.0",
     "markdown-it": "^15.0.0",
     "oxfmt": "^0.58.0",
     "oxlint": "^1.73.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,10 +11,16 @@ importers:
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
+      yauzl:
+        specifier: 3.4.0
+        version: 3.4.0
     devDependencies:
       '@types/node':
         specifier: ^24.13.3
         version: 24.13.3
+      '@types/yauzl':
+        specifier: 3.4.0
+        version: 3.4.0
       markdown-it:
         specifier: ^15.0.0
         version: 15.0.0
@@ -313,6 +319,9 @@ packages:
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
+  '@types/yauzl@3.4.0':
+    resolution: {integrity: sha512-NRPn5w6h8dhcnmx3YIRQcqMywY/+nND/uOkJessedcrowO3C0AssHp3tMJpxKAwOhFOo0OV1y9VtsC5hbKKBAw==}
+
   '@typescript/typescript-aix-ppc64@7.0.2':
     resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
     engines: {node: '>=16.20.0'}
@@ -480,6 +489,9 @@ packages:
       vite-plus:
         optional: true
 
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+
   playwright-core@1.62.1:
     resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
     engines: {node: '>=20'}
@@ -508,6 +520,10 @@ packages:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  yauzl@3.4.0:
+    resolution: {integrity: sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==}
+    engines: {node: '>=12'}
 
 snapshots:
 
@@ -647,6 +663,10 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
+  '@types/yauzl@3.4.0':
+    dependencies:
+      '@types/node': 24.13.3
+
   '@typescript/typescript-aix-ppc64@7.0.2':
     optional: true
 
@@ -782,6 +802,8 @@ snapshots:
       '@oxlint/binding-win32-x64-msvc': 1.73.0
       oxlint-tsgolint: 0.24.0
 
+  pend@1.2.0: {}
+
   playwright-core@1.62.1: {}
 
   punycode.js@2.3.1: {}
@@ -816,3 +838,7 @@ snapshots:
   undici-types@7.18.2: {}
 
   yaml@2.9.0: {}
+
+  yauzl@3.4.0:
+    dependencies:
+      pend: 1.2.0

--- a/src/repair/closed-publication-retirement.ts
+++ b/src/repair/closed-publication-retirement.ts
@@ -1,0 +1,377 @@
+import { fromBufferPromise } from "yauzl";
+import { sha256 } from "../content-hash.js";
+import { stableJson } from "../stable-json.js";
+import { requireRecord } from "../value-coerce.js";
+import {
+  EXACT_REVIEW_BUNDLE_MAX_ARTIFACT_BYTES,
+  EXACT_REVIEW_BUNDLE_MAX_FILE_BYTES,
+  EXACT_REVIEW_BUNDLE_MAX_FILES,
+  validateManifest,
+} from "./exact-review-bundle.js";
+import type { ExactReviewBatchQueueClient } from "./exact-review-batch-queue-client.js";
+
+const REPOSITORY = "openclaw/clawsweeper";
+const API = "https://api.github.com";
+const WORKFLOW = ".github/workflows/sweep.yml";
+const MAX_JSON_BYTES = 2 * 1024 * 1024;
+const MAX_ARCHIVE_BYTES = EXACT_REVIEW_BUNDLE_MAX_ARTIFACT_BYTES;
+const SHA = /^[0-9a-f]{40}$/;
+const HASH = /^[0-9a-f]{64}$/;
+
+export interface ClosedPublicationRetirementInput {
+  producerRunId: number;
+  artifactId: number;
+  publicationKeySha256: string;
+  queueRevision: number;
+  workflowSha: string;
+}
+
+export interface ClosedPublicationRetirementPlan {
+  version: 1;
+  workflowSha: string;
+  artifactId: number;
+  artifactSha256: string;
+  producerRunId: number;
+  producerRunAttempt: number;
+  producerSourceSha: string;
+  sourceRevision: number;
+  claimGeneration: number;
+  queueRevision: number;
+  canonicalTargetKey: string;
+  publicationKey: string;
+  publicationKeySha256: string;
+  targetNodeId: string;
+  mergedAt: string;
+  mergeCommitSha: string;
+}
+
+function check(condition: unknown): asserts condition {
+  if (!condition) throw new Error("invalid closed publication retirement evidence");
+}
+
+function positive(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+async function boundedBody(response: Response, limit: number): Promise<Buffer> {
+  const declared = response.headers.get("content-length");
+  check(declared === null || (/^\d+$/.test(declared) && Number(declared) <= limit));
+  check(response.body);
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let bytes = 0;
+  try {
+    while (true) {
+      const part = await reader.read();
+      if (part.done) break;
+      bytes += part.value.byteLength;
+      check(bytes <= limit);
+      chunks.push(part.value);
+    }
+  } finally {
+    await reader.cancel();
+  }
+  return Buffer.concat(chunks, bytes);
+}
+
+export async function readRetirementManifest(archive: Buffer, expectedDigest: string) {
+  check(HASH.test(expectedDigest) && archive.length <= MAX_ARCHIVE_BYTES);
+  // yauzl validates sizes, not file-data CRCs. Authenticate the complete archive
+  // against GitHub's independently fetched digest before interpreting any entry.
+  check(sha256(archive) === expectedDigest);
+  const zip = await fromBufferPromise(archive, {
+    lazyEntries: true,
+    strictFileNames: true,
+    validateEntrySizes: true,
+  });
+  let manifestBytes: Buffer | undefined;
+  let totalBytes = 0;
+  const paths = new Set<string>();
+  const files = new Map<string, number>();
+  try {
+    check(zip.entryCount <= EXACT_REVIEW_BUNDLE_MAX_FILES * 2 + 1);
+    for await (const entry of zip.eachEntry()) {
+      const name = entry.fileName;
+      check(name && !name.includes("\0") && !name.split("/").includes(".") && !paths.has(name));
+      paths.add(name);
+      check(!entry.isEncrypted() && [0, 8].includes(entry.compressionMethod));
+      check(Number.isSafeInteger(entry.uncompressedSize) && entry.uncompressedSize >= 0);
+      check(Number.isSafeInteger(entry.compressedSize) && entry.compressedSize >= 0);
+      check(entry.compressedSize <= MAX_ARCHIVE_BYTES);
+      totalBytes += entry.uncompressedSize;
+      check(totalBytes <= MAX_ARCHIVE_BYTES + EXACT_REVIEW_BUNDLE_MAX_FILE_BYTES);
+      const mode = (entry.externalFileAttributes >>> 16) & 0o170000;
+      const directory = name.endsWith("/");
+      check(mode === 0 || mode === (directory ? 0o040000 : 0o100000));
+      check(!(entry.externalFileAttributes & 0x10) || directory);
+      await zip.readLocalFileHeaderPromise(entry, { minimal: true });
+      if (directory) {
+        check(entry.uncompressedSize === 0);
+        continue;
+      }
+      if (name !== "manifest.json") {
+        files.set(name, entry.uncompressedSize);
+        continue;
+      }
+      check(!manifestBytes && entry.uncompressedSize <= EXACT_REVIEW_BUNDLE_MAX_FILE_BYTES);
+      const stream = await zip.openReadStreamPromise(entry);
+      const chunks: Buffer[] = [];
+      let bytes = 0;
+      try {
+        for await (const chunk of stream) {
+          bytes += chunk.length;
+          check(bytes <= EXACT_REVIEW_BUNDLE_MAX_FILE_BYTES);
+          chunks.push(chunk);
+        }
+      } finally {
+        stream.destroy();
+      }
+      manifestBytes = Buffer.concat(chunks, bytes);
+    }
+  } finally {
+    zip.close();
+  }
+  check(manifestBytes);
+  const manifest = validateManifest(
+    JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(manifestBytes)),
+  );
+  check(files.size === manifest.files.length);
+  for (const file of manifest.files) check(files.get(file.path) === file.bytes);
+  return manifest;
+}
+
+export async function prepareClosedPublicationRetirement(
+  input: ClosedPublicationRetirementInput,
+  token: string,
+  request: typeof fetch = fetch,
+): Promise<ClosedPublicationRetirementPlan> {
+  check(
+    positive(input.producerRunId) && positive(input.artifactId) && positive(input.queueRevision),
+  );
+  check(HASH.test(input.publicationKeySha256) && SHA.test(input.workflowSha) && token);
+  const headers = { accept: "application/vnd.github+json", authorization: `Bearer ${token}` };
+  async function get(path: string, authenticated = true) {
+    const response = await request(`${API}${path}`, {
+      headers: authenticated ? headers : { accept: headers.accept },
+      redirect: "error",
+      signal: AbortSignal.timeout(30_000),
+    });
+    check(response.ok);
+    return requireRecord(
+      JSON.parse((await boundedBody(response, MAX_JSON_BYTES)).toString("utf8")),
+      "metadata",
+    );
+  }
+  const artifact = await get(`/repos/${REPOSITORY}/actions/artifacts/${input.artifactId}`);
+  const artifactRun = requireRecord(artifact.workflow_run, "artifact run");
+  check(artifact.id === input.artifactId && artifactRun.id === input.producerRunId);
+  check(
+    artifact.expired === false &&
+      positive(artifact.size_in_bytes) &&
+      artifact.size_in_bytes <= MAX_ARCHIVE_BYTES,
+  );
+  check(typeof artifact.digest === "string" && /^sha256:[0-9a-f]{64}$/.test(artifact.digest));
+  const name =
+    typeof artifact.name === "string"
+      ? /^exact-review-(\d+)-([1-9]\d*)$/.exec(artifact.name)
+      : null;
+  check(name && name[1] === String(input.producerRunId) && positive(Number(name[2])));
+  const attempt = Number(name[2]);
+  const run = await get(
+    `/repos/${REPOSITORY}/actions/runs/${input.producerRunId}/attempts/${attempt}`,
+  );
+  const repo = requireRecord(run.repository, "producer repository");
+  check(run.id === input.producerRunId && run.run_attempt === attempt && run.path === WORKFLOW);
+  check(repo.full_name === REPOSITORY && repo.id === artifactRun.repository_id);
+  check(
+    typeof run.head_sha === "string" &&
+      SHA.test(run.head_sha) &&
+      run.head_sha === artifactRun.head_sha,
+  );
+
+  // GitHub authenticates only the exact-ID redirect request. Never forward its
+  // token to the signed blob URL, and bound each redirect and body independently.
+  let response = await request(
+    `${API}/repos/${REPOSITORY}/actions/artifacts/${input.artifactId}/zip`,
+    {
+      headers,
+      redirect: "manual",
+      signal: AbortSignal.timeout(30_000),
+    },
+  );
+  for (let redirects = 0; [301, 302, 303, 307, 308].includes(response.status); redirects += 1) {
+    check(redirects < 3);
+    const location = response.headers.get("location");
+    check(location);
+    const url = new URL(location);
+    check(url.protocol === "https:" && !url.username && !url.password);
+    await response.body?.cancel();
+    response = await request(url, { redirect: "manual", signal: AbortSignal.timeout(30_000) });
+  }
+  check(response.ok);
+  const digest = artifact.digest.slice(7);
+  const archive = await boundedBody(response, MAX_ARCHIVE_BYTES);
+  check(archive.length === artifact.size_in_bytes);
+  const manifest = await readRetirementManifest(archive, digest);
+  check(
+    manifest.workflow.repository === REPOSITORY && manifest.workflow.source_sha === run.head_sha,
+  );
+  check(
+    manifest.workflow.run_id === String(input.producerRunId) &&
+      manifest.workflow.run_attempt === attempt,
+  );
+  check(manifest.workflow.producer_job === "event-review-apply");
+  check(
+    manifest.queue.protocol_version === 2 &&
+      positive(manifest.queue.lease_revision) &&
+      positive(manifest.queue.claim_generation),
+  );
+  check(manifest.target.item_kind === "pull_request");
+  // This is the publication addressing contract in dashboard/exact-review-decision.ts,
+  // not the manifest's source-review key or source lease revision.
+  const publicationKey = `${manifest.queue.item_key}@publish:${input.producerRunId}:${attempt}`;
+  check(sha256(publicationKey) === input.publicationKeySha256);
+  const target = await get(
+    `/repos/${manifest.target.repo}/pulls/${manifest.target.item_number}`,
+    false,
+  );
+  const targetRepo = requireRecord(
+    requireRecord(target.base, "target base").repo,
+    "target repository",
+  );
+  check(targetRepo.private === false && targetRepo.full_name === manifest.target.repo);
+  check(
+    target.number === manifest.target.item_number &&
+      target.state === "closed" &&
+      target.merged === true,
+  );
+  check(
+    typeof target.node_id === "string" && target.node_id.length > 0 && target.node_id.length <= 200,
+  );
+  check(typeof target.merged_at === "string" && Number.isFinite(Date.parse(target.merged_at)));
+  check(typeof target.merge_commit_sha === "string" && SHA.test(target.merge_commit_sha));
+  return {
+    version: 1,
+    workflowSha: input.workflowSha,
+    artifactId: input.artifactId,
+    artifactSha256: digest,
+    producerRunId: input.producerRunId,
+    producerRunAttempt: attempt,
+    producerSourceSha: run.head_sha,
+    sourceRevision: manifest.queue.lease_revision,
+    claimGeneration: manifest.queue.claim_generation,
+    queueRevision: input.queueRevision,
+    canonicalTargetKey: manifest.queue.item_key,
+    publicationKey,
+    publicationKeySha256: input.publicationKeySha256,
+    targetNodeId: target.node_id,
+    mergedAt: target.merged_at,
+    mergeCommitSha: target.merge_commit_sha,
+  };
+}
+
+export function retirementPlanSummary(plan: ClosedPublicationRetirementPlan) {
+  return {
+    ok: true,
+    status: "preview" as const,
+    planSha256: sha256(stableJson(plan)),
+    publicationKeySha256: plan.publicationKeySha256,
+    artifactSha256: plan.artifactSha256,
+    workflowSha: plan.workflowSha,
+    queueRevision: plan.queueRevision,
+    sourceRevision: plan.sourceRevision,
+    claimGeneration: plan.claimGeneration,
+    protocolVersion: 2,
+  };
+}
+
+export async function applyClosedPublicationRetirement(
+  value: unknown,
+  reviewedPlanSha256: string,
+  workflowSha: string,
+  createClient: () => Pick<ExactReviewBatchQueueClient, "postEffect">,
+) {
+  const plan = requireRecord(value, "retirement plan");
+  check(Object.keys(plan).length === 16);
+  check(
+    ["workflowSha", "producerSourceSha", "mergeCommitSha"].every(
+      (key) => typeof plan[key] === "string" && SHA.test(plan[key]),
+    ),
+  );
+  check(
+    ["artifactSha256", "publicationKeySha256"].every(
+      (key) => typeof plan[key] === "string" && HASH.test(plan[key]),
+    ),
+  );
+  check(
+    [
+      "artifactId",
+      "producerRunId",
+      "producerRunAttempt",
+      "sourceRevision",
+      "claimGeneration",
+      "queueRevision",
+    ].every((key) => positive(plan[key])),
+  );
+  check(
+    typeof plan.targetNodeId === "string" &&
+      plan.targetNodeId.length > 0 &&
+      plan.targetNodeId.length <= 200,
+  );
+  check(typeof plan.mergedAt === "string" && Number.isFinite(Date.parse(plan.mergedAt)));
+  check(typeof plan.canonicalTargetKey === "string" && typeof plan.publicationKey === "string");
+  check(HASH.test(reviewedPlanSha256) && SHA.test(workflowSha));
+  check(plan.version === 1 && plan.workflowSha === workflowSha);
+  check(sha256(stableJson(plan)) === reviewedPlanSha256);
+  check(/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+#[1-9]\d*$/.test(plan.canonicalTargetKey));
+  check(
+    plan.publicationKey ===
+      `${plan.canonicalTargetKey}@publish:${plan.producerRunId}:${plan.producerRunAttempt}`,
+  );
+  check(sha256(plan.publicationKey) === plan.publicationKeySha256);
+  const result = await createClient().postEffect(
+    "terminal-disposition",
+    JSON.stringify({
+      canonical_target_key: plan.canonicalTargetKey,
+      fence_key: plan.publicationKey,
+      revision: plan.queueRevision,
+      kind: "target_closed",
+      operation_id: `operator-retire-target_closed:${plan.publicationKeySha256}:${plan.queueRevision}`,
+    }),
+  );
+  check(result.ok === true);
+  check(
+    typeof result.lifecycle_state === "string" &&
+      [
+        "pending",
+        "completed",
+        "acknowledgement_pending",
+        "acknowledgement_skipped",
+        "superseded",
+        "requeue",
+        "dead_letter",
+        "target_closed",
+        "target_missing",
+        "policy_noop",
+        "guarded_open",
+        "failed",
+      ].includes(result.lifecycle_state),
+  );
+  check(
+    typeof result.acknowledgement_state === "string" &&
+      [
+        "not_required",
+        "pending",
+        "observed",
+        "skipped_locked",
+        "skipped_missing_comment",
+        "unavailable",
+      ].includes(result.acknowledgement_state),
+  );
+  return {
+    ...retirementPlanSummary(plan as unknown as ClosedPublicationRetirementPlan),
+    status: "asserted" as const,
+    lifecycleState: result.lifecycle_state,
+    acknowledgementState: result.acknowledgement_state,
+  };
+}

--- a/src/repair/exact-review-bundle.ts
+++ b/src/repair/exact-review-bundle.ts
@@ -276,7 +276,7 @@ function validateContext(value: ExactReviewBundleContext): ExactReviewBundleCont
   return { ...value };
 }
 
-function validateManifest(value: unknown): ExactReviewBundleManifest {
+export function validateManifest(value: unknown): ExactReviewBundleManifest {
   const manifest = record(value, "manifest");
   exactKeys(manifest, [
     "schema_version",

--- a/src/repair/exact-review-queue-maintenance.ts
+++ b/src/repair/exact-review-queue-maintenance.ts
@@ -1,42 +1,131 @@
 #!/usr/bin/env node
 import { createHash } from "node:crypto";
+import { readFileSync, statSync, writeFileSync } from "node:fs";
+import { parseArgs } from "node:util";
 import { ExactReviewBatchQueueClient } from "./exact-review-batch-queue-client.js";
 
-const apply = process.argv.includes("--apply");
-const maxItems = integerArg("--max-items", 100, 1, 100);
-const requestedPasses = integerArg("--passes", 1, 1, 100);
-const client = new ExactReviewBatchQueueClient({
-  baseUrl: env("EXACT_REVIEW_QUEUE_URL"),
-  webhookSecret: env("CLAWSWEEPER_WEBHOOK_SECRET"),
-});
+if (process.argv[2] === "retire-closed-publication") {
+  try {
+    await retireClosedPublication();
+  } catch {
+    // Artifacts, signed redirect URLs, and transport failures can contain private
+    // identities. This operator surface deliberately emits no exception detail.
+    console.error('{"ok":false,"status":"retirement_failed"}');
+    console.error("[exact-review-queue-maintenance] FAILED (exit 1)");
+    process.exitCode = 1;
+  }
+} else if (validReconciliationArguments()) {
+  await reconcile();
+} else {
+  console.error("[exact-review-queue-maintenance] invalid arguments");
+  console.error("[exact-review-queue-maintenance] FAILED (exit 1)");
+  process.exitCode = 1;
+}
 
-if (requestedPasses > 1) {
-  console.error(
-    `--passes=${requestedPasses} is deprecated and clamped to one observed pass per invocation`,
+function validReconciliationArguments(): boolean {
+  const args = process.argv.slice(2);
+  try {
+    parseArgs({
+      args: args[0] === "--" ? args.slice(1) : args,
+      options: {
+        apply: { type: "boolean" },
+        "max-items": { type: "string" },
+        passes: { type: "string" },
+      },
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function retireClosedPublication() {
+  const { values } = parseArgs({
+    args: process.argv.slice(3),
+    options: {
+      apply: { type: "boolean", default: false },
+      "plan-file": { type: "string" },
+      "producer-run-id": { type: "string" },
+      "artifact-id": { type: "string" },
+      "publication-key-sha256": { type: "string" },
+      "queue-revision": { type: "string" },
+      "reviewed-plan-sha256": { type: "string" },
+    },
+  });
+  if (!values["plan-file"]) throw new Error("plan file required");
+  const {
+    prepareClosedPublicationRetirement,
+    applyClosedPublicationRetirement,
+    retirementPlanSummary,
+  } = await import("./closed-publication-retirement.js");
+  if (values.apply) {
+    if (statSync(values["plan-file"]).size > 8192) throw new Error("plan too large");
+    const bytes = readFileSync(values["plan-file"]);
+    if (bytes.length > 8192) throw new Error("plan too large");
+    const result = await applyClosedPublicationRetirement(
+      JSON.parse(bytes.toString("utf8")),
+      values["reviewed-plan-sha256"] ?? "",
+      env("GITHUB_SHA"),
+      () =>
+        new ExactReviewBatchQueueClient({
+          baseUrl: env("EXACT_REVIEW_QUEUE_URL"),
+          webhookSecret: env("CLAWSWEEPER_WEBHOOK_SECRET"),
+        }),
+    );
+    console.log(JSON.stringify(result));
+    return;
+  }
+  const plan = await prepareClosedPublicationRetirement(
+    {
+      producerRunId: Number(values["producer-run-id"]),
+      artifactId: Number(values["artifact-id"]),
+      publicationKeySha256: values["publication-key-sha256"] ?? "",
+      queueRevision: Number(values["queue-revision"]),
+      workflowSha: env("GITHUB_SHA"),
+    },
+    env("GH_TOKEN"),
+  );
+  writeFileSync(values["plan-file"], JSON.stringify(plan), { mode: 0o600, flag: "wx" });
+  console.log(JSON.stringify(retirementPlanSummary(plan)));
+}
+
+async function reconcile() {
+  const apply = process.argv.includes("--apply");
+  const maxItems = integerArg("--max-items", 100, 1, 100);
+  const requestedPasses = integerArg("--passes", 1, 1, 100);
+  const client = new ExactReviewBatchQueueClient({
+    baseUrl: env("EXACT_REVIEW_QUEUE_URL"),
+    webhookSecret: env("CLAWSWEEPER_WEBHOOK_SECRET"),
+  });
+
+  if (requestedPasses > 1) {
+    console.error(
+      `--passes=${requestedPasses} is deprecated and clamped to one observed pass per invocation`,
+    );
+  }
+  const result = await client.reconcilePublications({ apply, maxItems });
+  console.log(
+    JSON.stringify({
+      ok: true,
+      requestedPasses,
+      effectivePasses: 1,
+      ...result,
+      // Retain stable row correlation without logging target or producer identities.
+      sample: result.sample.map((sample) => ({
+        identity_hash: createHash("sha256").update(sample.itemKey).digest("hex"),
+        queueRevision: sample.queueRevision,
+        reason: sample.reason,
+        publicationRevision: sample.publicationRevision,
+        supersededByRevision: sample.supersededByRevision,
+        commandContext: sample.commandContext,
+        acknowledgementState: sample.acknowledgementState,
+        acknowledgementUnavailableReason: sample.acknowledgementUnavailableReason,
+        supersedeSafe: sample.supersedeSafe,
+        successorFenceState: sample.successorFenceState,
+      })),
+    }),
   );
 }
-const result = await client.reconcilePublications({ apply, maxItems });
-console.log(
-  JSON.stringify({
-    ok: true,
-    requestedPasses,
-    effectivePasses: 1,
-    ...result,
-    // Retain stable row correlation without logging target or producer identities.
-    sample: result.sample.map((sample) => ({
-      identity_hash: createHash("sha256").update(sample.itemKey).digest("hex"),
-      queueRevision: sample.queueRevision,
-      reason: sample.reason,
-      publicationRevision: sample.publicationRevision,
-      supersededByRevision: sample.supersededByRevision,
-      commandContext: sample.commandContext,
-      acknowledgementState: sample.acknowledgementState,
-      acknowledgementUnavailableReason: sample.acknowledgementUnavailableReason,
-      supersedeSafe: sample.supersedeSafe,
-      successorFenceState: sample.successorFenceState,
-    })),
-  }),
-);
 
 function integerArg(name: string, fallback: number, minimum: number, maximum: number): number {
   const index = process.argv.indexOf(name);

--- a/test/repair/closed-publication-retirement.test.ts
+++ b/test/repair/closed-publication-retirement.test.ts
@@ -137,7 +137,7 @@ function fixture() {
         headers: { location: "https://blob.example.test/private-signed-url-sentinel" },
       });
     }
-    if (String(url).startsWith("https://blob.example.test/")) {
+    if (String(url) === "https://blob.example.test/private-signed-url-sentinel") {
       assert.equal(new Headers(options?.headers).get("authorization"), null);
       return new Response(archive);
     }
@@ -350,22 +350,30 @@ test("bounded manifest-only parser rejects unsafe and malformed archives", async
 test("unsigned archive download refuses insecure or looping redirects", async () => {
   for (const location of [
     "http://blob.example.test/private",
-    "https://user:password@blob.example.test/",
+    "https://fixture-user:***@blob.example.test/",
   ]) {
     const f = fixture();
+    let rejectedDestinationRequests = 0;
     await assert.rejects(
-      prepareClosedPublicationRetirement(f.input, "token-sentinel", async (url, options) =>
-        String(url).endsWith("/zip")
+      prepareClosedPublicationRetirement(f.input, "token-sentinel", async (url, options) => {
+        if (String(url) === location) rejectedDestinationRequests += 1;
+        return String(url).endsWith("/zip")
           ? new Response(null, { status: 302, headers: { location } })
-          : f.request(url, options),
-      ),
+          : f.request(url, options);
+      }),
+      { message: "invalid closed publication retirement evidence" },
     );
+    assert.equal(rejectedDestinationRequests, 0);
   }
   const f = fixture();
   let requests = 0;
   await assert.rejects(
     prepareClosedPublicationRetirement(f.input, "token-sentinel", async (url, options) => {
-      if (String(url).endsWith("/zip") || String(url).startsWith("https://blob.example.test")) {
+      if (
+        String(url) ===
+          "https://api.github.com/repos/openclaw/clawsweeper/actions/artifacts/9001/zip" ||
+        String(url) === "https://blob.example.test/loop"
+      ) {
         requests += 1;
         return new Response(null, {
           status: 302,

--- a/test/repair/closed-publication-retirement.test.ts
+++ b/test/repair/closed-publication-retirement.test.ts
@@ -1,0 +1,379 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { crc32, deflateRawSync } from "node:zlib";
+import { sha256 } from "../../dist/content-hash.js";
+import {
+  applyClosedPublicationRetirement,
+  prepareClosedPublicationRetirement,
+  readRetirementManifest,
+  retirementPlanSummary,
+} from "../../dist/repair/closed-publication-retirement.js";
+
+type Member = {
+  name: string;
+  body: Buffer;
+  method?: number;
+  flags?: number;
+  mode?: number;
+  declaredBytes?: number;
+};
+
+function zip(members: Member[]) {
+  const locals: Buffer[] = [];
+  const central: Buffer[] = [];
+  let offset = 0;
+  for (const member of members) {
+    const name = Buffer.from(member.name);
+    const method = member.method ?? 8;
+    const data = method === 8 ? deflateRawSync(member.body) : member.body;
+    const local = Buffer.alloc(30);
+    local.writeUInt32LE(0x04034b50);
+    local.writeUInt16LE(20, 4);
+    local.writeUInt16LE(member.flags ?? 0, 6);
+    local.writeUInt16LE(method, 8);
+    local.writeUInt32LE(crc32(member.body), 14);
+    local.writeUInt32LE(data.length, 18);
+    local.writeUInt32LE(member.declaredBytes ?? member.body.length, 22);
+    local.writeUInt16LE(name.length, 26);
+    const entry = Buffer.alloc(46);
+    entry.writeUInt32LE(0x02014b50);
+    entry.writeUInt16LE(0x0314, 4);
+    local.copy(entry, 6, 4, 26);
+    entry.writeUInt16LE(name.length, 28);
+    entry.writeUInt32LE(((member.mode ?? 0o100644) * 0x10000) >>> 0, 38);
+    entry.writeUInt32LE(offset, 42);
+    locals.push(local, name, data);
+    central.push(entry, name);
+    offset += local.length + name.length + data.length;
+  }
+  const directory = Buffer.concat(central);
+  const end = Buffer.alloc(22);
+  end.writeUInt32LE(0x06054b50);
+  end.writeUInt16LE(members.length, 8);
+  end.writeUInt16LE(members.length, 10);
+  end.writeUInt32LE(directory.length, 12);
+  end.writeUInt32LE(offset, 16);
+  return Buffer.concat([...locals, directory, end]);
+}
+
+function fixture() {
+  const sourceSha = "a".repeat(40);
+  const targetKey = "openclaw/openclaw#770700";
+  const publicationKey = `${targetKey}@publish:8001:1`;
+  const report = Buffer.from("synthetic review");
+  const manifest = {
+    schema_version: 1,
+    created_at: "2026-08-18T12:00:00Z",
+    workflow: {
+      repository: "openclaw/clawsweeper",
+      source_sha: sourceSha,
+      run_id: "8001",
+      run_attempt: 1,
+      producer_job: "event-review-apply",
+    },
+    queue: { item_key: targetKey, protocol_version: 2, lease_revision: 7, claim_generation: 1 },
+    target: {
+      repo: "openclaw/openclaw",
+      branch: "main",
+      item_number: 770700,
+      item_kind: "pull_request",
+    },
+    review: {
+      decision_sha256: "b".repeat(64),
+      live_proceeded: true,
+      live_terminal_noop: false,
+      live_terminal_missing: false,
+      live_guarded_open: false,
+      artifact_present: true,
+    },
+    files: [{ path: "review/770700.md", bytes: report.length, sha256: sha256(report) }],
+  };
+  const members = [
+    { name: "manifest.json", body: Buffer.from(JSON.stringify(manifest)) },
+    { name: "review/770700.md", body: report },
+  ];
+  const archive = zip(members);
+  const artifact = {
+    id: 9001,
+    name: "exact-review-8001-1",
+    expired: false,
+    size_in_bytes: archive.length,
+    digest: `sha256:${sha256(archive)}`,
+    workflow_run: { id: 8001, repository_id: 42, head_sha: sourceSha },
+  };
+  const run = {
+    id: 8001,
+    run_attempt: 1,
+    path: ".github/workflows/sweep.yml",
+    head_sha: sourceSha,
+    repository: { id: 42, full_name: "openclaw/clawsweeper" },
+    conclusion: "failure",
+  };
+  const target = {
+    number: 770700,
+    base: { repo: { private: false, full_name: "openclaw/openclaw" } },
+    state: "closed",
+    merged: true,
+    node_id: "private-node-sentinel",
+    merged_at: "2026-08-18T14:00:00Z",
+    merge_commit_sha: "c".repeat(40),
+    updated_at: "2026-08-18T14:00:00Z",
+  };
+  const input = {
+    producerRunId: 8001,
+    artifactId: 9001,
+    publicationKeySha256: sha256(publicationKey),
+    queueRevision: 8,
+    workflowSha: "d".repeat(40),
+  };
+  const calls: Array<{ url: string; options?: RequestInit }> = [];
+  const request: typeof fetch = async (url, options) => {
+    calls.push({ url: String(url), options });
+    assert.notEqual(options?.method, "POST");
+    if (String(url).endsWith("/artifacts/9001/zip")) {
+      assert.equal(new Headers(options?.headers).get("authorization"), "Bearer token-sentinel");
+      return new Response(null, {
+        status: 302,
+        headers: { location: "https://blob.example.test/private-signed-url-sentinel" },
+      });
+    }
+    if (String(url).startsWith("https://blob.example.test/")) {
+      assert.equal(new Headers(options?.headers).get("authorization"), null);
+      return new Response(archive);
+    }
+    if (String(url).endsWith("/artifacts/9001")) return Response.json(artifact);
+    if (String(url).endsWith("/attempts/1")) return Response.json(run);
+    if (String(url).endsWith("/pulls/770700")) {
+      assert.equal(new Headers(options?.headers).get("authorization"), null);
+      return Response.json(target);
+    }
+    throw new Error("unexpected fixture request");
+  };
+  return {
+    input,
+    artifact,
+    run,
+    target,
+    manifest,
+    members,
+    archive,
+    calls,
+    request,
+    publicationKey,
+  };
+}
+
+test("retirement preview binds exact artifact, attempt, historical source and immutable merge identity", async () => {
+  const f = fixture();
+  const plan = await prepareClosedPublicationRetirement(f.input, "token-sentinel", f.request);
+  assert.equal(plan.sourceRevision, 7);
+  assert.equal(plan.queueRevision, 8);
+  assert.equal(plan.claimGeneration, 1);
+  assert.equal(plan.publicationKey, f.publicationKey);
+  assert.equal(plan.producerSourceSha, f.run.head_sha);
+  assert.equal(f.calls.length, 5);
+  const summary = retirementPlanSummary(plan);
+  assert.doesNotMatch(JSON.stringify(summary), /private-|token-sentinel|770700|8001|9001/);
+  f.target.updated_at = "2026-09-07T00:00:00Z";
+  assert.deepEqual(
+    retirementPlanSummary(
+      await prepareClosedPublicationRetirement(f.input, "token-sentinel", f.request),
+    ),
+    summary,
+  );
+});
+
+test("retirement makes one fixed post-effect only after reviewed-plan validation", async () => {
+  const f = fixture();
+  const plan = await prepareClosedPublicationRetirement(f.input, "token-sentinel", f.request);
+  let constructed = 0;
+  const posts: unknown[] = [];
+  const create = () => {
+    constructed += 1;
+    return {
+      postEffect: async (route: string, bytes: string) => {
+        assert.equal(route, "terminal-disposition");
+        posts.push(JSON.parse(bytes));
+        return {
+          ok: true,
+          lifecycle_state: "target_closed",
+          acknowledgement_state: "pending",
+          private: "private-response-sentinel",
+        };
+      },
+    };
+  };
+  await assert.rejects(applyClosedPublicationRetirement(plan, "", f.input.workflowSha, create));
+  await assert.rejects(
+    applyClosedPublicationRetirement(plan, "0".repeat(64), f.input.workflowSha, create),
+  );
+  await assert.rejects(
+    applyClosedPublicationRetirement(
+      plan,
+      retirementPlanSummary(plan).planSha256,
+      "e".repeat(40),
+      create,
+    ),
+  );
+  assert.equal(constructed, 0);
+  const result = await applyClosedPublicationRetirement(
+    plan,
+    retirementPlanSummary(plan).planSha256,
+    f.input.workflowSha,
+    create,
+  );
+  assert.equal(constructed, 1);
+  assert.deepEqual(posts, [
+    {
+      canonical_target_key: "openclaw/openclaw#770700",
+      fence_key: f.publicationKey,
+      revision: 8,
+      kind: "target_closed",
+      operation_id: `operator-retire-target_closed:${f.input.publicationKeySha256}:8`,
+    },
+  ]);
+  assert.doesNotMatch(JSON.stringify(result), /private-|770700|8001|9001/);
+});
+
+test("malformed lifecycle response enums fail after exactly one attempt", async () => {
+  const f = fixture();
+  const plan = await prepareClosedPublicationRetirement(f.input, "token-sentinel", f.request);
+  for (const response of [
+    { ok: true, lifecycle_state: ["target_closed"], acknowledgement_state: "pending" },
+    { ok: true, lifecycle_state: "target_closed", acknowledgement_state: ["pending"] },
+    { ok: true, lifecycle_state: "private-response-sentinel", acknowledgement_state: "pending" },
+  ]) {
+    let attempts = 0;
+    await assert.rejects(
+      applyClosedPublicationRetirement(
+        plan,
+        retirementPlanSummary(plan).planSha256,
+        f.input.workflowSha,
+        () => ({
+          postEffect: async () => {
+            attempts += 1;
+            return response;
+          },
+        }),
+      ),
+    );
+    assert.equal(attempts, 1);
+  }
+});
+
+test("all independent provenance and public merged-target preflight failures stop before signing", async (t) => {
+  const mutations = [
+    (f: ReturnType<typeof fixture>) => {
+      f.artifact.id = 9002;
+    },
+    (f: ReturnType<typeof fixture>) => {
+      f.artifact.expired = true;
+    },
+    (f: ReturnType<typeof fixture>) => {
+      f.artifact.digest = "";
+    },
+    (f: ReturnType<typeof fixture>) => {
+      f.artifact.digest = `sha256:${"0".repeat(64)}`;
+    },
+    (f: ReturnType<typeof fixture>) => {
+      f.artifact.size_in_bytes = 100_000_000;
+    },
+    (f: ReturnType<typeof fixture>) => {
+      f.artifact.workflow_run.id = 8002;
+    },
+    (f: ReturnType<typeof fixture>) => {
+      f.artifact.name = "other";
+    },
+    (f: ReturnType<typeof fixture>) => {
+      f.run.run_attempt = 2;
+    },
+    (f: ReturnType<typeof fixture>) => {
+      f.run.path = ".github/workflows/other.yml";
+    },
+    (f: ReturnType<typeof fixture>) => {
+      f.run.repository.full_name = "other/repo";
+    },
+    (f: ReturnType<typeof fixture>) => {
+      f.run.head_sha = "e".repeat(40);
+    },
+    (f: ReturnType<typeof fixture>) => {
+      f.input.publicationKeySha256 = "0".repeat(64);
+    },
+    (f: ReturnType<typeof fixture>) => {
+      f.target.merged = false;
+    },
+    (f: ReturnType<typeof fixture>) => {
+      f.target.state = "open";
+    },
+    (f: ReturnType<typeof fixture>) => {
+      f.target.base.repo.private = true;
+    },
+    (f: ReturnType<typeof fixture>) => {
+      f.target.base.repo.full_name = "other/repo";
+    },
+  ];
+  for (const [index, mutate] of mutations.entries())
+    await t.test(String(index), async () => {
+      const f = fixture();
+      mutate(f);
+      await assert.rejects(
+        prepareClosedPublicationRetirement(f.input, "token-sentinel", f.request),
+      );
+      assert.ok(f.calls.every(({ options }) => options?.method !== "POST"));
+    });
+});
+
+test("bounded manifest-only parser rejects unsafe and malformed archives", async (t) => {
+  const f = fixture();
+  const cases: Member[][] = [
+    [...f.members, f.members[0]!],
+    [...f.members, { name: "../outside", body: Buffer.from("x") }],
+    [...f.members, { name: "bad\\path", body: Buffer.from("x") }],
+    [...f.members, { name: "link", body: Buffer.from("x"), mode: 0o120777 }],
+    [{ ...f.members[0]!, flags: 1 }, f.members[1]!],
+    [{ ...f.members[0]!, method: 12 }, f.members[1]!],
+    [{ ...f.members[0]!, declaredBytes: 3 * 1024 * 1024 }, f.members[1]!],
+    [{ ...f.members[0]!, declaredBytes: 1 }, f.members[1]!],
+    [{ ...f.members[0]!, body: Buffer.from('{"private":"sentinel"}') }, f.members[1]!],
+    [f.members[1]!],
+  ];
+  for (const [index, members] of cases.entries())
+    await t.test(String(index), async () => {
+      const archive = zip(members);
+      await assert.rejects(readRetirementManifest(archive, sha256(archive)));
+    });
+  const truncated = f.archive.subarray(0, f.archive.length - 10);
+  await assert.rejects(readRetirementManifest(truncated, sha256(truncated)));
+  assert.deepEqual(await readRetirementManifest(f.archive, sha256(f.archive)), f.manifest);
+});
+
+test("unsigned archive download refuses insecure or looping redirects", async () => {
+  for (const location of [
+    "http://blob.example.test/private",
+    "https://user:password@blob.example.test/",
+  ]) {
+    const f = fixture();
+    await assert.rejects(
+      prepareClosedPublicationRetirement(f.input, "token-sentinel", async (url, options) =>
+        String(url).endsWith("/zip")
+          ? new Response(null, { status: 302, headers: { location } })
+          : f.request(url, options),
+      ),
+    );
+  }
+  const f = fixture();
+  let requests = 0;
+  await assert.rejects(
+    prepareClosedPublicationRetirement(f.input, "token-sentinel", async (url, options) => {
+      if (String(url).endsWith("/zip") || String(url).startsWith("https://blob.example.test")) {
+        requests += 1;
+        return new Response(null, {
+          status: 302,
+          headers: { location: "https://blob.example.test/loop" },
+        });
+      }
+      return f.request(url, options);
+    }),
+  );
+  assert.equal(requests, 4);
+});

--- a/test/repair/exact-review-queue-maintenance-workflow.test.ts
+++ b/test/repair/exact-review-queue-maintenance-workflow.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
-import { createHmac } from "node:crypto";
+import { createHash, createHmac } from "node:crypto";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { createServer } from "node:https";
 import { tmpdir } from "node:os";
@@ -8,6 +8,7 @@ import { join } from "node:path";
 import test from "node:test";
 import { promisify } from "node:util";
 import YAML from "yaml";
+import { stableJson } from "../../dist/stable-json.js";
 
 const path = ".github/workflows/exact-review-queue-maintenance.yml";
 const source = readFileSync(path, "utf8");
@@ -19,8 +20,17 @@ const workflow = YAML.parse(source) as {
   jobs: Record<
     string,
     {
-      env: Record<string, string>;
-      steps: Array<{ name?: string; env?: Record<string, string>; run?: string }>;
+      if?: string;
+      env?: Record<string, string>;
+      permissions?: Record<string, string>;
+      steps: Array<{
+        name?: string;
+        if?: string;
+        uses?: string;
+        with?: Record<string, unknown>;
+        env?: Record<string, string>;
+        run?: string;
+      }>;
     }
   >;
 };
@@ -28,9 +38,15 @@ const workflow = YAML.parse(source) as {
 test("queue maintenance is explicit, bounded, and non-cancelling", () => {
   assert.equal(workflow.on.schedule, undefined);
   assert.deepEqual(Object.keys(workflow.on.workflow_dispatch.inputs), [
+    "mode",
     "execute",
     "passes",
     "max_items",
+    "producer_run_id",
+    "artifact_id",
+    "publication_key_sha256",
+    "queue_revision",
+    "reviewed_plan_sha256",
   ]);
   assert.deepEqual(workflow.on.workflow_dispatch.inputs.max_items, {
     description: "Maximum reconciliation candidates to inspect",
@@ -55,6 +71,99 @@ test("queue maintenance is explicit, bounded, and non-cancelling", () => {
   assert.match(cliSource, /effectivePasses: 1/);
   assert.doesNotMatch(cliSource, /for \(let pass/);
   assert.doesNotMatch(source, /schedule:/);
+});
+
+test("retirement workflow executes isolated preview and apply argument routes", async (t) => {
+  const job = workflow.jobs["retire-closed-publication"]!;
+  assert.equal(
+    job.if,
+    "${{ inputs.mode == 'retire-closed-publication' && github.ref == 'refs/heads/main' }}",
+  );
+  assert.equal(
+    workflow.jobs.reconcile?.if,
+    "${{ inputs.mode == 'reconcile' || inputs.mode == '' }}",
+  );
+  assert.deepEqual(job.permissions, { contents: "read", actions: "read" });
+  assert.equal(job.env, undefined);
+  assert.equal(job.steps[0]?.with?.ref, "${{ github.sha }}");
+  assert.equal(job.steps[0]?.with?.["persist-credentials"], false);
+  assert.equal(workflow.jobs.reconcile?.env?.CLAWSWEEPER_WEBHOOK_SECRET, undefined);
+  const prepare = job.steps.find((step) => step.name === "Prepare closed publication retirement")!;
+  const apply = job.steps.find(
+    (step) => step.name === "Assert reviewed closed publication retirement",
+  )!;
+  assert.equal(apply.if, "${{ inputs.execute }}");
+  assert.equal(prepare.env?.CLAWSWEEPER_WEBHOOK_SECRET, undefined);
+  assert.equal(apply.env?.GH_TOKEN, undefined);
+  assert.equal(apply.env?.CLAWSWEEPER_WEBHOOK_SECRET, "${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}");
+  for (const step of job.steps) assert.doesNotMatch(step.run ?? "", /\$\{\{/);
+  const directory = mkdtempSync(join(tmpdir(), "clawsweeper-retirement-workflow-"));
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  writeFileSync(
+    join(directory, "pnpm"),
+    `#!${process.execPath}
+console.log(JSON.stringify({args:process.argv.slice(2), secret:!!process.env.CLAWSWEEPER_WEBHOOK_SECRET, token:!!process.env.GH_TOKEN}));
+`,
+    { mode: 0o700 },
+  );
+  const base = {
+    PATH: `${directory}:${process.env.PATH}`,
+    RUNNER_TEMP: directory,
+    PRODUCER_RUN_ID: "8001",
+    ARTIFACT_ID: "9001",
+    PUBLICATION_KEY_SHA256: "a".repeat(64),
+    QUEUE_REVISION: "8",
+    REVIEWED_PLAN_SHA256: "b".repeat(64),
+  };
+  const preview = JSON.parse(
+    (
+      await promisify(execFile)("bash", ["-euo", "pipefail", "-c", prepare.run!], {
+        env: { ...base, GH_TOKEN: "synthetic-token" },
+      })
+    ).stdout,
+  );
+  assert.deepEqual(preview, {
+    args: [
+      "run",
+      "--silent",
+      "repair:exact-review-queue-maintenance",
+      "retire-closed-publication",
+      "--producer-run-id",
+      "8001",
+      "--artifact-id",
+      "9001",
+      "--publication-key-sha256",
+      "a".repeat(64),
+      "--queue-revision",
+      "8",
+      "--plan-file",
+      join(directory, "closed-publication-retirement.json"),
+    ],
+    secret: false,
+    token: true,
+  });
+  const applied = JSON.parse(
+    (
+      await promisify(execFile)("bash", ["-euo", "pipefail", "-c", apply.run!], {
+        env: { ...base, CLAWSWEEPER_WEBHOOK_SECRET: "synthetic-secret" },
+      })
+    ).stdout,
+  );
+  assert.deepEqual(applied, {
+    args: [
+      "run",
+      "--silent",
+      "repair:exact-review-queue-maintenance",
+      "retire-closed-publication",
+      "--apply",
+      "--reviewed-plan-sha256",
+      "b".repeat(64),
+      "--plan-file",
+      join(directory, "closed-publication-retirement.json"),
+    ],
+    secret: true,
+    token: false,
+  });
 });
 
 test("maintenance CLI signs one HTTPS dry run, redacts identities, and refuses redirects", async (t) => {
@@ -94,9 +203,41 @@ test("maintenance CLI signs one HTTPS dry run, redacts identities, and refuses r
   let calls = 0;
   let redirectedCalls = 0;
   let redirect = false;
+  let retirementCalls = 0;
+  let retirementMode = "success";
   const server = createServer(
     { key: readFileSync(key), cert: readFileSync(cert) },
     async (request, response) => {
+      if (request.url === "/internal/exact-review/lifecycle/terminal-disposition") {
+        let body = "";
+        for await (const chunk of request) body += chunk;
+        retirementCalls += 1;
+        assert.equal(request.method, "POST");
+        assert.equal(
+          request.headers["x-clawsweeper-exact-review-signature"],
+          `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`,
+        );
+        const payload = JSON.parse(body);
+        assert.equal(payload.kind, "target_closed");
+        assert.equal(payload.revision, 8);
+        assert.equal(payload.fence_key, "openclaw/openclaw#770700@publish:8001:1");
+        if (retirementMode === "redirect") {
+          response.writeHead(307, { location: "/private-redirect-sentinel" }).end();
+        } else if (retirementMode === "500") {
+          response.writeHead(500).end("private-response-sentinel");
+        } else {
+          response.setHeader("content-type", "application/json");
+          response.end(
+            JSON.stringify({
+              ok: true,
+              lifecycle_state: retirementMode === "array" ? ["target_closed"] : "target_closed",
+              acknowledgement_state: "pending",
+              private: "private-response-sentinel",
+            }),
+          );
+        }
+        return;
+      }
       if (request.url !== "/internal/exact-review/publications/reconcile") {
         redirectedCalls += 1;
         response.writeHead(500).end();
@@ -205,6 +346,111 @@ test("maintenance CLI signs one HTTPS dry run, redacts identities, and refuses r
     assert.doesNotMatch(error.stderr, /private-.*-sentinel|synthetic-maintenance-secret/);
     return true;
   });
+  assert.equal(calls, 3);
+  assert.equal(redirectedCalls, 0);
+
+  const hash = (value: string) => createHash("sha256").update(value).digest("hex");
+  const plan = {
+    version: 1,
+    workflowSha: "d".repeat(40),
+    artifactId: 9001,
+    artifactSha256: "e".repeat(64),
+    producerRunId: 8001,
+    producerRunAttempt: 1,
+    producerSourceSha: "a".repeat(40),
+    sourceRevision: 7,
+    claimGeneration: 1,
+    queueRevision: 8,
+    canonicalTargetKey: "openclaw/openclaw#770700",
+    publicationKey: "openclaw/openclaw#770700@publish:8001:1",
+    publicationKeySha256: hash("openclaw/openclaw#770700@publish:8001:1"),
+    targetNodeId: "private-node-sentinel",
+    mergedAt: "2026-08-18T14:00:00Z",
+    mergeCommitSha: "c".repeat(40),
+  };
+  writeFileSync(join(directory, "closed-publication-retirement.json"), JSON.stringify(plan));
+  assert.equal((await promisify(execFile)("pnpm", ["--version"])).stdout.trim(), "11.10.0");
+  const env = {
+    PATH: process.env.PATH,
+    NODE_EXTRA_CA_CERTS: cert,
+    EXACT_REVIEW_QUEUE_URL: endpoint,
+    CLAWSWEEPER_WEBHOOK_SECRET: secret,
+    GITHUB_SHA: plan.workflowSha,
+    RUNNER_TEMP: directory,
+    REVIEWED_PLAN_SHA256: hash(stableJson(plan)),
+  };
+  const retirement = workflow.jobs["retire-closed-publication"]!;
+  const execute = retirement.steps.find(
+    (step) => step.name === "Assert reviewed closed publication retirement",
+  )!;
+  const prepare = retirement.steps.find(
+    (step) => step.name === "Prepare closed publication retirement",
+  )!;
+  const executeWorkflowStep = () =>
+    promisify(execFile)("bash", ["-euo", "pipefail", "-c", execute.run!], {
+      env,
+      timeout: 10_000,
+    });
+  await assert.rejects(
+    promisify(execFile)("bash", ["-euo", "pipefail", "-c", prepare.run!], {
+      env: {
+        ...env,
+        GH_TOKEN: "synthetic-token",
+        PRODUCER_RUN_ID: "0",
+        ARTIFACT_ID: "9001",
+        PUBLICATION_KEY_SHA256: plan.publicationKeySha256,
+        QUEUE_REVISION: "8",
+      },
+      timeout: 10_000,
+    }),
+    (error: Error & { stdout: string; stderr: string }) => {
+      assert.match(error.stderr, /"status":"retirement_failed"/);
+      assert.doesNotMatch(error.stdout + error.stderr, /private-.*-sentinel|synthetic-token/);
+      return true;
+    },
+  );
+  for (const args of [
+    ["unknown-mode"],
+    ["--", "retire-closed-publication"],
+    ["--max-items", "1", "unknown-mode"],
+  ]) {
+    await assert.rejects(
+      promisify(execFile)(
+        "pnpm",
+        ["run", "--silent", "repair:exact-review-queue-maintenance", ...args],
+        { env, timeout: 10_000 },
+      ),
+      (error: Error & { stderr: string }) => {
+        assert.match(error.stderr, /invalid arguments/);
+        return true;
+      },
+    );
+  }
+  assert.equal(calls, 3);
+  assert.equal(retirementCalls, 0);
+  const applied = await executeWorkflowStep();
+  assert.equal(JSON.parse(applied.stdout).status, "asserted");
+  assert.equal(retirementCalls, 1);
+  assert.doesNotMatch(
+    applied.stdout + applied.stderr,
+    /private-.*-sentinel|synthetic-maintenance-secret/,
+  );
+  for (const mode of ["redirect", "500", "array"]) {
+    retirementMode = mode;
+    const before = retirementCalls;
+    await assert.rejects(
+      executeWorkflowStep(),
+      (error: Error & { stdout: string; stderr: string }) => {
+        assert.match(error.stderr, /"status":"retirement_failed"/);
+        assert.doesNotMatch(
+          error.stdout + error.stderr,
+          /private-.*-sentinel|synthetic-maintenance-secret/,
+        );
+        return true;
+      },
+    );
+    assert.equal(retirementCalls, before + 1);
+  }
   assert.equal(calls, 3);
   assert.equal(redirectedCalls, 0);
 });


### PR DESCRIPTION
Related: https://github.com/openclaw/clawsweeper/issues/1396

## What Problem This Solves

Resolves a problem where maintainers cannot retire an explicitly approved historical publication for a merged target without supplying the Worker signing credential locally. Normal lineage reconciliation correctly leaves a publication without its own terminal fact unresolved; a later command's completion cannot discharge the original command.

## Why This Change Was Made

Extend the existing maintenance workflow with an exact-publication retirement mode. Preview binds the exact producer artifact and attempt, archive digest, public merged target, approved publication-key hash, queue revision, and immutable workflow SHA. Execution requires the reviewed plan hash and uses the existing terminal-disposition owner.

The signing credential is confined to the execution step. Preview makes no Worker request. The operation is deliberately a new, non-CAS `target_closed` assertion: it does not reconstruct historical success, reject concurrent ownership, claim batches, force a finalizer dispatch, or change Worker authentication.

## User Impact

Maintainers can preview and execute one approved retirement using existing GitHub Actions credentials. The normal lifecycle owner handles the original command's acknowledgement and removes only a matching pending or parked revision. Later commands remain independent.

## OpenClaw Bay Impact

No Bay change is needed. The existing terminal disposition and acknowledgement projections remain authoritative. Bay stays observer-only and gains no mutation control.

## Documentation Impact

Updated the active operator runbook in `docs/live-dashboard.md` with ownership, source verification, preview/apply inputs, non-CAS semantics, completion evidence, and stop-on-ambiguous-delivery rules. Added the operational release note.

## Evidence

- Source head: `37680e7566b3b9c0956b008558712578a58cf31c`; pinned base: `792b2ebaba37e331f3d03479451253780eced6e4`.
- The combined tree rebuilt successfully. All 152 focused tests passed in a clean Node 24/Bash environment: the 35 helper/workflow cases plus the publication-batch owner file's historical missing-witness, completed-successor, ambiguity, and ownership guards. These execute workflow argument routes and the compiled HTTPS CLI, including rejected plans, unsafe archives, provenance mismatches, redirect rejection, malformed responses, and one-attempt failures.
- Fresh pre-commit reviews covered each authored change. The conflict-free rebase added no authored patch, and its fresh committed-base Codex review found no actionable issues, including successor-witness compatibility and direct inspection of cached yauzl 3.4.0 source/types. That review was static; separate executed proof covers runtime behavior.
- Exact-head hosted check runs: full `pnpm check` https://github.com/openclaw/clawsweeper/actions/runs/34104065168; production automerge integration https://github.com/openclaw/clawsweeper/actions/runs/34104065278; CodeQL https://github.com/openclaw/clawsweeper/actions/runs/34104065123. Their run pages carry the current status; prior-head checks do not substitute for these combined-tree runs.
- CodeQL's fixture URL-prefix finding was addressed with exact synthetic URL equality. The input-screened URL fixture now uses an explicit all-asterisk redacted password, while still exercising nonempty userinfo rejection. The negative test also requires the exact generic validation error and zero requests to the rejected destination. No scanner policy or production validation was weakened.
- The native input scan passed against the exact rebased base/head using installed TruffleHog 3.97.4. A current-head/body ClawSweeper review and its hosted input screening remain required; the old refusal applied to the previous head.
- Live read-only preparation was refreshed on the rebased head on September 7, 2026. The 12,659-byte exact archive was downloaded once through normal guarded transport, cached privately, and authenticated against its expected digest and fresh artifact/run metadata; this refresh did not download it again. The helper's unauthenticated public merged-target GET returned 200. The resulting plan binds this source head, artifact, original source revision 7/generation 1/protocol 2, and approved queue revision 8. The signing secret was absent; Worker requests were zero. Pre-land plan hash: `ddd84e30f41027a6fe9865441c8264441e81866409983b364c50429ae2f71861`. This is data-only preparation proof, not permission to reuse the plan after landing; hosted main must derive a fresh reviewed plan before the separately approved production assertion.
- Rebased onto the successor-witness owner change in https://github.com/openclaw/clawsweeper/pull/1475 after independent compatibility review. Its historical missing-witness case remains intentionally unresolved by automatic supersession. The combined-tree runtime proof now directly invokes the real stale-publication prune transaction after later completion and before original retirement, verifying that the original unwitnessed row and terminal state remain unchanged. No successor-policy changes were added to this PR.

Production TypeScript: +499/-33 (net +466). Workflow: +69/-1 (net +68). Tests: +636/-3 (net +633). Package/lock metadata: +29/-1. Documentation/release note: +47/-0. The production growth provides a narrow secret-contained operator boundary with archive provenance, reviewed-plan binding, and sanitized output. No generic administration API or Worker branch was added.

## Real Behavior Proof

**Claim:** the compiled maintenance CLI can assert the original closed-target publication through the real Worker/SQLite lifecycle owner and normal marker-only command writer without discharging or changing a distinct later command.

**Surface and environment:** isolated local workerd `2026-07-01`, Wrangler `4.107.0`, Miniflare `4.20260701.0`, Node `24.16.0`, pnpm `11.10.0`; cache-only dependency overlay. The trusted-source local fallback followed the remote broker's TLS hostname mismatch; the task lease was released. No TLS check was disabled.

**Command:** `node run-local-runtime.mjs <exact-source-checkout> <proof-dir> <new-output-dir>`. The harness uses the actual compiled CLI, real Durable Object SQLite transactions, normal finalizer claim path, and actual `update-command-status` writer against a loopback GitHub fixture.

**Scenario:** reconstruct original protocol-2 source revision 7, generation 1, publication queue revision 8, null status-comment ID, original marker, and missing terminal fact. Subsequently complete a distinct source-11/queue-12 command and its acknowledgement. Explicitly verify the original successor witness and terminal fact are absent; invoke the real automatic stale-publication prune transaction and verify its relevant row/lifecycle snapshot is unchanged. Assert the original `target_closed` fact, then run its normal marker-only writer and observe its verified receipt. The fixture does not impose a global zero-storage-write rule.

**Observed:** 10 runtime scenarios passed. The original terminal fact became `target_closed`, its acknowledgement became observed, and its matching pending publication and terminal-finalization driver were removed. The original visible acknowledgement became `Complete` with `The item is closed; no stale verdict was published.` The later projection, publication, record bytes, source watermark, and comment were unchanged. Matching replay was a durable no-op; conflicting terminal operations rejected; SQLite rollback retained pre-operation state. Accepted ownership-drift cases preserved active or newer queue state. Each apply used one request; rejected plans used none. Redirect, timeout, HTTP 500, malformed JSON, and malformed response enums did not trigger retries.

**Trace:**

```json
{
  "runtimeScenarios": 10,
  "runtimePassed": 10,
  "sourceFilesBound": 407,
  "historicalWitness": "absent",
  "automaticPrune": "retained unchanged",
  "originalAcknowledgement": "observed",
  "originalPendingPublication": "removed",
  "originalFinalizationDriver": "removed",
  "laterCommand": "unchanged",
  "productionWorkerRequests": 0
}
```

The regenerated manifest binds 407 source files, three focused test files, and five executed/copied harness files. All hashes match the committed worktree and executed proof clone as applicable. The proof's `results.json` SHA256 is `360f4f444729995d3d26f9bab53c62c82e02f008f5147c63749bad1b6b54a04d`; its source/toolchain manifest SHA256 is `702f0c9178c72382cbc96f1e2382350196b0485dcb2f766c5b8ca534e774c1f8`. Proof-driver SHA256: `963a07d8a997898afafa294bcd85b31bd1c1b2d903520056f69f227504922d13`.

**Limits:** historical state was reconstructed, not replayed from historical ingress. Public-target eligibility was injected for the isolated fixture; the separate live data-only helper proof verified the actual public merged target. Alarms were suppressed except for the direct real-prune transaction, and the dispatch-state transition was substituted; claim/finalizer/writer logic was real. GitHub writes went only to the loopback fixture. This is not deployed-edge, hosted-scheduler, or production-retirement proof. Hosted main preview and the one separately approved production assertion remain separate gates.
