### PR TITLE
feat(review): give reviewers allowlisted network access and a truthful capability prompt

### DIFF
--- a/.github/actions/setup-codex/action.yml
+++ b/.github/actions/setup-codex/action.yml
@@ -13,6 +13,9 @@ inputs:
   codex-home:
     description: CODEX_HOME directory. Defaults to an isolated per-run ClawSweeper directory.
     default: ""
+  review-network:
+    description: Enable the credential-free, allowlisted read-only reviewer profile.
+    default: "false"
   cache-suffix:
     description: Extra cache key suffix for target-tool downloads.
     default: ""
@@ -88,7 +91,7 @@ runs:
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
         fi
 
-        # Exercise the same read-only, network-isolated backend used by reviews.
+        # Keep the baseline backend probe for non-review Codex consumers.
         # A sandbox regression must stop the job before it can publish a verdict.
         codex sandbox --permission-profile :read-only -C "$GITHUB_WORKSPACE" -- /bin/true
 
@@ -181,3 +184,13 @@ runs:
       run: |
         echo "Unsupported setup-codex auth-mode: ${{ inputs['auth-mode'] }}" >&2
         exit 1
+
+    - name: Configure review network profile
+      if: ${{ inputs['review-network'] == 'true' }}
+      shell: bash
+      run: node "${{ github.action_path }}/configure-review-network.mjs"
+
+    - name: Verify review sandbox capabilities
+      if: ${{ inputs['review-network'] == 'true' }}
+      shell: bash
+      run: bash "${{ github.action_path }}/smoke-review-network.sh"

--- a/.github/actions/setup-codex/configure-review-network.mjs
+++ b/.github/actions/setup-codex/configure-review-network.mjs
@@ -1,0 +1,14 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const home = process.env.CODEX_HOME;
+if (!home) throw new Error("Review network configuration requires an isolated CODEX_HOME.");
+const path = join(home, "config.toml");
+const existing = readFileSync(path, "utf8");
+const profile = readFileSync(new URL("./review-permissions.toml", import.meta.url), "utf8");
+// Root settings must precede the existing provider tables. Duplicate permission
+// settings fail config parsing rather than silently weakening the profile.
+const tables = profile.indexOf("[features]");
+writeFileSync(path, `${profile.slice(0, tables)}\n${existing}\n${profile.slice(tables)}`, {
+  mode: 0o600,
+});

--- a/.github/actions/setup-codex/review-permissions.toml
+++ b/.github/actions/setup-codex/review-permissions.toml
@@ -1,0 +1,30 @@
+# Reviewers inspect untrusted contributor PRs: never make them an open egress
+# channel. No credentials belong in the sandbox; use public, allowlisted hosts.
+approval_policy = "never"
+default_permissions = "clawsweeper-review"
+[features]
+network_proxy = true
+[permissions.clawsweeper-review]
+extends = ":read-only"
+[permissions.clawsweeper-review.network]
+enabled = true
+mode = "limited"
+allow_upstream_proxy = false
+allow_local_binding = false
+enable_socks5 = false
+[permissions.clawsweeper-review.network.domains]
+"github.com" = "allow"
+"api.github.com" = "allow"
+"raw.githubusercontent.com" = "allow"
+"objects.githubusercontent.com" = "allow"
+"user-images.githubusercontent.com" = "allow"
+"private-user-images.githubusercontent.com" = "allow"
+"avatars.githubusercontent.com" = "allow"
+"github-production-user-asset-6210df.s3.amazonaws.com" = "allow"
+"docs.github.com" = "allow"
+"registry.npmjs.org" = "allow"
+"www.npmjs.com" = "allow"
+"nodejs.org" = "allow"
+"developer.mozilla.org" = "allow"
+"docs.openclaw.ai" = "allow"
+"openclaw.ai" = "allow"

--- a/.github/actions/setup-codex/smoke-review-network.sh
+++ b/.github/actions/setup-codex/smoke-review-network.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+: "${CODEX_HOME:?}"
+: "${GITHUB_WORKSPACE:?}"
+# Use an empty environment so setup-step credentials cannot reach the sandbox.
+env -i PATH="$PATH" HOME="$HOME" CODEX_HOME="$CODEX_HOME" \
+  codex sandbox --permission-profile clawsweeper-review -C "$GITHUB_WORKSPACE" -- /bin/sh -eu -c '
+    curl -sS --max-time 20 https://api.github.com/zen
+    echo
+    echo "allowed HTTPS: passed"
+    set +e
+    blocked_output=$(curl -sS --max-time 20 https://example.com/ 2>&1)
+    blocked_exit=$?
+    set -e
+    printf "%s\n" "$blocked_output"
+    test "$blocked_exit" -ne 0
+    # A timeout or DNS failure does not prove proxy enforcement.
+    case "$blocked_output" in *"CONNECT tunnel failed, response 403"*) ;; *) exit 1 ;; esac
+    echo "unlisted HTTPS: blocked by proxy"
+    probe="$PWD/.clawsweeper-sandbox-probe.$$"
+    test ! -e "$probe"
+    if (set -C; : > "$probe"); then
+      rm -f "$probe"
+      echo "review sandbox allowed a checkout write" >&2
+      exit 1
+    fi
+    echo "checkout write: blocked"
+  '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,50 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  review-network-smoke:
+    name: review-network-smoke
+    runs-on: ubuntu-24.04
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+      - name: Install pinned Codex and prove Linux review sandbox
+        shell: bash
+        run: |
+          set -euo pipefail
+          codex_version="$(node --input-type=module -e '
+            import { readFileSync } from "node:fs";
+            const action = readFileSync(".github/actions/setup-codex/action.yml", "utf8");
+            const version = action.match(/^  codex-version:\n(?:    [^\n]*\n)*?    default: "(\d+\.\d+\.\d+)"$/m)?.[1];
+            if (!version) throw new Error("Missing exact setup-codex version pin");
+            process.stdout.write(version);
+          ')"
+          codex_prefix="$(mktemp -d "$RUNNER_TEMP/review-codex.XXXXXX")"
+          npm install --global --prefix "$codex_prefix" "@openai/codex@$codex_version" \
+            --no-audit --no-fund --ignore-scripts
+          export PATH="$codex_prefix/bin:$PATH"
+
+          # Match setup-codex's hosted Linux bubblewrap prerequisites.
+          current_userns="$(sysctl -n kernel.unprivileged_userns_clone 2>/dev/null || true)"
+          if [[ -n "$current_userns" && "$current_userns" != "1" ]]; then
+            sudo sysctl -w kernel.unprivileged_userns_clone=1
+          fi
+          current_apparmor="$(sysctl -n kernel.apparmor_restrict_unprivileged_userns 2>/dev/null || true)"
+          if [[ -n "$current_apparmor" && "$current_apparmor" != "0" ]]; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
+
+          CODEX_HOME="$(mktemp -d "$RUNNER_TEMP/review-codex-home.XXXXXX")"
+          export CODEX_HOME
+          printf 'model = "gpt-5.4"\n' > "$CODEX_HOME/config.toml"
+          export GITHUB_WORKSPACE="$PWD"
+          node .github/actions/setup-codex/configure-review-network.mjs
+          bash .github/actions/setup-codex/smoke-review-network.sh
+
   hosted-review-scan:
     name: Hosted native review scan smoke
     if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1107,6 +1107,7 @@ jobs:
         with:
           auth-mode: ${{ vars.CLAWSWEEPER_CODEX_AUTH_MODE || 'proxy' }}
           login-status: "true"
