### PR TITLE
feat(review): hand reviewers the read-only target repository token

### DIFF
--- a/.github/actions/setup-codex/review-permissions.toml
+++ b/.github/actions/setup-codex/review-permissions.toml
@@ -1,5 +1,5 @@
 # Reviewers inspect untrusted contributor PRs: never make them an open egress
-# channel. No credentials belong in the sandbox; use public, allowlisted hosts.
+# channel. Only the target repository's short-lived read-only token is supplied.
 approval_policy = "never"
 default_permissions = "clawsweeper-review"
 [features]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
-- Give reviewers the existing short-lived, read-only target-repository GitHub App token as `GH_TOKEN` for authenticated reads, and describe token availability from the actual reviewer environment.
+- Give Codex reviewers the existing short-lived, read-only target-repository GitHub App token as `GH_TOKEN` for authenticated reads, and describe token availability from the actual reviewer environment, including OpenClaw's credential filter.
 - Give hosted issue/PR reviewers allowlisted public research access through a managed proxy while keeping the checkout read-only; describe token, blocked-host, and downloaded-media capabilities accurately and fail setup when sandbox enforcement regresses.
 - Describe review capabilities from the active runner so OpenClaw gateway execution is not mistaken for the Codex allowlisted sandbox; prove Linux review sandbox enforcement in credential-free PR CI.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Give reviewers the existing short-lived, read-only target-repository GitHub App token as `GH_TOKEN` for authenticated reads, and describe token availability from the actual reviewer environment.
 - Give hosted issue/PR reviewers allowlisted public research access through a managed proxy while keeping the checkout read-only; describe token, blocked-host, and downloaded-media capabilities accurately and fail setup when sandbox enforcement regresses.
 - Describe review capabilities from the active runner so OpenClaw gateway execution is not mistaken for the Codex allowlisted sandbox; prove Linux review sandbox enforcement in credential-free PR CI.
 

--- a/README.md
+++ b/README.md
@@ -727,16 +727,20 @@ publication, and queue lifecycle.
   network proxy restricted to the hosts in
   [the review permission profile](.github/actions/setup-codex/review-permissions.toml):
   GitHub, npm, Node, MDN, and OpenClaw documentation. Limited mode inspects HTTPS
-  and permits only GET/HEAD/OPTIONS; other hosts are blocked. Review tools have
-  no GitHub token, so they use public endpoints and pre-fetched context, including
-  the local media proof manifest. A blocked request is not evidence against a PR.
+  and permits only GET/HEAD/OPTIONS; other hosts are blocked. When supplied by the
+  review job, tools receive the target repository's read-only GitHub App token
+  only as `GH_TOKEN` (contents, issues, and pull requests read; expires within the
+  hour). Use authenticated GitHub reads to avoid public rate limits; never put
+  the token in a URL, log it, or send it to a non-GitHub host. Without a token,
+  use public endpoints and pre-fetched context. Read downloaded media through
+  the local proof manifest. A blocked request is not evidence against a PR.
   Setup must prove allowed HTTPS, denied unlisted HTTPS, and denied checkout
   writes before reviews can publish. Offline local reviews retain their existing
   network restriction. The `review-network-smoke` PR CI job proves the same
   enforcement on Ubuntu without secrets. Capability text follows the active
   runner: OpenClaw uses gateway network execution without the Codex proxy or
-  filesystem sandbox, receives no GitHub token, and must keep the checkout
-  read-only by instruction.
+  filesystem sandbox, receives the same read-only token when supplied, and must
+  keep the checkout read-only by instruction.
 - Reviews fail if Codex leaves tracked or untracked changes behind.
 - Snapshot changes block apply unless the only change is the bot’s own review
   comment.

--- a/README.md
+++ b/README.md
@@ -728,7 +728,7 @@ publication, and queue lifecycle.
   [the review permission profile](.github/actions/setup-codex/review-permissions.toml):
   GitHub, npm, Node, MDN, and OpenClaw documentation. Limited mode inspects HTTPS
   and permits only GET/HEAD/OPTIONS; other hosts are blocked. When supplied by the
-  review job, tools receive the target repository's read-only GitHub App token
+  review job, Codex tools receive the target repository's read-only GitHub App token
   only as `GH_TOKEN` (contents, issues, and pull requests read; expires within the
   hour). Use authenticated GitHub reads to avoid public rate limits; never put
   the token in a URL, log it, or send it to a non-GitHub host. Without a token,
@@ -739,8 +739,8 @@ publication, and queue lifecycle.
   network restriction. The `review-network-smoke` PR CI job proves the same
   enforcement on Ubuntu without secrets. Capability text follows the active
   runner: OpenClaw uses gateway network execution without the Codex proxy or
-  filesystem sandbox, receives the same read-only token when supplied, and must
-  keep the checkout read-only by instruction.
+  filesystem sandbox, strips GitHub tokens through its final child environment
+  allowlist, and must keep the checkout read-only by instruction.
 - Reviews fail if Codex leaves tracked or untracked changes behind.
 - Snapshot changes block apply unless the only change is the bot’s own review
   comment.

