### PR TITLE
refactor(cli): deduplicate required argument validation

### DIFF
--- a/scripts/audit-report-metadata-spoofing.mjs
+++ b/scripts/audit-report-metadata-spoofing.mjs
@@ -3,6 +3,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
+import { requiredCliValue } from "../src/clawsweeper-args.ts";
 import { discoverWorkerRecordRepoSlugs, exportWorkerRecords } from "./worker-records.ts";
 
 const CANONICAL_PROMOTION_KEYS = Object.freeze([
@@ -136,12 +137,12 @@ function parseArgs(argv) {
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === "--") continue;
-    if (arg === "--output") parsed.output = requiredValue(argv, ++index, arg);
-    else if (arg === "--records-url") parsed.recordsUrl = requiredValue(argv, ++index, arg);
+    if (arg === "--output") parsed.output = requiredCliValue(argv, ++index, arg);
+    else if (arg === "--records-url") parsed.recordsUrl = requiredCliValue(argv, ++index, arg);
     else if (arg === "--repo-slugs") {
-      parsed.repoSlugs = parseRepoSlugs(requiredValue(argv, ++index, arg));
+      parsed.repoSlugs = parseRepoSlugs(requiredCliValue(argv, ++index, arg));
     } else if (arg === "--max-records") {
-      parsed.maxRecords = positiveInteger(requiredValue(argv, ++index, arg), arg);
+      parsed.maxRecords = positiveInteger(requiredCliValue(argv, ++index, arg), arg);
     } else {
       throw new Error(`Unknown argument: ${arg}`);
     }
@@ -152,12 +153,6 @@ function parseArgs(argv) {
 function parseRepoSlugs(value) {
   if (value === undefined || value.trim() === "") return undefined;
   return [...new Set(value.split(/[\s,]+/).filter(Boolean))].sort();
-}
-
-function requiredValue(argv, index, flag) {
-  const value = argv[index];
-  if (!value || value.startsWith("--")) throw new Error(`${flag} requires a value`);
-  return value;
 }
 
 function positiveInteger(value, name) {

--- a/scripts/hydrate-state.ts
+++ b/scripts/hydrate-state.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { parseArgs as parseNodeArgs } from "node:util";
 
+import { requiredCliValue } from "../src/clawsweeper-args.ts";
 import { materializeStateBlobs } from "./worker-blobs.ts";
 import {
   discoverWorkerRecordRepoSlugs,
@@ -151,7 +152,7 @@ function parseArgs(argv: string[]): Args {
         "--records-repo-slugs",
       ].includes(arg)
     ) {
-      normalized.push(`${arg}=${requiredValue(argv, ++index, arg)}`);
+      normalized.push(`${arg}=${requiredCliValue(argv, ++index, arg)}`);
     } else if (arg === "--skip-state-blobs" || arg === "--skip-git-state") normalized.push(arg);
     else throw new Error(`Unknown argument: ${arg}`);
   }
@@ -190,12 +191,6 @@ function parseArgs(argv: string[]): Args {
 function parseRepoSlugs(value: string | undefined) {
   if (value === undefined || value.trim() === "") return undefined;
   return [...new Set(value.split(/[\s,]+/).filter(Boolean))].sort();
-}
-
-function requiredValue(argv: string[], index: number, flag: string): string {
-  const value = argv[index];
-  if (!value || value.startsWith("--")) throw new Error(`${flag} requires a value`);
-  return value;
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1] || "").href) {

--- a/src/clawsweeper-args.ts
+++ b/src/clawsweeper-args.ts
@@ -25,6 +25,12 @@ export function parseArgs(argv: string[]): Args {
   return args;
 }
 
+export function requiredCliValue(argv: readonly string[], index: number, flag: string): string {
+  const value = argv[index];
+  if (!value || value.startsWith("--")) throw new Error(`${flag} requires a value`);
+  return value;
+}
+
 export function stringArg(
   value: string | boolean | string[] | undefined,
   fallback: string,

--- a/src/repair/action-ledger-cli.ts
+++ b/src/repair/action-ledger-cli.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { parseArgs as parseNodeArgs } from "node:util";
 
 import { importActionEventShards } from "../action-ledger-runtime.js";
+import { requiredCliValue } from "../clawsweeper-args.js";
 import {
   finalizeCommandActionLedgerManifest,
   parseCommandActionLedgerManifest,
@@ -63,7 +64,7 @@ function parseArgs(argv: readonly string[]) {
     const arg = argv[index];
     if (!arg) throw new Error(`unknown argument: ${arg}`);
     if (["--lane", "--manifest", "--source-root", "--state-root"].includes(arg)) {
-      normalized.push(`${arg}=${requiredValue(argv, ++index, arg)}`);
+      normalized.push(`${arg}=${requiredCliValue(argv, ++index, arg)}`);
     } else if (arg === "--allow-empty") normalized.push(arg);
     else throw new Error(`unknown argument: ${arg}`);
   }
@@ -84,12 +85,6 @@ function parseArgs(argv: readonly string[]) {
     stateRoot: values["state-root"],
     allowEmpty: values["allow-empty"],
   };
-}
-
-function requiredValue(argv: readonly string[], index: number, flag: string): string {
-  const value = argv[index];
-  if (!value || value.startsWith("--")) throw new Error(`${flag} requires a value`);
-  return value;
 }
 
 function requiredArg(value: string | undefined, flag: string): string {

--- a/src/repair/publish-main.ts
+++ b/src/repair/publish-main.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { sha256 } from "../content-hash.js";
+import { requiredCliValue } from "../clawsweeper-args.js";
 import { createHash } from "node:crypto";
 import {
   appendFileSync,
@@ -841,7 +842,7 @@ function parseArgs(argv: readonly string[]): Args {
         "--rebase-strategy",
       ].includes(arg)
     ) {
-      normalized.push(`${arg}=${requiredValue(argv, ++index, arg)}`);
+      normalized.push(`${arg}=${requiredCliValue(argv, ++index, arg)}`);
     } else throw new Error(`Unknown argument: ${arg}`);
   }
   const { values } = parseNodeArgs({
@@ -872,12 +873,6 @@ function parseArgs(argv: readonly string[]): Args {
   if (!parsed.message) throw new Error("--message is required");
   if (parsed.paths.length === 0) throw new Error("At least one --path is required");
   return parsed;
-}
-
-function requiredValue(argv: readonly string[], index: number, flag: string): string {
-  const value = argv[index];
-  if (!value || value.startsWith("--")) throw new Error(`${flag} requires a value`);
-  return value;
 }
 
 function parsePositiveInt(value: string, flag: string): number {


### PR DESCRIPTION
## What Problem This Solves

Four CLI parsers repeat the same required-value validation. Separate copies
add maintenance work and can drift in their accepted values or error messages.

## Why This Change Was Made

Reuse `requiredCliValue` across the four callers while preserving validation,
error text, and parser ordering. Script imports remain native TypeScript;
built repair CLIs retain `.js` imports. The five-file diff is +17/-31 lines,
net -14.

## User Impact

No intended user-visible change. Missing values and values beginning with
`--` retain their errors. Accepted values and subsequent parser errors remain
unchanged.

## OpenClaw Bay Impact

None. This changes no lifecycle, queue, workflow, telemetry, dashboard, or
public observer data contract. Bay needs no change.

## Documentation Impact

Reviewed `README.md`, `docs/README.md`, and `CONTRIBUTING.md`. Existing CLI and
contribution contracts remain accurate. No documentation or changelog entry
is needed for this behavior-preserving mechanical refactor.

## Evidence

- Base: `1f0fa2aeb33931cbb6e5a7f06b411aa02cbd8006`.
- Candidate: `671e566b4c7a2093c145f6818a71e26d3688c8b4`.
- Candidate tree: `bde1f33862ec8025de7ab59bef3c5e8519bbfbe4`.
- Controlled AWS proof: 12/12 equivalent baseline/candidate CLI pairs.
- Focused tests: 12 passed, zero failures, skips, or cancellations.
- `pnpm run check`: exit 0; full suite 4,993 tests, 4,975 passed,
  18 skipped, zero failures or cancellations.
- Configured changed-coverage stage (`fix-prompt-builder`): 13/13 passed.
  This is not an args-specific coverage measurement.
- Completed precommit and exact-head committed Codex reviews reported no
  actionable regression. The checkout head/tree remained unchanged and clean
  before and after the AWS run.

## Real Behavior Proof

**Claim:** the four actual CLI entrypoints preserve required-value validation,
observable errors, and the exercised parser ordering before guarded I/O.

**Surface:** `scripts/audit-report-metadata-spoofing.mjs`,
`scripts/hydrate-state.ts`, `dist/repair/action-ledger-cli.js`, and
`dist/repair/publish-main.js`.

**Scenarios:** each CLI receives a missing value, a next-option value, and an
accepted value followed by an unknown option. These are 12 paired scenarios,
24 CLI process launches. The harness rebuilt both TypeScript projects for
both baseline and candidate: four successful builds.

**Executed commands** (only private directory paths are replaced by variables):

```sh
node "$PROOF_DIR/cli-parity-proof.mjs" "$CANDIDATE_DIR" "$RESULTS" 1f0fa2aeb33931cbb6e5a7f06b411aa02cbd8006
node --test test/repair/stdlib-cli-parsers.test.ts test/report-metadata-audit.test.ts
CI=1 pnpm run check
```

**Environment:** AWS, Node `v24.18.1`, pnpm `11.10.0`, Crabbox `0.45.0`;
image `ami-0461d919be7deb53c`, lease `cbx_a107cf69c9b0`,
run `run_ef3155a920af`. The remote forwarded environment allowlist was `CI`.
The package completed on September 7, 2026 at `09:53:41.674 UTC`.
The native run, behavior harness, focused tests, and full check all exited 0.

**Observed trace:** each row covers missing, next-option, and
accepted-then-unknown, in that order.

| CLI | Missing / next-option error | Accepted-then-unknown error | Equivalent pairs |
| --- | --- | --- | --- |
| audit-report-metadata-spoofing | `--output requires a value` | `Unknown argument: --unknown` | 3/3 |
| hydrate-state | `--state-dir requires a value` | `Unknown argument: --unknown` | 3/3 |
| action-ledger | `--lane requires a value` | `unknown argument: --unknown` | 3/3 |
| publish-main | `--message requires a value` | `Unknown argument: --unknown` | 3/3 |

All paired CLIs exited 1 as expected for these error cases. Standard output
was empty; normalized standard error matched exactly. Isolated file
inventories were unchanged, no enumerated filesystem/network guard fired,
and no credential variables were present in the CLI child environments.

**Artifact and provenance:** the inline table is an allowlisted summary of
the verified `cli-parity-proof.json`. The full archive remains private;
its SHA-256 below is an integrity identifier, not a public download link.
The package contains 31 verified manifest entries.

| Pin | SHA-256 |
| --- | --- |
| Evidence archive | `4d5b2b04413117c28523c384559b2c6a6416fe0a355230f7d6b757834d56bf89` |
| CLI parity harness | `594005da218976573effb1cc53b7f14d4cd6c297b033ff6fe4063a034360c6bf` |
| I/O guard | `aa745a113f656c46d57f5c93e318ba621e9bb65dcf2b6104be31aa624d0d3807` |
| Precommit review receipt | `ad5b9e81f8ea4972564ba188372383b33ed7003f39fd49fb31c9c2b143e8c400` |
| Exact-head committed review receipt | `7e6034964acda7d259f022c0042bb33f47d5bf9feab7323755ebf10b3cf5691a` |
| Validator binary | `efc50f258cf19c44e34d5df684b9bb8c2ccdc308ec489926051e575995fa4e63` |

**Limits:** only stack locations and the moved helper name are normalized.
The guards cover enumerated entrypoints, not every possible I/O mechanism.
This proves the exercised error paths, not successful live hydration,
publication, authentication, GitHub, Worker/R2, queue mutation, or deployed
Worker behavior. It qualifies the pinned candidate, not a later rebase or
current `main`. Other refactor candidates are not covered by this evidence.