+          review-network: "true"
 
       - uses: ./.github/actions/setup-openclaw
         if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.live-item.outputs.proceed == 'true' }}
@@ -1474,7 +1475,7 @@ jobs:
             --max-pages 1 \
             --codex-model internal \
             --codex-reasoning-effort "$CLAWSWEEPER_CODEX_REASONING_EFFORT" \
-            --codex-sandbox read-only \
+            --codex-sandbox clawsweeper-review \
             --codex-timeout-ms "$codex_timeout_ms" \
             --item-numbers "${{ steps.target.outputs.item_number }}" \
             --readonly-openclaw \
@@ -4685,7 +4686,7 @@ jobs:
             --shard-count "$SHARD_COUNT" \
             --codex-model internal \
             --codex-reasoning-effort "$CLAWSWEEPER_CODEX_REASONING_EFFORT" \
-            --codex-sandbox read-only \
+            --codex-sandbox clawsweeper-review \
             --min-active-shards "$MIN_ACTIVE_SHARDS" \
             --min-backfill-review-age-minutes "$MIN_BACKFILL_REVIEW_AGE_MINUTES" \
             --coverage-tracked-items-manifest .artifacts/worker-records-manifest.json \
@@ -4900,6 +4901,7 @@ jobs:
         with:
           auth-mode: ${{ vars.CLAWSWEEPER_CODEX_AUTH_MODE || 'proxy' }}
           login-status: "true"
+          review-network: "true"
 
       - uses: ./clawsweeper/.github/actions/setup-openclaw
 
@@ -5003,7 +5005,7 @@ jobs:
             --max-pages ${{ needs.plan.outputs.max_pages }} \
             --codex-model internal \
             --codex-reasoning-effort "$CLAWSWEEPER_CODEX_REASONING_EFFORT" \
-            --codex-sandbox read-only \
+            --codex-sandbox clawsweeper-review \
             --codex-timeout-ms ${{ needs.plan.outputs.codex_timeout_ms }} \
             --item-numbers "${{ matrix.item_numbers }}" \
             "${pr_comment_activity_arg[@]}" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ checkpoint, and status-only commits are intentionally omitted.
 ### Changed
 
 - Give hosted issue/PR reviewers allowlisted public research access through a managed proxy while keeping the checkout read-only; describe token, blocked-host, and downloaded-media capabilities accurately and fail setup when sandbox enforcement regresses.
+- Describe review capabilities from the active runner so OpenClaw gateway execution is not mistaken for the Codex allowlisted sandbox; prove Linux review sandbox enforcement in credential-free PR CI.
 
 - Add reviewed-plan retirement of one merged-target publication through the existing maintenance workflow, keeping signing credentials confined to its execution step.
 - Admit the two approved Signal URL-rejection fixtures through exact URI, source-line, path, and native decoder bindings while retaining all scanner and verification checks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Give hosted issue/PR reviewers allowlisted public research access through a managed proxy while keeping the checkout read-only; describe token, blocked-host, and downloaded-media capabilities accurately and fail setup when sandbox enforcement regresses.
+
 - Add reviewed-plan retirement of one merged-target publication through the existing maintenance workflow, keeping signing credentials confined to its execution step.
 - Admit the two approved Signal URL-rejection fixtures through exact URI, source-line, path, and native decoder bindings while retaining all scanner and verification checks.
 - Admit the reviewed Crabbox PostgreSQL operations example through exact Postgres detector, observed `PLAIN`/`HTML` decoder, value-hash, source-line, path, mode, metadata, and committed base/head bindings.

--- a/README.md
+++ b/README.md
@@ -723,7 +723,16 @@ publication, and queue lifecycle.
   Codex exits.
 - The retired hosted commit-review lane no longer mints target credentials;
   `pnpm local-review` operates on the local branch range without GitHub writes.
-- CI makes the target checkout read-only for reviews.
+- CI keeps the target checkout read-only and gives issue/PR reviewers a managed
+  network proxy restricted to the hosts in
+  [the review permission profile](.github/actions/setup-codex/review-permissions.toml):
+  GitHub, npm, Node, MDN, and OpenClaw documentation. Limited mode inspects HTTPS
+  and permits only GET/HEAD/OPTIONS; other hosts are blocked. Review tools have
+  no GitHub token, so they use public endpoints and pre-fetched context, including
+  the local media proof manifest. A blocked request is not evidence against a PR.
+  Setup must prove allowed HTTPS, denied unlisted HTTPS, and denied checkout
+  writes before reviews can publish. Offline local reviews retain their existing
+  network restriction.
 - Reviews fail if Codex leaves tracked or untracked changes behind.
 - Snapshot changes block apply unless the only change is the bot’s own review
   comment.

--- a/README.md
+++ b/README.md
@@ -723,7 +723,7 @@ publication, and queue lifecycle.
   Codex exits.
 - The retired hosted commit-review lane no longer mints target credentials;
   `pnpm local-review` operates on the local branch range without GitHub writes.
-- CI keeps the target checkout read-only and gives issue/PR reviewers a managed
+- CI keeps the target checkout read-only and gives Codex issue/PR reviewers a managed
   network proxy restricted to the hosts in
   [the review permission profile](.github/actions/setup-codex/review-permissions.toml):
   GitHub, npm, Node, MDN, and OpenClaw documentation. Limited mode inspects HTTPS
@@ -732,7 +732,11 @@ publication, and queue lifecycle.
   the local media proof manifest. A blocked request is not evidence against a PR.
   Setup must prove allowed HTTPS, denied unlisted HTTPS, and denied checkout
   writes before reviews can publish. Offline local reviews retain their existing
-  network restriction.
+  network restriction. The `review-network-smoke` PR CI job proves the same
+  enforcement on Ubuntu without secrets. Capability text follows the active
+  runner: OpenClaw uses gateway network execution without the Codex proxy or
+  filesystem sandbox, receives no GitHub token, and must keep the checkout
+  read-only by instruction.
 - Reviews fail if Codex leaves tracked or untracked changes behind.
 - Snapshot changes block apply unless the only change is the bot’s own review
   comment.