--- a/docs/pr-review-comments.md
+++ b/docs/pr-review-comments.md
@@ -596,8 +596,16 @@ CLI, profile, credential handling, or setup smoke changes. The active profile
 extends read-only filesystem access and enables the managed proxy in limited
 mode for its explicit GitHub, npm, Node, MDN, and OpenClaw documentation hosts.
 Other hosts are blocked; blocked access is not evidence against the PR. The
-sandbox receives no GitHub token. Use public endpoints, pre-fetched GitHub
-context, and the downloaded screenshots/videos in the media proof manifest.
+sandbox receives the target repository's read-only GitHub App token only as
+`GH_TOKEN` when the review job supplies it (contents, issues, and pull requests
+read; expires within the hour). Use `gh api` or other authenticated GitHub reads
+to avoid public rate limits; the token cannot write. Never put it in a URL, log
+it, or send it to a non-GitHub host. Without a token, use public endpoints or
+pre-fetched GitHub context. Read downloaded screenshots/videos through the media
+proof manifest. The allowlist is not a credential containment boundary: a
+prompt-injected reviewer could leak the token in a GET query string to an
+allowlisted third-party host. Its read-only, single-repository, one-hour scope
+limits the impact.
 
 Review setup opts in with `review-network: "true"`; review commands select
 `--codex-sandbox clawsweeper-review`, translated to Codex configuration
@@ -610,8 +618,10 @@ reviews keep their existing sandbox settings.
 Capability text follows the active `CLAWSWEEPER_RUNNER` before the Codex sandbox
 argument. OpenClaw reviews have network access through gateway execution with
 sandbox mode off; they do not use the Codex allowlisted proxy, and must treat the
-checkout as read-only by instruction. Their child environment receives no GitHub
-token. Other Codex sandbox selections retain the no-review-tool-network statement.
+checkout as read-only by instruction. Their child environment receives the same
+read-only token when supplied. Token capability text follows the actual sanitized
+child environment for every runner and sandbox selection. Other Codex sandbox
+selections retain the no-review-tool-network statement.
 This reporting does not change either runner's execution policy.
 
 The required-style `review-network-smoke` CI job runs on every PR using

--- a/docs/pr-review-comments.md
+++ b/docs/pr-review-comments.md
@@ -618,9 +618,10 @@ reviews keep their existing sandbox settings.
 Capability text follows the active `CLAWSWEEPER_RUNNER` before the Codex sandbox
 argument. OpenClaw reviews have network access through gateway execution with
 sandbox mode off; they do not use the Codex allowlisted proxy, and must treat the
-checkout as read-only by instruction. Their child environment receives the same
-read-only token when supplied. Token capability text follows the actual sanitized
-child environment for every runner and sandbox selection. Other Codex sandbox
+checkout as read-only by instruction. Their final child environment allowlist
+strips GitHub tokens, so OpenClaw prompts retain the no-token guidance even when
+an inspection token was supplied to the parent. Token capability text accounts
+for that runner-specific filter as well as the sanitized Codex environment. Other Codex sandbox
 selections retain the no-review-tool-network statement.
 This reporting does not change either runner's execution policy.
 

--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -45,14 +45,16 @@ export function reviewNetworkCapability(
   networkCapability: "allowlisted-proxy" | "unrestricted" | "none";
   hasGitHubToken: boolean;
 } {
+  const runner = agentRunner(env);
   return {
     networkCapability:
-      agentRunner(env) === "openclaw"
+      runner === "openclaw"
         ? "unrestricted"
         : sandboxMode === "clawsweeper-review"
           ? "allowlisted-proxy"
           : "none",
-    hasGitHubToken: Boolean(env.GH_TOKEN?.trim()),
+    // OpenClaw's final child allowlist strips workflow credentials, including GH_TOKEN.
+    hasGitHubToken: runner === "codex" && Boolean(env.GH_TOKEN?.trim()),
   };
 }
 

