### PR TITLE
fix(dashboard): avoid webhook warnings in polling mode

### DIFF
--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -3434,6 +3434,7 @@ function refreshStatus(request, env) {
   const key = [
     new URL(request.url).origin,
     env.CLAWSWEEPER_REPO || "openclaw/clawsweeper",
+    dashboardWorkflowSource(env),
     env.TARGET_REPOS || "openclaw/openclaw",
     env.PUBLIC_BAY_REPOS || "",
     env.CLAWSWEEPER_STATE_REPO || CLAWSWEEPER_STATE_REPO,
@@ -4342,6 +4343,12 @@ async function githubWebhookReadModelQueuePost(
   );
   if (!response.ok) return null;
   return objectValue(await response.json().catch(() => null));
+}
+
+function dashboardWorkflowSource(env: DashboardEnv): "poll" | "webhook" {
+  // The shared signing secret also serves unrelated queue and ingress routes.
+  // Its presence does not mean this dashboard consumes workflow webhooks.
+  return stringEnv(env.CLAWSWEEPER_DASHBOARD_WORKFLOW_SOURCE) === "poll" ? "poll" : "webhook";
 }
 
 function githubWebhookReadModelWorkflowObject(
@@ -7638,13 +7645,17 @@ async function statusSnapshot(env) {
     .filter(Boolean);
   const budget = numberFrom(env.WORKER_BUDGET, 32);
   const activeRunErrors = [];
-  const workflowReadModel = stringEnv(env.CLAWSWEEPER_WEBHOOK_SECRET)
-    ? await githubWebhookReadModelQueuePost(env, "workflows", {
-        repository: repo,
-      }).catch(() => null)
-    : null;
+  const useWorkflowReadModel = dashboardWorkflowSource(env) === "webhook";
+  const workflowReadModel =
+    useWorkflowReadModel && stringEnv(env.CLAWSWEEPER_WEBHOOK_SECRET)
+      ? await githubWebhookReadModelQueuePost(env, "workflows", {
+          repository: repo,
+        }).catch(() => null)
+      : null;
   const workflowReadModelUsable = workflowReadModel?.usable === true;
-  if (!workflowReadModelUsable) reportGithubReadModelDashboardFallback(workflowReadModel);
+  if (useWorkflowReadModel && !workflowReadModelUsable) {
+    reportGithubReadModelDashboardFallback(workflowReadModel);
+  }
   let runs;
   let completedRuns;
   let activeRunCandidates;
@@ -7693,7 +7704,11 @@ async function statusSnapshot(env) {
     ...activeRunCandidates.filter((run) => isActiveWorkflowRun(run)),
     ...workflowRuns.filter((run) => isActiveWorkflowRun(run)),
   ]).sort(newestWorkflowRunFirst);
-  if (!workflowReadModelUsable && stringEnv(env.CLAWSWEEPER_WEBHOOK_SECRET)) {
+  if (
+    useWorkflowReadModel &&
+    !workflowReadModelUsable &&
+    stringEnv(env.CLAWSWEEPER_WEBHOOK_SECRET)
+  ) {
     const objects = uniqueWorkflowRuns([
       ...workflowRuns,
       ...completedWorkflowRuns,
@@ -10283,7 +10298,11 @@ export async function workflowJobsForRunSnapshot(
     const object = githubWebhookReadModelWorkflowObject(repo, "workflow_job", job);
     return object ? [object] : [];
   });
-  if ((repairObjects.length > 0 || census.complete) && stringEnv(env.CLAWSWEEPER_WEBHOOK_SECRET)) {
+  if (
+    dashboardWorkflowSource(env) === "webhook" &&
+    (repairObjects.length > 0 || census.complete) &&
+    stringEnv(env.CLAWSWEEPER_WEBHOOK_SECRET)
+  ) {
     await githubWebhookReadModelQueuePost(env, "repair", {
       repository: repo,
       repair_kind: "workflows",

--- a/dashboard/wrangler.toml
+++ b/dashboard/wrangler.toml
@@ -36,6 +36,7 @@ custom_domain = true
 
 [vars]
 CLAWSWEEPER_REPO = "openclaw/clawsweeper"
+CLAWSWEEPER_DASHBOARD_WORKFLOW_SOURCE = "poll"
 CLAWSWEEPER_APP_CLIENT_ID = "Iv23liOECG0slfuhz093"
 CLAWSWEEPER_CRABFLEET_URL = "https://crabfleet.openclaw.ai"
 TARGET_REPOS = "openclaw/openclaw,openclaw/clawhub,openclaw/clawsweeper,openclaw/fs-safe"

--- a/docs/github-webhook-read-model.md
+++ b/docs/github-webhook-read-model.md
@@ -10,7 +10,9 @@ The queue Durable Object materializes signed GitHub App deliveries into a bounde
 
 ## Required GitHub App event subscriptions
 
-The deployed GitHub App must deliver all of these repository events:
+Full read-model coverage requires the following repository events. Each
+consumer requires only the event classes it reads; dashboard workflow health
+in `poll` mode does not require workflow-run or workflow-job subscriptions.
 
 | Subscription | Materialized state |
 | --- | --- |
@@ -24,6 +26,17 @@ The deployed GitHub App must deliver all of these repository events:
 | Check runs and check suites | Current check state associated with delivered commits |
 
 Subscription readiness is detected per event class. A class remains unavailable until at least one signed delivery of that exact class has arrived. After the 30-minute probe window, consumers continue their live poll and emit one structured `github_read_model_degraded` line with `reason=never_observed`; enabling a related event does not satisfy the missing class.
+
+### Dashboard workflow source
+
+`CLAWSWEEPER_DASHBOARD_WORKFLOW_SOURCE=poll` selects the existing bounded
+GitHub run/job polls for dashboard health. This deployment selects `poll` in
+`dashboard/wrangler.toml`; it neither reads nor repairs the workflow read model
+and does not warn about missing workflow subscriptions. Leaving the setting
+unset, or setting `webhook`, preserves snapshot reuse, fallback warnings, and
+repair. The shared signing secret remains required for those read-model calls.
+Item/comment consumers, signed ingress, queue operations, and ETag caching are
+unchanged. Poll mode does not require new GitHub App event subscriptions.
 
 ## Stored schema and bounds
 

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -141,6 +141,17 @@ pipeline rows. Production also enables a bounded live fallback for the first
 few active PR rows so visible rows do not remain on workflow-only status when KV
 is absent or a cache event lands in another Cloudflare colo.
 
+### Workflow health source
+
+The deployment sets `CLAWSWEEPER_DASHBOARD_WORKFLOW_SOURCE=poll` to collect
+workflow health through the existing bounded GitHub run/job polls. It skips
+workflow read-model reads, repairs, and missing-subscription warnings even when
+the shared webhook signing secret is configured. Unset or `webhook` retains
+the existing webhook-first behavior. Snapshot and job-cache TTLs, pagination,
+freshness, genuine GitHub errors, and the public Bay contract are unchanged.
+Changing source does not flush persisted snapshots; normal expiry refreshes
+them. Concurrent refreshes with different resolved sources do not coalesce.
+
 ## What It Shows
 
 - bounded active-work counts and closed workflow, worker, status, stage, and

--- a/test/dashboard-worker-dashboard-status.test.ts
+++ b/test/dashboard-worker-dashboard-status.test.ts
@@ -288,6 +288,197 @@ function dashboardHealthHistoryFixture(range = "6h") {
   };
 }
 
+test("dashboard polling ignores workflow snapshots without disabling other durable reads", async (t) => {
+  const originalFetch = globalThis.fetch;
+  const originalCaches = globalThis.caches;
+  const warnings: unknown[][] = [];
+  t.mock.method(console, "warn", (...args: unknown[]) => warnings.push(args));
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+    Object.defineProperty(globalThis, "caches", { configurable: true, value: originalCaches });
+  });
+  Object.defineProperty(globalThis, "caches", {
+    configurable: true,
+    value: { default: { match: async () => undefined, put: async () => undefined } },
+  });
+
+  for (const usable of [true, false]) {
+    const completed = completedReviewRun(41, 100, "success", 60_000);
+    const active = {
+      ...completedReviewRun(42, 101, "success", 30_000),
+      status: "in_progress",
+      conclusion: null,
+    };
+    const phantom = {
+      ...completedReviewRun(999, 999, "success", 60 * 60_000),
+      status: "queued",
+      conclusion: null,
+    };
+    const paths: string[] = [];
+    const queue = new ExactReviewQueue({ storage: new MemoryDurableStorage() }, {});
+    const namespace = new MemoryDurableNamespace({
+      async fetch(request) {
+        const pathname = new URL(request.url).pathname;
+        paths.push(pathname);
+        if (pathname === "/github-read-model/workflows") {
+          return jsonResponse({
+            usable,
+            runs: [phantom],
+            jobs_usable: true,
+            jobs: [],
+            job_coverage_run_ids: [42],
+            class_state: { reason: "never_observed" },
+          });
+        }
+        return queue.fetch(request);
+      },
+    });
+    let runReads = 0;
+    let jobReads = 0;
+    globalThis.fetch = async (input) => {
+      const url = new URL(String(input));
+      if (url.pathname === "/repos/openclaw/clawsweeper/actions/runs") {
+        runReads += 1;
+        const status = url.searchParams.get("status");
+        return jsonResponse({
+          workflow_runs: !status
+            ? [active, completed]
+            : status === "completed"
+              ? [completed]
+              : status === "in_progress"
+                ? [active]
+                : [],
+        });
+      }
+      const jobMatch = /\/actions\/runs\/(41|42)\/jobs$/.exec(url.pathname);
+      if (jobMatch) {
+        jobReads += 1;
+        const run = jobMatch[1] === "42" ? active : completed;
+        return jsonResponse({
+          total_count: 1,
+          jobs: [
+            {
+              id: run.id * 10,
+              run_id: run.id,
+              name: "Review shard",
+              status: run.status,
+              conclusion: run.conclusion,
+              started_at: run.created_at,
+              completed_at: run.status === "completed" ? run.updated_at : null,
+              updated_at: run.updated_at,
+              steps: [
+                {
+                  number: 1,
+                  name: "Review shard",
+                  status: run.status,
+                  conclusion: run.conclusion,
+                  started_at: run.created_at,
+                  completed_at: run.status === "completed" ? run.updated_at : null,
+                },
+              ],
+            },
+          ],
+        });
+      }
+      if (url.pathname.includes("/actions/workflows/")) {
+        return jsonResponse({ workflow_runs: [] });
+      }
+      if (url.pathname === "/search/issues") return jsonResponse({ items: [] });
+      if (url.pathname.includes("/issues")) return jsonResponse([]);
+      throw new Error(`unexpected fetch ${url}`);
+    };
+    const env = {
+      CLAWSWEEPER_REPO: "openclaw/clawsweeper",
+      TARGET_REPOS: "openclaw/openclaw",
+      CLAWSWEEPER_DASHBOARD_WORKFLOW_SOURCE: "poll",
+      CLAWSWEEPER_WEBHOOK_SECRET: "synthetic-polling-secret",
+      EXACT_REVIEW_QUEUE: namespace,
+      STATUS_STORE: new MemoryKv(),
+      CACHE_TTL_SECONDS: "-1",
+    };
+    const request = new Request("https://clawsweeper.openclaw.ai/api/status");
+    const first = await worker.fetch(request, env);
+    const snapshot = await first.json();
+    assert.equal(first.status, 200);
+    assert.equal(snapshot.fleet.active_workflow_runs, 1);
+    assert.equal(snapshot.fleet.active_codex_jobs, 1);
+    assert.equal(snapshot.operational_health.status, "healthy");
+    assert.equal(snapshot.operational_health.queued_over_threshold, 0);
+    assert.equal(snapshot.health.attempts, 1);
+    assert.equal(snapshot.health.successful_attempts, 1);
+    assert.equal(runReads, 7);
+    assert.equal(jobReads, 2);
+    assert.ok(paths.some((pathname) => !pathname.startsWith("/github-read-model/")));
+    assert.equal(
+      paths.some((pathname) => pathname.startsWith("/github-read-model/")),
+      false,
+    );
+    const generatedAt = snapshot.generated_at;
+    await new Promise((resolve) => setTimeout(resolve, 2));
+    const refreshed = await (await worker.fetch(request, env)).json();
+    assert.ok(Date.parse(refreshed.generated_at) > Date.parse(generatedAt));
+    assert.equal(runReads, 14);
+    assert.equal(jobReads, 2, "normal job caches remain enabled in poll mode");
+    assert.equal(
+      paths.some((pathname) => pathname.startsWith("/github-read-model/")),
+      false,
+    );
+  }
+  assert.equal(JSON.stringify(warnings).includes("github_read_model_degraded"), false);
+});
+
+test("polling job censuses preserve versioned caches, incomplete pages, and errors", async () => {
+  for (const totalCount of [1, 2]) {
+    const store = new MemoryKv();
+    let queueReads = 0;
+    const env = {
+      CLAWSWEEPER_DASHBOARD_WORKFLOW_SOURCE: "poll",
+      CLAWSWEEPER_WEBHOOK_SECRET: "synthetic-polling-secret",
+      STATUS_STORE: store,
+      EXACT_REVIEW_QUEUE: new MemoryDurableNamespace({
+        async fetch() {
+          queueReads += 1;
+          return jsonResponse({ ok: true });
+        },
+      }),
+    };
+    const github = async () => ({
+      total_count: totalCount,
+      jobs: [{ id: 2, run_id: 41, updated_at: isoAgo(1_000) }],
+    });
+    const first = await workflowJobsForRunSnapshot(
+      env,
+      "generated-owner/generated-repo",
+      41,
+      github,
+    );
+    assert.equal(first.complete, totalCount === 1);
+    assert.equal(first.jobs.length, 1);
+    const record = JSON.parse(
+      String(await store.get("workflow-jobs:generated-owner/generated-repo:41")),
+    );
+    assert.equal(record.schema_version, 2);
+    assert.equal(record.complete, totalCount === 1);
+    const cached = await workflowJobsForRunSnapshot(
+      env,
+      "generated-owner/generated-repo",
+      41,
+      async () => {
+        throw new Error("polling must retain the normal job cache");
+      },
+    );
+    assert.deepEqual(cached, first);
+    assert.equal(queueReads, 0);
+    await assert.rejects(
+      workflowJobsForRunSnapshot(env, "generated-owner/generated-repo", 42, async () => {
+        throw new Error("synthetic GitHub failure");
+      }),
+      /synthetic GitHub failure/,
+    );
+    assert.equal(queueReads, 0);
+  }
+});
+
 test("worker job pagination marks a capped census incomplete across cache reuse", async () => {
   const statusStore = new MemoryKv();
   let reads = 0;
@@ -3740,133 +3931,146 @@ test("dashboard skips raw event persistence when the private status store is not
   }
 });
 
-test("dashboard serves stale status while coalescing one background refresh", async () => {
-  const originalFetch = globalThis.fetch;
-  const originalCaches = globalThis.caches;
-  const cache = new MemoryCache();
-  Object.defineProperty(globalThis, "caches", {
-    configurable: true,
-    value: { default: cache },
-  });
-  await cache.put(
-    new Request("https://clawsweeper.openclaw.ai/api/status-cache/v7/_/stale"),
-    jsonResponse({
-      schema_version: 1,
-      generated_at: "2026-06-13T18:00:00Z",
-      source: {
-        clawsweeper_repo: "openclaw/clawsweeper",
-        target_repositories: ["openclaw/openclaw"],
-      },
-      fleet: { active_workflow_runs: 1 },
-      workers: [],
-      automatic_work: [],
-      pipeline: [{ id: "stale-row" }],
-      bay: {},
-      recent: {},
-      exact_review_queue: {
-        pending: 1,
-        dispatching: 1,
-        leased: 0,
-        handoff_health: { status: "stalled" },
-      },
-      diagnostics: { errors: [], exact_review_queue_error: null },
-    }),
-  );
+for (const sources of [
+  [undefined, undefined],
+  [undefined, "webhook"],
+  ["poll", "poll"],
+  ["poll", "webhook"],
+]) {
+  test(`dashboard stale refresh coalescing respects workflow sources ${sources.join("/")}`, async () => {
+    const originalFetch = globalThis.fetch;
+    const originalCaches = globalThis.caches;
+    const cache = new MemoryCache();
+    Object.defineProperty(globalThis, "caches", {
+      configurable: true,
+      value: { default: cache },
+    });
+    await cache.put(
+      new Request("https://clawsweeper.openclaw.ai/api/status-cache/v7/_/stale"),
+      jsonResponse({
+        schema_version: 1,
+        generated_at: "2026-06-13T18:00:00Z",
+        source: {
+          clawsweeper_repo: "openclaw/clawsweeper",
+          target_repositories: ["openclaw/openclaw"],
+        },
+        fleet: { active_workflow_runs: 1 },
+        workers: [],
+        automatic_work: [],
+        pipeline: [{ id: "stale-row" }],
+        bay: {},
+        recent: {},
+        exact_review_queue: {
+          pending: 1,
+          dispatching: 1,
+          leased: 0,
+          handoff_health: { status: "stalled" },
+        },
+        diagnostics: { errors: [], exact_review_queue_error: null },
+      }),
+    );
 
-  const currentQueue = {
-    pending: 7,
-    dispatching: 0,
-    leased: 28,
-    storage_schema_version: 1,
-    handoff_health: {
-      status: "healthy",
-      reason: "handoff_current",
-      phases: {
-        pending: { count: 7 },
-        dispatching: { count: 0 },
-        leased: { count: 28 },
+    const currentQueue = {
+      pending: 7,
+      dispatching: 0,
+      leased: 28,
+      storage_schema_version: 1,
+      handoff_health: {
+        status: "healthy",
+        reason: "handoff_current",
+        phases: {
+          pending: { count: 7 },
+          dispatching: { count: 0 },
+          leased: { count: 28 },
+        },
       },
-    },
-  };
-  let queueReads = 0;
-  const exactReviewQueue = new MemoryDurableNamespace({
-    fetch: async () => {
-      queueReads += 1;
-      return jsonResponse(currentQueue);
-    },
-  });
+    };
+    let queueReads = 0;
+    const exactReviewQueue = new MemoryDurableNamespace({
+      fetch: async () => {
+        queueReads += 1;
+        return jsonResponse(currentQueue);
+      },
+    });
 
-  let releaseFetch!: () => void;
-  const fetchGate = new Promise<void>((resolve) => {
-    releaseFetch = resolve;
-  });
-  let unfilteredRunRequests = 0;
-  globalThis.fetch = async (input) => {
-    const url = new URL(String(input));
-    await fetchGate;
-    if (url.pathname.includes("/actions/")) {
-      if (url.pathname.endsWith("/actions/runs") && !url.searchParams.has("status")) {
-        unfilteredRunRequests += 1;
+    let releaseFetch!: () => void;
+    const fetchGate = new Promise<void>((resolve) => {
+      releaseFetch = resolve;
+    });
+    let unfilteredRunRequests = 0;
+    globalThis.fetch = async (input) => {
+      const url = new URL(String(input));
+      await fetchGate;
+      if (url.pathname.includes("/actions/")) {
+        if (url.pathname.endsWith("/actions/runs") && !url.searchParams.has("status")) {
+          unfilteredRunRequests += 1;
+        }
+        return jsonResponse({ workflow_runs: [] });
       }
-      return jsonResponse({ workflow_runs: [] });
+      if (url.pathname === "/search/issues") return jsonResponse({ items: [] });
+      if (url.pathname === "/repos/openclaw/openclaw/issues") return jsonResponse([]);
+      return new Response(JSON.stringify({ message: "not found" }), { status: 404 });
+    };
+
+    try {
+      const waitUntilPromises: Promise<unknown>[] = [];
+      const env = {
+        CLAWSWEEPER_REPO: "openclaw/clawsweeper",
+        CLAWSWEEPER_DASHBOARD_WORKFLOW_SOURCE: sources[0],
+        TARGET_REPOS: "openclaw/openclaw",
+        CACHE_TTL_SECONDS: "20",
+        EXACT_REVIEW_QUEUE: exactReviewQueue,
+      };
+      const context = {
+        waitUntil(promise: Promise<unknown>) {
+          waitUntilPromises.push(promise);
+        },
+      };
+      const request = new Request("https://clawsweeper.openclaw.ai/api/status");
+      const [first, second] = await Promise.all([
+        worker.fetch(
+          request,
+          { ...env, CLAWSWEEPER_DASHBOARD_WORKFLOW_SOURCE: sources[1] },
+          context,
+        ),
+        worker.fetch(request, env, context),
+      ]);
+
+      assert.equal(first.headers.get("x-clawsweeper-cache"), "stale");
+      assert.equal(second.headers.get("x-clawsweeper-cache"), "stale");
+      const firstStatus = await first.json();
+      const secondStatus = await second.json();
+      assert.equal(firstStatus.pipeline[0].id, undefined);
+      assert.equal(firstStatus.exact_review_queue.pending, 1);
+      assert.equal(firstStatus.exact_review_queue.handoff_health.status, "stalled");
+      assert.equal(firstStatus.freshness.state, "stale");
+      assert.equal(firstStatus.freshness.cache_state, "stale");
+      assert.equal(firstStatus.freshness.maximum_age_ms, 20_000);
+      assert.equal(secondStatus.exact_review_queue.handoff_health.status, "stalled");
+      assert.equal(queueReads, 0);
+      assert.equal(waitUntilPromises.length, 2);
+
+      releaseFetch();
+      await Promise.all(waitUntilPromises);
+      const refreshes = sources[0] === "poll" && sources[1] === "webhook" ? 2 : 1;
+      assert.equal(unfilteredRunRequests, refreshes);
+      assert.equal(queueReads, 3 * refreshes);
+
+      const refreshed = await worker.fetch(request, env);
+      assert.equal(refreshed.headers.get("x-clawsweeper-cache"), "fresh");
+      const refreshedStatus = await refreshed.json();
+      assert.deepEqual(refreshedStatus.pipeline, []);
+      assert.equal(refreshedStatus.freshness.state, "fresh");
+      assert.equal(refreshedStatus.freshness.cache_state, "fresh");
+      assert.equal(refreshedStatus.exact_review_queue.pending, 7);
+      assert.equal(refreshedStatus.exact_review_queue.handoff_health.status, "healthy");
+      assert.equal(queueReads, 3 * refreshes);
+    } finally {
+      globalThis.fetch = originalFetch;
+      Object.defineProperty(globalThis, "caches", { configurable: true, value: originalCaches });
     }
-    if (url.pathname === "/search/issues") return jsonResponse({ items: [] });
-    if (url.pathname === "/repos/openclaw/openclaw/issues") return jsonResponse([]);
-    return new Response(JSON.stringify({ message: "not found" }), { status: 404 });
-  };
-
-  try {
-    const waitUntilPromises: Promise<unknown>[] = [];
-    const env = {
-      CLAWSWEEPER_REPO: "openclaw/clawsweeper",
-      TARGET_REPOS: "openclaw/openclaw",
-      CACHE_TTL_SECONDS: "20",
-      EXACT_REVIEW_QUEUE: exactReviewQueue,
-    };
-    const context = {
-      waitUntil(promise: Promise<unknown>) {
-        waitUntilPromises.push(promise);
-      },
-    };
-    const request = new Request("https://clawsweeper.openclaw.ai/api/status");
-    const [first, second] = await Promise.all([
-      worker.fetch(request, env, context),
-      worker.fetch(request, env, context),
-    ]);
-
-    assert.equal(first.headers.get("x-clawsweeper-cache"), "stale");
-    assert.equal(second.headers.get("x-clawsweeper-cache"), "stale");
-    const firstStatus = await first.json();
-    const secondStatus = await second.json();
-    assert.equal(firstStatus.pipeline[0].id, undefined);
-    assert.equal(firstStatus.exact_review_queue.pending, 1);
-    assert.equal(firstStatus.exact_review_queue.handoff_health.status, "stalled");
-    assert.equal(firstStatus.freshness.state, "stale");
-    assert.equal(firstStatus.freshness.cache_state, "stale");
-    assert.equal(firstStatus.freshness.maximum_age_ms, 20_000);
-    assert.equal(secondStatus.exact_review_queue.handoff_health.status, "stalled");
-    assert.equal(queueReads, 0);
-    assert.equal(waitUntilPromises.length, 2);
-
-    releaseFetch();
-    await Promise.all(waitUntilPromises);
-    assert.equal(unfilteredRunRequests, 1);
-    assert.equal(queueReads, 3);
-
-    const refreshed = await worker.fetch(request, env);
-    assert.equal(refreshed.headers.get("x-clawsweeper-cache"), "fresh");
-    const refreshedStatus = await refreshed.json();
-    assert.deepEqual(refreshedStatus.pipeline, []);
-    assert.equal(refreshedStatus.freshness.state, "fresh");
-    assert.equal(refreshedStatus.freshness.cache_state, "fresh");
-    assert.equal(refreshedStatus.exact_review_queue.pending, 7);
-    assert.equal(refreshedStatus.exact_review_queue.handoff_health.status, "healthy");
-    assert.equal(queueReads, 3);
-  } finally {
-    globalThis.fetch = originalFetch;
-    Object.defineProperty(globalThis, "caches", { configurable: true, value: originalCaches });
-  }
-});
+  });
+}
 
 test("dashboard status survives cache persistence failures", async () => {
   const originalFetch = globalThis.fetch;


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where dashboard workflow health emits missing-subscription
warnings and performs workflow read-model repair even when the deployment
intentionally uses GitHub polling without workflow webhook subscriptions.

## Why This Change Was Made

The dashboard inferred its workflow source from a signing secret that also
serves unrelated ingress and queue operations. A dashboard-owned source
selector now governs workflow snapshot reads, fallback warnings, run repair,
job repair, and in-flight refresh identity.

This deployment selects `CLAWSWEEPER_DASHBOARD_WORKFLOW_SOURCE=poll`. Unset or
`webhook` preserves existing behavior, including separate secret checks.
No new webhook, subscription, permission, timeout, concurrency, queue, schema,
or public response field is introduced. Persisted cache keys and TTLs are unchanged;
switching sources takes effect through normal cache expiry, not a flush.

Production TypeScript: +19 net lines; deployment configuration: +1;
tests: +204 net lines. The added runtime surface owns the explicit source
decision without changing the existing polling or read-model implementations.

## User Impact

Dashboard workflow health uses bounded GitHub run/job polling without warnings
or repair work for workflow subscriptions it does not consume. Real acquisition
errors remain visible. Other installations keep webhook-first behavior unless
they explicitly select `poll`.

This does not diagnose or claim to repair the two separately observed generic
status errors. No production recovery claim is made.

## OpenClaw Bay Impact

Bay's public data contract, queue projection, lifecycle records, and consumers
are unchanged. Poll mode still exercises unrelated Durable Object reads; the
focused suite includes existing dashboard/Bay projection and freshness tests.
The separate queue-projection changes are outside this branch.

## Documentation Impact

Updated active documentation: `docs/github-webhook-read-model.md` and
`docs/live-dashboard.md`. The dashboard workflow-source owner is
`dashboard/worker.ts`; `dashboard/wrangler.toml` is this deployment's source
of truth. The sections cover the reviewed branch behavior and must change if
source selection, default behavior, or cache lifecycle changes.

No `CHANGELOG.md` entry: this repository reserves it for releases. The
operational release context is recorded here and in the commit message.

## Evidence

- Focused tests: 92/92 passed across dashboard status, webhook read model,
  GitHub API/ETag handling, and operational health.
- Added coverage: secret-present polling ignores usable and unusable phantom
  snapshots; active/completed runs and jobs; freshness and job-cache reuse;
  versioned complete/incomplete job censuses; errors; same-source coalescing
  and distinct-source separation.
- Existing default webhook, pagination, malformed/incomplete input, stale
  revalidation, signed ingress, and unrelated durable consumer tests passed.
- `git diff --check`, targeted formatting, and documentation checks passed.
- Local `build:repair` did not pass: the existing shared dependency install
  lacks `yauzl` from the base branch. No installation or unrelated fix was
  attempted. Matching-source emitted modules supported the focused tests;
  this does not make the failed build successful.
- Full `pnpm run check` must complete in exact-head hosted CI before landing.
- Fresh precommit and committed-against-base Codex reviews: clean.
- Local disk subsequently fell below the 3 GiB stop floor. No further local
  build or test work is planned; exact-head native proof had already completed.

## Real Behavior Proof

**Claim:** explicit polling skips workflow read-model-only work while
preserving actual workflow health, cache/freshness behavior, unrelated durable
traffic, and genuine upstream errors.

**Surface and environment:** actual `dashboard/worker.ts` served through
Wrangler 4.107.0/workerd 1.20260701.1 with native SQLite Durable Objects and
HTTP `/api/status`; Node 26.7.0. The task-owned controller runs
`node .artifacts/dashboard-polling-mode/run-proof.mjs committed-2a64a166` with
`PROOF_WRANGLER_BIN` pointing to an existing cached Wrangler binary. It uses
loopback GitHub HTTP fixtures, an ephemeral synthetic App key, and signed
workflow deliveries. The Worker transport guard rejects non-loopback requests.

**Observed result:** seven scenarios passed. Polling ignored both cold and
usable phantom workflow stores, returned one real active run/job and one
recent successful attempt, and left workflow rows/watermarks unchanged.
Default fallback still warned and repaired; unset and explicit `webhook`
reused the usable snapshot. Refresh saw a new run and fetched its job.
A fixture HTTP 503 produced health `unknown` and one diagnostic error.

| Scenario | Run-list requests | Job requests | Workflow reads | Workflow repairs | Health |
| --- | ---: | ---: | ---: | ---: | --- |
| Poll, cold workflow store | 7 | 2 | 0 | 0 | healthy |
| Default, unusable workflow store | 7 | 0 | 1 | 1 | healthy |
| Poll, usable phantom store | 7 | 0 | 0 | 0 | healthy |
| Default, usable phantom store | 0 | 0 | 1 | 0 | degraded |
| Explicit webhook, usable phantom store | 0 | 0 | 1 | 0 | degraded |
| Poll, new run after refresh | 7 | 1 | 0 | 0 | healthy |
| Poll, genuine upstream 503 | 7 | 0 | 0 | 0 | unknown |

**Trace:** 68 loopback GitHub requests, including two synthetic authentication
requests, zero GitHub mutations. ETag 304 revalidation occurred. Other Durable
Object traffic remained active in all polling cases. The owned Worker child
and process group exited, with no forced termination. Native receipt:
`committed-2a64a166/result.json`, observed September 8, 2026 at 01:59:02 UTC
on exact head `2a64a166993df868a30c1da3e70b7063a218c4e1`.
Worker blob `575ced5823f28c6e9210a7fec31b836d6240f455`; deployment config blob
`43f3a2610eede9f9430b3fc51af7b55d35f73aff`.

**Limits:** this is a local real-Worker proof with controlled GitHub transport,
not live production or live GitHub acquisition. It does not prove a deployment,
subscription change, or recovery of unrelated status errors. No production
credentials or production deployment, queue, or settings changes were used;
no cache flush occurred.
Earlier harness failures are retained separately; they are not reported as passes.