--- a/docs/pr-review-comments.md
+++ b/docs/pr-review-comments.md
@@ -586,3 +586,23 @@ pnpm run apply-decisions -- --target-repo openclaw/openclaw --sync-comments-only
 ```
 
 - Normal review/apply workflows also refresh missing or stale durable comments.
+
+### Reviewer network boundary
+
+Hosted issue/PR review tools use the `clawsweeper-review` permission profile in
+`.github/actions/setup-codex/review-permissions.toml`, owned by ClawSweeper
+maintainers and verified with Codex 0.153.3. Update this guidance when the pinned
+CLI, profile, credential handling, or setup smoke changes. The active profile
+extends read-only filesystem access and enables the managed proxy in limited
+mode for its explicit GitHub, npm, Node, MDN, and OpenClaw documentation hosts.
+Other hosts are blocked; blocked access is not evidence against the PR. The
+sandbox receives no GitHub token. Use public endpoints, pre-fetched GitHub
+context, and the downloaded screenshots/videos in the media proof manifest.
+
+Review setup opts in with `review-network: "true"`; review commands select
+`--codex-sandbox clawsweeper-review`, translated to Codex configuration
+`default_permissions="clawsweeper-review"`. Neither exec nor the app-server
+thread/turn path overrides that profile with a legacy sandbox policy. Setup
+fails before publication if allowed HTTPS fails, unlisted HTTPS is not rejected
+by the proxy, or a checkout write succeeds. Non-review callers and offline local
+reviews keep their existing sandbox settings.

--- a/docs/pr-review-comments.md
+++ b/docs/pr-review-comments.md
@@ -589,7 +589,7 @@ pnpm run apply-decisions -- --target-repo openclaw/openclaw --sync-comments-only
 
 ### Reviewer network boundary
 
-Hosted issue/PR review tools use the `clawsweeper-review` permission profile in
+Hosted Codex issue/PR review tools use the `clawsweeper-review` permission profile in
 `.github/actions/setup-codex/review-permissions.toml`, owned by ClawSweeper
 maintainers and verified with Codex 0.153.3. Update this guidance when the pinned
 CLI, profile, credential handling, or setup smoke changes. The active profile
@@ -606,3 +606,16 @@ thread/turn path overrides that profile with a legacy sandbox policy. Setup
 fails before publication if allowed HTTPS fails, unlisted HTTPS is not rejected
 by the proxy, or a checkout write succeeds. Non-review callers and offline local
 reviews keep their existing sandbox settings.
+
+Capability text follows the active `CLAWSWEEPER_RUNNER` before the Codex sandbox
+argument. OpenClaw reviews have network access through gateway execution with
+sandbox mode off; they do not use the Codex allowlisted proxy, and must treat the
+checkout as read-only by instruction. Their child environment receives no GitHub
+token. Other Codex sandbox selections retain the no-review-tool-network statement.
+This reporting does not change either runner's execution policy.
+
+The required-style `review-network-smoke` CI job runs on every PR using
+`ubuntu-24.04`, Node 24, and the Codex version pin read from setup-codex. It installs
+into a temporary prefix without secrets, creates an isolated Codex home, applies
+the same hosted Linux user-namespace prerequisites, and runs the configuration
+writer and enforcement smoke unchanged. Any smoke failure fails the job.

--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -38,6 +38,14 @@ export function agentRunner(env: NodeJS.ProcessEnv = process.env): AgentRunner {
   throw new Error(`Invalid CLAWSWEEPER_RUNNER: ${value}. Expected "codex" or "openclaw".`);
 }
 
+export function reviewNetworkCapability(
+  sandboxMode: string,
+  env: NodeJS.ProcessEnv = process.env,
+): "allowlisted-proxy" | "unrestricted" | "none" {
+  if (agentRunner(env) === "openclaw") return "unrestricted";
+  return sandboxMode === "clawsweeper-review" ? "allowlisted-proxy" : "none";
+}
+
 export function runAgentProcess(options: RunAgentProcessOptions): CodexProcessResult {
   if (options.diagnosticPromptPath) rmSync(options.diagnosticPromptPath, { force: true });
   const runner = agentRunner(options.env);

--- a/src/clawsweeper-review-command-workflow.ts
+++ b/src/clawsweeper-review-command-workflow.ts
@@ -7,6 +7,7 @@ import {
 import { ACTION_EVENT_REASON_CODES, ACTION_EVENT_STATUSES } from "./action-ledger.js";
 import { AgentInputScanError, agentInputScanFailureExitCode } from "./agent-input-scan.js";
 import { serializeReviewContext } from "./agent-input-scan-fixtures.js";
+import { reviewNetworkCapability } from "./agent-runner.js";
 import type { Args } from "./clawsweeper-args.js";
 import {
   isBulkFilerExemptRepositoryPermission as isVerifiedMaintainerRepositoryPermission,
@@ -1274,7 +1275,7 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
           {
             ...mediaProofRuntimeHints(proofScratchDir, preparedMediaProof),
             targetDir: reviewOpenclawDir,
-            allowlistedNetwork: sandboxMode === "clawsweeper-review",
+            networkCapability: reviewNetworkCapability(sandboxMode),
           },
         );
         diagnosticPrompt = prompt.text;

--- a/src/clawsweeper-review-command-workflow.ts
+++ b/src/clawsweeper-review-command-workflow.ts
@@ -1271,7 +1271,11 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
           context,
           git,
           additionalPrompt,
-          { ...mediaProofRuntimeHints(proofScratchDir, preparedMediaProof), targetDir: reviewOpenclawDir },
+          {
+            ...mediaProofRuntimeHints(proofScratchDir, preparedMediaProof),
+            targetDir: reviewOpenclawDir,
+            allowlistedNetwork: sandboxMode === "clawsweeper-review",
+          },
         );
         diagnosticPrompt = prompt.text;
         const snapshotHash = itemSnapshotHash(item, context);

--- a/src/clawsweeper-review-runtime.ts
+++ b/src/clawsweeper-review-runtime.ts
@@ -531,9 +531,9 @@ ${additionalPrompt.trim()}
 
 ## Runtime Capabilities
 
-- You may use the available network and read-only GitHub token to inspect PR body links, comments, screenshots, videos, logs, terminal output, and target-repo artifacts.
-- Download proof artifacts into ${proofScratchDir ? `\`${proofScratchDir}\`` : "a temporary scratch directory"} before inspecting them.
-- The target checkout is read-only for review. Do not modify repository files; use the scratch directory or /tmp for downloaded evidence and generated video stills/contact sheets.
+- ${runtimeHints.allowlistedNetwork ? "Network egress uses a managed proxy limited to allowlisted GitHub, npm, Node, MDN, and OpenClaw documentation hosts; other hosts are blocked. A blocked request is not evidence about the PR." : "No review-tool network access is configured; use the pre-fetched context. An inaccessible request is not evidence about the PR."}
+- There is no GitHub token in the sandbox; use public endpoints or pre-fetched context. Linked screenshots and videos are downloaded before review into the media proof manifest; read those files rather than re-fetching.
+- The target checkout is read-only. Use ${proofScratchDir ? `\`${proofScratchDir}\`` : "the proof scratch directory"} for evidence and generated video stills/contact sheets.
 ${mediaProofPrompt}
 ${introductionEvidence}
 
@@ -987,9 +987,9 @@ ${extra}
       buildReviewPrompt(options.item, options.context, options.git, options.additionalPrompt, {
         ...mediaProofRuntimeHints(proofScratchDir, preparedMediaProof),
         targetDir: options.openclawDir,
+        allowlistedNetwork: options.sandboxMode === "clawsweeper-review",
       }).text;
     const codexEnv = untrustedCodexEnv({
-      ghToken: process.env.CLAWSWEEPER_PROOF_INSPECTION_TOKEN,
       preserveCodexAuth: options.preserveCodexAuth,
     });
     const pull = asRecord(options.context.pullRequest);
@@ -1026,6 +1026,10 @@ ${extra}
     }
     // Codex owns transport recovery; the durable queue owns fresh review attempts.
     const codexConfig = ['approval_policy="never"'];