--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -41,9 +41,19 @@ export function agentRunner(env: NodeJS.ProcessEnv = process.env): AgentRunner {
 export function reviewNetworkCapability(
   sandboxMode: string,
   env: NodeJS.ProcessEnv = process.env,
-): "allowlisted-proxy" | "unrestricted" | "none" {
-  if (agentRunner(env) === "openclaw") return "unrestricted";
-  return sandboxMode === "clawsweeper-review" ? "allowlisted-proxy" : "none";
+): {
+  networkCapability: "allowlisted-proxy" | "unrestricted" | "none";
+  hasGitHubToken: boolean;
+} {
+  return {
+    networkCapability:
+      agentRunner(env) === "openclaw"
+        ? "unrestricted"
+        : sandboxMode === "clawsweeper-review"
+          ? "allowlisted-proxy"
+          : "none",
+    hasGitHubToken: Boolean(env.GH_TOKEN?.trim()),
+  };
 }
 
 export function runAgentProcess(options: RunAgentProcessOptions): CodexProcessResult {

--- a/src/clawsweeper-review-command-dependencies.ts
+++ b/src/clawsweeper-review-command-dependencies.ts
@@ -35,6 +35,7 @@ import type { ReviewStructuralRecord } from "./review-structural-cache.js";
 import type { PrHydrationSnapshot } from "./pr-hydration-snapshot.js";
 
 export interface CreateReviewCommandWorkflowDependencies {
+  reviewEnvironment: (preserveCodexAuth?: boolean) => NodeJS.ProcessEnv;
   actionLedgerFailureDisposition: (error: unknown) => {
     status: ActionEventStatus;
     reasonCode: ActionEventReasonCode;
@@ -333,6 +334,7 @@ export interface CreateReviewCommandWorkflowDependencies {
     additionalPrompt?: string;
     proofScratchDir?: string;
     prompt?: string;
+    reviewEnv?: NodeJS.ProcessEnv;
     quietLogs?: boolean;
     extraCodexConfig?: string[];
   }) => Decision;

--- a/src/clawsweeper-review-command-workflow.ts
+++ b/src/clawsweeper-review-command-workflow.ts
@@ -137,6 +137,7 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
     verifyRegressionProvenance,
     authorIssueCountInBulkFilerWindow,
     buildReviewPrompt,
+    reviewEnvironment,
     bulkFilerPolicyInvalidatesCachedReview,
     bulkFilerRepositoryPermission,
     codexFailureDecision,
@@ -1267,6 +1268,7 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
         const preparedMediaProof: PreparedMediaProof = localRangeData
           ? { manifestPath: null, summaryPath: null, artifacts: [] }
           : prepareMediaProofArtifacts(context, proofScratchDir);
+        const reviewEnv = reviewEnvironment(localOnly);
         const prompt = buildReviewPrompt(
           item,
           context,
@@ -1275,7 +1277,7 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
           {
             ...mediaProofRuntimeHints(proofScratchDir, preparedMediaProof),
             targetDir: reviewOpenclawDir,
-            networkCapability: reviewNetworkCapability(sandboxMode),
+            ...reviewNetworkCapability(sandboxMode, reviewEnv),
           },
         );
         diagnosticPrompt = prompt.text;
@@ -1316,6 +1318,7 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
             additionalPrompt,
             proofScratchDir,
             prompt: prompt.text,
+            reviewEnv,
             quietLogs: humanLocalReview,
             ...(localRange ? { extraCodexConfig: [LOCAL_REVIEW_WEB_SEARCH_CONFIG] } : {}),
           });

--- a/src/clawsweeper-review-runtime.ts
+++ b/src/clawsweeper-review-runtime.ts
@@ -522,6 +522,9 @@ ${additionalPrompt.trim()}
         : runtimeHints.networkCapability === "unrestricted"
           ? "Network access is available through OpenClaw gateway execution; the Codex managed allowlisted proxy does not apply. An inaccessible request is not evidence about the PR."
           : "No review-tool network access is configured; use the pre-fetched context. An inaccessible request is not evidence about the PR.";
+    const tokenDescription = runtimeHints.hasGitHubToken
+      ? "A read-only GitHub App token for the target repository is available as `GH_TOKEN` (contents, issues, and pull requests read; expires within the hour); use it for `gh api`/authenticated GitHub reads so public rate limits do not apply; it cannot write. Never place it in a URL, log it, or send it to any non-GitHub host."
+      : "No GitHub token is supplied to the review process; use public endpoints or pre-fetched context.";
     const text = `${prompt}
 
 ## Repository State
@@ -542,7 +545,8 @@ ${additionalPrompt.trim()}
 ## Runtime Capabilities
 
 - ${networkDescription}
-- No GitHub token is supplied to the review process; use public endpoints or pre-fetched context. Linked screenshots and videos are downloaded before review into the media proof manifest; read those files rather than re-fetching.
+- ${tokenDescription}
+- Linked screenshots and videos are downloaded before review into the media proof manifest; read those files rather than re-fetching.
 - ${runtimeHints.networkCapability === "unrestricted" ? "Treat the target checkout as read-only; OpenClaw gateway execution does not enforce the Codex filesystem sandbox." : "The target checkout is read-only."} Use ${proofScratchDir ? `\`${proofScratchDir}\`` : "the proof scratch directory"} for evidence and generated video stills/contact sheets.
 ${mediaProofPrompt}
 ${introductionEvidence}
@@ -956,6 +960,13 @@ ${extra}
     });
   }
 
