### PR TITLE
fix(review): report initial Git fetch failures for exact reviews

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1326,6 +1326,7 @@ jobs:
           ADDITIONAL_PROMPT: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).additionalPrompt || '' }}
           CLAWSWEEPER_RELATED_GITHUB_SEARCH: ${{ vars.CLAWSWEEPER_RELATED_GITHUB_SEARCH || '1' }}
           EXACT_REVIEW_ITEM_KEY: ${{ steps.claim-exact-review-queue.outputs.item_key }}
+          EXACT_REVIEW_ITEM_KIND: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).itemKind }}
           EXACT_REVIEW_LEASE_ID: ${{ steps.claim-exact-review-queue.outputs.lease_id }}
           EXACT_REVIEW_LEASE_REVISION: ${{ steps.claim-exact-review-queue.outputs.lease_revision }}
           EXACT_REVIEW_CLAIM_GENERATION: ${{ steps.claim-exact-review-queue.outputs.claim_generation }}

--- a/src/clawsweeper-review-blobs.ts
+++ b/src/clawsweeper-review-blobs.ts
@@ -20,12 +20,16 @@ export class ReviewGitError extends ReviewSourcePreparationError {
   readonly errorCode: string | null;
   readonly stderr: string;
 
-  constructor(diagnosticReason: ReviewGitFailureReason, result: SpawnSyncReturns<string>) {
+  constructor(
+    diagnosticReason: ReviewGitFailureReason,
+    result: SpawnSyncReturns<string> | (Error & Partial<SpawnSyncReturns<string>>),
+  ) {
     // Public errors omit process output; the diagnostic writer owns its redaction.
     super(diagnosticReason, "Review source preparation failed.");
     this.name = "ReviewGitError";
-    this.status = result.status;
-    this.signal = result.signal;
+    this.cause = result instanceof Error ? result : result.error;
+    this.status = result.status ?? null;
+    this.signal = result.signal ?? null;
     this.errorCode = (result.error as NodeJS.ErrnoException | undefined)?.code ?? null;
     this.stderr = result.stderr ?? "";
   }

--- a/src/clawsweeper-review-preparation.ts
+++ b/src/clawsweeper-review-preparation.ts
@@ -17,6 +17,8 @@ import {
 import type { Args } from "./clawsweeper-args.js";
 import type { CreateReviewCommandWorkflowDependencies } from "./clawsweeper-review-command-dependencies.js";
 import { parsePrCommentActivityRevisionMap } from "./pr-hydration-snapshot.js";
+import { writeExactReviewFailureDiagnostics } from "./clawsweeper-review-failure-diagnostics.js";
+import { ReviewSourcePreparationError } from "./review-source-preparation.js";
 
 const AUTOMATIC_REVIEW_SOURCE_ACTIONS = new Set([
   "scheduled_hot_intake",
@@ -172,13 +174,54 @@ export function prepareReviewCommand(
     );
   }
   const forcedLoginMethod = reviewCodexForcedLoginMethod(args);
+  const exactItemNumber = itemNumbers
+    ? itemNumber === undefined && itemNumbers.length === 1
+      ? itemNumbers[0]
+      : undefined
+    : itemNumber;
+  const itemKind = process.env.EXACT_REVIEW_ITEM_KIND;
+  // No hydrated item exists yet. Only the matching workflow claim can identify this failure.
+  const exactReviewIdentity =
+    !localOnly &&
+    exactItemNumber !== undefined &&
+    (itemKind === "issue" || itemKind === "pull_request") &&
+    process.env.EXACT_REVIEW_ITEM_KEY?.toLowerCase() ===
+      `${targetRepo()}#${exactItemNumber}`.toLowerCase()
+      ? ({ repo: targetRepo(), itemKind, itemNumber: exactItemNumber } as const)
+      : null;
   const loadReviewGitInfo = (): GitInfo =>
-    checkout.gitTargetBranch
-      ? gitInfo(openclawDir, { targetBranch: checkout.gitTargetBranch })
-      : gitInfo(openclawDir);
-  let git: GitInfo = localRangeData
-    ? { mainSha: localRangeData.baseSha, releaseStateComplete: true, latestRelease: null }
-    : loadReviewGitInfo();
+    gitInfo(openclawDir, {
+      ...(checkout.gitTargetBranch ? { targetBranch: checkout.gitTargetBranch } : {}),
+      ...(exactReviewIdentity ? { classifyFetchFailure: true } : {}),
+    });
+  let git: GitInfo;
+  try {
+    git = localRangeData
+      ? { mainSha: localRangeData.baseSha, releaseStateComplete: true, latestRelease: null }
+      : loadReviewGitInfo();
+  } catch (error) {
+    if (error instanceof ReviewSourcePreparationError && exactReviewIdentity) {
+      try {
+        writeExactReviewFailureDiagnostics({
+          artifactDir,
+          error,
+          prompt: additionalPrompt,
+          model,
+          classification: "source_preparation",
+          ...exactReviewIdentity,
+          sourceSha:
+            exactReviewIdentity.itemKind === "pull_request"
+              ? process.env.EXACT_REVIEW_SOURCE_HEAD_SHA
+              : null,
+          retryable: dependencies.codexReviewFailureRetryable(error),
+          workflowExit: 1,
+        });
+      } catch {
+        console.error("[review] exact-review failure diagnostics could not be written.");
+      }
+    }
+    throw error;
+  }
   const reviewPolicy = reviewPolicyHash({ model, reasoningEffort, sandboxMode, serviceTier });
   const explicitDispatch = isExplicitReviewDispatch(
     args,

--- a/src/clawsweeper-review-runtime.ts
+++ b/src/clawsweeper-review-runtime.ts
@@ -15,6 +15,7 @@ import {
   serializeReviewContext,
 } from "./agent-input-scan-fixtures.js";
 import { stringArg, type Args } from "./clawsweeper-args.js";
+import { ReviewGitError } from "./clawsweeper-review-blobs.js";
 import {
   mediaProofRuntimeHints,
   mediaProofRuntimePrompt,
@@ -103,22 +104,28 @@ export function createReviewRuntime({
     const targetBranch = options.targetBranch ?? reviewTargetBranch(openclawDir);
     requireSafeGitBranchName(targetBranch, "target branch");
     const shallow = run("git", ["rev-parse", "--is-shallow-repository"], { cwd: openclawDir });
-    run(
-      "git",
-      [
-        "fetch",
-        "--filter=blob:none",
-        "--no-tags",
-        "--recurse-submodules=no",
-        ...(shallow === "true" ? ["--unshallow"] : []),
-        "origin",
-        `refs/heads/${targetBranch}:refs/remotes/origin/${targetBranch}`,
-      ],
-      {
-        cwd: openclawDir,
-        timeoutMs: 30_000,
-      },
-    );
+    try {
+      run(
+        "git",
+        [
+          "fetch",
+          "--filter=blob:none",
+          "--no-tags",
+          "--recurse-submodules=no",
+          ...(shallow === "true" ? ["--unshallow"] : []),
+          "origin",
+          `refs/heads/${targetBranch}:refs/remotes/origin/${targetBranch}`,
+        ],
+        {
+          cwd: openclawDir,
+          timeoutMs: 30_000,
+        },
+      );
+    } catch (error) {
+      if (!options.classifyFetchFailure || !(error instanceof Error)) throw error;
+      // runText preserves execFileSync's native spawn result, including timeout evidence.
+      throw new ReviewGitError("review_commit_fetch_failed", error);
+    }
     const mainSha = run("git", ["rev-parse", `refs/remotes/origin/${targetBranch}`], {
       cwd: openclawDir,
     });

--- a/src/clawsweeper-types.ts
+++ b/src/clawsweeper-types.ts
@@ -1224,6 +1224,7 @@ export interface ExistingReviewIndex {
 
 export type ReviewGitInfoOptions = {
   targetBranch?: string;
+  classifyFetchFailure?: boolean;
 };
 
 export type LocalPullMetadata = {

--- a/test/review-preparation.test.ts
+++ b/test/review-preparation.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { parseArgs } from "../dist/clawsweeper-args.js";
@@ -12,6 +12,10 @@ import { reviewPromptForTest } from "../dist/clawsweeper.js";
 import { repositoryProfileFor } from "../dist/repository-profiles.js";
 import { hydratePrimaryBody, longProofBody } from "./primary-body-fixture.ts";
 import { git } from "./helpers.ts";
+import { runText } from "../dist/command.js";
+import { ReviewGitError } from "../dist/clawsweeper-review-blobs.js";
+import { createReviewRuntime } from "../dist/clawsweeper-review-runtime.js";
+import { createReviewCommandWorkflow } from "../dist/clawsweeper-review-command-workflow.js";
 
 test("body-file keeps its authoritative precedence over compact hosted context", () => {
   const dir = mkdtempSync(join(tmpdir(), "clawsweeper-body-override-"));
@@ -67,4 +71,161 @@ test("scheduled queue source actions are automatic while exact actions remain ex
 test("planned review compatibility and non-exact selection preserve existing behavior", () => {
   assert.equal(isExplicitReviewDispatch(parseArgs(["--planned-automatic-review"]), true), false);
   assert.equal(isExplicitReviewDispatch(parseArgs([]), false), false);
+});
+
+test("initial fetch timeout retains native evidence before any review work", () => {
+  let nativeError: Error;
+  try {
+    runText(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { timeoutMs: 25 });
+    assert.fail("native command must time out");
+  } catch (error) {
+    assert.ok(error instanceof Error);
+    nativeError = error;
+  }
+  let fetches = 0;
+  const runtime = createReviewRuntime({
+    run: (command: string, args: string[], options?: { timeoutMs?: number }) => {
+      assert.equal(command, "git");
+      if (args.includes("--abbrev-ref")) return "main";
+      if (args.includes("--is-shallow-repository")) return "false";
+      assert.equal(args[0], "fetch");
+      assert.equal(options?.timeoutMs, 30_000);
+      fetches += 1;
+      throw nativeError;
+    },
+  } as Parameters<typeof createReviewRuntime>[0]);
+  let failure: ReviewGitError;
+  try {
+    runtime.gitInfo("fixture", { classifyFetchFailure: true });
+    assert.fail("initial fetch must fail");
+  } catch (error) {
+    assert.ok(error instanceof ReviewGitError);
+    failure = error;
+  }
+  assert.equal(fetches, 1);
+  assert.equal(failure.cause, nativeError);
+  assert.equal(failure.errorCode, "ETIMEDOUT");
+  assert.equal(failure.status, null);
+  assert.match(failure.signal ?? "", /^SIG[A-Z0-9]+$/);
+  assert.throws(
+    () => runtime.gitInfo("fixture"),
+    (error) => error === nativeError,
+  );
+
+  const oldEnv = process.env;
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-initial-fetch-"));
+  try {
+    for (const scenario of [
+      { kind: "issue", args: ["--item-number", "42"], expected: true },
+      { kind: "pull_request", args: ["--item-numbers", "42"], expected: true },
+      { kind: "", args: ["--item-number", "42"], expected: false },
+      { kind: "unknown", args: ["--item-number", "42"], expected: false },
+      { kind: "issue", args: ["--item-number", "43"], expected: false },
+      { kind: "issue", args: ["--item-numbers", "42,43"], expected: false },
+      { kind: "issue", args: ["--item-number", "42", "--item-numbers", "42"], expected: false },
+      { kind: "issue", args: [], expected: false },
+      { kind: "issue", args: ["--item-number", "42"], key: "", expected: false },
+      { kind: "issue", args: ["--item-number", "42"], key: "other/repo#42", expected: false },
+      { kind: "issue", args: ["--item-number", "42", "--local-only"], expected: false },
+    ]) {
+      const dir = join(root, String(readdirSync(root).length));
+      process.env = {
+        ...oldEnv,
+        EXACT_REVIEW_ITEM_KEY: scenario.key ?? "openclaw/openclaw#42",
+        EXACT_REVIEW_ITEM_KIND: scenario.kind,
+        EXACT_REVIEW_SOURCE_HEAD_SHA: "a".repeat(40),
+      };
+      const unexpectedCalls: string[] = [];
+      const dependencies = {
+        DEFAULT_PLAN_BATCH_SIZE: 3,
+        repoFromArgs: () => repositoryProfileFor("openclaw/openclaw"),
+        targetRepo: () => "openclaw/openclaw",
+        localExactReviewItem: () => false,
+        defaultReviewArtifactDir: () => dir,
+        defaultItemsDir: () => dir,
+        resolveReviewCheckout: () => ({ openclawDir: dir }),
+        ensureDir: () => {},
+        suppliedReviewStartLeaseFromArgs: () => null,
+        reviewCodexForcedLoginMethod: () => "chatgpt",
+        gitInfo: (_dir: string, options: { classifyFetchFailure?: boolean }) => {
+          assert.equal(options.classifyFetchFailure, scenario.expected ? true : undefined);
+          throw scenario.expected ? failure : nativeError;
+        },
+        codexReviewFailureRetryable: runtime.codexReviewFailureRetryable,
+      };
+      const workflow = createReviewCommandWorkflow(
+        new Proxy(dependencies, {
+          get(target, key) {
+            if (key in target) return target[key as keyof typeof target];
+            return () => {
+              unexpectedCalls.push(String(key));
+              throw new Error(`Unexpected review work: ${String(key)}`);
+            };
+          },
+        }) as unknown as Parameters<typeof createReviewCommandWorkflow>[0],
+      );
+      assert.throws(
+        () => workflow.reviewCommand(parseArgs(["--artifact-dir", dir, ...scenario.args])),
+        (error) => error === (scenario.expected ? failure : nativeError),
+      );
+      assert.deepEqual(unexpectedCalls, []);
+      const manifestPath = join(dir, "failure-diagnostics", "manifest.json");
+      assert.equal(existsSync(manifestPath), scenario.expected, JSON.stringify(scenario));
+      assert.equal(existsSync(join(dir, "selection.json")), false);
+      if (scenario.expected) {
+        const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+        assert.equal(manifest.classification, "source_preparation");
+        assert.deepEqual(manifest.failure, {
+          stage: "source_preparation",
+          reason_code: "review_commit_fetch_failed",
+        });
+        assert.equal(manifest.process.error_code, "ETIMEDOUT");
+        assert.equal(manifest.process.signal, failure.signal);
+        assert.equal(manifest.process.workflow_exit, 1);
+        assert.equal(manifest.retryable, true);
+        assert.equal(manifest.source.item_kind, scenario.kind);
+        assert.equal(manifest.source.item_number, 42);
+        assert.equal(manifest.source.sha, scenario.kind === "pull_request" ? "a".repeat(40) : null);
+      }
+    }
+  } finally {
+    process.env = oldEnv;
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("local-range preparation remains offline even with a claimed exact item in the environment", () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-local-range-"));
+  const oldEnv = process.env;
+  try {
+    process.env = {
+      ...oldEnv,
+      EXACT_REVIEW_ITEM_KEY: "openclaw/openclaw#42",
+      EXACT_REVIEW_ITEM_KIND: "pull_request",
+    };
+    const prepared = prepareReviewCommand(parseArgs(["--local-range", "--artifact-dir", root]), {
+      DEFAULT_PLAN_BATCH_SIZE: 3,
+      repoFromArgs: () => repositoryProfileFor("openclaw/openclaw"),
+      targetRepo: () => "openclaw/openclaw",
+      localExactReviewItem: () => false,
+      defaultReviewArtifactDir: () => root,
+      defaultItemsDir: () => root,
+      defaultLocalRangeHistoryPath: () => join(root, "history"),
+      resolveReviewCheckout: () => ({ openclawDir: root }),
+      ensureDir: () => {},
+      suppliedReviewStartLeaseFromArgs: () => null,
+      reviewCodexForcedLoginMethod: () => "chatgpt",
+      buildLocalRangeReview: () => ({ baseSha: "b".repeat(40), headSha: "c".repeat(40) }),
+      gitInfo: () => {
+        assert.fail("local-range must not fetch Git metadata");
+      },
+      reviewPolicyHash: () => "fixture-policy",
+    } as unknown as Parameters<typeof prepareReviewCommand>[1]);
+    assert.equal(prepared.git.mainSha, "b".repeat(40));
+    assert.equal(prepared.git.releaseStateComplete, true);
+    assert.equal(existsSync(join(root, "failure-diagnostics")), false);
+  } finally {
+    process.env = oldEnv;
+    rmSync(root, { recursive: true, force: true });
+  }
 });

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1147,6 +1147,10 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
   assert.match(step(reviewer, "Review exact event item").run ?? "", /claim_generation/);
   assert.match(step(reviewer, "Review exact event item").run ?? "", /run_attempt/);
   assert.match(step(reviewer, "Review exact event item").run ?? "", /source_head_sha/);
+  assert.equal(
+    step(reviewer, "Review exact event item").env?.EXACT_REVIEW_ITEM_KIND,
+    "${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).itemKind }}",
+  );
   assert.match(
     step(reviewer, "Review exact event item").run ?? "",
     /review_exit_code.*-eq 78[\s\S]*failure_reason=incomplete_source/,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where an exact issue or pull-request review that fails during
the initial Git fetch is recorded as a generic workflow failure without the
source-preparation diagnostic artifact.

The initial fetch runs before candidate selection and the existing per-item
failure handler. A native timeout therefore escaped that handler even though
later source-acquisition failures already received the correct classification.

## Why This Change Was Made

The existing Git command dependency and `GIT_BIN` handling remain authoritative.
For verified exact claims, the initial fetch now uses the existing `ReviewGitError`
classification and preserves the native process evidence. Other callers retain
their original native exceptions. The early preparation owner writes
diagnostics through the existing bounded, sanitizing writer, then rethrows.

Only an exact, single selected item whose repository and number match the
workflow claim can receive an early manifest. The workflow forwards the claim's
authoritative issue/PR kind; no kind is inferred from a SHA. Issue manifests
retain a null SHA, including when unrelated head metadata is present.

This does not repair network slowness, change the 30-second deadline, introduce
retries, alter complete ancestry/release refresh, change scanner policy, or
requeue existing work.

## User Impact

Operators can distinguish an initial Git source-acquisition failure from a
generic workflow failure and inspect bounded native status, signal, and error
code evidence. Failed review commands and their workflow steps remain nonzero.
No candidate selection, review ledger start, new lease, or model call occurs.

Release-note context: exact-review initial Git failures now retain their
source-preparation classification and sanitized diagnostics.

## OpenClaw Bay Impact

No Bay change is needed. The existing failure stage/reason vocabulary and
observer data contract are unchanged. This repairs the producer of an existing
classification, without adding routes, schema fields, or controls.

## Documentation Impact

Reviewed `docs/review-cache.md`, `docs/scheduler.md`, and
`docs/live-dashboard.md`. Existing documentation already describes bounded
source-preparation diagnostics, nonzero workflow failure, and unchanged public
observer contracts. No documentation change is needed.

## Evidence

- Exact signed head: `b25c2f7f359da2d6a1e5001e23701f8396733e05`.
- Base: `792b2ebaba37e331f3d03479451253780eced6e4`.
- Build and focused preparation/diagnostic tests passed.
- Corrected preparation/diagnostic/workflow invocation passed 146/146 tests.
- Complete ancestry and release refresh retained all 71 expected ancestors;
  later per-item source-failure tests passed.
- Local `pnpm run check` passed static checks, all builds, lint, and changed
  coverage, then was stopped by the explicit 3 GiB disk floor during the full
  test/coverage phase. Full-check proof remains incomplete and requires hosted
  CI; the stopped run is not reported as a pass.
- The accepted precommit review finding about hiding non-exact/local errors was
  addressed by making classification opt-in only for a matching exact claim.
- Final precommit Codex review: no actionable regressions; its build, 242
  focused tests, formatting, and independent CLI fixture passed.
- Committed-branch Codex review against the base: no actionable regressions;
  its build and 148 focused tests passed.

## Real Behavior Proof

- Claim: an initial native Git transport timeout produces
  `source_preparation / review_commit_fetch_failed` before review work, without
  changing the failure exit or pretending that source acquisition succeeded.
- Surface: actual `dist/clawsweeper.js review` CLI, native Git via the existing
  command override, diagnostic writer, and the exact failure-decoding shell
  block extracted from `.github/workflows/sweep.yml`.
- Fixture: isolated real Git repositories with a controlled local transport
  server that accepts the fetch and stalls. Separate issue and PR claims,
  missing-kind, repository-mismatch, and local-only cases. GitHub/model sentinel executables
  fail and record any unexpected invocation.
- Command/environment: `node .artifacts/early-source-diagnostics/proof.mjs`;
  Node 26.7.0, Apple Git 2.50.1, macOS, isolated home/config and no mutation or
  provider credentials.
- Observed result: issue and PR timeouts each returned exit 1 after about 30.1
  seconds, recorded native `ETIMEDOUT`, null status and observed `SIGTERM`, and
  produced the correct stage/reason. The workflow decoder also returned exit 1.
  Missing or mismatched identity produced no manifest. No GitHub/model sentinel,
  selection output, or review ledger was created.
- Artifact/trace: sanitized `public-proof.json`, per-scenario readiness
  manifests and workflow outputs retained with the execution handoff. Native
  Git trace confirmed the existing blobless, non-depth initial fetch.
- Exact-commit results:

  | Scenario | CLI Exit | Manifest | Native Evidence | Workflow Exit |
  | --- | ---: | --- | --- | ---: |
  | issue timeout | 1 | source preparation; issue SHA null | ETIMEDOUT, SIGTERM, null status; 30.131s | 1 |
  | PR timeout | 1 | source preparation; claimed PR SHA | ETIMEDOUT, SIGTERM, null status; 30.118s | 1 |
  | missing kind | 1 | absent | original native failure retained | not applicable |
  | mismatched repository | 1 | absent | original native failure retained | not applicable |
  | local-only | 1 | absent | original native failure retained | not applicable |

  Both timeout manifests used `review_commit_fetch_failed`, remained retryable,
  and retained `workflow_exit: 1`. All five scenarios recorded zero
  GitHub/model calls, no selection output, and an unchanged review-ledger store.
- Limits: controlled local transport only. This proves classification and
  admission ordering, not the cause of production network slowness, recovery of
  already failed items, or a production deployment.

## Scope

Production TypeScript delta: +55 lines; workflow delta: +1 line. The added code
owns early failure classification and validates claim identity at the boundary
where no hydrated item yet exists. No alternate Git path or retry loop is added.
Tests are counted separately.