+    if (options.sandboxMode === "clawsweeper-review") {
+      // Legacy --sandbox overrides suppress startup of the configured managed proxy.
+      codexConfig.push('default_permissions="clawsweeper-review"');
+    }
     if (options.forcedLoginMethod) {
       codexConfig.unshift(`forced_login_method="${options.forcedLoginMethod}"`);
     } else if (!options.preserveCodexAuth) {
@@ -1064,8 +1068,7 @@ ${extra}
         "--output-last-message",
         outputPath,
         "--json",
-        "--sandbox",
-        options.sandboxMode,
+        ...(options.sandboxMode === "clawsweeper-review" ? [] : ["--sandbox", options.sandboxMode]),
         "--add-dir",
         proofScratchDir,
         "-",

--- a/src/clawsweeper-review-runtime.ts
+++ b/src/clawsweeper-review-runtime.ts
@@ -8,7 +8,11 @@ import {
   unlinkSync,
 } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
-import { runAgentCheckoutInspection, runAgentProcess } from "./agent-runner.js";
+import {
+  reviewNetworkCapability,
+  runAgentCheckoutInspection,
+  runAgentProcess,
+} from "./agent-runner.js";
 import { AgentInputScanError, type AgentScanSource } from "./agent-input-scan.js";
 import {
   omitReviewedFixtureReferences,
@@ -512,6 +516,12 @@ export function createReviewRuntime({
 ${additionalPrompt.trim()}
 `
       : "";
+    const networkDescription =
+      runtimeHints.networkCapability === "allowlisted-proxy"
+        ? "Network egress uses a managed proxy limited to allowlisted GitHub, npm, Node, MDN, and OpenClaw documentation hosts; other hosts are blocked. A blocked request is not evidence about the PR."
+        : runtimeHints.networkCapability === "unrestricted"
+          ? "Network access is available through OpenClaw gateway execution; the Codex managed allowlisted proxy does not apply. An inaccessible request is not evidence about the PR."
+          : "No review-tool network access is configured; use the pre-fetched context. An inaccessible request is not evidence about the PR.";
     const text = `${prompt}
 
 ## Repository State
@@ -531,9 +541,9 @@ ${additionalPrompt.trim()}
 
 ## Runtime Capabilities
 
-- ${runtimeHints.allowlistedNetwork ? "Network egress uses a managed proxy limited to allowlisted GitHub, npm, Node, MDN, and OpenClaw documentation hosts; other hosts are blocked. A blocked request is not evidence about the PR." : "No review-tool network access is configured; use the pre-fetched context. An inaccessible request is not evidence about the PR."}
-- There is no GitHub token in the sandbox; use public endpoints or pre-fetched context. Linked screenshots and videos are downloaded before review into the media proof manifest; read those files rather than re-fetching.
-- The target checkout is read-only. Use ${proofScratchDir ? `\`${proofScratchDir}\`` : "the proof scratch directory"} for evidence and generated video stills/contact sheets.
+- ${networkDescription}
+- No GitHub token is supplied to the review process; use public endpoints or pre-fetched context. Linked screenshots and videos are downloaded before review into the media proof manifest; read those files rather than re-fetching.
+- ${runtimeHints.networkCapability === "unrestricted" ? "Treat the target checkout as read-only; OpenClaw gateway execution does not enforce the Codex filesystem sandbox." : "The target checkout is read-only."} Use ${proofScratchDir ? `\`${proofScratchDir}\`` : "the proof scratch directory"} for evidence and generated video stills/contact sheets.
 ${mediaProofPrompt}
 ${introductionEvidence}
 
@@ -982,16 +992,16 @@ ${extra}
       : prepareMediaProofArtifacts(options.context, proofScratchDir);
     const outputPath = join(options.workDir, `${options.item.number}.json`);
     if (existsSync(outputPath)) unlinkSync(outputPath);
+    const codexEnv = untrustedCodexEnv({
+      preserveCodexAuth: options.preserveCodexAuth,
+    });
     const prompt =
       options.prompt ??
       buildReviewPrompt(options.item, options.context, options.git, options.additionalPrompt, {
         ...mediaProofRuntimeHints(proofScratchDir, preparedMediaProof),
         targetDir: options.openclawDir,
-        allowlistedNetwork: options.sandboxMode === "clawsweeper-review",
+        networkCapability: reviewNetworkCapability(options.sandboxMode, codexEnv),
       }).text;
-    const codexEnv = untrustedCodexEnv({
-      preserveCodexAuth: options.preserveCodexAuth,
-    });
     const pull = asRecord(options.context.pullRequest);
     const scanSource: AgentScanSource =
       options.item.kind === "pull_request"

--- a/src/clawsweeper-types.ts
+++ b/src/clawsweeper-types.ts
@@ -772,6 +772,7 @@ export interface ReviewContextLedgerEntry {
 }
 
 export interface ReviewPromptRuntimeHints {
+  allowlistedNetwork?: boolean;
   targetDir?: string;
   proofScratchDir?: string;
   mediaProofManifestPath?: string;

--- a/src/clawsweeper-types.ts
+++ b/src/clawsweeper-types.ts
@@ -772,7 +772,7 @@ export interface ReviewContextLedgerEntry {
 }
 
 export interface ReviewPromptRuntimeHints {
-  allowlistedNetwork?: boolean;
+  networkCapability?: "allowlisted-proxy" | "unrestricted" | "none";
   targetDir?: string;
   proofScratchDir?: string;
   mediaProofManifestPath?: string;

--- a/src/codex-app-server-worker.ts
+++ b/src/codex-app-server-worker.ts
@@ -50,6 +50,7 @@ interface ExecOptions {
   additionalWritableRoots: string[];
   sandbox: "read-only" | "workspace-write" | "danger-full-access";
   networkAccess: boolean;
+  permissionsProfile?: string;
   loginMethod?: "api" | "chatgpt";
   model?: string;
   effort?: string;
@@ -97,6 +98,9 @@ const child = spawnCodex(
   [
     ...(execOptions.loginMethod
       ? ["-c", `forced_login_method=${JSON.stringify(execOptions.loginMethod)}`]
+      : []),
+    ...(execOptions.permissionsProfile
+      ? ["-c", `default_permissions=${JSON.stringify(execOptions.permissionsProfile)}`]
       : []),
     "app-server",
     "--listen",
@@ -203,12 +207,16 @@ try {
     input: [{ type: "text", text: prompt }],
     cwd: execOptions.cwd,
     approvalPolicy: "never",
-    sandboxPolicy: sandboxPolicy(
-      execOptions.sandbox,
-      execOptions.cwd,
-      execOptions.networkAccess,
-      execOptions.additionalWritableRoots,
-    ),
+    ...(execOptions.permissionsProfile
+      ? {}
+      : {
+          sandboxPolicy: sandboxPolicy(
+            execOptions.sandbox,
+            execOptions.cwd,
+            execOptions.networkAccess,
+            execOptions.additionalWritableRoots,
+          ),
+        }),
     ...(execOptions.model ? { model: execOptions.model } : {}),
     ...(execOptions.effort ? { effort: execOptions.effort } : {}),
     ...(execOptions.serviceTier ? { serviceTier: execOptions.serviceTier } : {}),
@@ -230,7 +238,7 @@ async function startThread(): Promise<Record<string, unknown>> {
   return request("thread/start", {
     cwd: execOptions.cwd,
     approvalPolicy: "never",
-    sandbox: execOptions.sandbox,
+    ...(execOptions.permissionsProfile ? {} : { sandbox: execOptions.sandbox }),
     ephemeral: Boolean(options.appServer.reviewProof),
     ...(options.appServer.reviewProof
       ? { dynamicTools: reviewProofTools(options.appServer.reviewProof) }
@@ -249,7 +257,7 @@ async function resumeThread(previousThreadId: string): Promise<Record<string, un
       threadId: previousThreadId,
       cwd: execOptions.cwd,
       approvalPolicy: "never",
-      sandbox: execOptions.sandbox,
+      ...(execOptions.permissionsProfile ? {} : { sandbox: execOptions.sandbox }),
       personality: "pragmatic",
       ...(execOptions.model ? { model: execOptions.model } : {}),
       ...(execOptions.serviceTier ? { serviceTier: execOptions.serviceTier } : {}),
@@ -529,6 +537,7 @@ function parseExecOptions(args: string[], fallbackCwd: string): ExecOptions {
   const additionalWritableRoots: string[] = [];
   let sandbox: ExecOptions["sandbox"] = "read-only";
   let networkAccess = false;
+  let permissionsProfile: string | undefined;
   let loginMethod: ExecOptions["loginMethod"];
   let model: string | undefined;
   let effort: string | undefined;
@@ -546,6 +555,7 @@ function parseExecOptions(args: string[], fallbackCwd: string): ExecOptions {
     if (arg === "--output-last-message" && value) outputLastMessagePath = value;
     if (arg === "-c" && value) {
       const parsed = parseConfig(value);
+      if (parsed.key === "default_permissions") permissionsProfile = parsed.value;
       if (parsed.key === "model_reasoning_effort") effort = parsed.value;
       if (parsed.key === "service_tier") serviceTier = parsed.value;
       if (
@@ -564,6 +574,7 @@ function parseExecOptions(args: string[], fallbackCwd: string): ExecOptions {
     additionalWritableRoots,
     sandbox,
     networkAccess,
+    ...(permissionsProfile ? { permissionsProfile } : {}),
     ...(loginMethod ? { loginMethod } : {}),
     ...(model ? { model } : {}),
     ...(effort ? { effort } : {}),

--- a/test/agent-runner.test.ts
+++ b/test/agent-runner.test.ts
@@ -9,6 +9,7 @@ import { useFakeScanner } from "./agent-input-scan-helpers.ts";
 import {
   agentRunner,
   codexAgentArgs,
+  reviewNetworkCapability,
   runAgentCheckoutInspection,
   runAgentProcess,
 } from "../dist/agent-runner.js";
@@ -20,6 +21,27 @@ test("agent runner defaults to Codex and fails closed on unknown values", () => 
   assert.throws(
     () => agentRunner({ CLAWSWEEPER_RUNNER: "claude" }),
     /Invalid CLAWSWEEPER_RUNNER.*codex.*openclaw/,
+  );
+});
+
+test("review network capability follows the selected runner before the Codex sandbox", () => {
+  assert.equal(reviewNetworkCapability("clawsweeper-review", {}), "allowlisted-proxy");
+  assert.equal(
+    reviewNetworkCapability("clawsweeper-review", { CLAWSWEEPER_RUNNER: " codex " }),
+    "allowlisted-proxy",
+  );
+  for (const sandboxMode of ["clawsweeper-review", "read-only", "workspace-write"]) {
+    assert.equal(
+      reviewNetworkCapability(sandboxMode, { CLAWSWEEPER_RUNNER: " openclaw " }),
+      "unrestricted",
+    );
+  }
+  for (const sandboxMode of ["read-only", "workspace-write", "danger-full-access", ""]) {
+    assert.equal(reviewNetworkCapability(sandboxMode, { CLAWSWEEPER_RUNNER: "codex" }), "none");
+  }
+  assert.throws(
+    () => reviewNetworkCapability("clawsweeper-review", { CLAWSWEEPER_RUNNER: "unknown" }),
+    /Invalid CLAWSWEEPER_RUNNER/,
   );
 });
 

--- a/test/codex-process.test.ts
+++ b/test/codex-process.test.ts
@@ -526,18 +526,19 @@ setInterval(() => {}, 1000);
   }
 });
 
-test("Codex app-server mode persists and resumes a thread", () => {
-  const root = mkdtempSync(tmpPrefix);
-  const binDir = join(root, "node_modules", ".bin");
-  const statePath = join(root, "session", "state.json");
-  const outputPath = join(root, "last-message.json");
-  const requestsPath = join(root, "requests.jsonl");
-  const argsPath = join(root, "args.json");
-  mkdirSync(binDir, { recursive: true });
-  const scriptPath = join(root, "app-server-codex.cjs");
-  writeFileSync(
-    scriptPath,
-    `
+for (const configuredProfile of [false, true]) {
+  test(`Codex app-server persists and resumes with configured profile: ${configuredProfile}`, () => {
+    const root = mkdtempSync(tmpPrefix);
+    const binDir = join(root, "node_modules", ".bin");
+    const statePath = join(root, "session", "state.json");
+    const outputPath = join(root, "last-message.json");
+    const requestsPath = join(root, "requests.jsonl");
+    const argsPath = join(root, "args.json");
+    mkdirSync(binDir, { recursive: true });
+    const scriptPath = join(root, "app-server-codex.cjs");
+    writeFileSync(
+      scriptPath,
+      `
 const fs = require("node:fs");
 const readline = require("node:readline");
 const requestsPath = process.env.CODEX_TEST_REQUESTS_PATH;
@@ -570,76 +571,88 @@ rl.on("line", (line) => {
   }
 });
 `,
-  );
-  const codexPath =
-    process.platform === "win32" ? join(binDir, "codex.cmd") : join(binDir, "codex");
-  if (process.platform === "win32") {
-    writeFileSync(codexPath, `@echo off\r\nnode "%~dp0\\..\\..\\app-server-codex.cjs" %*\r\n`);
-  } else {
-    writeFileSync(codexPath, `#!/usr/bin/env node\n${readFileSync(scriptPath, "utf8")}`, {
-      mode: 0o755,
-    });
-  }
-  const env = {
-    ...process.env,
-    CODEX_BIN: codexPath,
-    CODEX_TEST_ARGS_PATH: argsPath,
-    CODEX_TEST_REQUESTS_PATH: requestsPath,
-  };
-
-  try {
-    for (let attempt = 0; attempt < 2; attempt += 1) {
-      const result = runCodexProcess({
-        args: [
-          "exec",
-          "--cd",
-          root,
-          "--sandbox",
-          "workspace-write",
-          "-c",
-          "sandbox_workspace_write.network_access=false",
-          "-c",
-          'forced_login_method="chatgpt"',
-          "--output-last-message",
-          outputPath,
-          "--json",
-          "-",
-        ],
-        cwd: root,
-        env,
-        input: "Plan the repair.",
-        timeoutMs: 10_000,
-        appServer: { statePath, label: "test worker" },
-      });
-      assert.equal(result.status, 0, result.stderr);
-      assert.equal(result.error, undefined);
-      assert.equal(readFileSync(outputPath, "utf8"), '{"status":"planned"}');
-    }
-
-    const state = JSON.parse(readFileSync(statePath, "utf8"));
-    assert.equal(state.threadId, "thread-1");
-    assert.deepEqual(JSON.parse(readFileSync(argsPath, "utf8")), [
-      "-c",
-      'forced_login_method="chatgpt"',
-      "app-server",
-      "--listen",
-      "stdio://",
-    ]);
-    const requests = readFileSync(requestsPath, "utf8")
-      .trim()
-      .split("\n")
-      .map((line) => JSON.parse(line));
-    assert.equal(requests.filter((request) => request.method === "thread/start").length, 1);
-    assert.equal(requests.filter((request) => request.method === "thread/resume").length, 1);
-    assert.equal(requests.filter((request) => request.method === "turn/start").length, 2);
-    for (const request of requests.filter((request) => request.method === "turn/start")) {
-      assert.deepEqual(request.params.sandboxPolicy, {
-        type: "workspaceWrite",
-        writableRoots: [root],
-        networkAccess: false,
+    );
+    const codexPath =
+      process.platform === "win32" ? join(binDir, "codex.cmd") : join(binDir, "codex");
+    if (process.platform === "win32") {
+      writeFileSync(codexPath, `@echo off\r\nnode "%~dp0\\..\\..\\app-server-codex.cjs" %*\r\n`);
+    } else {
+      writeFileSync(codexPath, `#!/usr/bin/env node\n${readFileSync(scriptPath, "utf8")}`, {
+        mode: 0o755,
       });
     }
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
-});
+    const env = {
+      ...process.env,
+      CODEX_BIN: codexPath,
+      CODEX_TEST_ARGS_PATH: argsPath,
+      CODEX_TEST_REQUESTS_PATH: requestsPath,
+    };
+
+    try {
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        const result = runCodexProcess({
+          args: [
+            "exec",
+            "--cd",
+            root,
+            ...(configuredProfile
+              ? ["-c", 'default_permissions="clawsweeper-review"']
+              : ["--sandbox", "workspace-write"]),
+            "-c",
+            "sandbox_workspace_write.network_access=false",
+            "-c",
+            'forced_login_method="chatgpt"',
+            "--output-last-message",
+            outputPath,
+            "--json",
+            "-",
+          ],
+          cwd: root,
+          env,
+          input: "Plan the repair.",
+          timeoutMs: 10_000,
+          appServer: { statePath, label: "test worker" },
+        });
+        assert.equal(result.status, 0, result.stderr);
+        assert.equal(result.error, undefined);
+        assert.equal(readFileSync(outputPath, "utf8"), '{"status":"planned"}');
+      }
+
+      const state = JSON.parse(readFileSync(statePath, "utf8"));
+      assert.equal(state.threadId, "thread-1");
+      assert.deepEqual(JSON.parse(readFileSync(argsPath, "utf8")), [
+        "-c",
+        'forced_login_method="chatgpt"',
+        ...(configuredProfile ? ["-c", 'default_permissions="clawsweeper-review"'] : []),
+        "app-server",
+        "--listen",
+        "stdio://",
+      ]);
+      const requests = readFileSync(requestsPath, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      assert.equal(requests.filter((request) => request.method === "thread/start").length, 1);
+      assert.equal(requests.filter((request) => request.method === "thread/resume").length, 1);
+      assert.equal(requests.filter((request) => request.method === "turn/start").length, 2);
+      if (configuredProfile) {
+        for (const request of requests.filter((request) => request.method.startsWith("thread/"))) {
+          assert.equal(request.params.sandbox, undefined);
+        }
+      }
+      for (const request of requests.filter((request) => request.method === "turn/start")) {
+        if (configuredProfile) {
+          assert.equal(request.params.sandboxPolicy, undefined);
+          continue;
+        }
+        assert.deepEqual(request.params.sandboxPolicy, {
+          type: "workspaceWrite",
+          writableRoots: [root],
+          networkAccess: false,
+        });
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+}

--- a/test/codex-review-runner.test.ts
+++ b/test/codex-review-runner.test.ts
@@ -694,6 +694,7 @@ test("runCodex honors env login config unless preserving local Codex auth", () =
     `#!/usr/bin/env node
 ${fakeCodexSandboxPass}
 const fs = require("node:fs");
+if (process.env.GH_TOKEN || process.env.CLAWSWEEPER_PROOF_INSPECTION_TOKEN) process.exit(3);
 fs.writeFileSync(process.env.CODEX_ARGS_PATH, JSON.stringify(process.argv.slice(2)));
 const outputIndex = process.argv.indexOf("--output-last-message");
 if (outputIndex === -1) process.exit(2);
@@ -706,10 +707,12 @@ fs.writeFileSync(process.argv[outputIndex + 1], process.env.CODEX_DECISION_JSON)
     CODEX_ARGS_PATH: process.env.CODEX_ARGS_PATH,
     CODEX_DECISION_JSON: process.env.CODEX_DECISION_JSON,
     CLAWSWEEPER_CODEX_LOGIN_METHOD: process.env.CLAWSWEEPER_CODEX_LOGIN_METHOD,
+    CLAWSWEEPER_PROOF_INSPECTION_TOKEN: process.env.CLAWSWEEPER_PROOF_INSPECTION_TOKEN,
   };
   process.env.PATH = `${binDir}${delimiter}${process.env.PATH ?? ""}`;
   process.env.CODEX_ARGS_PATH = argsPath;
   process.env.CLAWSWEEPER_CODEX_LOGIN_METHOD = "chatgpt";
+  process.env.CLAWSWEEPER_PROOF_INSPECTION_TOKEN = "synthetic-inspection-token";
   process.env.CODEX_DECISION_JSON = JSON.stringify(
     closeDecision({
       decision: "keep_open",
@@ -722,7 +725,7 @@ fs.writeFileSync(process.argv[outputIndex + 1], process.env.CODEX_DECISION_JSON)
     }),
   );
 
-  const runAndReadArgs = (preserveCodexAuth: boolean): string[] => {
+  const runAndReadArgs = (preserveCodexAuth: boolean, sandboxMode = "read-only"): string[] => {
     const decision = runCodexForTest({
       item: item({ number: 83395 }),
       context: { issue: {}, comments: [], timeline: [] },
@@ -730,7 +733,7 @@ fs.writeFileSync(process.argv[outputIndex + 1], process.env.CODEX_DECISION_JSON)
       model: "model-test",
       openclawDir,
       reasoningEffort: "high",
-      sandboxMode: "read-only",
+      sandboxMode,
       serviceTier: "",
       preserveCodexAuth,
       timeoutMs: 10_000,
@@ -742,6 +745,10 @@ fs.writeFileSync(process.argv[outputIndex + 1], process.env.CODEX_DECISION_JSON)
   };
 
   try {
+    const networkArgs = runAndReadArgs(false, "clawsweeper-review");
+    assert.ok(networkArgs.includes('default_permissions="clawsweeper-review"'));
+    assert.ok(networkArgs.includes('approval_policy="never"'));
+    assert.equal(networkArgs.includes("--sandbox"), false);
     const defaultArgs = runAndReadArgs(false);
     assert.deepEqual(defaultArgs, [
       "exec",

--- a/test/review-prompt-policy.test.ts
+++ b/test/review-prompt-policy.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { performance } from "node:perf_hooks";
 import test from "node:test";
+import { reviewNetworkCapability } from "../dist/agent-runner.js";
 
 import {
   isGitHubLabelCapacityErrorForTest,
@@ -783,30 +784,49 @@ test("media preparation kills a timed-out probe even when it ignores SIGTERM", (
 });
 
 test("runtime capabilities describe the configured network and credential boundary", () => {
-  for (const allowlistedNetwork of [true, false]) {
+  for (const [runner, sandboxMode, expected] of [
+    ["codex", "clawsweeper-review", "allowlisted-proxy"],
+    ["openclaw", "clawsweeper-review", "unrestricted"],
+    ["openclaw", "read-only", "unrestricted"],
+    ["codex", "read-only", "none"],
+  ]) {
     const prompt = reviewPromptForTest(
       item({ kind: "pull_request" }),
       { issue: {}, comments: [], timeline: [] },
       { mainSha: "abc123", latestRelease: null },
       "",
-      { allowlistedNetwork },
+      { networkCapability: reviewNetworkCapability(sandboxMode, { CLAWSWEEPER_RUNNER: runner }) },
     );
-    assert.match(prompt, /There is no GitHub token in the sandbox/);
+    assert.match(prompt, /No GitHub token is supplied to the review process/);
     assert.match(prompt, /read those files rather than re-fetching/);
-    assert.match(prompt, /The target checkout is read-only/);
     assert.doesNotMatch(prompt, /available network and read-only GitHub token/);
-    if (allowlistedNetwork) {
+    if (expected === "allowlisted-proxy") {
       assert.match(
         prompt,
         /managed proxy limited to allowlisted GitHub, npm, Node, MDN, and OpenClaw/,
       );
       assert.match(prompt, /other hosts are blocked/);
       assert.match(prompt, /A blocked request is not evidence about the PR/);
+      assert.match(prompt, /The target checkout is read-only/);
+      assert.doesNotMatch(prompt, /Network access is available through OpenClaw/);
+    } else if (expected === "unrestricted") {
+      assert.match(prompt, /Network access is available through OpenClaw gateway execution/);
+      assert.match(prompt, /the Codex managed allowlisted proxy does not apply/);
+      assert.match(prompt, /Treat the target checkout as read-only/);
+      assert.doesNotMatch(prompt, /The target checkout is read-only/);
+      assert.doesNotMatch(prompt, /other hosts are blocked|No review-tool network access/);
     } else {
       assert.match(prompt, /No review-tool network access is configured/);
+      assert.match(prompt, /The target checkout is read-only/);
       assert.doesNotMatch(prompt, /Network egress uses a managed proxy/);
     }
   }
+  const defaultPrompt = reviewPromptForTest(
+    item(),
+    { issue: {}, comments: [], timeline: [] },
+    { mainSha: "abc123", latestRelease: null },
+  );
+  assert.match(defaultPrompt, /No review-tool network access is configured/);
 });
 
 test("runtime prompt tells Codex to inspect local media artifacts before browser fallback", () => {

--- a/test/review-prompt-policy.test.ts
+++ b/test/review-prompt-policy.test.ts
@@ -782,6 +782,33 @@ test("media preparation kills a timed-out probe even when it ignores SIGTERM", (
   assert.match(prepared.artifacts[0]?.detail ?? "", /ffprobe failed: .*ETIMEDOUT/);
 });
 
+test("runtime capabilities describe the configured network and credential boundary", () => {
+  for (const allowlistedNetwork of [true, false]) {
+    const prompt = reviewPromptForTest(
+      item({ kind: "pull_request" }),
+      { issue: {}, comments: [], timeline: [] },
+      { mainSha: "abc123", latestRelease: null },
+      "",
+      { allowlistedNetwork },
+    );
+    assert.match(prompt, /There is no GitHub token in the sandbox/);
+    assert.match(prompt, /read those files rather than re-fetching/);
+    assert.match(prompt, /The target checkout is read-only/);
+    assert.doesNotMatch(prompt, /available network and read-only GitHub token/);
+    if (allowlistedNetwork) {
+      assert.match(
+        prompt,
+        /managed proxy limited to allowlisted GitHub, npm, Node, MDN, and OpenClaw/,
+      );
+      assert.match(prompt, /other hosts are blocked/);
+      assert.match(prompt, /A blocked request is not evidence about the PR/);
+    } else {
+      assert.match(prompt, /No review-tool network access is configured/);
+      assert.doesNotMatch(prompt, /Network egress uses a managed proxy/);
+    }
+  }
+});
+
 test("runtime prompt tells Codex to inspect local media artifacts before browser fallback", () => {
   const context = {
     issue: {},

--- a/test/setup-codex-action.test.ts
+++ b/test/setup-codex-action.test.ts
@@ -929,3 +929,54 @@ test(
     }
   },
 );
+
+test("review network writer preserves provider settings and uses one bounded profile", () => {
+  const home = mkdtempSync(join(tmpdir(), "clawsweeper-review-config-"));
+  try {
+    const existing =
+      'model = "test-model"\nmodel_provider = "test"\n[model_providers.test]\nname = "Test"\nbase_url = "http://127.0.0.1:1234/v1"\nwire_api = "responses"\n';
+    writeFileSync(join(home, "config.toml"), existing);
+    const result = spawnSync(process.execPath, [join(actionPath, "configure-review-network.mjs")], {
+      env: { ...process.env, CODEX_HOME: home },
+      encoding: "utf8",
+    });
+    assert.equal(result.status, 0, result.stderr);
+    const config = readFileSync(join(home, "config.toml"), "utf8");
+    assert.ok(config.includes(existing));
+    assert.ok(
+      config.indexOf('default_permissions = "clawsweeper-review"') <
+        config.indexOf("[model_providers.test]"),
+    );
+    assert.ok(config.indexOf("[features]") > config.indexOf(existing));
+    assert.match(config, /network_proxy = true/);
+    assert.match(config, /extends = ":read-only"/);
+    assert.match(config, /mode = "limited"/);
+    assert.match(config, /approval_policy = "never"/);
+    assert.match(config, /allow_upstream_proxy = false/);
+    assert.match(config, /allow_local_binding = false/);
+    const domains = config
+      .split("[permissions.clawsweeper-review.network.domains]\n")[1]!
+      .trim()
+      .split("\n");
+    assert.equal(domains.length, 15);
+    assert.ok(domains.every((line) => /^"[a-z0-9.-]+" = "allow"$/.test(line)));
+    assert.ok(domains.includes('"api.github.com" = "allow"'));
+    assert.ok(domains.includes('"docs.openclaw.ai" = "allow"'));
+    assert.doesNotMatch(config, /example\.com|\*|danger-full-access|"write"/);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("only review setup opts into the profile and enforcement smoke", () => {
+  const action = parse(readFileSync(join(actionPath, "action.yml"), "utf8"));
+  assert.equal(action.inputs["review-network"].default, "false");
+  for (const name of ["Configure review network profile", "Verify review sandbox capabilities"]) {
+    const step = action.runs.steps.find((entry: { name: string }) => entry.name === name);
+    assert.equal(step.if, "${{ inputs['review-network'] == 'true' }}");
+  }
+  const smoke = readFileSync(join(actionPath, "smoke-review-network.sh"), "utf8");
+  assert.match(smoke, /env -i/);
+  assert.match(smoke, /sandbox --permission-profile clawsweeper-review/);
+  assert.match(smoke, /CONNECT tunnel failed, response 403/);
+});

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -751,9 +751,9 @@ test("review workflow gives Codex a read-only inspection token", () => {
   assert.match(exactReviewStep, /Exact review produced no artifact for open item/);
   assert.match(reviewJob, /uses: \.\/clawsweeper\/\.github\/actions\/setup-codex/);
   assert.doesNotMatch(reviewJob, /uses: \.\/\.github\/actions\/setup-codex/);
-  assert.match(exactReviewStep, /--codex-sandbox read-only/);
+  assert.match(exactReviewStep, /--codex-sandbox clawsweeper-review/);
   assert.match(exactReviewStep, /--skip-start-comment/);
-  assert.match(reviewJob, /--codex-sandbox read-only/);
+  assert.match(reviewJob, /--codex-sandbox clawsweeper-review/);
   assert.doesNotMatch(workflow, /--codex-sandbox danger-full-access/);
 });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where issue/PR reviewers could publish inaccessible-evidence judgments after their prompt promised network access and a GitHub token that the review sandbox did not provide.

## Why This Change Was Made

Hosted Codex review setup installs the `clawsweeper-review` profile in its isolated CODEX_HOME. It extends read-only filesystem permissions and enables a managed proxy in limited mode for the single checked-in host allowlist. Review exec and app-server calls preserve the configured policy instead of overriding it with a legacy read-only sandbox. The reviewer receives no GitHub inspection token, and its prompt describes public endpoints, blocked hosts, pre-fetched context, and downloaded media accurately.

Setup runs an enforcement smoke before any review can publish. It requires allowed HTTPS to succeed, unlisted HTTPS to receive a proxy rejection, and checkout writes to fail. Non-review callers retain their existing sandbox behavior.

Capability selection now follows the active runner before the Codex sandbox argument. Both prompt paths use the shared runner selector: Codex plus `clawsweeper-review` describes the allowlisted proxy, OpenClaw describes network access through gateway execution, and other Codex settings retain the no-review-tool-network statement. OpenClaw receives no GitHub token; its existing execution policy is unchanged, and its checkout guidance is explicitly instructional. The new `review-network-smoke` PR CI job proves the unchanged enforcement smoke on Linux bubblewrap without secrets.

## User Impact

Codex reviewers can research public GitHub, npm, Node, MDN, and OpenClaw documentation while remaining confined to the listed hosts and a read-only checkout. Blocked hosts do not count as evidence against a PR. Offline local reviews retain an offline capability statement.

## OpenClaw Bay Impact

Bay is unaffected: no dashboard/public API schema, lifecycle, action, or status contract changes. Existing report front matter `review_sandbox` now records `clawsweeper-review` for these jobs; Bay has no consumer of that field. Bay remains observer-only.

## Documentation Impact

Updated active README security guidance and the active reviewer-network section in `docs/pr-review-comments.md`, plus the Unreleased changelog. The documentation names ClawSweeper maintainers as owner, the checked-in permission TOML as source of truth, Codex 0.153.3 as verified runtime, and CLI/profile/credential/smoke changes as update triggers. Reviewed the docs map and repository validation rules.

## Evidence

Original implementation head: `114b9408b6e870bd17115e64b97d93b4e97fbe12`. Detailed results and source citations are in `.artifacts/review-network-profile/report.md`. Build, format, lint, static checks, coverage thresholds, and independent Codex P0–P2 review passed. The unit run had 3891 passes / 19 failures / 6 skips; the full check had 5491 passes / 18 failures / 13 skips. Failures were confined to the workflow-subprocess and terminal/live-proof categories described in the work order. One additional focused installer-validator `kill EPERM` failure passed on isolated retry and in both broad runs; it is explicitly recorded in the report. All changed-network tests passed.

Follow-up head: `1e8c79b519544e8b1ce709fb323218fea8641be8`. The pre-commit P0–P2 autoreview is scoped-clean. The two follow-up findings are addressed by runner-aware capability selection and the new `review-network-smoke` CI job. Focused validation passed all 140 tests, including the three capability selections, prompt rendering, OpenClaw credential filtering, and unchanged runner execution policy. The workflow reads Codex 0.153.3 from the setup action pin rather than duplicating it. Hosted Linux [review-network-smoke](https://github.com/openclaw/clawsweeper/actions/runs/34191247054/job/101949589071) passed on this head in 15 seconds (smoke/install step: 6 seconds). Its exact result lines are quoted below. [CI for this head](https://github.com/openclaw/clawsweeper/actions/runs/34191247054) passed without retries: `pnpm check`, `review-network-smoke`, sparse repair build smoke, and Windows Codex launcher all succeeded; the dispatch-only hosted review scan was skipped.

## Real Behavior Proof

- Runner capability probe: the built runtime selector and prompt builder were exercised for `codex` + `clawsweeper-review`, `openclaw` + `clawsweeper-review`, and `codex` + `read-only`. The emitted capabilities are respectively `allowlisted-proxy`, `unrestricted` gateway execution, and `none`; all three state that no GitHub token is supplied. Artifact: `.artifacts/runner-capability-proof.log`. This proves prompt generation, not model inference.
- Linux enforcement: `review-network-smoke` in `.github/workflows/ci.yml` uses GitHub-hosted `ubuntu-24.04`, Node 24, a temporary npm prefix, and a fresh isolated Codex home containing only `model = "gpt-5.4"` before configuration. It reads the setup action pin, applies the same user-namespace/AppArmor prerequisites, then runs `configure-review-network.mjs` and `smoke-review-network.sh` unchanged with `GITHUB_WORKSPACE` set to the checkout. No secrets, inference, or remote lease are used. The three-minute job fails on every smoke failure. [Hosted job](https://github.com/openclaw/clawsweeper/actions/runs/34191247054/job/101949589071) passed on follow-up head `1e8c79b519544e8b1ce709fb323218fea8641be8` in 15 seconds. Its exact output:

  ```text
  allowed HTTPS: passed
  unlisted HTTPS: blocked by proxy
  checkout write: blocked
  ```

  The rejected host also emitted `curl: (56) CONNECT tunnel failed, response 403`. Artifact: `.artifacts/findings-linux-smoke.log`.
- Claim: the pinned reviewer CLI provides bounded public HTTPS research without network approval prompts and keeps the target checkout read-only.
- Surface: actual Codex 0.153.3 permission config loader, managed network proxy, curl, and macOS Seatbelt; the committed smoke script and configuration writer were executed unchanged.
- Fixture: this worktree at base `175d75537c5fd3e68cde68e2098157957265fb51` plus the uncommitted changes. Synthetic local Responses fixtures supply fixed tool calls for exec/app-server probes; no model credentials or real model inference are used.
- Environment: macOS 27.0 (arm64), Node v24.20.0, pnpm 11.10.0, codex-cli 0.153.3. Local provider: native Seatbelt, no remote lease/image.
- Installation: `PATH=$PATH npm install --prefix "$PWD/.artifacts/review-network-profile/codex-0.153.3" --no-save --no-audit --no-fund --ignore-scripts @openai/codex@0.153.3`; global installations unchanged.
- Config: create `.artifacts/review-network-profile/codex-home/config.toml` containing `model = "gpt-5.4"`, then run `CODEX_HOME="$PWD/.artifacts/review-network-profile/codex-home" node .github/actions/setup-codex/configure-review-network.mjs`.
- Smoke command: `CODEX_HOME="$PWD/.artifacts/review-network-profile/codex-home" GITHUB_WORKSPACE="$PWD" PATH="$PWD/.artifacts/review-network-profile/codex-0.153.3/node_modules/.bin:$PATH" bash .github/actions/setup-codex/smoke-review-network.sh`.
- Observed: api.github.com/zen returned a zen string and exit 0; example.com returned `curl: (56) CONNECT tunnel failed, response 403`; checkout creation returned `Operation not permitted`; smoke exit 0.
- Exec command: `PATH=$PATH node .artifacts/review-network-profile/probe-exec.mjs`. The real exec tool returned allowed_exit=0; blocked_exit=56 plus `domain is not on the allowlist for the current sandbox mode`; write_exit=1. No approval event occurred. Also repeated with the review's `--add-dir` scratch argument.
- Negative comparison: repeat the exec harness with `--sandbox read-only`. Both hosts fail with curl exit 6 (`Could not resolve host`); the checkout write still fails. This proves the legacy override suppresses the useful configured network path.
- App-server proof: `node .artifacts/review-network-profile/probe-app-server.mjs` also preserved the profile, denied the unlisted host without prompting, and denied writes. GitHub returned its unauthenticated rate-limit response in this extra probe (allowed transport, not available API capacity).
- Artifacts: `app-server-proof.log`, `smoke-proof.log`, `exec-profile-proof.log`, `exec-profile-scratch-proof.log`, `exec-override-proof.log`, and reproducible harnesses under `.artifacts/review-network-profile/`.
- Limits: local proof exercises Seatbelt, not Linux bubblewrap. Linux bubblewrap enforcement passed in the [dedicated PR CI smoke](https://github.com/openclaw/clawsweeper/actions/runs/34191247054/job/101949589071) on the follow-up head. The proof exercises public endpoints and policy enforcement, not private GitHub access, all 15 individual hosts, inference quality, or real PR publication. No version bump was needed.