+  function reviewEnvironment(preserveCodexAuth?: boolean): NodeJS.ProcessEnv {
+    return untrustedCodexEnv({
+      ghToken: process.env.CLAWSWEEPER_PROOF_INSPECTION_TOKEN,
+      preserveCodexAuth,
+    });
+  }
+
   function runCodex(options: {
     item: Item;
     context: ItemContext;
@@ -972,6 +983,7 @@ ${extra}
     additionalPrompt?: string;
     proofScratchDir?: string;
     prompt?: string;
+    reviewEnv?: NodeJS.ProcessEnv;
     quietLogs?: boolean;
     extraCodexConfig?: string[];
   }): Decision {
@@ -992,15 +1004,13 @@ ${extra}
       : prepareMediaProofArtifacts(options.context, proofScratchDir);
     const outputPath = join(options.workDir, `${options.item.number}.json`);
     if (existsSync(outputPath)) unlinkSync(outputPath);
-    const codexEnv = untrustedCodexEnv({
-      preserveCodexAuth: options.preserveCodexAuth,
-    });
+    const codexEnv = options.reviewEnv ?? reviewEnvironment(options.preserveCodexAuth);
     const prompt =
       options.prompt ??
       buildReviewPrompt(options.item, options.context, options.git, options.additionalPrompt, {
         ...mediaProofRuntimeHints(proofScratchDir, preparedMediaProof),
         targetDir: options.openclawDir,
-        networkCapability: reviewNetworkCapability(options.sandboxMode, codexEnv),
+        ...reviewNetworkCapability(options.sandboxMode, codexEnv),
       }).text;
     const pull = asRecord(options.context.pullRequest);
     const scanSource: AgentScanSource =
@@ -1186,6 +1196,7 @@ ${extra}
     runCodexForTest,
     CodexReviewError,
     buildReviewPrompt,
+    reviewEnvironment,
     codexFailureDecision,
     codexFailureLogKind,
     codexFailureReason,

--- a/src/clawsweeper-types.ts
+++ b/src/clawsweeper-types.ts
@@ -773,6 +773,7 @@ export interface ReviewContextLedgerEntry {
 
 export interface ReviewPromptRuntimeHints {
   networkCapability?: "allowlisted-proxy" | "unrestricted" | "none";
+  hasGitHubToken?: boolean;
   targetDir?: string;
   proofScratchDir?: string;
   mediaProofManifestPath?: string;

--- a/test/agent-runner.test.ts
+++ b/test/agent-runner.test.ts
@@ -63,7 +63,7 @@ test("review token capability uses only the supplied child GH_TOKEN", () => {
             GITHUB_TOKEN: "synthetic-ambient-token",
             CLAWSWEEPER_PROOF_INSPECTION_TOKEN: "synthetic-source-token",
           }).hasGitHubToken,
-          Boolean(token?.trim()),
+          runner === "codex" && Boolean(token?.trim()),
         );
       }
     }

