### PR TITLE
fix(publish): prevent slow ledger uploads from blocking reviews

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -5257,14 +5257,6 @@ jobs:
           path: review-metrics
           merge-multiple: true
 
-      - uses: actions/download-artifact@v8
-        id: download-review-action-ledger
-        continue-on-error: true
-        with:
-          pattern: action-ledger-review-*
-          path: .clawsweeper-repair/action-ledger-download
-          merge-multiple: true
-
       - name: Install review live-proof media validators
         if: ${{ steps.download-review-artifacts.outcome == 'success' && hashFiles('artifacts/live-proof/*/live-proof-manifest.json') != '' }}
         run: |
@@ -5280,41 +5272,6 @@ jobs:
           CLAWSWEEPER_LIVE_PROOF_BUCKET: ${{ secrets.CLAWSWEEPER_LIVE_PROOF_BUCKET }}
           CLAWSWEEPER_LIVE_PROOF_BASE_URL: ${{ secrets.CLAWSWEEPER_LIVE_PROOF_BASE_URL }}
         run: node dist/clawsweeper.js live-proof-publish-artifacts --artifact-dir artifacts
-
-      - name: Import immutable review action events
-        id: import-review-action-ledger
-        if: ${{ always() && steps.setup-publish-state.outcome == 'success' && steps.setup-publish-pnpm.outcome == 'success' && steps.download-review-action-ledger.outcome == 'success' }}
-        continue-on-error: true
-        run: |
-          set -euo pipefail
-          mkdir -p .artifacts
-          : > .artifacts/action-ledger-paths.txt
-          pnpm run --silent publish-action-events -- \
-            --source-root .clawsweeper-repair/action-ledger-download \
-            --state-root . \
-            --expected-producer-job review \
-            --expected-producer-max-run-attempt "$GITHUB_RUN_ATTEMPT" |
-            jq -r '.paths[]?' >> .artifacts/action-ledger-paths.txt
-          pnpm run --silent publish-action-events -- \
-            --source-root "$CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT" \
-            --state-root . \
-            --expected-producer-job "$GITHUB_JOB" |
-            jq -r '.paths[]?' >> .artifacts/action-ledger-paths.txt
-          sort -u -o .artifacts/action-ledger-paths.txt .artifacts/action-ledger-paths.txt
-
-      - name: Publish immutable review action ledger
-        if: ${{ always() && steps.import-review-action-ledger.outcome == 'success' }}
-        continue-on-error: true
-        env:
-          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
-          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
-        run: |
-          if [ ! -s .artifacts/action-ledger-paths.txt ]; then
-            echo "No immutable review action events to publish."
-            exit 0
-          fi
-          node dist/clawsweeper.js publish-action-event-paths \
-            --paths-file .artifacts/action-ledger-paths.txt
 
       - name: Apply review artifacts
         id: apply-review-artifacts
@@ -5700,6 +5657,112 @@ jobs:
             sleep "$((attempt * 10))"
           done
           echo "::warning::Unable to dispatch the next sweep after three attempts; the scheduled backstop will pick it up."
