### PR TITLE
fix(ci): avoid unnecessary ffmpeg validator downloads

### DIFF
--- a/.github/workflows/exact-review-batch-publish.yml
+++ b/.github/workflows/exact-review-batch-publish.yml
@@ -119,7 +119,7 @@ jobs:
         if: ${{ steps.batch.outputs.claimed == 'true' && steps.batch.outputs.item_count != '0' }}
         run: |
           sudo apt-get update
-          sudo apt-get install --yes ffmpeg
+          sudo apt-get install --yes --no-install-recommends ffmpeg
 
       - name: Prepare each item independently
         if: ${{ steps.batch.outputs.claimed == 'true' && steps.batch.outputs.item_count != '0' }}

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2921,7 +2921,7 @@ jobs:
         if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.publication-context.outputs.direct_lifecycle_recovery != 'true' && steps.validate-exact-review-bundle.outcome == 'success' && hashFiles('.artifacts/exact-review-bundle/live-proof/*/live-proof-manifest.json') != '' }}
         run: |
           sudo apt-get update
-          sudo apt-get install --yes ffmpeg
+          sudo apt-get install --yes --no-install-recommends ffmpeg
 
       - name: Fold exact live proof into the review artifact
         id: fold-exact-live-proof
@@ -5222,7 +5222,7 @@ jobs:
         if: ${{ steps.download-review-artifacts.outcome == 'success' && hashFiles('artifacts/live-proof/*/live-proof-manifest.json') != '' }}
         run: |
           sudo apt-get update
-          sudo apt-get install --yes ffmpeg
+          sudo apt-get install --yes --no-install-recommends ffmpeg
 
       - name: Fold live proofs into review artifacts
         if: ${{ steps.download-review-artifacts.outcome == 'success' }}


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Resolves a problem where ClawSweeper's live-proof publication jobs download optional playback and hardware-driver packages while provisioning media validators.

## Why This Change Was Made

Use `--no-install-recommends` at the three existing ffmpeg installation sites. Keep the required dependency closure, package selection, APT update, workflow conditions, validators, and deadlines unchanged.

This is a resource reduction, not a latency optimization. No cache, runner, lazy-install, or Git-fetch changes are included.

## User Impact

In the controlled Ubuntu 24.04 comparison, provisioning downloaded 31,262,250 fewer package-archive bytes (33.22385%), installed 12 fewer new packages, and added 53,263 KiB less package-declared `Installed-Size` (23.99191%). `Installed-Size` is dpkg metadata, not a measurement of whole-runner disk usage.

The same media binaries and validator outcomes were retained. No wall-time speedup, throughput increase, billing reduction, or timing-neutrality claim is made.

## OpenClaw Bay Impact

Bay is unaffected. Only dependency installation options change; publication data, queue behavior, status contracts, and observer UI are unchanged.

## Documentation Impact

Reviewed `docs/live-proof.md`, `CONTRIBUTING.md`, and `AGENTS.md`. The media-validation and publication contracts remain accurate, so no documentation or release-version changes are needed.

## Evidence

- Base: `330b8ee4e32dccf73f99b2d3e92203dbf70523c8`.
- Signed commit: `5b38b05e167ef98876bfd03e0b53171be214483f`.
- Exact scope: three flag insertions in `.github/workflows/exact-review-batch-publish.yml` and `.github/workflows/sweep.yml`.
- Aligned build passed.
- Focused media/workflow validation: 320 passed, zero failed or skipped.
- Native Git validation: all 18 cases passed on the original proof revision and within both aligned full checks; no duplicate standalone rerun.
- Original local full check: 5,371 tests, 5,355 passed, three failed, 13 skipped. The failures involved host Git hooks configuration, shell startup/external dependency setup, and a media-child HOME mismatch. Controlled local retries resolved the first two; the exact HOME producer remains unproven.
- Clean configured AWS Linux qualification: the three failed cases passed first, then unchanged `pnpm run check` passed with 5,371 tests, 5,353 passed, zero failed, and 18 skipped. Changed coverage passed 13/13. Toolchain: Node 24.18.1, pnpm 11.10.0, Bash 5.3.9, frozen dependencies.
- Linux skips: seven macOS-only cases, four opt-in benchmarks, and seven existing delegated-namespace/containment capability skips. No test, assertion, or user configuration was changed.
- Qualification-lease cleanup verified complete: released, not ready, no host, and zero task runners.
- Fresh precommit and committed-branch reviews against the pinned base: both scoped-clean through P2, with no findings.

## Real Behavior Proof

**Claim and surface:** avoid optional package downloads at the existing live-proof media-validator installers while preserving real ffprobe and ClawSweeper media-validator behavior.