--- a/test/agent-runner.test.ts
+++ b/test/agent-runner.test.ts
@@ -25,24 +25,49 @@ test("agent runner defaults to Codex and fails closed on unknown values", () => 
 });
 
 test("review network capability follows the selected runner before the Codex sandbox", () => {
-  assert.equal(reviewNetworkCapability("clawsweeper-review", {}), "allowlisted-proxy");
   assert.equal(
-    reviewNetworkCapability("clawsweeper-review", { CLAWSWEEPER_RUNNER: " codex " }),
+    reviewNetworkCapability("clawsweeper-review", {}).networkCapability,
+    "allowlisted-proxy",
+  );
+  assert.equal(
+    reviewNetworkCapability("clawsweeper-review", { CLAWSWEEPER_RUNNER: " codex " })
+      .networkCapability,
     "allowlisted-proxy",
   );
   for (const sandboxMode of ["clawsweeper-review", "read-only", "workspace-write"]) {
     assert.equal(
-      reviewNetworkCapability(sandboxMode, { CLAWSWEEPER_RUNNER: " openclaw " }),
+      reviewNetworkCapability(sandboxMode, { CLAWSWEEPER_RUNNER: " openclaw " }).networkCapability,
       "unrestricted",
     );
   }
   for (const sandboxMode of ["read-only", "workspace-write", "danger-full-access", ""]) {
-    assert.equal(reviewNetworkCapability(sandboxMode, { CLAWSWEEPER_RUNNER: "codex" }), "none");
+    assert.equal(
+      reviewNetworkCapability(sandboxMode, { CLAWSWEEPER_RUNNER: "codex" }).networkCapability,
+      "none",
+    );
   }
   assert.throws(
     () => reviewNetworkCapability("clawsweeper-review", { CLAWSWEEPER_RUNNER: "unknown" }),
     /Invalid CLAWSWEEPER_RUNNER/,
   );
+});
+
+test("review token capability uses only the supplied child GH_TOKEN", () => {
+  for (const runner of ["codex", "openclaw"]) {
+    for (const sandboxMode of ["clawsweeper-review", "read-only"]) {
+      for (const token of [undefined, "", "   ", "synthetic-inspection-token"]) {
+        assert.equal(
+          reviewNetworkCapability(sandboxMode, {
+            CLAWSWEEPER_RUNNER: runner,
+            GH_TOKEN: token,
+            GITHUB_TOKEN: "synthetic-ambient-token",
+            CLAWSWEEPER_PROOF_INSPECTION_TOKEN: "synthetic-source-token",
+          }).hasGitHubToken,
+          Boolean(token?.trim()),
+        );
+      }
+    }
+  }
 });
 
 test("agent runner preserves review-style Codex argument composition", () => {

--- a/test/codex-process.test.ts
+++ b/test/codex-process.test.ts
@@ -13,6 +13,7 @@ import { delimiter, join } from "node:path";
 import test from "node:test";
 import { spawn } from "node:child_process";
 import { createInterface } from "node:readline";
+import { codexEnv } from "../dist/codex-env.js";
 
 import {
   codexProcessCommand,
@@ -542,6 +543,9 @@ for (const configuredProfile of [false, true]) {
 const fs = require("node:fs");
 const readline = require("node:readline");
 const requestsPath = process.env.CODEX_TEST_REQUESTS_PATH;
+require("node:assert/strict").equal(process.env.GH_TOKEN, "synthetic-inspection-token");
+require("node:assert/strict").equal(process.env.GITHUB_TOKEN, undefined);
+require("node:assert/strict").equal(process.env.CLAWSWEEPER_PROOF_INSPECTION_TOKEN, undefined);
 fs.writeFileSync(process.env.CODEX_TEST_ARGS_PATH, JSON.stringify(process.argv.slice(2)));
 const rl = readline.createInterface({ input: process.stdin });
 function send(value) { process.stdout.write(JSON.stringify(value) + "\\n"); }
@@ -582,7 +586,7 @@ rl.on("line", (line) => {
       });
     }
     const env = {
-      ...process.env,
+      ...codexEnv({ ghToken: "synthetic-inspection-token" }),
       CODEX_BIN: codexPath,
       CODEX_TEST_ARGS_PATH: argsPath,
       CODEX_TEST_REQUESTS_PATH: requestsPath,

--- a/test/codex-review-runner.test.ts
+++ b/test/codex-review-runner.test.ts
@@ -694,7 +694,8 @@ test("runCodex honors env login config unless preserving local Codex auth", () =
     `#!/usr/bin/env node
 ${fakeCodexSandboxPass}
 const fs = require("node:fs");
-if (process.env.GH_TOKEN || process.env.CLAWSWEEPER_PROOF_INSPECTION_TOKEN) process.exit(3);
+if (process.env.CLAWSWEEPER_PROOF_INSPECTION_TOKEN || process.env.GITHUB_TOKEN) process.exit(3);
+fs.writeFileSync(process.env.CODEX_ARGS_PATH + ".env", JSON.stringify({ GH_TOKEN: process.env.GH_TOKEN }));
 fs.writeFileSync(process.env.CODEX_ARGS_PATH, JSON.stringify(process.argv.slice(2)));
 const outputIndex = process.argv.indexOf("--output-last-message");
 if (outputIndex === -1) process.exit(2);
@@ -741,6 +742,12 @@ fs.writeFileSync(process.argv[outputIndex + 1], process.env.CODEX_DECISION_JSON)
       prompt: "Return a review decision.",
     });
     assert.equal(decision.decision, "keep_open");
+    assert.deepEqual(
+      JSON.parse(readFileSync(argsPath + ".env", "utf8")),
+      process.env.CLAWSWEEPER_PROOF_INSPECTION_TOKEN
+        ? { GH_TOKEN: "synthetic-inspection-token" }
+        : {},
+    );
     return JSON.parse(readFileSync(argsPath, "utf8")) as string[];
   };
 
@@ -749,6 +756,10 @@ fs.writeFileSync(process.argv[outputIndex + 1], process.env.CODEX_DECISION_JSON)
     assert.ok(networkArgs.includes('default_permissions="clawsweeper-review"'));
     assert.ok(networkArgs.includes('approval_policy="never"'));
     assert.equal(networkArgs.includes("--sandbox"), false);
+    delete process.env.CLAWSWEEPER_PROOF_INSPECTION_TOKEN;
+    runAndReadArgs(false, "clawsweeper-review");
+    runAndReadArgs(false);
+    process.env.CLAWSWEEPER_PROOF_INSPECTION_TOKEN = "synthetic-inspection-token";
     const defaultArgs = runAndReadArgs(false);
     assert.deepEqual(defaultArgs, [
       "exec",

--- a/test/openclaw-process.test.ts
+++ b/test/openclaw-process.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import test from "node:test";
 import { useFakeScanner } from "./agent-input-scan-helpers.ts";
 
-import { runAgentProcess } from "../dist/agent-runner.js";
+import { reviewNetworkCapability, runAgentProcess } from "../dist/agent-runner.js";
 import { parseOpenclawJsonEnvelope, runOpenclawProcess } from "../dist/openclaw-process.js";
 import { codexProcessErrorCode } from "../dist/codex-process.js";
 
@@ -546,27 +546,34 @@ test("OpenClaw subprocess env strips workflow credentials and keeps provider key
   const recordPath = join(root, "record.json");
   const binary = fakeOpenclaw(root);
   try {
+    const env = {
+      ...process.env,
+      CLAWSWEEPER_OPENCLAW_BIN: binary,
+      OPENCLAW_TEST_RECORD: recordPath,
+      GITHUB_TOKEN: "workflow-github",
+      GH_TOKEN: "workflow-gh",
+      CLAWSWEEPER_WEBHOOK_SECRET: "workflow-webhook",
+      CLAWSWEEPER_APP_PRIVATE_KEY: "workflow-app",
+      KIMI_API_KEY: "provider-kimi",
+    };
+    const capability = reviewNetworkCapability("clawsweeper-review", {
+      ...env,
+      CLAWSWEEPER_RUNNER: "openclaw",
+    });
     const result = runOpenclawProcess({
       label: "env-allowlist",
-      prompt: "hi",
+      prompt: JSON.stringify(capability),
       model: "kimi/k3",
       cwd: root,
-      env: {
-        ...process.env,
-        CLAWSWEEPER_OPENCLAW_BIN: binary,
-        OPENCLAW_TEST_RECORD: recordPath,
-        GITHUB_TOKEN: "workflow-github",
-        GH_TOKEN: "workflow-gh",
-        CLAWSWEEPER_WEBHOOK_SECRET: "workflow-webhook",
-        CLAWSWEEPER_APP_PRIVATE_KEY: "workflow-app",
-        KIMI_API_KEY: "provider-kimi",
-      },
+      env,
       timeoutMs: 60_000,
     });
     assert.equal(result.status, 0, result.stderr);
     const record = JSON.parse(readFileSync(recordPath, "utf8"));
     assert.equal(record.env.GITHUB_TOKEN, null);
     assert.equal(record.env.GH_TOKEN, null);
+    assert.equal(capability.hasGitHubToken, Boolean(record.env.GH_TOKEN));
+    assert.deepEqual(JSON.parse(record.prompt), capability);
     assert.equal(record.env.CLAWSWEEPER_WEBHOOK_SECRET, null);
     assert.equal(record.env.CLAWSWEEPER_APP_PRIVATE_KEY, null);
     assert.equal(record.env.KIMI_API_KEY, "provider-kimi");

--- a/test/review-command-workflow.test.ts
+++ b/test/review-command-workflow.test.ts
@@ -662,7 +662,9 @@ function testScheduledCacheScenario(scenario: string, publicationCase?: Publicat
         return { status: 0, signal: null, stdout: "", stderr: "" };
       },
       prepareMediaProofArtifacts: () => ({ manifestPath: null, summaryPath: null, artifacts: [] }),
-      buildReviewPrompt: (_item, reviewContext) => {
+      reviewEnvironment: () => ({ GH_TOKEN: "synthetic-inspection-token" }),
+      buildReviewPrompt: (_item, reviewContext, _git, _additionalPrompt, runtimeHints) => {
+        assert.equal(runtimeHints.hasGitHubToken, true);
         if (publicationCacheMiss)
           assert.deepEqual(reviewContext.previousClawSweeperReview, {
             verdictDigest: digest("previous"),
@@ -683,7 +685,8 @@ function testScheduledCacheScenario(scenario: string, publicationCase?: Publicat
           });
         throw new Error("scan refusal must not become a decision");
       },
-      runCodex: ({ openclawDir }) => {
+      runCodex: ({ openclawDir, reviewEnv }) => {
+        assert.equal(reviewEnv.GH_TOKEN, "synthetic-inspection-token");
         generationCalls += 1;
         if (cacheRecovery) {
           assert.equal(

--- a/test/review-prompt-policy.test.ts
+++ b/test/review-prompt-policy.test.ts
@@ -807,23 +807,27 @@ test("runtime capabilities describe the configured network and credential bounda
         GH_TOKEN: "synthetic-inspection-token",
       }),
     );
-    assert.match(
-      authenticatedPrompt,
-      /read-only GitHub App token for the target repository is available as `GH_TOKEN`/,
-    );
-    assert.match(
-      authenticatedPrompt,
-      /contents, issues, and pull requests read; expires within the hour/,
-    );
-    assert.match(
-      authenticatedPrompt,
-      /use it for `gh api`\/authenticated GitHub reads so public rate limits do not apply; it cannot write/,
-    );
-    assert.match(
-      authenticatedPrompt,
-      /Never place it in a URL, log it, or send it to any non-GitHub host/,
-    );
-    assert.doesNotMatch(authenticatedPrompt, /No GitHub token|synthetic-inspection-token/);
+    if (runner === "openclaw") {
+      assert.equal(authenticatedPrompt, prompt);
+    } else {
+      assert.match(
+        authenticatedPrompt,
+        /read-only GitHub App token for the target repository is available as `GH_TOKEN`/,
+      );
+      assert.match(
+        authenticatedPrompt,
+        /contents, issues, and pull requests read; expires within the hour/,
+      );
+      assert.match(
+        authenticatedPrompt,
+        /use it for `gh api`\/authenticated GitHub reads so public rate limits do not apply; it cannot write/,
+      );
+      assert.match(
+        authenticatedPrompt,
+        /Never place it in a URL, log it, or send it to any non-GitHub host/,
+      );
+      assert.doesNotMatch(authenticatedPrompt, /No GitHub token|synthetic-inspection-token/);
+    }
     assert.match(prompt, /No GitHub token is supplied to the review process/);
     assert.match(prompt, /read those files rather than re-fetching/);
     assert.doesNotMatch(prompt, /available network and read-only GitHub token/);

--- a/test/review-prompt-policy.test.ts
+++ b/test/review-prompt-policy.test.ts
@@ -795,8 +795,35 @@ test("runtime capabilities describe the configured network and credential bounda
       { issue: {}, comments: [], timeline: [] },
       { mainSha: "abc123", latestRelease: null },
       "",
-      { networkCapability: reviewNetworkCapability(sandboxMode, { CLAWSWEEPER_RUNNER: runner }) },
+      reviewNetworkCapability(sandboxMode, { CLAWSWEEPER_RUNNER: runner }),
     );
+    const authenticatedPrompt = reviewPromptForTest(
+      item({ kind: "pull_request" }),
+      { issue: {}, comments: [], timeline: [] },
+      { mainSha: "abc123", latestRelease: null },
+      "",
+      reviewNetworkCapability(sandboxMode, {
+        CLAWSWEEPER_RUNNER: runner,
+        GH_TOKEN: "synthetic-inspection-token",
+      }),
+    );
+    assert.match(
+      authenticatedPrompt,
+      /read-only GitHub App token for the target repository is available as `GH_TOKEN`/,
+    );
+    assert.match(
+      authenticatedPrompt,
+      /contents, issues, and pull requests read; expires within the hour/,
+    );
+    assert.match(
+      authenticatedPrompt,
+      /use it for `gh api`\/authenticated GitHub reads so public rate limits do not apply; it cannot write/,
+    );
+    assert.match(
+      authenticatedPrompt,
+      /Never place it in a URL, log it, or send it to any non-GitHub host/,
+    );
+    assert.doesNotMatch(authenticatedPrompt, /No GitHub token|synthetic-inspection-token/);
     assert.match(prompt, /No GitHub token is supplied to the review process/);
     assert.match(prompt, /read those files rather than re-fetching/);
     assert.doesNotMatch(prompt, /available network and read-only GitHub token/);


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where hosted ClawSweeper reviewers hit unauthenticated GitHub API limits on shared runners despite having allowlisted network access. Related: https://github.com/openclaw/clawsweeper/pull/1484 and https://github.com/openclaw/clawsweeper/pull/1487.

## Why This Change Was Made

Restore the existing target-repository GitHub App inspection token to the review child only as `GH_TOKEN`, through `codexEnv`. It has read-only contents, issues, and pull-request access and expires within an hour. Both the hosted workflow's prebuilt prompt and runtime-generated prompts use the same sanitized environment that reaches the reviewer. Legacy Codex sandbox selections retain token pass-through; the app-server worker already inherits this environment. OpenClaw retains its existing final child credential filter, so its prompts correctly continue to say that no GitHub token is supplied.

The managed proxy mode, host allowlist, filesystem permissions, and write-credential boundary are unchanged. Reviewers are instructed to use authenticated GitHub reads and never put the token in a URL, log it, or send it to a non-GitHub host.

## User Impact

Codex reviewers can authenticate target-repository reads instead of consuming the shared runner's public GitHub rate limit. When no token is supplied, prompts continue to direct reviewers to public endpoints and pre-fetched context. This change does not give reviewers GitHub write access.

## OpenClaw Bay Impact

Unaffected: this changes reviewer authentication and capability guidance only. It changes no lifecycle state, review publication format, queue behavior, public observer data contract, or Bay UI/API surface.

## Documentation Impact

Updated active security guidance in `README.md` and the active “Reviewer network boundary” section in `docs/pr-review-comments.md`, plus the Unreleased changelog. ClawSweeper maintainers own the boundary; the review runtime, `codexEnv`, and setup permission profile are its sources of truth. Scope verified against this PR and Codex 0.153.3; update when token handling, runner selection, the pinned CLI, or the permission profile changes. Corrected the stale credential comment in the permission profile without changing its settings.

## Evidence

- Node 24.20.0, pnpm 11.10.0: all 179 focused tests passed across `codex-review-runner`, `review-prompt-policy`, `agent-runner`, `codex-process`, `review-command-workflow`, and `openclaw-process` after the accepted OpenClaw finding was fixed.
- Coverage checks token-present/token-absent exec environments, source-token stripping, both prompt variants, hosted prebuilt prompts, and app-server inheritance for profile and legacy sandbox selections.
- Build, repair/dashboard builds, formatting, documentation/static checks, lint, and all 13 focused changed-coverage tests passed.
- Full local `check`: 5,347 passed, 19 failed, 13 skipped. The additional workflow failures were traced to Homebrew Bash 5.3.15 blocking in `heredoc_write`; affected stalled test processes were terminated, and all 151 sweep/cluster/reconcile tests plus all 6 dispatcher tests passed when rerun with system Bash through a task-local PATH wrapper. The remaining unrecovered failures are confined to the known host-environment fixtures `test/apply-drift-refresh.test.ts` and `test/live-proof-review-environment.test.ts`.
- Initial `test:unit`: 3,497 passed, 22 failed, 6 skipped. It began before all repair artifacts were built; the scanner file affected by that setup error passed all 260 tests after the build. The same Bash recovery and known host-fixture limitations apply. No source changes were made for host/toolchain failures.
- All hosted CI, including `pnpm check`, passed for the initial head `294c48dde52241b2c611680206db24342b85a2fb`. CI runs again for the OpenClaw correction; the follow-up local full check also runs with the system Bash wrapper.
- Pre-commit Codex reviews, including the consolidated candidate after the OpenClaw correction: scoped-clean at P0–P2; no accepted/actionable findings.

## Real Behavior Proof

**Claim and surface:** a synthetic inspection token reaches the real Codex exec review sandbox only as `GH_TOKEN`; a bearer-authenticated GitHub request reaches GitHub while an unlisted host remains blocked.

**Revision:** 8ca545360b53ff6b16b94990de9276dd146e1932. Both boundary probes were rerun after this commit.

**Environment and fixture:** local macOS 27.0 arm64, Node 24.20.0, pinned `@openai/codex@0.153.3`, isolated `CODEX_HOME`, and the repository's `clawsweeper-review` permission profile. Provider: local macOS Codex sandbox; container image/lease: not applicable. The Responses provider was a local scripted fixture that emitted the tool calls; Codex exec, its shell tools, managed proxy, and the HTTPS requests were real. The parent environment was cleared with `env -i`; only the synthetic token was supplied. No real GitHub credential or model-service credential was used.

**Harness command and environment handoff:**

```sh
npm install --prefix .artifacts/codex-0.153.3 @openai/codex@0.153.3
# With Node 24 first on PATH:
env -i HOME="$HOME" PATH="$PATH" \
  CLAWSWEEPER_PROOF_INSPECTION_TOKEN=ghs_synthetic_not_a_real_token \
  node .artifacts/proof-exec.mjs
```

The harness calls `codexEnv({ ghToken: process.env.CLAWSWEEPER_PROOF_INSPECTION_TOKEN })`, sets the isolated `CODEX_HOME`, and launches the pinned binary with `exec --ephemeral --skip-git-repo-check --json -C <proof-directory> -c 'default_permissions="clawsweeper-review"'`. It uses the unchanged permission-profile contents. The controlled provider requests these three commands as separate real shell calls:

```sh
printf 'GH_TOKEN='; printenv GH_TOKEN
printf 'source token and GITHUB_TOKEN (must be empty):\n'
printenv CLAWSWEEPER_PROOF_INSPECTION_TOKEN GITHUB_TOKEN || true

curl -sS --max-time 20 -w '\nGitHub HTTP %{http_code}\n' \
  -H "Authorization: Bearer $GH_TOKEN" https://api.github.com/rate_limit

curl -sS --max-time 20 https://example.com/
```

**Observed output:**

```text
Codex exit: 0
GH_TOKEN=ghs_synthetic_not_a_real_token
source token and GITHUB_TOKEN (must be empty):

{
  "message": "Bad credentials",
  "documentation_url": "https://docs.github.com/rest",
  "status": "401"
}
GitHub HTTP 401

exec_command failed: ProcessFailed { message: "Network access to \"example.com\" was blocked: domain is not on the allowlist for the current sandbox mode." }
```

The environment command exited 0 with no output for the two forbidden names. The GitHub command exited 0 and returned HTTP 401, proving transport and bearer-header pass-through with a synthetic credential. The unlisted host was rejected by Codex's managed network enforcement.

**Artifact/trace:** the observed tool outputs are transcribed above; the local harness retained `proof-transcript.txt`, the exec JSONL trace, and tool-output JSON for the handoff. The runtime and app-server regression tests separately verify that production environment wiring supplies the same token-only mapping.

**Limits:** this synthetic proof does not validate a real installation token's permissions, expiration, or authenticated quota. It exercises local macOS; the existing credential-free Ubuntu `review-network-smoke` CI job covers hosted Linux proxy/filesystem enforcement. No claim of resistance to prompt injection is made.

### OpenClaw final child boundary

The accepted P2 finding is corrected: OpenClaw strips `GH_TOKEN` in its final child environment allowlist. Capability reporting now accounts for that filter, its existing subprocess test compares the advertised capability to the observed child environment, and README/review guidance no longer promise a token to OpenClaw.

A controlled execution of production `runOpenclawProcess` used a synthetic child CLI probe to record the actual worker/child environment. This exercises the real environment filtering and subprocess chain; it does not exercise the OpenClaw gateway or contact a model provider.

```sh
env -i HOME="$HOME" PATH="$PATH" \
  CLAWSWEEPER_PROOF_INSPECTION_TOKEN=ghs_synthetic_not_a_real_token \
  node .artifacts/proof-openclaw.mjs
```

```text
capabilities: {"networkCapability":"unrestricted","hasGitHubToken":false}
child environment: {"GH_TOKEN":null,"GITHUB_TOKEN":null,"CLAWSWEEPER_PROOF_INSPECTION_TOKEN":null}
exit: 0
```

## Review Disposition and Maintainer Decision

- **Accepted and fixed:** the P2 OpenClaw capability mismatch. Its final credential filter is preserved; capability reporting, docs, prompt tests, and a production subprocess-boundary probe now agree.
- **Owner decision already made:** the maintainer explicitly authorized handing the existing read-only, single-repository, one-hour GitHub App token to Codex reviewers, with the documented allowed-third-party disclosure risk. This PR implements that decision. Replacing the token with a trusted credential-holding read broker is outside this approved scope.
- **Proof scope explicitly selected by the maintainer:** use only a synthetic token; GitHub HTTP 401 is an acceptable transport/header result. Real-token successful reads, denied operations, and revocation tests were not authorized for this proof and were not run. The existing workflow permission requests establish the requested read scope; this PR changes token handoff, not token minting or lifetime.
- **Rank-up disposition:** the OpenClaw improvement is implemented. The broader authority-chain and allowed-third-party-recipient demonstrations remain outside the selected synthetic-only proof; the recipient exposure is an accepted known gap, not an enforced protection or a resolved containment claim.

## Known Gaps

A prompt-injected reviewer could still leak the token in a GET query string to an allowlisted third-party host. The mitigation is the token's read-only, single-repository, one-hour scope. The prompt warning is guidance, not an enforced credential containment boundary. Authenticated installation limits still apply.


## Maintainer Decision

The repository owner decided to hand reviewers the read-only target-repository token and accepts the documented exception: the credential handoff, bearer transport, unlisted-host rejection, and OpenClaw child filtering are proven with a synthetic token on the current head; scoped authorization and revocation are not exercised with a live App token outside the hosted job, and the residual disclosure path is a prompt-injected GET to an allowlisted third-party host, bounded by the token's read-only, single-repository, one-hour scope. `proof: override` records this decision.