+
+      # Each production CLI seals its producer on exit. Keep those exact shards
+      # even when a later primary step fails; required receipt uploads stay above.
+      - name: Retain publisher action events
+        if: always()
+        timeout-minutes: 2
+        uses: actions/upload-artifact@v7
+        with:
+          name: action-ledger-publisher-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/clawsweeper-action-ledger/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}/**
+          include-hidden-files: true
+          if-no-files-found: ignore
+          retention-days: 7
+
+  publish-review-action-ledger:
+    name: Publish optional action ledger
+    needs: [review, publish]
+    if: ${{ always() && needs.publish.result != 'skipped' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      actions: read
+      contents: read
+    # Deliberately outside the target publisher lock and all primary dependencies.
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          filter: blob:none
+          persist-credentials: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: clawsweeper-runtime-dist
+          path: .artifacts
+
+      - name: Extract action ledger runtime
+        run: tar -xzf .artifacts/review-runtime.tar.gz
+
+      - name: Download shard action events
+        uses: actions/download-artifact@v8
+        with:
+          pattern: action-ledger-review-*
+          path: .clawsweeper-repair/action-ledger-download
+          merge-multiple: true
+
+      - name: Download publisher action events
+        uses: actions/download-artifact@v8
+        with:
+          pattern: action-ledger-publisher-*
+          path: .clawsweeper-repair/action-ledger-publisher
+          merge-multiple: true
+
+      - name: Import immutable action events
+        id: import-action-ledger
+        timeout-minutes: 2
+        run: |
+          set -euo pipefail
+          mkdir -p .artifacts
+          : > .artifacts/action-ledger-paths.txt
+          node dist/clawsweeper.js publish-action-events \
+            --source-root .clawsweeper-repair/action-ledger-download \
+            --state-root . \
+            --expected-producer-job review \
+            --expected-producer-max-run-attempt "$GITHUB_RUN_ATTEMPT" |
+            jq -r '.paths[]?' >> .artifacts/action-ledger-paths.txt
+          node dist/clawsweeper.js publish-action-events \
+            --source-root .clawsweeper-repair/action-ledger-publisher \
+            --state-root . \
+            --expected-producer-job publish \
+            --expected-producer-max-run-attempt "$GITHUB_RUN_ATTEMPT" |
+            jq -r '.paths[]?' >> .artifacts/action-ledger-paths.txt
+          sort -u -o .artifacts/action-ledger-paths.txt .artifacts/action-ledger-paths.txt
+
+      - name: Publish immutable action ledger
+        id: publish-action-ledger
+        timeout-minutes: 5
+        env:
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+        run: |
+          set -euo pipefail
+          if [ ! -s .artifacts/action-ledger-paths.txt ]; then
+            echo "No immutable action events to publish."
+            echo "empty=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          node dist/clawsweeper.js publish-action-event-paths \
+            --paths-file .artifacts/action-ledger-paths.txt
+
+      - name: Report optional ledger outcome
+        if: always()
+        env:
+          IMPORT_OUTCOME: ${{ steps.import-action-ledger.outcome || 'not_started' }}
+          UPLOAD_OUTCOME: ${{ steps.publish-action-ledger.outcome || 'not_started' }}
+          EMPTY: ${{ steps.publish-action-ledger.outputs.empty || 'false' }}
+        run: |
+          {
+            echo "### Optional immutable action ledger"
+            echo "Import: $IMPORT_OUTCOME; upload: $UPLOAD_OUTCOME; empty: $EMPTY."
+            echo "Primary records and comments have separate completion receipts."
+            echo "Producer artifacts remain attached to this run for recovery."
+          } >> "$GITHUB_STEP_SUMMARY"
 
   recover-review-failures:
     name: Recover failed review shards

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -5772,7 +5772,7 @@ jobs:
             echo "### Optional immutable action ledger"
             echo "Import: $IMPORT_OUTCOME; upload: $UPLOAD_OUTCOME; empty: $EMPTY."
             echo "Primary records and comments have separate completion receipts."
-            echo "Producer artifacts remain attached to this run for recovery."
+            echo "Available producer artifacts remain attached to this run for recovery."
           } >> "$GITHUB_STEP_SUMMARY"
 
   recover-review-failures:

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -5661,7 +5661,9 @@ jobs:
       # Each production CLI seals its producer on exit. Keep those exact shards
       # even when a later primary step fails; required receipt uploads stay above.
       - name: Retain publisher action events
+        id: retain-publisher-action-events
         if: always()
+        continue-on-error: true
         timeout-minutes: 2
         uses: actions/upload-artifact@v7
         with:
@@ -5670,6 +5672,15 @@ jobs:
           include-hidden-files: true
           if-no-files-found: ignore
           retention-days: 7
+
+      - name: Report publisher ledger retention failure
+        if: ${{ always() && steps.retain-publisher-action-events.outcome != 'success' }}
+        continue-on-error: true
+        env:
+          RETENTION_OUTCOME: ${{ steps.retain-publisher-action-events.outcome || 'not_started' }}
+        run: |
+          echo "::warning::Optional publisher action-event retention: $RETENTION_OUTCOME."
+          echo "Optional publisher action-event retention: $RETENTION_OUTCOME. Primary completion receipts are unchanged." >> "$GITHUB_STEP_SUMMARY"
 
   publish-review-action-ledger:
     name: Publish optional action ledger

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Move optional aggregate review-ledger uploads out of the target publisher lock into a bounded artifact-backed job, preserving producer artifacts and required record/comment receipts when telemetry is slow or unavailable.
+
 - Give Codex reviewers the existing short-lived, read-only target-repository GitHub App token as `GH_TOKEN` for authenticated reads, and describe token availability from the actual reviewer environment, including OpenClaw's credential filter.
 - Give hosted issue/PR reviewers allowlisted public research access through a managed proxy while keeping the checkout read-only; describe token, blocked-host, and downloaded-media capabilities accurately and fail setup when sandbox enforcement regresses.
 - Describe review capabilities from the active runner so OpenClaw gateway execution is not mistaken for the Codex allowlisted sandbox; prove Linux review sandbox enforcement in credential-free PR CI.

--- a/docs/action-ledger.md
+++ b/docs/action-ledger.md
@@ -376,6 +376,14 @@ privacy-checked.
 
 ## Projections
 
+Aggregate review uploads run in the bounded `publish-review-action-ledger` job
+after the primary publisher, outside its target concurrency lock. Review and
+publisher artifacts retain their distinct producer identities; imports publish
+the complete canonical event and binding manifests. Optional upload failure is
+reported separately and does not delay primary artifact application, record
+publication, selected comments, or recovery. The primary artifact and comment
+receipt publication phases remain in the publisher.
+
 Consumers fold immutable events into purpose-specific views:
 
 - the marker-backed GitHub review comment shows a bounded review history;

--- a/docs/proof/review-publisher-ledger-isolation/README.md
+++ b/docs/proof/review-publisher-ledger-isolation/README.md
@@ -43,7 +43,9 @@ same boundaries complete before optional blob I/O is released.
 
 Additional cases cover ordinary success, optional HTTP failure, empty artifacts,
 primary failure, cancellation, exact manifest replay, a wrong producer job,
-and conflicting canonical bytes. The canonical importer tests additionally
+and conflicting canonical bytes. Publisher artifact retention fails open with
+an explicit warning and summary; the proof executes that reporting command.
+The canonical importer tests additionally
 cover incomplete numbered sets, bounded prior attempts, provenance, and causal
 bindings.
 

--- a/docs/proof/review-publisher-ledger-isolation/README.md
+++ b/docs/proof/review-publisher-ledger-isolation/README.md
@@ -1,0 +1,62 @@
+# Review Publisher Ledger Isolation
+
+Status: historical controlled proof. Owner: ClawSweeper maintainers.
+
+## Claim
+
+Optional aggregate ledger import/upload must not precede primary publication,
+hold its target concurrency lock, or block recovery. The separate artifact and
+selected-comment receipt phases remain required producer paths.
+
+## Reproduce
+
+Build the checkout with its pinned dependencies, then run:
+
+```sh
+pnpm run build:all
+node docs/proof/review-publisher-ledger-isolation/run-proof.mjs --baseline --output .artifacts/ledger-baseline.json
+node docs/proof/review-publisher-ledger-isolation/run-proof.mjs --output .artifacts/ledger-candidate.json
+node --test test/sweep-workflow.test.ts test/clawsweeper-action-ledger.test.ts
+```
+
+The baseline uses the workflow at
+`c6ead2181a5c958c37fb717c7186d48613caeeb0`. This repair does not change its
+production TypeScript CLIs. Each receipt records the executing checkout SHA,
+workflow digest, fixture digest, monotonic completion events, and wire counts.
+
+## Exercised Boundary
+
+The harness copies the built production runtime into isolated temporary roots.
+It executes the workflow's actual import/upload and required receipt shell
+blocks, plus the production `apply-artifacts`, `publish-main`, and comment-only
+`apply-decisions` CLIs. The existing GitHub command adapter forwards synthetic
+requests to a loopback HTTP server; blob and canonical record writes use their
+real signed HTTP clients. The server verifies signatures, content digests, and
+immutable replay. Outbound fetches and sockets are restricted to that server.
+All credentials are synthetic. Child process groups and temporary roots are
+removed before exit.
+
+The original ordered commands block before artifact application while optional
+blob I/O is withheld. After release, artifact, record, comment, and their
+required receipt boundaries complete. With the new dependency graph, those
+same boundaries complete before optional blob I/O is released.
+
+Additional cases cover ordinary success, optional HTTP failure, empty artifacts,
+primary failure, cancellation, exact manifest replay, a wrong producer job,
+and conflicting canonical bytes. The canonical importer tests additionally
+cover incomplete numbered sets, bounded prior attempts, provenance, and causal
+bindings.
+
+## Limits
+
+This proves controlled executable command boundaries and the parsed workflow
+dependency graph, not hosted runner scheduling, Actions artifact service
+availability, production GitHub mutations, or deployment health. Transport
+responses and issue data are synthetic. The read-model fixture is deliberately
+unavailable, so its existing fallback reads the synthetic GitHub transport.
+Absolute timings are ordering evidence, not a throughput benchmark.
+
+Bay's existing public projection is exercised for every named optional job
+step. None is classified as model review or review publication. No Bay runtime,
+controls, model capacity, scheduler cadence, credential, or schema changes are
+part of this repair.

--- a/docs/proof/review-publisher-ledger-isolation/local-transport.mjs
+++ b/docs/proof/review-publisher-ledger-isolation/local-transport.mjs
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import net from "node:net";
+import { syncBuiltinESMExports } from "node:module";
+
+const endpoint = new URL(process.env.PROOF_ENDPOINT);
+const fetchLocal = globalThis.fetch;
+globalThis.fetch = (input, init) => {
+  const url = new URL(input instanceof Request ? input.url : input);
+  if (url.origin !== endpoint.origin) throw new Error("Proof refused non-loopback fetch");
+  return fetchLocal(input, init);
+};
+const connect = net.Socket.prototype.connect;
+net.Socket.prototype.connect = function (...args) {
+  const normalized = Array.isArray(args[0]) ? args[0] : args;
+  const options =
+    typeof normalized[0] === "object"
+      ? normalized[0]
+      : { port: normalized[0], host: normalized[1] };
+  if (
+    options.path ||
+    Number(options.port) !== Number(endpoint.port) ||
+    !["127.0.0.1", "localhost", "::1"].includes(options.host)
+  ) {
+    throw new Error("Proof refused non-loopback socket");
+  }
+  return connect.apply(this, args);
+};
+syncBuiltinESMExports();
+
+if (resolve(process.argv[1] ?? "") === fileURLToPath(import.meta.url)) {
+  const args = process.argv.slice(2);
+  const input = args.indexOf("--input");
+  const payload = input >= 0 ? JSON.parse(readFileSync(args[input + 1], "utf8")) : undefined;
+  const response = await fetch(`${endpoint.origin}/gh`, {
+    method: "POST",
+    body: JSON.stringify({ args, payload }),
+  });
+  const value = await response.json();
+  if (!response.ok) {
+    console.error(value.error);
+    process.exitCode = 1;
+  } else {
+    process.stdout.write(value.stdout);
+  }
+}

--- a/docs/proof/review-publisher-ledger-isolation/run-proof.mjs
+++ b/docs/proof/review-publisher-ledger-isolation/run-proof.mjs
@@ -1,0 +1,565 @@
+import assert from "node:assert/strict";
+import { spawn, execFileSync } from "node:child_process";
+import { createHash, createHmac } from "node:crypto";
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import YAML from "yaml";
+import {
+  recordWorkflowActionEvent,
+  flushWorkflowActionEvents,
+} from "../../../dist/action-ledger-runtime.js";
+import { ACTION_EVENT_TYPES } from "../../../dist/action-ledger.js";
+
+const repo = resolve(import.meta.dirname, "../../..");
+const baseline = process.argv.includes("--baseline");
+const original = "c6ead2181a5c958c37fb717c7186d48613caeeb0";
+const workflowText = baseline
+  ? execFileSync("git", ["show", `${original}:.github/workflows/sweep.yml`], {
+      cwd: repo,
+      encoding: "utf8",
+    })
+  : readFileSync(join(repo, ".github/workflows/sweep.yml"), "utf8");
+const workflow = YAML.parse(workflowText);
+const temporary = realpathSync(mkdtempSync(join(tmpdir(), "ledger-isolation-")));
+const transport = join(import.meta.dirname, "local-transport.mjs");
+const sha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: repo, encoding: "utf8" }).trim();
+const secret = "synthetic-proof-only";
+const now = "2026-09-08T08:00:00.000Z";
+const issue = {
+  number: 42,
+  title: "Publication isolation proof",
+  body: "Synthetic issue",
+  html_url: "https://github.com/openclaw/clawsweeper/issues/42",
+  created_at: now,
+  updated_at: now,
+  closed_at: null,
+  state: "open",
+  locked: false,
+  active_lock_reason: null,
+  author_association: "CONTRIBUTOR",
+  user: { login: "reporter" },
+  labels: [],
+  comments: 0,
+  pull_request: null,
+};
+const report = `---
+repository: openclaw/clawsweeper
+number: 42
+type: issue
+title: Publication isolation proof
+url: https://github.com/openclaw/clawsweeper/issues/42
+author: reporter
+author_association: CONTRIBUTOR
+reviewed_at: ${now}
+item_updated_at: ${now}
+item_snapshot_hash: synthetic-proof-snapshot
+labels: []
+review_status: complete
+local_checkout_access: verified
+local_checkout_access_source: runner_preflight_v1
+decision: keep_open
+action_taken: kept_open
+close_reason: none
+confidence: high
+work_candidate: none
+work_status: none
+---
+
+# Publication isolation proof
+
+## Summary
+
+Synthetic retained review.
+`;
+const receipt = {
+  source_sha: sha,
+  workflow_sha256: digest(workflowText),
+  baseline,
+  fixture_sha256: digest(report),
+  scenarios: [],
+};
+function digest(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+function directory(path) {
+  mkdirSync(path, { recursive: true });
+  return realpathSync(path);
+}
+function step(job, name) {
+  const result = job.steps.find((value) => value.name === name);
+  assert.ok(result, name);
+  return result;
+}
+function child(root, args, env) {
+  const proc = spawn(process.execPath, args, { cwd: root, env, stdio: ["ignore", "pipe", "pipe"] });
+  let stdout = "",
+    stderr = "";
+  proc.stdout.on("data", (chunk) => {
+    stdout += chunk;
+  });
+  proc.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+  const done = new Promise((resolve, reject) => {
+    proc.once("error", reject);
+    proc.once("close", (code, signal) => resolve({ code, signal, stdout, stderr }));
+  });
+  return { proc, done };
+}
+async function checked(root, args, env) {
+  const result = await child(root, args, env).done;
+  assert.equal(result.code, 0, result.stderr);
+  return result;
+}
+function commandBlock(root, value, env) {
+  const cli =
+    'pnpm() { shift; [ "$1" = "--silent" ] && shift; local command="$1"; shift; [ "${1:-}" = "--" ] && shift; node dist/clawsweeper.js "$command" "$@"; }';
+  const proc = spawn("bash", ["-e", "-o", "pipefail", "-c", `${cli}\n${value.run}`], {
+    cwd: root,
+    env,
+    detached: true,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stdout = "",
+    stderr = "";
+  proc.stdout.on("data", (chunk) => {
+    stdout += chunk;
+  });
+  proc.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+  const done = new Promise((resolve, reject) => {
+    proc.once("error", reject);
+    proc.once("close", (code, signal) => resolve({ code, signal, stdout, stderr }));
+  });
+  return { proc, done };
+}
+async function seed(root, output, env, job, retryable = false) {
+  root = directory(join(root, `seed-${job}`));
+  const producerEnv = { ...env, GITHUB_JOB: job, CLAWSWEEPER_ACTION_LEDGER_INVOCATION: "fixture" };
+  recordWorkflowActionEvent(
+    root,
+    {
+      scope: "review.completed",
+      identity: { number: 42 },
+      type: ACTION_EVENT_TYPES.reviewCompleted,
+      component: "review",
+      subject: { repository: "openclaw/clawsweeper", kind: "issue", number: 42 },
+      action: { name: "review", status: "completed", retryable, mutation: false },
+      occurredAt: now,
+    },
+    { env: producerEnv },
+  );
+  await flushWorkflowActionEvents(root, { env: producerEnv, outputRoot: output });
+}
+async function scenario(kind) {
+  const root = directory(join(temporary, kind));
+  for (const path of ["dist", "config", "schema", "prompts", "package.json"]) {
+    cpSync(join(repo, path), join(root, path), { recursive: true });
+  }
+  for (const name of ["yaml", "yauzl"]) {
+    cpSync(
+      realpathSync(join(repo, "node_modules", name)),
+      join(directory(join(root, "node_modules")), name),
+      { recursive: true },
+    );
+  }
+  const producer = directory(join(root, "publisher"));
+  const review = directory(join(root, ".clawsweeper-repair/action-ledger-download"));
+  directory(join(root, "artifacts"));
+  directory(join(root, ".artifacts"));
+  const markers = [];
+  const timeline = [];
+  const mark = (name) => {
+    markers.push(name);
+    timeline.push({ name, milliseconds: Number(performance.now().toFixed(3)) });
+  };
+  const comments = [];
+  const blobs = new Map();
+  let pending, acknowledgeHold, rejectUnexpected, unexpectedFailure;
+  const held = new Promise((resolve) => {
+    acknowledgeHold = resolve;
+  });
+  const unexpected = new Promise((_, reject) => {
+    rejectUnexpected = reject;
+  });
+  unexpected.catch(() => {});
+  let hold = kind === "held" || kind === "cancelled";
+  const server = createServer(async (request, response) => {
+    try {
+      let text = "";
+      for await (const chunk of request) text += chunk;
+      const body = JSON.parse(text);
+      const send = (value, status = 200) => {
+        response.writeHead(status, { "content-type": "application/json" });
+        response.end(JSON.stringify(value));
+      };
+      if (request.url === "/gh") {
+        const args = body.args[0] === "--repo" ? body.args.slice(2) : body.args;
+        const path = args.includes("-i") ? args[args.indexOf("-i") + 1] : (args[1] ?? "");
+        const method = args.includes("--method") ? args[args.indexOf("--method") + 1] : "GET";
+        let value;
+        if (args[0] === "api" && /\/issues\/42$/.test(path))
+          value = { ...issue, comments: comments.length };
+        else if (args[0] === "api" && /\/issues\/42\/comments(?:\?|$)/.test(path)) {
+          if (method === "POST") {
+            value = {
+              id: 9042,
+              body: body.payload.body,
+              user: { login: "clawsweeper[bot]" },
+              created_at: now,
+              updated_at: now,
+              html_url: "https://github.com/openclaw/clawsweeper/issues/42#issuecomment-9042",
+            };
+            comments.push(value);
+            mark("comment-accepted");
+          } else value = args.includes("--slurp") ? [comments] : comments;
+        } else if (args[0] === "api" && /\/issues\/42\/timeline(?:\?|$)/.test(path))
+          value = args.includes("--slurp") ? [[]] : [];
+        else if (args[0] === "api" && path.startsWith("search/issues?"))
+          value = { total_count: 0, items: [] };
+        else if (args[0] === "api" && /\/collaborators\/reporter\/permission$/.test(path))
+          value = { permission: "read" };
+        else if (args[0] === "issue" && args[1] === "view")
+          value = { closedByPullRequestsReferences: [] };
+        else if (args[0] === "label" && args[1] === "create") value = { name: args[2] };
+        else if (args[0] === "issue" && args[1] === "edit") value = "";
+        else throw new Error(`Unexpected synthetic gh command: ${JSON.stringify(args)}`);
+        send({ stdout: typeof value === "string" ? value : JSON.stringify(value) });
+        return;
+      }
+      const signature = `sha256=${createHmac("sha256", secret).update(text).digest("hex")}`;
+      assert.equal(request.headers["x-clawsweeper-exact-review-signature"], signature);
+      if (
+        [
+          "/internal/state/github-read-model/item",
+          "/internal/state/github-read-model/repair",
+        ].includes(request.url)
+      ) {
+        send({ error: "synthetic_read_model_unavailable" }, 404);
+      } else if (request.url === "/internal/state/records/tuples") {
+        mark("record-accepted");
+        send({ ok: true, revision: 1, deduped: false });
+      } else if (
+        ["/internal/state/blobs/put", "/optional/internal/state/blobs/put"].includes(request.url)
+      ) {
+        assert.equal(digest(Buffer.from(body.contentBase64, "base64")), body.digest);
+        const respond = () => {
+          if (kind === "failed" && request.url.startsWith("/optional/"))
+            return send({ error: "synthetic_unavailable" }, 400);
+          const old = blobs.get(body.path);
+          assert.ok(!old || old === body.digest, "immutable blob conflict");
+          blobs.set(body.path, body.digest);
+          send({ unchanged: old === body.digest });
+        };
+        if (hold && request.url.startsWith("/optional/")) {
+          pending = respond;
+          acknowledgeHold();
+        } else respond();
+      } else throw new Error(`Unexpected local route: ${request.url}`);
+    } catch (error) {
+      response.writeHead(500);
+      response.end(JSON.stringify({ error: "proof_failed" }));
+      unexpectedFailure = error;
+      rejectUnexpected(error);
+    }
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const endpoint = `http://127.0.0.1:${server.address().port}`;
+  const env = {
+    PATH: `${dirname(process.execPath)}:/opt/homebrew/opt/bash/bin:/opt/homebrew/bin:/usr/bin:/bin`,
+    HOME: directory(join(root, "home")),
+    LANG: "C.UTF-8",
+    PROOF_ENDPOINT: endpoint,
+    NODE_OPTIONS: `--import=${pathToFileURL(transport)}`,
+    GH_BIN: process.execPath,
+    GH_BIN_ARGS: JSON.stringify([transport]),
+    GH_TOKEN: "synthetic",
+    QUEUE_URL: endpoint,
+    CLAWSWEEPER_WEBHOOK_SECRET: secret,
+    CLAWSWEEPER_CANONICAL_RECORD_BASELINE_DIR: directory(join(root, ".artifacts/baseline")),
+    CLAWSWEEPER_ACTION_LEDGER_FORCE: "1",
+    CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT: producer,
+    CLAWSWEEPER_ACTION_LEDGER_PARTITION_DATE: "2026-09-08",
+    GITHUB_REPOSITORY: "openclaw/clawsweeper",
+    GITHUB_JOB: "publish",
+    GITHUB_SHA: sha,
+    GITHUB_RUN_ID: "100",
+    GITHUB_RUN_ATTEMPT: "1",
+    GITHUB_WORKFLOW_REF: "openclaw/clawsweeper/.github/workflows/sweep.yml@refs/heads/main",
+    GITHUB_WORKFLOW: "ClawSweeper Sweep",
+    GITHUB_OUTPUT: join(root, ".artifacts/output"),
+  };
+  let upload;
+  try {
+    if (kind !== "empty") {
+      await seed(root, review, env, "review");
+      await seed(root, producer, env, "publish");
+      writeFileSync(join(root, "artifacts/42.md"), report);
+    }
+    const publish = async () => {
+      cpSync(producer, join(root, ".clawsweeper-repair/action-ledger-publisher"), {
+        recursive: true,
+      });
+      const job = baseline ? workflow.jobs.publish : workflow.jobs["publish-review-action-ledger"];
+      const importName = baseline
+        ? "Import immutable review action events"
+        : "Import immutable action events";
+      const uploadName = baseline
+        ? "Publish immutable review action ledger"
+        : "Publish immutable action ledger";
+      const optionalEnv = {
+        ...env,
+        QUEUE_URL: `${endpoint}/optional`,
+        GITHUB_JOB: baseline ? "publish" : "publish-review-action-ledger",
+      };
+      const imported = await commandBlock(root, step(job, importName), optionalEnv).done;
+      assert.equal(imported.code, 0, imported.stderr);
+      const manifest = readFileSync(join(root, ".artifacts/action-ledger-paths.txt"), "utf8")
+        .trim()
+        .split("\n")
+        .filter(Boolean);
+      if (!manifest.length) {
+        const result = await commandBlock(root, step(job, uploadName), optionalEnv).done;
+        assert.match(result.stdout, /No immutable/);
+        return result;
+      }
+      for (const kind of [
+        "events/",
+        "import-bindings/events/",
+        "import-bindings/producer-runs/",
+        "import-bindings/shard-sets/",
+        "import-bindings/completed-shard-sets/",
+      ]) {
+        assert.ok(
+          manifest.some((path) => path.startsWith(`ledger/v1/${kind}`)),
+          kind,
+        );
+      }
+      upload = commandBlock(root, step(job, uploadName), optionalEnv);
+      return upload.done;
+    };
+    const requiredReceipt = async (name) => {
+      const result = await commandBlock(root, step(workflow.jobs.publish, name), env).done;
+      assert.equal(result.code, 0, result.stderr);
+      mark(name);
+    };
+    const critical = async () => {
+      if (kind === "cancelled") return;
+      if (kind === "empty") {
+        mark("primary-empty");
+        return;
+      }
+      const applied = await child(
+        root,
+        [
+          "dist/clawsweeper.js",
+          "apply-artifacts",
+          "--target-repo",
+          kind === "primary-failed" ? "invalid" : "openclaw/clawsweeper",
+          "--artifact-dir",
+          "artifacts",
+          "--skip-dashboard",
+          "--skip-reconcile",
+        ],
+        env,
+      ).done;
+      if (kind === "primary-failed") {
+        assert.notEqual(applied.code, 0);
+        mark("primary-failed");
+        return;
+      }
+      assert.equal(applied.code, 0, applied.stderr);
+      mark("apply-completed");
+      await requiredReceipt("Publish review artifact action ledger");
+      await checked(
+        root,
+        [
+          "dist/repair/publish-main.js",
+          "--message",
+          "proof records",
+          "--path",
+          "records/openclaw-clawsweeper",
+          "--rebase-strategy",
+          "normal",
+        ],
+        env,
+      );
+      mark("record-completed");
+      const sync = await checked(
+        root,
+        [
+          "dist/clawsweeper.js",
+          "apply-decisions",
+          "--target-repo",
+          "openclaw/clawsweeper",
+          "--skip-dashboard",
+          "--item-numbers",
+          "42",
+          "--sync-comments-only",
+          "--apply-kind",
+          "all",
+          "--limit",
+          "0",
+          "--processed-limit",
+          "1",
+          "--comment-sync-min-age-days",
+          "0",
+        ],
+        env,
+      );
+      assert.equal(
+        comments.length,
+        1,
+        `${sync.stdout}\n${sync.stderr}\n${readFileSync(join(root, "apply-report.json"), "utf8")}`,
+      );
+      mark("comment-completed");
+      await requiredReceipt("Publish selected review comment action ledger");
+    };
+    const oldStep = workflow.jobs.publish.steps.find(
+      (value) => value.name === "Publish immutable review action ledger",
+    );
+    assert.equal(
+      Boolean(oldStep),
+      baseline,
+      "workflow must match the requested baseline/candidate mode",
+    );
+    if (baseline) {
+      assert.ok(
+        workflow.jobs.publish.steps.indexOf(oldStep) <
+          workflow.jobs.publish.steps.indexOf(
+            step(workflow.jobs.publish, "Apply review artifacts"),
+          ),
+      );
+      const publishing = publish();
+      if (hold) {
+        await Promise.race([
+          held,
+          unexpected,
+          publishing.then((result) => {
+            throw new Error(`Upload ended before hold: ${result.stderr}`);
+          }),
+        ]);
+        assert.deepEqual(markers, []);
+        mark("critical-blocked-by-ledger");
+        hold = false;
+        mark("ledger-released");
+        pending();
+      }
+      await publishing;
+      await critical();
+    } else {
+      const optional = workflow.jobs["publish-review-action-ledger"];
+      assert.ok(optional);
+      assert.ok(optional.needs.includes("publish"));
+      assert.equal(optional.concurrency, undefined);
+      for (const job of Object.values(workflow.jobs)) {
+        assert.ok(![job.needs].flat().includes("publish-review-action-ledger"));
+      }
+      await critical();
+      const publishing = publish();
+      if (hold) {
+        await Promise.race([
+          held,
+          unexpected,
+          publishing.then((result) => {
+            throw new Error(`Upload ended before hold: ${result.stderr}`);
+          }),
+        ]);
+        assert.equal(markers.includes("comment-completed"), kind !== "cancelled");
+        if (kind === "cancelled") {
+          process.kill(-upload.proc.pid, "SIGTERM");
+          assert.notEqual((await publishing).code, 0);
+          mark("optional-cancelled");
+        } else {
+          mark("critical-finished-before-ledger-release");
+          hold = false;
+          mark("ledger-released");
+          pending();
+          assert.equal((await publishing).code, 0);
+        }
+      } else {
+        const result = await publishing;
+        assert.equal(result.code === 0, kind !== "failed");
+        mark(
+          kind === "failed"
+            ? "optional-failed"
+            : kind === "empty"
+              ? "optional-empty"
+              : "optional-completed",
+        );
+      }
+    }
+    if (unexpectedFailure) throw unexpectedFailure;
+    if (kind === "success") {
+      const importArgs = (source, destination, job) => [
+        "dist/clawsweeper.js",
+        "publish-action-events",
+        "--source-root",
+        source,
+        "--state-root",
+        destination,
+        "--expected-producer-job",
+        job,
+      ];
+      const replay = await checked(root, importArgs(review, root, "review"), env);
+      assert.equal(JSON.parse(replay.stdout).unchanged, 1);
+      const wrongProducer = await child(
+        root,
+        importArgs(review, directory(join(root, "wrong-producer")), "publish"),
+        env,
+      ).done;
+      assert.notEqual(wrongProducer.code, 0);
+      assert.match(wrongProducer.stderr, /producer provenance mismatch for job/);
+      const conflict = directory(join(root, "conflict"));
+      await seed(directory(join(root, "conflict-writer")), conflict, env, "review", true);
+      const conflictingImport = await child(root, importArgs(conflict, root, "review"), env).done;
+      assert.notEqual(conflictingImport.code, 0);
+      assert.match(conflictingImport.stderr, /conflict/);
+      mark("exact-replay-retained");
+      mark("wrong-producer-rejected");
+      mark("conflicting-bytes-rejected");
+    }
+    receipt.scenarios.push({
+      kind,
+      markers,
+      timeline,
+      blob_paths: blobs.size,
+      comments: comments.length,
+    });
+  } finally {
+    if (upload?.proc.exitCode === null && upload.proc.signalCode === null) {
+      process.kill(-upload.proc.pid, "SIGTERM");
+      await upload.done;
+    }
+    server.closeAllConnections();
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+try {
+  for (const kind of baseline
+    ? ["held"]
+    : ["held", "success", "failed", "empty", "primary-failed", "cancelled"])
+    await scenario(kind);
+  const output = `${JSON.stringify(receipt, null, 2)}\n`;
+  const outputIndex = process.argv.indexOf("--output");
+  if (outputIndex >= 0) {
+    const path = resolve(process.argv[outputIndex + 1]);
+    directory(dirname(path));
+    writeFileSync(path, output);
+  }
+  console.log(output);
+} finally {
+  rmSync(temporary, { recursive: true, force: true });
+}

--- a/docs/proof/review-publisher-ledger-isolation/run-proof.mjs
+++ b/docs/proof/review-publisher-ledger-isolation/run-proof.mjs
@@ -467,7 +467,23 @@ async function scenario(kind) {
       for (const job of Object.values(workflow.jobs)) {
         assert.ok(![job.needs].flat().includes("publish-review-action-ledger"));
       }
+      assert.equal(
+        step(workflow.jobs.publish, "Retain publisher action events")["continue-on-error"],
+        true,
+      );
       await critical();
+      if (kind === "failed") {
+        const summary = join(root, "retention-summary.md");
+        const report = await commandBlock(
+          root,
+          step(workflow.jobs.publish, "Report publisher ledger retention failure"),
+          { ...env, RETENTION_OUTCOME: "failure", GITHUB_STEP_SUMMARY: summary },
+        ).done;
+        assert.equal(report.code, 0, report.stderr);
+        assert.match(report.stdout, /::warning::.*retention: failure/);
+        assert.match(readFileSync(summary, "utf8"), /retention: failure/);
+        mark("retention-failure-visible");
+      }
       const publishing = publish();
       if (hold) {
         await Promise.race([

--- a/test/clawsweeper-action-ledger.test.ts
+++ b/test/clawsweeper-action-ledger.test.ts
@@ -998,8 +998,8 @@ test("sweep publishes complete immutable shards for every review and apply produ
   );
 
   for (const name of [
-    "Import immutable review action events",
-    "Publish immutable review action ledger",
+    "Import immutable action events",
+    "Publish immutable action ledger",
     "Publish review artifact action ledger",
     "Publish selected review comment action ledger",
     "Publish failed-review retry action ledger",
@@ -1021,7 +1021,7 @@ test("sweep publishes complete immutable shards for every review and apply produ
   assert.doesNotMatch(workflow, /durable_event_path|CLAWSWEEPER_STATE_APPEND_ENABLED/);
   assert.equal((workflow.match(/publish-action-event-paths/g) ?? []).length, 6);
   for (const name of [
-    "Publish immutable review action ledger",
+    "Publish immutable action ledger",
     "Publish review artifact action ledger",
     "Publish selected review comment action ledger",
     "Publish failed-review retry action ledger",

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -602,7 +602,12 @@ test("review and apply primary boundaries ignore ledger-only failures", () => {
   );
   const publisherArtifact = step("publish", "Retain publisher action events");
   assert.equal(publisherArtifact.if, "always()");
+  assert.equal(publisherArtifact["continue-on-error"], true);
   assert.equal(publisherArtifact.with?.["include-hidden-files"], true);
+  assert.match(
+    step("publish", "Report publisher ledger retention failure").if ?? "",
+    /always\(\).*steps\.retain-publisher-action-events\.outcome != 'success'/,
+  );
   for (const producerJob of ["review", "publish"]) {
     assert.match(
       step("publish-review-action-ledger", "Import immutable action events").run ?? "",

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -245,6 +245,7 @@ test("exact event review exposes the token-only signal before runtime setup", ()
     uses?: string;
     id?: string;
     "continue-on-error"?: boolean;
+    "timeout-minutes"?: number;
   };
   const workflow = YAML.parse(readText(".github/workflows/sweep.yml")) as {
     jobs: Record<string, { steps: Step[] }>;
@@ -507,6 +508,7 @@ test("review and apply primary boundaries ignore ledger-only failures", () => {
     if?: string;
     needs?: string | string[];
     outputs?: Record<string, string>;
+    "timeout-minutes"?: number;
     steps: WorkflowStep[];
   };
 
@@ -584,16 +586,28 @@ test("review and apply primary boundaries ignore ledger-only failures", () => {
     false,
   );
 
-  const ledgerDownload = job("publish").steps.find(
-    (candidate) => candidate.id === "download-review-action-ledger",
+  const optionalLedger = job("publish-review-action-ledger");
+  assert.deepEqual(optionalLedger.needs, ["review", "publish"]);
+  assert.match(optionalLedger.if ?? "", /always\(\)/);
+  assert.match(optionalLedger.if ?? "", /needs\.publish\.result != 'skipped'/);
+  assert.equal("concurrency" in optionalLedger, false);
+  assert.equal(optionalLedger["timeout-minutes"], 15);
+  for (const value of Object.values(workflow.jobs)) {
+    assert.ok(![value.needs].flat().includes("publish-review-action-ledger"));
+  }
+  assert.ok(!job("publish").steps.some((value) => value.id === "import-review-action-ledger"));
+  assert.equal(
+    step("publish-review-action-ledger", "Publish immutable action ledger")["timeout-minutes"],
+    5,
   );
-  assert.ok(ledgerDownload);
-  assert.equal(ledgerDownload["continue-on-error"], true);
-  for (const name of [
-    "Import immutable review action events",
-    "Publish immutable review action ledger",
-  ]) {
-    assert.equal(step("publish", name)["continue-on-error"], true, `${name} must fail open`);
+  const publisherArtifact = step("publish", "Retain publisher action events");
+  assert.equal(publisherArtifact.if, "always()");
+  assert.equal(publisherArtifact.with?.["include-hidden-files"], true);
+  for (const producerJob of ["review", "publish"]) {
+    assert.match(
+      step("publish-review-action-ledger", "Import immutable action events").run ?? "",
+      new RegExp(`--expected-producer-job ${producerJob}`),
+    );
   }
   const artifactApply = step("publish", "Apply review artifacts");
   assert.match(artifactApply.if ?? "", /setup-publish-state\.outcome == 'success'/);
@@ -6932,6 +6946,37 @@ test("review finalizers recover start-only ledger attempts after hard timeout", 
   }
 });
 
+test("optional ledger work is never presented as model review or review publication in Bay", async () => {
+  const { publicStatusProjection } = await import("../dashboard/worker.ts");
+  const job = YAML.parse(readText(".github/workflows/sweep.yml")).jobs[
+    "publish-review-action-ledger"
+  ];
+  const projected = publicStatusProjection({
+    schema_version: 1,
+    generated_at: "2026-09-08T08:00:00.000Z",
+    source: { target_repository_count: 0 },
+    fleet: {},
+    workers: job.steps.map((entry: { name?: string; uses?: string }) => ({
+      name: job.name,
+      status: "in_progress",
+      current_step: entry.name ?? entry.uses,
+      steps: job.steps.map((step: { name?: string; uses?: string }) => ({
+        name: step.name ?? step.uses,
+      })),
+    })),
+    automatic_work: [],
+    pipeline: [],
+    bay: {},
+    recent: {},
+    diagnostics: { errors: [], error_count: 0 },
+  });
+  assert.equal(projected.workers.length, job.steps.length);
+  for (const worker of projected.workers) {
+    assert.ok(!["reviewing", "publishing"].includes(worker.stage));
+    assert.equal(worker.status, "in_progress");
+  }
+});
+
 test("every action-ledger publication authenticates the expected producer job", () => {
   const workflow = YAML.parse(readText(".github/workflows/sweep.yml")) as {
     jobs: Record<string, { steps?: Array<{ run?: string }> }>;
@@ -6977,9 +7022,8 @@ test("every action-ledger publication authenticates the expected producer job", 
       const occurrences = countOccurrences(line);
       if (occurrences === 0) continue;
       assert.equal(occurrences, 1, "publisher lines must contain one invocation");
-      assert.equal(
-        line.trimStart(),
-        commandStart,
+      assert.ok(
+        [commandStart, `node dist/clawsweeper.js ${invocation} \\`].includes(line.trimStart()),
         "publisher invocations must use the standalone canonical command form",
       );
 
@@ -7052,7 +7096,7 @@ test("every action-ledger publication authenticates the expected producer job", 
     assert.throws(() => commandsFromScript(malformed));
   }
   assert.equal(commands.length, 7);
-  const expectedProducerJobs = new Set(['"$GITHUB_JOB"', "apply-proof", "review"]);
+  const expectedProducerJobs = new Set(['"$GITHUB_JOB"', "apply-proof", "review", "publish"]);
   assert.ok(
     commands.every((command) =>
       expectedProducerJobs.has(command.get("--expected-producer-job") ?? ""),


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where aggregate review records and comments wait behind slow optional immutable-ledger uploads. Optional telemetry currently occupies the target publisher's critical path and concurrency lock before artifact application, record publication, and selected-comment synchronization.

## Why This Change Was Made

Move optional review/publisher ledger import and upload into a finite artifact-backed job after the primary publisher. Nothing depends on that job, and it holds no target-publisher lock. Reuse the existing architecture-neutral runtime artifact instead of adding another install/build route.

Review and publisher artifacts keep their distinct producer identities. Canonical import still validates repository, SHA, workflow, job, run, allowed attempt, complete shard sets, digests, reservations, and completion bindings. The separate required artifact and selected-comment receipt phases remain unchanged in the primary publisher. Optional failures remain visible. Producer artifact retention is bounded and fail-open; failed retention emits a warning and summary without failing primary publication.

No queue, retry, capacity, schedule, security-scan, credential, deployment, schema, or dashboard-runtime changes. The separately approved terminal-recovery repair will follow in another PR after this one lands.

## User Impact

Primary records and selected comments no longer wait for optional ledger blob I/O. Operators can distinguish optional telemetry failure from primary publication outcomes and retain exact producer evidence for recovery.

## OpenClaw Bay Impact

No Bay runtime change is needed. The existing `publicStatusProjection` is exercised against every new optional job step. None is classified as an active model review or review publication; the running optional job is not presented as published-review success. Bay remains observer-only.

## Documentation Impact

Updated the active `docs/action-ledger.md` projection contract. Added historical controlled proof under `docs/proof/review-publisher-ledger-isolation/`, including runnable commands, observable boundaries, and limits. Added the operational entry under 0.3.1 in `CHANGELOG.md`.

## Evidence

- Base: `c6ead2181a5c958c37fb717c7186d48613caeeb0`.
- Signed head: `d7719dfd906f5d83e841478ba23c3efd3ebaace1`.
- Frozen install and `pnpm run build:all`: passed.
- All 162 focused workflow/ledger tests passed, including the Bay classifier regression and optional retention failure guard.
- Canonical import integrity selection: 21 tests passed, including incomplete numbered sets, producer provenance, exact prior-attempt bounds, manifest bindings, and conflicting bytes.
- Actual prepared architecture-neutral artifact ran `publish-action-events` without dependency installation.
- Fresh precommit and final committed-base Codex reviews: scoped-clean after fixing the accepted artifact-retention finding. Exact-head CI is required before landing.
- Local `pnpm run check` passed static checks, builds, lint, changed coverage, and all but two existing live-proof environment tests: the sanitized terminal fixture and the nested npm fixture. Earlier restricted-PATH/non-login-shell retries did not resolve them. A targeted retry of only those two cases passed with installed Node 24.18.0, modern Bash, and inherited `TMUX`, `TMUX_PANE`, and `TMUX_TMPDIR` removed before starting the test process (2 passed, 0 failed; 9.50 seconds). No assertions or runtime files were changed. The original full-run failure remains recorded; no green full local rerun is claimed, and hosted exact-head `pnpm check` remains required.
- Current correction also passed `pnpm run check:static` and `git diff --check`.
- Production TypeScript delta: zero. Workflow: +117/-43, net +74 for separate bounded job, artifact transport, and visible fail-open retention. Test delta: +65/-16. Historical proof support: 628 JavaScript lines; documentation: 74 lines.

### Review Disposition

The committed-base review found that an optional artifact-retention error could mark primary publication failed. Addressed: both retention and its failure reporter use `continue-on-error`, with a bounded retention step and visible warning/summary. The workflow regression and actual reporting-command proof cover this correction.

Independent candidate review approved the implementation and executable proof, with one wording correction: the optional summary now says "Available producer artifacts" instead of promising retention after an upload failure. Fresh precommit and committed-base reviews of this final head are clean.

The initial ClawSweeper review found no actionable findings or Rank-up moves and accepted the controlled proof. Its old-head verdict is not landing authority; the current head and this body require a fresh durable review.

Named follow-up outside this PR: diagnose the local terminal-proof child environment/version-manager inheritance with synthetic fixtures. Recovery, dashboard runtime, and live-proof isolation-owner changes are not mixed into this repair.

## Real Behavior Proof

**Claim:** withheld or failing optional ledger blob I/O cannot delay critical artifact application, record publication, selected comments, or their required receipt completion.

**Surface and environment:** macOS arm64, Node 26.8.1, pinned pnpm 11.10.0. Built production CLIs and the actual workflow shell blocks execute in isolated temporary roots. A loopback HTTP server accepts only synthetic credentials and data, verifies signed requests and blob digests, and observes canonical record/comment writes. Child fetches and sockets are restricted to that server. No live apply, queue, workflow-dispatch, service, or target-repository writes were performed.

```sh
pnpm run build:all
node docs/proof/review-publisher-ledger-isolation/run-proof.mjs --baseline --output .artifacts/ledger-baseline.json
node docs/proof/review-publisher-ledger-isolation/run-proof.mjs --output .artifacts/ledger-candidate.json
```

**Identity:** baseline workflow SHA-256 `9e4d1e34bb0ac739f24d4f3a2a37061a564a6122f9a5c7249eb3c235691544bf`; candidate workflow SHA-256 `292af05d66908512f16d0b07579df31e16a944226871f57125a5dd2d73ae734c`; fixture SHA-256 `66d53d64628ff912c38520feac70d384b0515c179b1a6c09acb49ca12b622ca6`. Candidate proof reran successfully on the signed head above.

**Observed before/after:** the original workflow remained blocked before artifact application until the optional response was released. The candidate produced these monotonic completion markers while that response was still withheld:

| Candidate boundary | Milliseconds from proof start |
| --- | ---: |
| Artifact application completed | 2068.060 |
| Required artifact receipt completed | 3234.909 |
| Canonical record completed | 3295.998 |
| Selected comment completed | 6005.183 |
| Required selected-comment receipt completed | 7244.001 |
| Optional response released | 8351.475 |

These are ordering observations, not a speedup benchmark. Both held cases retained 34 unique canonical blob paths and one synthetic comment after release.

**Additional observed scenarios:** ordinary success; optional HTTP failure after primary completion; explicit empty artifacts; primary failure with no record/comment success; cancellation with no primary comment. The failure scenario also executed the production retention reporter, observing its warning, summary, and zero exit status. The real importer retained exact replay and rejected wrong producer identity and conflicting canonical bytes. Baseline and all six candidate scenarios exited successfully.

**Artifacts:** committed harness and proof README at `docs/proof/review-publisher-ledger-isolation/`; locally generated normalized receipts are reproduced by the commands above. This body contains the compact source identities and observed receipt ordering.

**Limits:** controlled executable command boundaries plus the parsed workflow dependency graph, not hosted Actions scheduling/artifact availability or production deployment health. GitHub responses and source items are synthetic. Read-model endpoints intentionally return unavailable so existing GitHub fallback reads use the loopback adapter. All task-owned proof process groups and temporary roots were removed.

The artifact handoff still holds the publisher job and its lock for up to two minutes; recovery can wait for that bounded handoff. Only the aggregate blob import/upload moves outside that lock. Whole-run completion still includes the optional job. Cancellation proof stops the optional upload process, not a mid-mutation primary operation. This proof does not claim artifacts survived an actual artifact-service retention failure.