**Hosted trigger:** [the observed publication job](https://github.com/openclaw/clawsweeper/actions/runs/34127689679/job/101760145007), using Ubuntu 24.04 image `20260831.293.1`, installed 99 new packages, reported 94.1 MB of archives, and spent 22 seconds in the **whole APT step**, not install-only. The optional packages below were newly installed, not already present. Two bounded log reads were needed because the first extraction lost wrapped package names; raw logs were discarded.

**Command and environment:** clean amd64 Ubuntu 24.04 Docker containers on a task-owned AWS Crabbox lease, with the same image, starting inventory, APT configuration, sources, index hashes, and cold package-cache state. Each measurement ran `apt-get update` followed by either `apt-get install --yes ffmpeg` or `apt-get install --yes --no-install-recommends ffmpeg`. Containers ran as root; the workflow's equivalent commands retain `sudo`.

The dependency-reconciled baseline installed the exact same 99 package names seen in the hosted log. All six samples had zero package upgrades and removals. Shared package versions, ffmpeg/ffprobe binary hashes, and fixture hashes matched.

| Resource | Baseline | Candidate | Reduction |
| --- | ---: | ---: | ---: |
| New packages | 99 | 87 | 12 |
| Package-archive bytes | 94,095,802 | 62,833,552 | 31,262,250 (33.22385%) |
| Package-declared Installed-Size increase, KiB | 222,004 | 168,741 | 53,263 (23.99191%) |

Omitted packages: `i965-va-driver`, `intel-media-va-driver`, `libaacs0`, `libbdplus0`, `libdecor-0-plugin-1-gtk`, `libigdgmm12`, `librsvg2-common`, `mesa-va-drivers`, `mesa-vdpau-drivers`, `pocketsphinx-en-us`, `va-driver-all`, and `vdpau-driver-all`.

**All timing samples:** order B, C, C, B, B, C. These timings include APT update plus install. They do not include container creation, baseline-image preparation, or proof instrumentation.

| Sample | Pair | Mode | Update, s | Install, s | Total APT, s |
| --- | --- | --- | ---: | ---: | ---: |
| 0 | 1 | Baseline | 2.2550 | 11.1231 | 13.3781 |
| 1 | 1 | Candidate | 2.1659 | 26.0120 | 28.1779 |
| 2 | 2 | Candidate | 3.3465 | 9.6886 | 13.0351 |
| 3 | 2 | Baseline | 3.4961 | 12.0073 | 15.5035 |
| 4 | 3 | Baseline | 1.7687 | 10.9977 | 12.7664 |
| 5 | 3 | Candidate | 1.9586 | 7.9692 | 9.9278 |

Signed baseline-minus-candidate total differences: **-14.7998 s, +2.4684 s, +2.8386 s**. Timing did not show a repeatable benefit. The candidate was accepted only for the resource reductions; no additional timing samples were sought.

**Actual consumer:** `validateAttachedMedia` in `src/live-proof/manifest.ts`, using `ffprobeMedia` in `src/clawsweeper-media-proof.ts` and real ffprobe `6.1.1-3ubuntu5`, produced the same four outcomes in both environments:

- Valid 2-second, 320x240 MP4 and JPEG poster: accepted.
- Nonempty corrupt MP4: invalid media, with the expected ffprobe invalid-data reason.
- Nonempty corrupt JPEG: invalid media, specifically `ffprobe returned invalid dimensions`.
- Manifest duration 5 seconds versus actual 2 seconds: duration mismatch, preserving the one-second tolerance.

Execution failures remained distinct `MediaProbeExecutionError` failures; arbitrary exceptions were not accepted as invalid-media proof. An initial exploratory consumer-classification failure was corrected before the six complete samples; it is retained separately and is not represented as a successful timing sample.

**Source and artifacts:** original raw proof SHA-256 `607e9f670aec140997933368fbaed2440c72a701724bc6a2250f4dcd5f8ff8d1` is preserved unchanged, including its original unapplied timing verdict. A separate binding records the approved resource-only criterion, final Git revision/diff, all three YAML-derived argv arrays, and unchanged media-consumer Git blobs from the original proof revision through the aligned base. Detailed proof and sanitized review artifacts are retained for maintainer review; no private infrastructure identifiers or paths are published here.

**Cleanup:** all owned measurement containers were removed, the exact temporary baseline image was removed, and the containing AWS lease was released and verified without a host or remaining task runner. No broad prune or speculative replacement lease was used.

A separate configured AWS lease was acquired only after the local host/environment diagnosis, for the exact three failed cases and the required full check. It performed no new APT sampling. Its automatic release initially reported pending; an explicit stop succeeded, and fresh native status fields verified cleanup complete, released, not ready, and no host. The fresh runner list was empty.

**Limits:** this was a dependency-reconciled container comparison, not a reproduction of the entire hosted runner image or a complete publication workflow. Unrelated hosted packages were not recreated; CDN behavior and upstream state were uncontrolled. Hardware acceleration, arbitrary media formats, fleet-wide behavior, and billing were not tested. The proof supports the measured package-resource reduction and the four exercised validator outcomes only.

<!--
Punchcard-Session: coral-workshop-orchard-9x
Punchcard-Receipt: pc1.cHVuY2hjYXJkLXNlcnZlci1yZWNlaXB0LXYxAGF0dF8wMU0xWTZHVEVSWkI2MUFWN1RSWEtEMlo0NQB0bnRfMDFKMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAAdXNyXzAxSjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAxAGRldl9BRDREQzA3NDE5MUVGRUFCNTREQTQ3MjhFRQB3cmtfMDFNMVdQWjhEV0VLMThXU0tGWU1TWE1EMzYAc2VzXzAxTTFZMlRKTUg3RkFKTldBVFhGTVYxMjdGAGNvcmFsLXdvcmtzaG9wLW9yY2hhcmQtOXgAb3BlbmNsYXcvY2xhd3N3ZWVwZXIAADE0ODAAOWNkMmYzYTE4NGI2MTkzM2E3YmM0NTdhZjFjYTQ3YTgzNTQxNjIzYTQ4NDlmNTc4YmFiM2VlYmNiMWU5Y2U4MABzaWduaW5nLXYxAExpN012dktGcXJYR0RtWlgxQ2o5dlo1R1VBOERYQkduQ2RPeG12S2t1TUtacTF0NVMxV0FJQXNHM2VKRHB5UDZPTGhWN2x5YVRHa0FKaUF5WWI3MkNnADIwMjYtMDktMDdUMTU6MDY6NTIuNzYwWgA.VYtifuDMJcZLo87bNc6VNP87kpt7-E8t0oHxJDS_2FrUHfwU60o70MQDW05zlnJ1rJPgy50n1QCd4QzLyXdgAg
-->
