### PR TITLE
fix(review): stop retrying terminal refusals after shard failure

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -5076,6 +5076,34 @@ jobs:
           }
           JSON
 
+      - name: Stage verified completed reports
+        id: completed-prefix
+        if: ${{ always() && steps.review-shard.outcome == 'failure' }}
+        continue-on-error: true
+        working-directory: clawsweeper
+        env:
+          ITEM_NUMBERS: ${{ matrix.item_numbers }}
+          TARGET_REPO: ${{ needs.plan.outputs.target_repo }}
+        run: |
+          set -euo pipefail
+          result="$(node dist/repair/workflow-utils.js review-recovery \
+            --ledger-dir "$RUNNER_TEMP/clawsweeper-action-ledger/$GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT/review" \
+            --producer-repository "$GITHUB_REPOSITORY" --producer-sha "$GITHUB_SHA" \
+            --run-id "$GITHUB_RUN_ID" --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --target-repo "$TARGET_REPO" --shard "${{ matrix.shard }}" \
+            --shard-count "${{ needs.plan.outputs.planned_shards }}" --item-numbers "$ITEM_NUMBERS" \
+            --reports-dir "../review-artifacts/shard-${{ matrix.shard }}" \
+            --stage-dir "../review-artifacts/completed-${{ matrix.shard }}")"
+          echo "$result" | jq -r '.items[] | "Item #\(.number): \(.disposition), publication \(.publication) (\(.reason))"' | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "Review step failed; retained reports still require normal publisher guards." >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@v7
+        if: ${{ always() && steps.review-shard.outcome == 'failure' && steps.completed-prefix.outcome == 'success' }}
+        with:
+          name: review-shard-${{ matrix.shard }}
+          path: review-artifacts/completed-${{ matrix.shard }}/*.md
+          if-no-files-found: ignore
+
       - uses: actions/upload-artifact@v7
         if: ${{ always() && steps.review-shard.outcome == 'success' }}
         with:
@@ -5776,7 +5804,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   recover-review-failures:
-    name: Recover failed review shards
+    name: Apply bounded item recovery
     needs: [plan, review, publish]
     if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.queue_feed != 'true' && needs.review.result != 'skipped' && !contains(github.event.inputs.additional_prompt || '', '[clawsweeper-recovery-attempt=1]') && needs.plan.outputs.planned_item_numbers != '' && github.event_name != 'repository_dispatch' }}
     runs-on: ubuntu-latest
@@ -5785,6 +5813,24 @@ jobs:
       actions: read
       contents: read
     steps:
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: clawsweeper-runtime-dist
+          path: .artifacts
+
+      - name: Extract recovery runtime artifact
+        run: tar -xzf .artifacts/review-runtime.tar.gz
+
+      - uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: action-ledger-review-*
+          path: recovery-ledgers
+
       - uses: actions/download-artifact@v8
         id: failed-shards
         continue-on-error: true
@@ -5793,7 +5839,7 @@ jobs:
           path: failed-review-shards
           merge-multiple: true
 
-      - name: Requeue planned review items once
+      - name: Requeue eligible item terminals once
         env:
           GH_TOKEN: ${{ github.token }}
           ADDITIONAL_PROMPT: ${{ github.event.inputs.additional_prompt || '' }}
@@ -5840,25 +5886,24 @@ jobs:
             echo "No failed review shard jobs found; nothing to requeue."
             exit 0
           fi
-          item_numbers="$(
-            jq -r --arg failed_shards ",$failed_shards," '
-              [
-                .[]
-                | . as $matrix_entry
-                | select($failed_shards | contains("," + ($matrix_entry.shard | tostring) + ","))
-                | $matrix_entry.item_numbers
-                | split(",")[]
-                | select(test("^[0-9]+$"))
-              ]
-              | unique
-              | join(",")
-            ' <<<"$MATRIX_JSON"
-          )"
+          recovery_items=()
+          while IFS=$'\t' read -r shard planned_items; do
+            result="$(node dist/repair/workflow-utils.js review-recovery \
+              --ledger-dir "recovery-ledgers/action-ledger-review-$shard" \
+              --producer-repository "$GITHUB_REPOSITORY" --producer-sha "$GITHUB_SHA" \
+              --run-id "$GITHUB_RUN_ID" --run-attempt "$GITHUB_RUN_ATTEMPT" \
+              --target-repo "${{ needs.plan.outputs.target_repo }}" --shard "$shard" \
+              --shard-count "${{ needs.plan.outputs.planned_shards }}" --item-numbers "$planned_items")"
+            echo "$result" | jq -r '.items[] | "Item #\(.number): \(.disposition) (\(.reason))"' | tee -a "$GITHUB_STEP_SUMMARY"
+            while IFS= read -r item_number; do
+              recovery_items+=("$item_number")
+            done < <(jq -r '.retryable[]' <<<"$result")
+          done < <(jq -r --arg failed ",$failed_shards," '.[] | select(.shard as $s | $failed | contains("," + ($s | tostring) + ",")) | [.shard, .item_numbers] | @tsv' <<<"$MATRIX_JSON")
+          item_numbers="$(IFS=,; echo "${recovery_items[*]}")"
           if [ -z "$item_numbers" ]; then
-            echo "Failed shards had no item numbers to requeue: $failed_shards"
+            echo "No evidence-backed retryable item terminals; failed review work remains terminal, completed, or held." | tee -a "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
-          IFS=',' read -r -a recovery_items <<<"$item_numbers"
           failed_recovery_dispatches=()
           for item_number in "${recovery_items[@]}"; do
             if ! [[ "$item_number" =~ ^[0-9]+$ ]]; then
@@ -5899,9 +5944,13 @@ jobs:
                 "$queue_url/internal/exact-review/enqueue")" || response=""
               if jq -e '.ok == true and (.queued == true or .deduped == true or .shed == true or .accepted == false)' <<<"$response" >/dev/null; then
                 if jq -e '.accepted == false' <<<"$response" >/dev/null; then
-                  echo "Recovery skipped because the target is disabled."
+                  echo "Item #$item_number: Recovery skipped because the target is disabled." | tee -a "$GITHUB_STEP_SUMMARY"
                 elif jq -e '.shed == true' <<<"$response" >/dev/null; then
-                  echo "Recovery shed by exact-review queue backpressure."
+                  echo "Item #$item_number: Recovery shed by exact-review queue backpressure." | tee -a "$GITHUB_STEP_SUMMARY"
+                elif jq -e '.deduped == true' <<<"$response" >/dev/null; then
+                  echo "Item #$item_number: recovery admission deduplicated." | tee -a "$GITHUB_STEP_SUMMARY"
+                else
+                  echo "Item #$item_number: recovery admission queued." | tee -a "$GITHUB_STEP_SUMMARY"
                 fi
                 queued=true
                 break
@@ -5916,10 +5965,10 @@ jobs:
             fi
           done
           if [ "${#failed_recovery_dispatches[@]}" -gt 0 ]; then
-            echo "Unable to queue failed review recovery for item numbers: ${failed_recovery_dispatches[*]}" >&2
+            echo "Unable to queue failed review recovery for item numbers: ${failed_recovery_dispatches[*]}" | tee -a "$GITHUB_STEP_SUMMARY" >&2
             exit 1
           fi
-          echo "Queued failed review shards $failed_shards through the exact-review control plane: $item_numbers"
+          echo "Recovery acknowledgements handled for eligible items: $item_numbers. Original failed-review outcomes remain recorded; this is not publication success." | tee -a "$GITHUB_STEP_SUMMARY"
 
   retry-failed-reviews:
     name: Retry failed Codex reviews

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Recover failed aggregate review shards only from recognized retryable item terminals in the complete exact-attempt ledger. Keep completed, nonretryable, uncertain, and unstarted items out of recovery, and retain identity- and digest-verified completed reports for normal guarded publication.
+
 - Move optional aggregate review-ledger uploads out of the target publisher lock into a bounded artifact-backed job, preserving producer artifacts and required record/comment receipts when telemetry is slow or unavailable.
 
 - Give Codex reviewers the existing short-lived, read-only target-repository GitHub App token as `GH_TOKEN` for authenticated reads, and describe token availability from the actual reviewer environment, including OpenClaw's credential filter.

--- a/docs/action-ledger.md
+++ b/docs/action-ledger.md
@@ -11,6 +11,20 @@ canonical reports. Publication attempts do not authorize label, close, repair,
 implementation, or router actions. Artifact retention is evidence, not a
 completion receipt or authority to adopt a historical producer lease.
 
+Aggregate failed-review recovery is a read-only projection in
+`src/review-recovery.ts`, invoked by the workflow utility CLI. It uses the
+canonical importer with an exact run attempt, complete shard parts, and
+producer/causal bindings. A native item start and recognized retryable item
+terminal are required; batch terminals and coordination mutation outcomes
+cannot substitute. Later cleanup remains part of the fold, so an unmatched or
+unknown mutation holds the item even after its terminal.
+
+Completed reports may be staged for the existing guarded publisher only after
+their terminal digest, subject identity, complete status, and checkout
+provenance match. Missing evidence is a visible hold, never an inferred retry.
+No selected-item event, schema, or producer fact is added; automatic recovery
+of the unstarted tail remains a follow-up.
+
 Writers first spool individual events locally:
 
 ```text

--- a/docs/proof/aggregate-review-recovery/README.md
+++ b/docs/proof/aggregate-review-recovery/README.md
@@ -1,0 +1,84 @@
+# Aggregate Review Recovery
+
+Status: historical controlled proof. Owner: ClawSweeper maintainers.
+
+## Claim
+
+A failed aggregate shard must not turn its planned matrix into retry authority.
+Only recognized native retryable item terminals from the complete exact
+producer attempt may reach recovery admission. Completed and nonretryable
+items stay excluded; uncertain, missing, ambiguous, and unstarted work stays
+held. Verified completed reports survive for the existing guarded publisher.
+
+## Reproduce
+
+Use Node 24, Bash 4+, and the pinned frozen dependencies in a clean environment.
+
+```sh
+pnpm run build:all
+node docs/proof/aggregate-review-recovery/run-proof.mjs --baseline --output .artifacts/recovery-baseline.json
+node docs/proof/aggregate-review-recovery/run-proof.mjs --output .artifacts/recovery-candidate.json
+node --test test/repair/review-recovery.test.ts test/sweep-workflow.test.ts
+```
+
+The baseline executes the workflow at
+`7f29952363878ca3b5d1f25be8d40a9f6ced784c`. Its failed-shard recovery admits
+every planned item, including a nonretryable refusal, completed items, an
+uncertain late mutation, and an unstarted tail. The filtered fixture uses the
+production selection owner: planned `[1,2,3]` becomes selected `[1,3]`, but
+baseline recovery still admits all three. These are intended red outcomes.
+
+## Executed Boundaries
+
+The native review ledger owner emits starts, logs, item terminals, coordination
+receipts, and the final batch terminal. Its native finalizer writes canonical
+shards. A synthetic input-scan refusal exits the producer process with code 79;
+recovery never changes that outcome. Negative fixtures use native canonical
+writers, except the deliberate byte-corruption unit case.
+
+The harness executes the actual workflow staging and enqueue shell blocks.
+The built production workflow utility reads exact-attempt artifacts and stages
+verified reports; production `apply-artifacts --skip-reconcile` and targeted
+`reconcile` consume them through the existing publisher boundaries. The
+retained-prefix success and late-uncertainty cases also run `publish-main`,
+comment-only `apply-decisions`, and both required artifact/comment receipt
+workflow blocks. Their signed record tuple, comment, and immutable receipt
+writes must contain only the retained items.
+
+The actual enqueue `curl` reaches only a local signed HTTP server, which checks the
+signature, delivery identity, item membership, and non-superseding decision.
+Queue, GitHub, and read-model responses and credentials are synthetic. The
+existing ledger-isolation transport restricts Node sockets and fetches to that
+server and adapts the production GitHub command boundary.
+
+Scenarios cover accepted, deduplicated, shed, disabled, and failed ACKs;
+completed/cached and nonretryable exclusion; filtered membership; late and
+unmatched mutation; resolved accepted/rejected mutation; mutation-only and
+unsupported/ambiguous terminals; missing/incomplete/foreign artifacts; and
+report identity/digest mismatches. Failed ACKs retain the existing three tries
+per eligible item and a failed recovery exit. Item dispositions, admission
+results, and the original review failure remain visible in the actual summary.
+
+Receipts record the checkout/base SHAs, workflow/fixture/harness/source digests,
+actual queue requests, producer/recovery exits, and retained report names.
+Focused CLI tests additionally reject every foreign producer identity field,
+corrupted canonical bytes, and linked reports.
+
+## Limits
+
+This proves executable production command boundaries with synthetic data, not
+hosted Actions scheduling/artifact availability, model execution, scanner
+effectiveness, live queue admission, production record durability, or public
+comments. The real record and receipt clients receive synthetic loopback
+acknowledgements; this is not production publication. Existing publisher guard
+and receipt paths are unchanged. No live
+apply, queue, workflow dispatch, deployment, or credential change is used.
+
+Bay's existing public projection is checked for every optional-ledger and
+recovery job step. Workflow wording prevents recovery from being presented as
+active model review or completed publication. No dashboard runtime or controls
+change. The existing review-step failure and job-level continuation policy are
+preserved; a green aggregate job is not evidence that every item recovered.
+
+Automatic unstarted-tail recovery and independent locked-item classification
+remain named follow-ups, not inferred behavior in this change.

--- a/docs/proof/aggregate-review-recovery/fixture.mjs
+++ b/docs/proof/aggregate-review-recovery/fixture.mjs
@@ -1,0 +1,381 @@
+import { createHash } from "node:crypto";
+import { appendFileSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import { createReviewActionLedger } from "../../../dist/clawsweeper-review-ledger.js";
+import { createReviewPlanningSelection } from "../../../dist/clawsweeper-review-planning-selection.js";
+import { issueSourceRevisionSha256 } from "../../../dist/repair/issue-source-guard.js";
+import {
+  AgentInputScanError,
+  agentInputScanFailureExitCode,
+} from "../../../dist/agent-input-scan.js";
+import { flushWorkflowActionEvents } from "../../../dist/action-ledger-runtime.js";
+import {
+  actionEventKey,
+  actionOperationId,
+  actionAttemptId,
+  createActionEvent,
+  readActionEventShard,
+  writeActionEventShard,
+} from "../../../dist/action-ledger.js";
+
+export const baselineSha = "7f29952363878ca3b5d1f25be8d40a9f6ced784c";
+export const targetRepo = "openclaw/clawsweeper";
+export const digest = (value) => createHash("sha256").update(value).digest("hex");
+export const producerEnv = {
+  GITHUB_REPOSITORY: targetRepo,
+  GITHUB_SHA: baselineSha,
+  GITHUB_WORKFLOW_REF: `${targetRepo}/.github/workflows/sweep.yml@refs/heads/main`,
+  GITHUB_WORKFLOW: "ClawSweeper",
+  GITHUB_JOB: "review",
+  GITHUB_ACTION: "review-shard",
+  GITHUB_RUN_ID: "123456",
+  GITHUB_RUN_ATTEMPT: "1",
+  GITHUB_RUN_STARTED_AT: "2026-09-08T08:00:00Z",
+  CLAWSWEEPER_ACTION_LEDGER_FORCE: "1",
+};
+
+export function fixtureIssue(number) {
+  return {
+    number: Number(number),
+    title: "Synthetic recovery fixture",
+    body: "Synthetic issue",
+    html_url: `https://github.com/${targetRepo}/issues/${number}`,
+    created_at: producerEnv.GITHUB_RUN_STARTED_AT,
+    updated_at: producerEnv.GITHUB_RUN_STARTED_AT,
+    closed_at: null,
+    state: "open",
+    locked: false,
+    active_lock_reason: null,
+    author_association: "CONTRIBUTOR",
+    user: { login: "reporter" },
+    labels: [],
+    comments: 0,
+    pull_request: null,
+  };
+}
+
+export async function fixture(root, kind = "mixed") {
+  mkdirSync(root, { recursive: true });
+  const reports = join(root, "artifacts");
+  const ledgerDir = join(root, "ledger");
+  mkdirSync(reports, { recursive: true });
+  mkdirSync(ledgerDir, { recursive: true });
+  const planned = kind === "filtered" ? [1, 2, 3] : [1, 2, 3, 4, 5, 6, 7, 8];
+  const items = planned.map((number) => ({
+    repo: targetRepo,
+    number,
+    kind: "issue",
+    title: "Synthetic recovery fixture",
+    updatedAt: producerEnv.GITHUB_RUN_STARTED_AT,
+  }));
+  const { selectCandidates } = createReviewPlanningSelection({
+    fetchItem: (number) => ({
+      item: items.find((item) => item.number === number),
+      state: kind === "filtered" && number === 2 ? "closed" : "open",
+    }),
+  });
+  const { candidates } = selectCandidates({
+    itemNumbers: planned,
+    batchSize: planned.length,
+    maxPages: 1,
+    shardIndex: 0,
+    shardCount: 1,
+    itemsDir: reports,
+  });
+  const originalEnv = process.env;
+  process.env = { ...producerEnv };
+  try {
+    const owner = createReviewActionLedger({
+      root,
+      targetRepo: () => targetRepo,
+      repoRelativePath: (file) => relative(root, file),
+      sha256: digest,
+      isRuntimeBudgetError: () => false,
+    });
+    const ledger = owner.startReviewActionLedger({
+      candidates,
+      reviewPolicy: "synthetic",
+      shardIndex: 0,
+      shardCount: 1,
+      batchSize: planned.length,
+    });
+    const start = (number) => {
+      const item = candidates.find((item) => item.number === number);
+      owner.startReviewActionLedgerItem(ledger, item);
+      return item;
+    };
+    const finish = (item, status, retryable, extra = {}) =>
+      owner.finishReviewActionLedgerItem({
+        ledger,
+        item,
+        status,
+        reasonCode: status === "completed" ? "completed" : "exception",
+        retryable,
+        cached: status === "cached",
+        startedAtMs: ledger.startedAtMs,
+        ...extra,
+      });
+    const mutation = (item, outcome) => {
+      try {
+        owner.reviewMutationRunner(
+          ledger,
+          item,
+        )({
+          identity: `synthetic-${outcome}`,
+          idempotencyIdentity: `synthetic-${outcome}`,
+          operation: () => {
+            if (outcome === "unknown") throw new Error("synthetic uncertain cleanup");
+            return outcome === "accepted";
+          },
+          didMutate: (result) => result,
+        });
+      } catch (error) {
+        if (error.message !== "synthetic uncertain cleanup") throw error;
+      }
+    };
+    if (kind === "filtered") {
+      start(1);
+    } else {
+      for (const number of [1, 2]) {
+        const item = start(number);
+        const revision = issueSourceRevisionSha256(fixtureIssue(number));
+        const report = `---
+repository: ${kind === "report-identity" && number === 1 ? "example/other" : targetRepo}
+number: ${number}
+type: issue
+title: Synthetic recovery fixture
+url: https://github.com/${targetRepo}/issues/${number}
+author: reporter
+author_association: CONTRIBUTOR
+reviewed_at: ${producerEnv.GITHUB_RUN_STARTED_AT}
+item_updated_at: ${producerEnv.GITHUB_RUN_STARTED_AT}
+item_source_revision: ${revision}
+item_snapshot_hash: synthetic-proof-snapshot
+labels: []
+review_status: complete
+local_checkout_access: verified
+local_checkout_access_source: runner_preflight_v1
+decision: keep_open
+action_taken: kept_open
+close_reason: none
+confidence: high
+work_candidate: none
+work_status: none
+---
+
+# Synthetic recovery fixture
+
+## Summary
+
+Complete retained review.
+`;
+        const reportPath = join(reports, `${number}.md`);
+        writeFileSync(reportPath, report);
+        finish(item, number === 1 ? "completed" : "cached", false, {
+          reportPath,
+          sourceRevision: revision,
+        });
+      }
+      const retryable = start(3);
+      if (kind === "accepted-mutation") mutation(retryable, "accepted");
+      finish(retryable, "failed", true);
+      const deferred = start(4);
+      mutation(deferred, "rejected");
+      finish(deferred, "blocked", true, { completionReason: "coordination_deferred" });
+      const uncertain = start(5);
+      mutation(uncertain, "unknown");
+      finish(uncertain, "failed", true);
+      const late = start(6);
+      finish(late, "failed", true);
+      // Match producer cleanup order: another item fails before earlier-item cleanup.
+      start(7);
+      mutation(late, "unknown");
+      if (kind === "late-completed") mutation(candidates[0], "unknown");
+    }
+    const activeItem = candidates.find((item) => item.number === (kind === "filtered" ? 1 : 7));
+    const error = new AgentInputScanError("findings");
+    owner.finishReviewActionLedger({
+      ledger,
+      error,
+      activeItem,
+      completedCount: kind === "filtered" ? 0 : 2,
+      cacheHits: kind === "filtered" ? 0 : 1,
+    });
+    await flushWorkflowActionEvents(root, { outputRoot: ledgerDir });
+    return {
+      planned,
+      selected: candidates.map((item) => item.number),
+      ledgerDir,
+      reports,
+      originalReviewExit: agentInputScanFailureExitCode(error),
+    };
+  } finally {
+    process.env = originalEnv;
+  }
+}
+
+export function rewriteLedger(ledgerDir, transform, partCount = 1) {
+  const files = readdirSync(ledgerDir, { recursive: true }).filter((name) =>
+    name.endsWith(".jsonl"),
+  );
+  const events = files.flatMap((name) => readActionEventShard(join(ledgerDir, name)));
+  const modified = transform(events).map((event) =>
+    createActionEvent({
+      eventKey: event.event_key,
+      operationId: event.operation_id,
+      attemptId: event.attempt_id,
+      parentEventId: event.parent_event_id,
+      phaseSeq: event.phase_seq,
+      idempotencyKeySha256: event.idempotency_key_sha256,
+      type: event.event_type,
+      producer: {
+        component: event.producer.component,
+        repository: event.producer.repository,
+        sha: event.producer.sha,
+        workflow: event.producer.workflow,
+        job: event.producer.job,
+        runId: event.producer.run_id,
+        runAttempt: event.producer.run_attempt,
+      },
+      subject: {
+        repository: event.subject.repository,
+        kind: event.subject.kind,
+        ...(event.subject.number ? { number: event.subject.number } : {}),
+        ...(event.subject.source_revision ? { sourceRevision: event.subject.source_revision } : {}),
+      },
+      action: {
+        name: event.action.name,
+        status: event.action.status,
+        retryable: event.action.retryable,
+        mutation: event.action.mutation,
+        reasonCode: event.action.reason_code,
+      },
+      attributes: event.attributes,
+      evidence: event.evidence?.map((entry) => ({
+        kind: entry.kind,
+        ...(entry.sha256 ? { sha256: entry.sha256 } : {}),
+        ...(entry.run_url ? { runUrl: entry.run_url } : {}),
+      })),
+      privacy: {
+        classification: event.privacy.classification,
+        redactionVersion: event.privacy.redaction_version,
+        fieldsDropped: event.privacy.fields_dropped,
+      },
+    }),
+  );
+  const producer = modified[0].producer;
+  const identity = {
+    repository: producer.repository,
+    sha: producer.sha,
+    workflow: producer.workflow,
+    job: producer.job,
+    runId: producer.run_id,
+    runAttempt: producer.run_attempt,
+    producer: producer.component,
+    partitionDate: "2026-09-08",
+  };
+  rmSync(ledgerDir, { recursive: true });
+  mkdirSync(ledgerDir);
+  writeActionEventShard(ledgerDir, identity, modified, 1, partCount);
+}
+
+export function perturbFixture(seeded, kind) {
+  if (kind === "missing") {
+    rmSync(seeded.ledgerDir, { recursive: true });
+    mkdirSync(seeded.ledgerDir);
+  } else if (kind === "incomplete") {
+    rewriteLedger(seeded.ledgerDir, (events) => events, 2);
+  } else if (kind === "report-digest") {
+    appendFileSync(join(seeded.reports, "1.md"), "\nChanged after the recorded terminal.\n");
+  } else if (kind === "foreign-batch") {
+    rewriteLedger(seeded.ledgerDir, (events) =>
+      events.map((event) => {
+        if (event.event_type !== "review.batch" || event.phase_seq !== 1_000_000) return event;
+        const operationId = actionOperationId(targetRepo, "review", { fixture: "foreign-batch" });
+        return {
+          ...event,
+          operation_id: operationId,
+          attempt_id: actionAttemptId(operationId, { fixture: "foreign-batch" }),
+        };
+      }),
+    );
+  } else if (kind === "ambiguous") {
+    rewriteLedger(seeded.ledgerDir, (events) => {
+      const terminal = events.find(
+        (event) => event.subject.number === 3 && event.attributes?.duration_ms !== undefined,
+      );
+      const phase =
+        Math.max(
+          ...events.filter((event) => event.phase_seq < 1_000_000).map((event) => event.phase_seq),
+        ) + 1;
+      return [
+        ...events,
+        {
+          ...terminal,
+          event_key: actionEventKey("synthetic.duplicate-terminal", { number: 3 }),
+          phase_seq: phase,
+          parent_event_id: terminal.event_id,
+        },
+      ];
+    });
+  } else if (
+    [
+      "unmatched",
+      "mutation-only",
+      "unsupported",
+      "missing-terminal",
+      "wrong-shard",
+      "receipt-reason",
+    ].includes(kind)
+  ) {
+    rewriteLedger(seeded.ledgerDir, (events) =>
+      events.flatMap((event) => {
+        if (
+          kind === "unmatched" &&
+          event.subject.number === 6 &&
+          event.attributes?.completion_reason === "mutation_outcome_unknown"
+        )
+          return [];
+        if (
+          kind === "missing-terminal" &&
+          event.event_type === "review.batch" &&
+          event.phase_seq === 1_000_000
+        )
+          return [];
+        if (
+          kind === "mutation-only" &&
+          event.subject.number === 3 &&
+          event.attributes?.review_mode === "propose" &&
+          event.action.status === "failed"
+        )
+          return [];
+        if (
+          kind === "unsupported" &&
+          event.subject.number === 3 &&
+          event.attributes?.duration_ms !== undefined
+        ) {
+          const { duration_ms, ...attributes } = event.attributes;
+          return [{ ...event, attributes }];
+        }
+        if (kind === "wrong-shard" && event.attributes?.shard_index === 0) {
+          return [{ ...event, attributes: { ...event.attributes, shard_index: 1 } }];
+        }
+        if (
+          kind === "receipt-reason" &&
+          event.subject.number === 4 &&
+          event.action.status === "skipped"
+        ) {
+          return [{ ...event, action: { ...event.action, reason_code: "completed" } }];
+        }
+        return [event];
+      }),
+    );
+  }
+}
+
+if (process.argv[2] === "--produce-failure") {
+  const result = await fixture(process.argv[3], process.argv[4]);
+  perturbFixture(result, process.argv[4]);
+  console.log(JSON.stringify(result));
+  process.exitCode = result.originalReviewExit;
+}

--- a/docs/proof/aggregate-review-recovery/run-proof.mjs
+++ b/docs/proof/aggregate-review-recovery/run-proof.mjs
@@ -1,0 +1,538 @@
+import assert from "node:assert/strict";
+import { spawn, execFileSync } from "node:child_process";
+import { createHmac } from "node:crypto";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import YAML from "yaml";
+import { baselineSha, targetRepo, digest, producerEnv, fixtureIssue } from "./fixture.mjs";
+
+const repo = resolve(import.meta.dirname, "../../..");
+const baseline = process.argv.includes("--baseline");
+const source = baseline
+  ? execFileSync("git", ["show", `${baselineSha}:.github/workflows/sweep.yml`], {
+      cwd: repo,
+      encoding: "utf8",
+    })
+  : readFileSync(join(repo, ".github/workflows/sweep.yml"), "utf8");
+const workflow = YAML.parse(source);
+const temp = realpathSync(mkdtempSync(join(tmpdir(), "review-recovery-proof-")));
+const secret = "synthetic-recovery-proof-only";
+const receipt = {
+  baseline,
+  baseline_sha: baselineSha,
+  head_sha: execFileSync("git", ["rev-parse", "HEAD"], { cwd: repo, encoding: "utf8" }).trim(),
+  workflow_sha256: digest(source),
+  fixture_sha256: digest(readFileSync(join(import.meta.dirname, "fixture.mjs"))),
+  harness_sha256: digest(readFileSync(import.meta.filename)),
+  recovery_source_sha256: digest(readFileSync(join(repo, "src/review-recovery.ts"))),
+  scenarios: [],
+};
+
+async function scenario(kind, ack = "accepted") {
+  const root = join(temp, `${kind}-${ack}`);
+  mkdirSync(root, { recursive: true });
+  const produced = await run(
+    process.execPath,
+    [
+      join(import.meta.dirname, "fixture.mjs"),
+      "--produce-failure",
+      join(root, "review-producer"),
+      kind,
+    ],
+    {
+      cwd: repo,
+      env: { PATH: process.env.PATH, HOME: root },
+    },
+  );
+  assert.equal(produced.code, 79, produced.stderr);
+  const seeded = JSON.parse(produced.stdout);
+  for (const name of ["dist", "config", "schema", "prompts", "package.json"]) {
+    cpSync(join(repo, name), join(root, name), { recursive: true });
+  }
+  for (const name of ["yaml", "yauzl"]) {
+    cpSync(realpathSync(join(repo, "node_modules", name)), join(root, "node_modules", name), {
+      recursive: true,
+    });
+  }
+  cpSync(seeded.ledgerDir, join(root, "recovery-ledgers/action-ledger-review-0"), {
+    recursive: true,
+  });
+  const requests = [];
+  const failures = [];
+  const comments = new Map();
+  const recordKeys = new Set();
+  const blobs = new Map();
+  const provePublication =
+    !baseline && ack === "accepted" && ["mixed", "late-completed"].includes(kind);
+  const server = createServer(async (request, response) => {
+    try {
+      let raw = "";
+      for await (const chunk of request) raw += chunk;
+      if (request.url === "/gh") {
+        const input = JSON.parse(raw);
+        const args = input.args[0] === "--repo" ? input.args.slice(2) : input.args;
+        const path = args.includes("-i") ? args[args.indexOf("-i") + 1] : args[1];
+        const method = args.includes("--method") ? args[args.indexOf("--method") + 1] : "GET";
+        const number = path?.match(/^repos\/openclaw\/clawsweeper\/issues\/([12])(?:\/|\?|$)/)?.[1];
+        const issue = {
+          ...fixtureIssue(number),
+          comments: (comments.get(number) ?? []).length,
+        };
+        let value;
+        if (args[0] === "api" && number && /\/issues\/[12]$/.test(path) && method === "GET") {
+          value = issue;
+        } else if (
+          provePublication &&
+          args[0] === "api" &&
+          number &&
+          /\/comments(?:\?|$)/.test(path)
+        ) {
+          const rows = comments.get(number) ?? [];
+          if (method === "POST") {
+            value = {
+              id: 9000 + Number(number),
+              body: input.payload.body,
+              user: { login: "clawsweeper[bot]" },
+              created_at: producerEnv.GITHUB_RUN_STARTED_AT,
+              updated_at: producerEnv.GITHUB_RUN_STARTED_AT,
+              html_url: `https://github.com/${targetRepo}/issues/${number}#issuecomment-${9000 + Number(number)}`,
+            };
+            rows.push(value);
+            comments.set(number, rows);
+          } else {
+            assert.equal(method, "GET");
+            value = args.includes("--slurp") ? [rows] : rows;
+          }
+        } else if (
+          provePublication &&
+          args[0] === "api" &&
+          number &&
+          /\/timeline(?:\?|$)/.test(path)
+        ) {
+          assert.equal(method, "GET");
+          value = args.includes("--slurp") ? [[]] : [];
+        } else if (provePublication && args[0] === "api" && path.startsWith("search/issues?")) {
+          assert.equal(method, "GET");
+          value = { total_count: 0, items: [] };
+        } else if (
+          provePublication &&
+          args[0] === "api" &&
+          /\/collaborators\/reporter\/permission$/.test(path)
+        ) {
+          assert.equal(method, "GET");
+          value = { permission: "read" };
+        } else if (provePublication && args[0] === "issue" && args[1] === "view") {
+          value = { closedByPullRequestsReferences: [] };
+        } else if (provePublication && args[0] === "label" && args[1] === "create") {
+          value = { name: args[2] };
+        } else if (provePublication && args[0] === "issue" && args[1] === "edit") {
+          value = "";
+        } else assert.fail("unexpected publisher GitHub command");
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(
+          JSON.stringify({ stdout: typeof value === "string" ? value : JSON.stringify(value) }),
+        );
+        return;
+      }
+      assert.equal(
+        request.headers["x-clawsweeper-exact-review-signature"],
+        `sha256=${createHmac("sha256", secret).update(raw).digest("hex")}`,
+      );
+      if (
+        [
+          "/internal/state/github-read-model/item",
+          "/internal/state/github-read-model/repair",
+        ].includes(request.url)
+      ) {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({ ok: true, usable: false, hit: false }));
+        return;
+      }
+      if (provePublication && request.url === "/internal/state/records/tuples") {
+        const body = JSON.parse(raw);
+        assert.match(body.key, /^openclaw-clawsweeper\/[12]$/);
+        recordKeys.add(body.key);
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({ ok: true, revision: 1, deduped: false }));
+        return;
+      }
+      if (provePublication && request.url === "/internal/state/blobs/put") {
+        const body = JSON.parse(raw);
+        assert.equal(digest(Buffer.from(body.contentBase64, "base64")), body.digest);
+        const prior = blobs.get(body.path);
+        assert.ok(!prior || prior === body.digest, "receipt replay must be immutable");
+        blobs.set(body.path, body.digest);
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({ unchanged: prior === body.digest }));
+        return;
+      }
+      assert.equal(request.url, "/internal/exact-review/enqueue");
+      const body = JSON.parse(raw);
+      assert.equal(body.decision.supersedesInProgress, false);
+      assert.equal(
+        body.delivery_id,
+        `router:failed-review-recovery-123456-1-${body.decision.itemNumber}`,
+      );
+      requests.push(body.decision.itemNumber);
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify(
+          {
+            accepted: { ok: true, queued: true },
+            deduped: { ok: true, deduped: true },
+            shed: { ok: true, shed: true },
+            disabled: { ok: true, accepted: false },
+            failed: { ok: false },
+          }[ack],
+        ),
+      );
+    } catch (error) {
+      failures.push(error.message);
+      response.writeHead(500).end();
+    }
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  try {
+    mkdirSync(join(root, "failed-review-shards"));
+    writeFileSync(join(root, "failed-review-shards/shard-0.json"), '{"shard":0}');
+    const values = {
+      "needs.plan.outputs.target_repo": targetRepo,
+      "needs.plan.outputs.target_branch": "main",
+      "needs.plan.outputs.codex_timeout_ms": "1200000",
+      "needs.plan.outputs.planned_shards": "1",
+      "matrix.shard": "0",
+    };
+    const command = workflow.jobs["recover-review-failures"].steps.find((step) =>
+      step.name?.startsWith("Requeue "),
+    );
+    assert.ok(command);
+    const resolveScript = (text) =>
+      text.replace(/\$\{\{\s*(.*?)\s*\}\}/g, (_, key) => {
+        assert.ok(key in values, `unbound workflow expression: ${key}`);
+        return values[key];
+      });
+    const script = resolveScript(command.run);
+    const endpoint = `http://127.0.0.1:${server.address().port}`;
+    const env = {
+      PATH: process.env.PATH,
+      HOME: root,
+      ...producerEnv,
+      GH_TOKEN: "synthetic",
+      QUEUE_URL: endpoint,
+      PROOF_ENDPOINT: endpoint,
+      CLAWSWEEPER_WEBHOOK_SECRET: secret,
+      ADDITIONAL_PROMPT: "",
+      MATRIX_JSON: JSON.stringify([{ shard: 0, item_numbers: seeded.planned.join(",") }]),
+      GITHUB_STEP_SUMMARY: join(root, "summary.md"),
+      NODE_OPTIONS: `--import=${join(repo, "docs/proof/review-publisher-ledger-isolation/local-transport.mjs")}`,
+      GH_BIN: process.execPath,
+      GH_BIN_ARGS: JSON.stringify([
+        join(repo, "docs/proof/review-publisher-ledger-isolation/local-transport.mjs"),
+      ]),
+    };
+    if (kind === "foreign-attempt") env.GITHUB_RUN_ATTEMPT = "2";
+    if (kind === "foreign-sha") env.GITHUB_SHA = "a".repeat(40);
+    const holdAll = [
+      "filtered",
+      "foreign-attempt",
+      "foreign-sha",
+      "missing",
+      "incomplete",
+      "wrong-shard",
+      "missing-terminal",
+      "foreign-batch",
+    ].includes(kind);
+    let staged = [];
+    if (!baseline) {
+      cpSync(seeded.ledgerDir, join(root, "runner/clawsweeper-action-ledger/123456/1/review"), {
+        recursive: true,
+      });
+      cpSync(seeded.reports, join(root, "review-artifacts/shard-0"), { recursive: true });
+      mkdirSync(join(root, "clawsweeper"));
+      for (const name of ["dist", "config", "node_modules", "package.json"]) {
+        cpSync(join(root, name), join(root, "clawsweeper", name), { recursive: true });
+      }
+      const prefix = workflow.jobs.review.steps.find((entry) => entry.id === "completed-prefix");
+      assert.ok(prefix);
+      const result = await run("bash", ["-e", "-o", "pipefail", "-c", resolveScript(prefix.run)], {
+        cwd: join(root, "clawsweeper"),
+        env: {
+          ...env,
+          RUNNER_TEMP: join(root, "runner"),
+          TARGET_REPO: targetRepo,
+          ITEM_NUMBERS: seeded.planned.join(","),
+        },
+      });
+      assert.equal(result.code, 0, result.stderr);
+      const stagedDir = join(root, "review-artifacts/completed-0");
+      staged = existsSync(stagedDir) ? readdirSync(stagedDir).sort() : [];
+      assert.deepEqual(
+        staged,
+        holdAll
+          ? []
+          : ["late-completed", "report-identity", "report-digest"].includes(kind)
+            ? ["2.md"]
+            : ["1.md", "2.md"],
+      );
+      for (const filename of staged) {
+        assert.equal(
+          readFileSync(join(stagedDir, filename), "utf8"),
+          readFileSync(join(seeded.reports, filename), "utf8"),
+        );
+      }
+      // The real apply-artifacts CLI, not an alternate copy path, consumes the retained prefix.
+      if (staged.length) {
+        mkdirSync(join(root, ".artifacts/baseline"), { recursive: true });
+        mkdirSync(join(root, "publisher-ledger"));
+        const publisherEnv = {
+          ...env,
+          GITHUB_JOB: "publish",
+          CLAWSWEEPER_ACTION_LEDGER_FORCE: provePublication ? "1" : "0",
+          CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT: join(root, "publisher-ledger"),
+          CLAWSWEEPER_CANONICAL_RECORD_BASELINE_DIR: join(root, ".artifacts/baseline"),
+        };
+        const publishReceipt = async (name) => {
+          const priorBlobCount = blobs.size;
+          const step = workflow.jobs.publish.steps.find((entry) => entry.name === name);
+          assert.ok(step);
+          const cli =
+            'pnpm() { shift; [ "$1" = "--silent" ] && shift; local command="$1"; shift; [ "${1:-}" = "--" ] && shift; node dist/clawsweeper.js "$command" "$@"; }';
+          const outcome = await run("bash", ["-e", "-o", "pipefail", "-c", `${cli}\n${step.run}`], {
+            cwd: root,
+            env: publisherEnv,
+          });
+          assert.equal(outcome.code, 0, outcome.stderr);
+          assert.ok(blobs.size > priorBlobCount, `${name} must publish its own required receipts`);
+        };
+        const applied = await run(
+          process.execPath,
+          [
+            "dist/clawsweeper.js",
+            "apply-artifacts",
+            "--artifact-dir",
+            stagedDir,
+            "--target-repo",
+            targetRepo,
+            "--skip-dashboard",
+            "--skip-reconcile",
+          ],
+          { cwd: root, env: publisherEnv },
+        );
+        assert.equal(applied.code, 0, applied.stderr);
+        if (provePublication) await publishReceipt("Publish review artifact action ledger");
+        const reconciled = await run(
+          process.execPath,
+          [
+            "dist/clawsweeper.js",
+            "reconcile",
+            "--target-repo",
+            targetRepo,
+            "--item-numbers",
+            staged.map((name) => name.slice(0, -3)).join(","),
+            "--only-item-numbers",
+            "--skip-closed-at",
+          ],
+          { cwd: root, env: publisherEnv },
+        );
+        assert.equal(reconciled.code, 0, reconciled.stderr);
+        assert.deepEqual(
+          readdirSync(join(root, "records/openclaw-clawsweeper/items"))
+            .filter((name) => name.endsWith(".md"))
+            .sort(),
+          staged,
+        );
+        if (provePublication) {
+          const committed = await run(
+            process.execPath,
+            [
+              "dist/repair/publish-main.js",
+              "--message",
+              "proof completed prefix",
+              "--path",
+              "records/openclaw-clawsweeper",
+              "--rebase-strategy",
+              "normal",
+            ],
+            { cwd: root, env: publisherEnv },
+          );
+          assert.equal(committed.code, 0, committed.stderr);
+          assert.deepEqual(
+            [...recordKeys].sort(),
+            staged.map((name) => `openclaw-clawsweeper/${name.slice(0, -3)}`),
+          );
+          const synced = await run(
+            process.execPath,
+            [
+              "dist/clawsweeper.js",
+              "apply-decisions",
+              "--target-repo",
+              targetRepo,
+              "--skip-dashboard",
+              "--item-numbers",
+              staged.map((name) => name.slice(0, -3)).join(","),
+              "--sync-comments-only",
+              "--apply-kind",
+              "all",
+              "--limit",
+              "0",
+              "--processed-limit",
+              String(staged.length),
+              "--comment-sync-min-age-days",
+              "0",
+            ],
+            { cwd: root, env: publisherEnv },
+          );
+          assert.equal(synced.code, 0, synced.stderr);
+          assert.deepEqual(
+            [...comments.keys()].sort(),
+            staged.map((name) => name.slice(0, -3)),
+            `${synced.stderr}\n${readFileSync(join(root, "apply-report.json"), "utf8")}`,
+          );
+          assert.ok([...comments.values()].every((rows) => rows.length === 1));
+          await publishReceipt("Publish selected review comment action ledger");
+          assert.ok(blobs.size > 0, "required publisher receipt blobs reached the signed endpoint");
+        }
+      }
+    }
+    const child = spawn("bash", ["-e", "-o", "pipefail", "-c", script], {
+      cwd: root,
+      env,
+      timeout: 90_000,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "",
+      stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    const code = await new Promise((resolve, reject) => {
+      child.once("error", reject);
+      child.once("close", resolve);
+    });
+    assert.deepEqual(failures, []);
+    assert.equal(code, ack === "failed" ? 1 : 0, stderr);
+    const intended = holdAll
+      ? []
+      : ["mutation-only", "unsupported", "ambiguous"].includes(kind)
+        ? [4]
+        : kind === "receipt-reason"
+          ? [3]
+          : [3, 4];
+    const unique = [...new Set(requests)].sort((a, b) => a - b);
+    if (baseline) {
+      assert.deepEqual(unique, seeded.planned);
+      assert.ok(
+        unique.includes(kind === "filtered" ? 1 : 7),
+        "original must enqueue terminal refusal",
+      );
+    } else {
+      assert.deepEqual(unique, intended, "only native retryable item terminals may enqueue");
+      assert.equal(requests.length, intended.length * (ack === "failed" ? 3 : 1));
+      const summary = readFileSync(env.GITHUB_STEP_SUMMARY, "utf8");
+      assert.match(
+        summary,
+        /Review step failed; retained reports still require normal publisher guards/,
+      );
+      if (intended.length) {
+        const message = {
+          accepted: "recovery admission queued",
+          deduped: "recovery admission deduplicated",
+          shed: "Recovery shed by exact-review queue backpressure",
+          disabled: "Recovery skipped because the target is disabled",
+          failed: "Unable to queue failed review recovery for item numbers: 3 4",
+        }[ack];
+        assert.ok(summary.includes(message), "the actual acknowledgement remains operator-visible");
+      }
+    }
+    receipt.scenarios.push({
+      kind,
+      acknowledgement: ack,
+      planned: seeded.planned,
+      selected: seeded.selected,
+      original_review_exit: produced.code,
+      recovery_exit: code,
+      requests,
+      retained_reports: staged,
+      published_records: [...recordKeys].sort(),
+      published_comments: [...comments.keys()].sort(),
+      required_receipt_blobs: blobs.size,
+      original_failure_visible: baseline ? "producer exit only" : true,
+      terminal_exclusion: baseline ? "FAIL (intended baseline)" : "PASS",
+    });
+    console.error(
+      `${baseline ? "baseline" : "candidate"} ${kind}/${ack}: ${requests.length} requests, ${staged.length} retained reports`,
+    );
+    return { root, seeded, stdout, stderr };
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+function run(command, args, options) {
+  const child = spawn(command, args, {
+    ...options,
+    timeout: 60_000,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stdout = "",
+    stderr = "";
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk;
+  });
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+  return new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+try {
+  await scenario("mixed");
+  await scenario("filtered");
+  if (!baseline) {
+    for (const ack of ["deduped", "shed", "disabled", "failed"]) await scenario("mixed", ack);
+    for (const kind of [
+      "late-completed",
+      "unmatched",
+      "accepted-mutation",
+      "mutation-only",
+      "unsupported",
+      "ambiguous",
+      "receipt-reason",
+      "missing",
+      "incomplete",
+      "missing-terminal",
+      "foreign-batch",
+      "foreign-attempt",
+      "foreign-sha",
+      "wrong-shard",
+      "report-identity",
+      "report-digest",
+    ]) {
+      await scenario(kind);
+    }
+  }
+  const output = process.argv.indexOf("--output");
+  if (output >= 0)
+    writeFileSync(resolve(process.argv[output + 1]), `${JSON.stringify(receipt, null, 2)}\n`);
+  console.log(JSON.stringify(receipt, null, 2));
+} finally {
+  rmSync(temp, { recursive: true, force: true });
+}

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -892,17 +892,34 @@ dispatches another `sweep.yml` run with the same lane inputs. The 5-minute
 normal schedule is still the safety net if continuation dispatch fails or GitHub
 delays it.
 
-If review shards fail, the recovery job reads failed shard artifacts or failed
-job names, extracts their planned item numbers from the original matrix, and
-requeues those exact item numbers once with a recovery marker in the additional
-prompt.
+If review shards fail, failed-shard artifacts or failed job names identify the
+shards to inspect, not the items to retry. Recovery reads each complete
+producer artifact through the canonical ledger importer, binding the exact
+repository, source SHA, workflow, job, run, attempt, and matrix shard. Only a
+recognized owner-recorded retryable **item terminal** with no unresolved
+mutation is admitted once through the existing signed exact-review queue.
+Batch failures and mutation receipts are not retry authority. The whole item
+chain is inspected, including cleanup after an earlier terminal.
 
-Review shard jobs are allowed to finish as recovered failures instead of making
-the whole sweep appear broken when the recovery job can requeue exact item
-numbers. Each shard uploads a small metrics artifact with item numbers, target
-repo, start/end timestamps, and review-step outcome. Publish includes artifact
-and metric counts in the status detail so setup noise, missing artifacts, and
-real review failures can be separated while monitoring.
+Completed/cached and nonretryable items are never requeued. Missing, corrupt,
+incomplete, ambiguous, uncertain, unselected, and unstarted evidence stays held.
+Automatic unstarted-tail recovery is a named follow-up: the current ledger
+does not record that membership, so the original matrix cannot authorize it.
+Each item has a visible disposition; queue acknowledgements distinguish queued,
+deduplicated, shed, disabled, and failed admission. None means review or
+publication succeeded.
+
+Before uploading a failed shard, the same projection stages only completed
+reports whose native terminal digest, repository/item/source identity, complete
+review status, and verified checkout provenance match. The existing publisher
+consumes those reports through its normal guards and required receipts.
+Recovery does not depend on the optional ledger-upload job.
+
+The original failed review-step outcome and failed-shard metrics remain visible;
+the existing job-level `continue-on-error` policy is unchanged and must not be
+read as all items recovered. Metrics retain item numbers, target repository,
+timestamps, and review-step outcome. Publish includes artifact and metric
+counts so setup noise, missing artifacts, and actual failures remain distinct.
 
 Each item report also records durable review cost proxies in front matter and a
 `Review Telemetry` section: prompt characters, static prompt characters, GitHub

--- a/src/clawsweeper-review-command-workflow.ts
+++ b/src/clawsweeper-review-command-workflow.ts
@@ -1540,7 +1540,7 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
         throw new Error(
           `Could not acquire durable review coordination for ${leaseAcquisitionFailures} item${
             leaseAcquisitionFailures === 1 ? "" : "s"
-          }; the workflow recovery lane can requeue the planned set. ${leaseAcquisitionFailureDetails.join("; ")}`,
+          }; the workflow recovery lane can requeue evidence-backed retryable items. ${leaseAcquisitionFailureDetails.join("; ")}`,
         );
       }
       if (reviewTreeCleanupFailures.length > 0) {
@@ -1555,7 +1555,7 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
         }
         const message = `Codex failed for ${codexFailures} item${
           codexFailures === 1 ? "" : "s"
-        }; local failure reports were written and the workflow recovery lane can requeue the planned set.${
+        }; local failure reports were written and the workflow recovery lane can requeue evidence-backed retryable items.${
           codexFailureReports.length > 0
             ? ` Report${codexFailureReports.length === 1 ? "" : "s"}: ${codexFailureReports
                 .map(displayPath)

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -19,6 +19,7 @@ import {
   isSelectableApplyCloseAction,
 } from "../apply-close-actions.js";
 import { repositoryProfileFor, slugForRepo } from "../repository-profiles.js";
+import { recoverReviewShard } from "../review-recovery.js";
 
 type ApplyAction = {
   action: string;
@@ -180,6 +181,31 @@ async function runCli(): Promise<void> {
     case "artifact-item-numbers":
       process.stdout.write(artifactItemNumbers(requiredString("artifact-dir")).join(","));
       break;
+    case "review-recovery": {
+      const result = recoverReviewShard({
+        ledgerDir: path.resolve(requiredString("ledger-dir")),
+        targetRepo: requiredString("target-repo"),
+        shard: nonNegativeIntegerArg("shard"),
+        shardCount: positiveIntegerArg("shard-count"),
+        itemNumbers: csvItems(requiredString("item-numbers")).map(Number),
+        expectedProducer: {
+          repository: requiredString("producer-repository"),
+          sha: requiredString("producer-sha"),
+          workflow: "sweep.yml",
+          job: "review",
+          runId: requiredString("run-id"),
+          runAttempt: positiveIntegerArg("run-attempt"),
+        },
+        ...(optionalString("reports-dir") || optionalString("stage-dir")
+          ? {
+              reportsDir: path.resolve(requiredString("reports-dir")),
+              stageDir: path.resolve(requiredString("stage-dir")),
+            }
+          : {}),
+      });
+      console.log(JSON.stringify(result));
+      break;
+    }
     case "count-csv":
       console.log(csvItems(optionalString("items")).length);
       break;

--- a/src/review-recovery.ts
+++ b/src/review-recovery.ts
@@ -1,0 +1,386 @@
+import { mkdirSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { sha256 } from "./content-hash.js";
+import { type ActionEvent, readActionEventShardAt } from "./action-ledger.js";
+import {
+  importActionEventShards,
+  type ExpectedActionEventProducer,
+} from "./action-ledger-runtime.js";
+import {
+  prepareSafeReadTarget,
+  prepareSafeWriteTarget,
+  readUtf8FileNoFollow,
+  writeUtf8FileCreateOnlyNoFollow,
+} from "./action-ledger-files.js";
+import { readReportFrontMatterField } from "./report-front-matter.js";
+
+type Disposition = "completed" | "terminal" | "retryable" | "held";
+type RecoveryItem = {
+  number: number;
+  disposition: Disposition;
+  reason: string;
+  publication: "not_requested" | "staged" | "held";
+};
+
+export type ReviewRecoveryOptions = {
+  ledgerDir: string;
+  expectedProducer: Extract<ExpectedActionEventProducer, { runAttempt: number }>;
+  targetRepo: string;
+  shard: number;
+  shardCount: number;
+  itemNumbers: readonly number[];
+  reportsDir?: string;
+  stageDir?: string;
+};
+
+// These shapes belong to createReviewActionLedger, not the interruption finalizer.
+// Unknown variants stay held; mutation receipts must never become item terminals.
+function attributesAre(event: ActionEvent, required: string[], optional: string[] = []): boolean {
+  const attributes = event.attributes ?? {};
+  return (
+    required.every((key) => key in attributes) &&
+    Object.keys(attributes).every((key) => required.includes(key) || optional.includes(key))
+  );
+}
+
+function nativeTerminal(event: ActionEvent): boolean {
+  return (
+    event.event_type === "review.item" &&
+    ["completed", "cached", "failed", "blocked", "cancelled", "yielded"].includes(
+      event.action.status,
+    ) &&
+    attributesAre(
+      event,
+      ["cached", "duration_ms", "review_mode"],
+      ["finding_count", "completion_reason"],
+    ) &&
+    event.attributes?.cached === (event.action.status === "cached") &&
+    typeof event.attributes.duration_ms === "number" &&
+    event.attributes.duration_ms >= 0 &&
+    event.attributes.review_mode === "propose"
+  );
+}
+
+function itemDisposition(
+  events: ActionEvent[],
+  batch: ActionEvent,
+): {
+  disposition: Disposition;
+  reason: string;
+  terminal?: ActionEvent;
+} {
+  const held = (reason: string) => ({ disposition: "held" as const, reason });
+  const start = events[0];
+  if (!start) return held("unstarted_or_unselected");
+  if (
+    start.event_type !== "review.item" ||
+    start.action.status !== "started" ||
+    start.action.retryable ||
+    start.action.mutation ||
+    start.action.reason_code !== "selected" ||
+    start.parent_event_id !== batch.event_id ||
+    !attributesAre(start, ["batch_index", "review_mode"]) ||
+    start.attributes?.review_mode !== "propose" ||
+    !Number.isSafeInteger(start.attributes.batch_index) ||
+    Number(start.attributes.batch_index) < 0 ||
+    Number(start.attributes.batch_index) >= Number(batch.attributes?.candidate_count)
+  )
+    return held("unrecognized_item_start");
+  let parent = start.event_id;
+  let terminal: ActionEvent | undefined;
+  let pending: ActionEvent | undefined;
+  let mutationObserved = false;
+  let uncertain = false;
+  let mutationCount = 0;
+  let logs = 0;
+  for (const event of events.slice(1)) {
+    if (event.parent_event_id !== parent || event.subject.kind !== start.subject.kind) {
+      return held("ambiguous_item_chain");
+    }
+    parent = event.event_id;
+    if (event.event_type === "review.log_publication") {
+      if (
+        ++logs !== 1 ||
+        terminal ||
+        pending ||
+        event.action.mutation ||
+        !attributesAre(event, ["cached", "log_count", "log_kind", "publication_kind"]) ||
+        event.attributes?.log_kind !== "codex" ||
+        event.attributes.publication_kind !== "local_artifact"
+      )
+        return held("unrecognized_log_phase");
+    } else if (nativeTerminal(event)) {
+      if (terminal || pending || logs !== 1 || event.action.mutation !== mutationObserved) {
+        return held("ambiguous_item_terminal");
+      }
+      terminal = event;
+    } else if (
+      event.event_type === "review.item" &&
+      attributesAre(event, [
+        "batch_index",
+        "attempt",
+        "action_count",
+        "partial",
+        "completion_reason",
+      ]) &&
+      event.attributes?.batch_index === start.attributes.batch_index
+    ) {
+      const attrs = event.attributes!;
+      if (attrs.completion_reason === "mutation_attempted") {
+        if (
+          pending ||
+          event.action.status !== "started" ||
+          !event.action.retryable ||
+          event.action.mutation ||
+          event.action.reason_code !== "selected" ||
+          attrs.partial !== true ||
+          attrs.action_count !== 1 ||
+          attrs.attempt !== ++mutationCount
+        )
+          return held("unrecognized_mutation_attempt");
+        pending = event;
+      } else {
+        if (
+          !pending ||
+          pending.event_id !== event.parent_event_id ||
+          pending.idempotency_key_sha256 !== event.idempotency_key_sha256 ||
+          attrs.attempt !== pending.attributes?.attempt
+        )
+          return held("unmatched_mutation_outcome");
+        const accepted =
+          attrs.completion_reason === "mutation_accepted" &&
+          event.action.status === "executed" &&
+          event.action.reason_code === "completed" &&
+          !event.action.retryable &&
+          event.action.mutation &&
+          attrs.partial === false &&
+          attrs.action_count === 1;
+        const rejected =
+          attrs.completion_reason === "mutation_rejected" &&
+          event.action.status === "skipped" &&
+          event.action.reason_code === "not_applicable" &&
+          !event.action.retryable &&
+          !event.action.mutation &&
+          attrs.partial === false &&
+          attrs.action_count === 0;
+        const unknown =
+          attrs.completion_reason === "mutation_outcome_unknown" &&
+          event.action.status === "failed" &&
+          event.action.reason_code === "unavailable" &&
+          event.action.retryable &&
+          event.action.mutation &&
+          attrs.partial === true &&
+          attrs.action_count === 1;
+        if (!accepted && !rejected && !unknown) return held("unrecognized_mutation_outcome");
+        mutationObserved ||= accepted || unknown;
+        uncertain ||= unknown;
+        pending = undefined;
+      }
+    } else return held("unsupported_item_event");
+  }
+  // Cleanup can append receipts after a terminal. Never stop the fold at completion.
+  if (pending || uncertain) return held("unresolved_mutation");
+  if (!terminal) return held("missing_item_terminal");
+  const disposition = ["completed", "cached"].includes(terminal.action.status)
+    ? "completed"
+    : terminal.action.retryable
+      ? "retryable"
+      : "terminal";
+  return { disposition, reason: terminal.action.reason_code ?? terminal.action.status, terminal };
+}
+
+function stageReport(options: ReviewRecoveryOptions, terminal: ActionEvent): void {
+  const number = terminal.subject.number!;
+  const filename = `${number}.md`;
+  const markdown = readUtf8FileNoFollow(
+    prepareSafeReadTarget(options.reportsDir!, filename, "completed review report"),
+    2 * 1024 * 1024,
+  );
+  const evidence = terminal.evidence?.filter((entry) => entry.kind === "review_record") ?? [];
+  const field = (key: string) => {
+    const parsed = readReportFrontMatterField(markdown, key);
+    if (parsed.status !== "value") return "";
+    const value = parsed.value.trim();
+    return value.startsWith('"') ? String(JSON.parse(value)) : value;
+  };
+  const revision = terminal.subject.source_revision;
+  if (
+    evidence.length !== 1 ||
+    evidence[0]?.sha256 !== sha256(markdown) ||
+    field("repository") !== options.targetRepo ||
+    field("number") !== String(number) ||
+    field("type") !== terminal.subject.kind ||
+    field("review_status") !== "complete" ||
+    field("local_checkout_access") !== "verified" ||
+    field("local_checkout_access_source") !== "runner_preflight_v1" ||
+    !revision ||
+    (field("item_source_revision") !== revision &&
+      !(
+        terminal.action.status === "cached" &&
+        terminal.subject.kind === "pull_request" &&
+        field("pull_head_sha") === revision
+      ))
+  )
+    throw new Error("completed report identity, digest, or completion evidence mismatch");
+  const target = prepareSafeWriteTarget(options.stageDir!, filename, "completed review staging");
+  if (
+    writeUtf8FileCreateOnlyNoFollow(target, markdown) === "exists" &&
+    readUtf8FileNoFollow(target, 2 * 1024 * 1024) !== markdown
+  ) {
+    throw new Error("completed review staging conflict");
+  }
+}
+
+export function recoverReviewShard(options: ReviewRecoveryOptions) {
+  if (
+    !Number.isSafeInteger(options.shard) ||
+    options.shard < 0 ||
+    !Number.isSafeInteger(options.shardCount) ||
+    options.shard >= options.shardCount ||
+    options.itemNumbers.length > 10000 ||
+    new Set(options.itemNumbers).size !== options.itemNumbers.length ||
+    options.itemNumbers.some((number) => !Number.isSafeInteger(number) || number < 1) ||
+    Boolean(options.reportsDir) !== Boolean(options.stageDir) ||
+    !Number.isSafeInteger(options.expectedProducer.runAttempt) ||
+    options.expectedProducer.runAttempt < 1 ||
+    options.expectedProducer.maxRunAttempt !== undefined
+  )
+    throw new Error("invalid review recovery shard input");
+  const items: RecoveryItem[] = options.itemNumbers.map((number) => ({
+    number,
+    disposition: "held",
+    reason: "missing_or_invalid_ledger",
+    publication: options.stageDir ? "held" : "not_requested",
+  }));
+  const scratch = realpathSync(mkdtempSync(join(tmpdir(), "clawsweeper-recovery-import-")));
+  let evidenceComplete = false;
+  try {
+    const imported = importActionEventShards(options.ledgerDir, scratch, {
+      expectedProducer: options.expectedProducer,
+    });
+    const events = imported.eventPaths.flatMap((file) => readActionEventShardAt(scratch, file));
+    const batches = events.filter((event) => event.event_type === "review.batch");
+    const start = batches.find((event) => event.action.status === "started");
+    const end = batches.find((event) => event.action.status !== "started");
+    if (
+      batches.length !== 2 ||
+      !start ||
+      !end ||
+      start.phase_seq !== 1 ||
+      start.parent_event_id !== null ||
+      start.action.name !== "review.batch" ||
+      start.action.reason_code !== "selected" ||
+      start.action.retryable ||
+      start.action.mutation ||
+      start.subject.repository !== options.targetRepo ||
+      start.subject.kind !== "workflow" ||
+      !attributesAre(start, [
+        "candidate_count",
+        "batch_size",
+        "shard_index",
+        "shard_count",
+        "review_mode",
+      ]) ||
+      start.attributes?.shard_index !== options.shard ||
+      start.attributes.shard_count !== options.shardCount ||
+      start.attributes.review_mode !== "propose" ||
+      !Number.isSafeInteger(start.attributes.candidate_count) ||
+      Number(start.attributes.candidate_count) < 0 ||
+      Number(start.attributes.candidate_count) > options.itemNumbers.length ||
+      end.phase_seq !== 1_000_000 ||
+      end.parent_event_id !== start.event_id ||
+      end.subject.repository !== options.targetRepo ||
+      end.subject.kind !== "workflow" ||
+      !["completed", "failed", "cancelled", "yielded"].includes(end.action.status) ||
+      !attributesAre(end, [
+        "candidate_count",
+        "processed_count",
+        "skipped_count",
+        "failed_count",
+        "duration_ms",
+        "cached",
+        "partial",
+        "completion_reason",
+        "review_mode",
+      ]) ||
+      end.attributes?.candidate_count !== start.attributes.candidate_count ||
+      end.attributes?.review_mode !== "propose"
+    )
+      return summarize();
+    const phases = events.filter(
+      (event) =>
+        event.operation_id === start.operation_id ||
+        ["review.batch", "review.item", "review.log_publication"].includes(event.event_type),
+    );
+    if (
+      phases.some(
+        (event) =>
+          event.operation_id !== start.operation_id ||
+          event.attempt_id !== start.attempt_id ||
+          JSON.stringify(event.producer) !== JSON.stringify(start.producer) ||
+          event.subject.repository !== options.targetRepo ||
+          event.action.name !== event.event_type ||
+          event.phase_seq < 1 ||
+          event.phase_seq > end.phase_seq ||
+          !["review.batch", "review.item", "review.log_publication"].includes(event.event_type),
+      ) ||
+      new Set(phases.map((event) => event.phase_seq)).size !== phases.length
+    )
+      return summarize();
+    const perItem = new Map<number, ActionEvent[]>();
+    for (const event of phases.filter((event) => event.event_type !== "review.batch")) {
+      if (
+        !event.subject.number ||
+        !options.itemNumbers.includes(event.subject.number) ||
+        !["issue", "pull_request"].includes(event.subject.kind)
+      )
+        return summarize();
+      const current = perItem.get(event.subject.number) ?? [];
+      current.push(event);
+      perItem.set(event.subject.number, current);
+    }
+    const indexes = [...perItem.values()].map(
+      (events) => events.toSorted((a, b) => a.phase_seq - b.phase_seq)[0]?.attributes?.batch_index,
+    );
+    if (new Set(indexes).size !== indexes.length) return summarize();
+    evidenceComplete = true;
+    if (options.stageDir) mkdirSync(options.stageDir, { recursive: true });
+    for (const item of items) {
+      const result = itemDisposition(
+        (perItem.get(item.number) ?? []).toSorted((a, b) => a.phase_seq - b.phase_seq),
+        start,
+      );
+      item.disposition = result.disposition;
+      item.reason = result.reason;
+      if (options.stageDir && result.disposition === "completed" && result.terminal) {
+        try {
+          stageReport(options, result.terminal);
+          item.publication = "staged";
+        } catch {
+          item.reason = "completed_report_held";
+        }
+      }
+    }
+  } catch {
+    // Artifact loss/corruption is an intentional visible hold, never a retry fallback.
+    evidenceComplete = false;
+  } finally {
+    rmSync(scratch, { recursive: true, force: true });
+  }
+  return summarize();
+
+  function summarize() {
+    return {
+      shard: options.shard,
+      evidence_complete: evidenceComplete,
+      items,
+      retryable: evidenceComplete
+        ? items.filter((item) => item.disposition === "retryable").map((item) => item.number)
+        : [],
+      staged: evidenceComplete
+        ? items.filter((item) => item.publication === "staged").map((item) => item.number)
+        : [],
+    };
+  }
+}

--- a/test/repair/review-recovery.test.ts
+++ b/test/repair/review-recovery.test.ts
@@ -1,0 +1,165 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import test from "node:test";
+import {
+  fixture,
+  perturbFixture,
+  rewriteLedger,
+  baselineSha,
+  targetRepo,
+} from "../../docs/proof/aggregate-review-recovery/fixture.mjs";
+
+const cli = resolve("dist/repair/workflow-utils.js");
+
+for (const kind of [
+  "mixed",
+  "filtered",
+  "late-completed",
+  "unmatched",
+  "accepted-mutation",
+  "mutation-only",
+  "unsupported",
+  "ambiguous",
+  "receipt-reason",
+  "missing",
+  "incomplete",
+  "missing-terminal",
+  "foreign-batch",
+  "wrong-shard",
+  "report-identity",
+  "report-digest",
+]) {
+  test(`recovery CLI preserves per-item authority: ${kind}`, async (t) => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "review-recovery-test-")));
+    t.after(() => rmSync(root, { recursive: true, force: true }));
+    const seeded = await fixture(root, kind);
+    perturbFixture(seeded, kind);
+    const result = recover(root, seeded);
+    const holdAll = [
+      "filtered",
+      "missing",
+      "incomplete",
+      "missing-terminal",
+      "foreign-batch",
+      "wrong-shard",
+    ].includes(kind);
+    assert.deepEqual(
+      result.retryable,
+      holdAll
+        ? []
+        : ["mutation-only", "unsupported", "ambiguous"].includes(kind)
+          ? [4]
+          : kind === "receipt-reason"
+            ? [3]
+            : [3, 4],
+    );
+    assert.deepEqual(
+      result.staged,
+      holdAll
+        ? []
+        : ["late-completed", "report-identity", "report-digest"].includes(kind)
+          ? [2]
+          : [1, 2],
+    );
+    if (!holdAll) {
+      const item = (number) => result.items.find((entry) => entry.number === number);
+      assert.equal(item(7).disposition, "terminal");
+      for (const number of [5, 6, 8]) assert.equal(item(number).disposition, "held");
+      for (const number of result.staged) {
+        assert.equal(
+          readFileSync(join(root, "staged", `${number}.md`), "utf8"),
+          readFileSync(join(seeded.reports, `${number}.md`), "utf8"),
+        );
+      }
+    }
+  });
+}
+
+for (const [key, value] of [
+  ["repository", "example/other"],
+  ["sha", "a".repeat(40)],
+  ["workflow", "other.yml"],
+  ["job", "publish"],
+  ["run_id", "987654"],
+  ["run_attempt", 2],
+]) {
+  test(`recovery CLI rejects a foreign producer ${key}`, async (t) => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "review-recovery-identity-")));
+    t.after(() => rmSync(root, { recursive: true, force: true }));
+    const seeded = await fixture(root);
+    rewriteLedger(seeded.ledgerDir, (events) =>
+      events.map((event) => ({ ...event, producer: { ...event.producer, [key]: value } })),
+    );
+    const result = recover(root, seeded);
+    assert.equal(result.evidence_complete, false);
+    assert.deepEqual(result.retryable, []);
+    assert.deepEqual(result.staged, []);
+    assert.ok(result.items.every((item) => item.disposition === "held"));
+  });
+}
+
+test("recovery CLI holds corrupted ledger bytes and never follows a report symlink", async (t) => {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "review-recovery-files-")));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const seeded = await fixture(root);
+  const linkedReport = join(root, "linked-report.md");
+  writeFileSync(linkedReport, readFileSync(join(seeded.reports, "1.md")));
+  rmSync(join(seeded.reports, "1.md"));
+  symlinkSync(linkedReport, join(seeded.reports, "1.md"));
+  assert.deepEqual(recover(root, seeded).staged, [2]);
+  rmSync(join(root, "staged"), { recursive: true });
+  const shard = readdirSync(seeded.ledgerDir, { recursive: true }).find((file) =>
+    String(file).endsWith(".jsonl"),
+  )!;
+  writeFileSync(join(seeded.ledgerDir, String(shard)), "{}\n");
+  const result = recover(root, seeded);
+  assert.equal(result.evidence_complete, false);
+  assert.deepEqual(result.retryable, []);
+  assert.deepEqual(result.staged, []);
+});
+
+function recover(root, seeded) {
+  return JSON.parse(
+    execFileSync(
+      process.execPath,
+      [
+        cli,
+        "review-recovery",
+        "--ledger-dir",
+        seeded.ledgerDir,
+        "--producer-repository",
+        targetRepo,
+        "--producer-sha",
+        baselineSha,
+        "--run-id",
+        "123456",
+        "--run-attempt",
+        "1",
+        "--target-repo",
+        targetRepo,
+        "--shard",
+        "0",
+        "--shard-count",
+        "1",
+        "--item-numbers",
+        seeded.planned.join(","),
+        "--reports-dir",
+        seeded.reports,
+        "--stage-dir",
+        join(root, "staged"),
+      ],
+      { env: { PATH: process.env.PATH }, encoding: "utf8" },
+    ),
+  );
+}

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -2031,13 +2031,21 @@ test("scheduled review shards retire automatic live proof without removing histo
   const metrics = reviewSteps.find((candidate) => candidate.name === "Record shard metrics");
   assert.ok(metrics);
   assert.doesNotMatch(JSON.stringify(metrics), /live[_-]proof/i);
-  const upload = reviewSteps.find(
+  const uploads = reviewSteps.filter(
     (candidate) => candidate.with?.name === "review-shard-${{ matrix.shard }}",
   );
-  assert.ok(upload);
-  assert.match(upload.if ?? "", /review-shard\.outcome/);
-  assert.match(String(upload.with?.path), /review-artifacts\/shard-/);
-  assert.doesNotMatch(String(upload.with?.path), /live-proof/);
+  assert.equal(uploads.length, 2);
+  for (const upload of uploads) {
+    assert.match(upload.if ?? "", /review-shard\.outcome/);
+    assert.doesNotMatch(String(upload.with?.path), /live-proof/);
+  }
+  const completed = uploads.find((upload) => upload.if?.includes("== 'failure'"))!;
+  const successful = uploads.find(
+    (upload) => upload.if?.includes("== 'success'") && !upload.if?.includes("== 'failure'"),
+  )!;
+  assert.match(String(successful.with?.path), /review-artifacts\/shard-/);
+  assert.match(String(completed.with?.path), /review-artifacts\/completed-.*\/\*\.md$/);
+  assert.match(completed.if!, /completed-prefix\.outcome == 'success'/);
 
   assert.ok(
     workflow.jobs.publish!.steps.some(
@@ -6951,36 +6959,36 @@ test("review finalizers recover start-only ledger attempts after hard timeout", 
   }
 });
 
-test("optional ledger work is never presented as model review or review publication in Bay", async () => {
-  const { publicStatusProjection } = await import("../dashboard/worker.ts");
-  const job = YAML.parse(readText(".github/workflows/sweep.yml")).jobs[
-    "publish-review-action-ledger"
-  ];
-  const projected = publicStatusProjection({
-    schema_version: 1,
-    generated_at: "2026-09-08T08:00:00.000Z",
-    source: { target_repository_count: 0 },
-    fleet: {},
-    workers: job.steps.map((entry: { name?: string; uses?: string }) => ({
-      name: job.name,
-      status: "in_progress",
-      current_step: entry.name ?? entry.uses,
-      steps: job.steps.map((step: { name?: string; uses?: string }) => ({
-        name: step.name ?? step.uses,
+for (const jobId of ["publish-review-action-ledger", "recover-review-failures"]) {
+  test(`${jobId} is never presented as model review or review publication in Bay`, async () => {
+    const { publicStatusProjection } = await import("../dashboard/worker.ts");
+    const job = YAML.parse(readText(".github/workflows/sweep.yml")).jobs[jobId];
+    const projected = publicStatusProjection({
+      schema_version: 1,
+      generated_at: "2026-09-08T08:00:00.000Z",
+      source: { target_repository_count: 0 },
+      fleet: {},
+      workers: job.steps.map((entry: { name?: string; uses?: string }) => ({
+        name: job.name,
+        status: "in_progress",
+        current_step: entry.name ?? entry.uses,
+        steps: job.steps.map((step: { name?: string; uses?: string }) => ({
+          name: step.name ?? step.uses,
+        })),
       })),
-    })),
-    automatic_work: [],
-    pipeline: [],
-    bay: {},
-    recent: {},
-    diagnostics: { errors: [], error_count: 0 },
+      automatic_work: [],
+      pipeline: [],
+      bay: {},
+      recent: {},
+      diagnostics: { errors: [], error_count: 0 },
+    });
+    assert.equal(projected.workers.length, job.steps.length);
+    for (const worker of projected.workers) {
+      assert.ok(!["reviewing", "publishing"].includes(worker.stage));
+      assert.equal(worker.status, "in_progress");
+    }
   });
-  assert.equal(projected.workers.length, job.steps.length);
-  for (const worker of projected.workers) {
-    assert.ok(!["reviewing", "publishing"].includes(worker.stage));
-    assert.equal(worker.status, "in_progress");
-  }
-});
+}
 
 test("every action-ledger publication authenticates the expected producer job", () => {
   const workflow = YAML.parse(readText(".github/workflows/sweep.yml")) as {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This branch is in `openclaw/clawsweeper`, not a fork. The fork-collaboration switch is inapplicable: GitHub rejects enabling it on a same-repository PR (HTTP 422). Repository write/maintain access is verified; no access or review gate is bypassed.

</details>

## What Problem This Solves

Resolves a problem where a failed aggregate review shard requeued completed reviews and terminal refusals, while dropping completed reports from that shard.

The failed-shard marker identified an entire planned matrix entry. Recovery treated every planned item as eligible, even when the native item owner had recorded completion, nonretryability, or mutation uncertainty. Actual candidate selection could also differ from that matrix.

## Why This Change Was Made

Recovery now consumes the complete exact-attempt producer artifact through the canonical importer. Only recognized owner-recorded retryable item terminals with an actual start and no unresolved mutation enter the existing signed queue. The same projection stages complete, identity- and digest-verified reports for the existing guarded publisher.

The whole item chain is inspected, including cleanup after an earlier terminal. Completed/cached and nonretryable items never requeue. Unknown, incomplete, foreign, ambiguous, uncertain, unselected, and unstarted work stays visibly held. The old unconditional matrix expansion is removed.

This is the separate follow-up to https://github.com/openclaw/clawsweeper/pull/1490. Recovery has no dependency on the optional ledger-upload job. No new producer facts, selected events, schema, storage, configuration, credentials, capacity, schedule, queue retry policy, deployment change, or scanner bypass.

## User Impact

Terminal refusals no longer trigger another review merely because another item in the shard failed. Completed reports survive a later shard failure when their native identity, digest, and completion evidence verify; normal publication guards still decide whether to publish them.

Per-item summaries distinguish held, terminal, completed, and retryable work. Queue outcomes distinguish queued, deduplicated, shed, disabled, and failed admission. Neither a queue ACK nor the unchanged job-level continuation policy means that review or publication succeeded.

## OpenClaw Bay Impact

The recovery job is named `Apply bounded item recovery`; its step names avoid being classified as active model review. The existing public projection is exercised for every actual recovery and optional-ledger step: workers retain `in_progress` and never become `reviewing` or `publishing`. No dashboard runtime, UI, browser network call, or mutation control changes.

The original failed-review outcome remains visible. The workflow's existing `continue-on-error` policy is unchanged; a green aggregate job is not an all-items-recovered claim.

## Documentation Impact

Updated the active scheduler and action-ledger documentation for evidence-backed terminal recovery, late-mutation holds, and completed-prefix publication. Added the historical, reproducible controlled proof under `docs/proof/aggregate-review-recovery/` and the operational entry under ClawSweeper 0.3.1. No OpenClaw release changelog changes.

Named follow-ups: automatic recovery of unstarted selected work and unrecognized interruption variants needs independently proven membership/lifecycle evidence; locked-item classification stays with its existing producer. Neither is inferred or added here.

## Evidence

- Candidate head: `ca32e9520afc393169781c692036504555e13b63` (signed; locally verified).
- Base: `7f29952363878ca3b5d1f25be8d40a9f6ced784c`.
- Focused failed-surface rerun: 2/2 passed, including the existing disabled-target assertion unchanged.
- `actionlint` 1.7.12 and `git diff --check`: passed.
- Final `pnpm run check`: 5,535 passed, one failed, 13 skipped; **exit 1, not a green full run**. All changed-surface tests passed. The sole failure was an unchanged local-checkout fixture's `git clone` exit 128 before its production call. That test passed both the earlier full run and its exact unchanged focused rerun in the same clean environment; suppressed fixture stderr leaves the underlying Git cause unknown. No workaround or unrelated test/source edit. Hosted full CI remains required.
- Fresh precommit Codex review: scoped-clean through P3, no accepted/actionable findings after the exact-batch correction.
- Committed-base Codex review: scoped-clean through P3 at the candidate head, no accepted/actionable findings.
- Hosted exact-head CI and current-head/body ClawSweeper review remain subsequent landing gates; no bypass or manual workflow dispatch.

The initial full check had 5,534 passes, one capitalization assertion failure, and 13 skips. Restored the original `Recovery skipped because the target is disabled` capitalization in production and the new proof expectation; did not edit the existing assertion.

The first precommit review found one accepted P2: a foreign batch terminal could be excluded from phase identity validation. The real CLI regression admitted `[3,4]` before the correction. Including `review.batch` in the existing validation set now holds the entire foreign attempt; its CLI regression and executable workflow proof pass. No separate validator or producer change was added.

Production delta: +485/-24, net **+461** (workflow +49; CLI +26; shared recovery projection +386; operator wording net zero). This is one bounded artifact projection reused for admission and report staging, absorbing the unsafe matrix selector while reusing canonical parsing, manifests, digests, identity checks, and file safety. A net-neutral shell patch cannot preserve the item/causal boundary without duplicating that policy or adding forbidden producer facts. Tests: +206/-33; executable fixture/proof support: +919; docs/changelog: +128/-11.

## Real Behavior Proof

**Claim:** a failed shard admits only recognized retryable item terminals from its complete exact finalized attempt, while retaining verified completed-prefix reports and the original failed-review disposition.

**Environment:** macOS, Node 24.18.0, pnpm 11.10.0, Bash 5.3.15, physically owned frozen dependencies/build. Normal local test environment with inherited tmux variables removed. Synthetic credentials and local-only transport; no live apply, queue, dispatch, deploy, or target writes.

**Exercised surface:** native selection and review-ledger producers/finalizer; actual workflow staging and enqueue shell; production workflow utility CLI; HMAC-verified loopback `curl`; existing `apply-artifacts --skip-reconcile`, targeted `reconcile`, `publish-main`, comment-only `apply-decisions`, and both required artifact/comment receipt boundaries.

```sh
pnpm install --frozen-lockfile
pnpm run build:all
node docs/proof/aggregate-review-recovery/run-proof.mjs --baseline --output .artifacts/recovery-baseline.json
node docs/proof/aggregate-review-recovery/run-proof.mjs --output .artifacts/recovery-candidate.json
node --test test/repair/review-recovery.test.ts test/sweep-workflow.test.ts
pnpm run check
```

**Observed:** all 22 scenarios passed again on the exact signed candidate head on September 8, 2026. Source hashes and all scenario results match the clean precommit/committed-review evidence. The baseline executes the original workflow at the base above, using the same unchanged native producer boundary and synthetic fixture.

| Scenario | Original workflow | Candidate |
| --- | --- | --- |
| Mixed failed shard, planned `[1..8]` | Enqueues all eight, including completed items and terminal refusal | Only `[3,4]`; completed reports 1/2 retained |
| Actual selection filters `[1,2,3]` to `[1,3]`; only 1 starts and refuses | Enqueues all three | No admission or staged report |
| Accepted, deduped, shed, disabled ACKs | Baseline selection remains unsafe | Exactly one request per eligible item, each outcome visible |
| Failed ACK | Not used as a selection fix | Existing three tries per eligible item, six total; recovery exits 1 |
| Late uncertainty after completed item 1 | Matrix still authorizes retry | Item 1 held; only completed report 2 retained |
| Late/unmatched mutation; resolved accepted mutation | No item disposition check | Unknown/unmatched stays held; resolved receipt alone grants no retry |
| Mutation-only, unsupported, ambiguous terminal | No item disposition check | Item 3 held; only item 4 admitted |
| Invalid mutation receipt reason | No item disposition check | Item 4 held; only item 3 admitted |
| Missing/incomplete/missing-terminal/foreign-batch/foreign-attempt/foreign-SHA/wrong-shard evidence | No ledger eligibility check | Zero admissions and zero staged reports |
| Report identity or digest mismatch | Failed shard reports are omitted | Invalid report 1 held; valid report 2 retained |

All producer cases exit **79** through the native refusal classifier. Candidate summaries preserve the original failed-review outcome. The before-edit baseline receipt remains retained separately from refreshed paired proof.

The retained-prefix success case actually publishes signed record tuples and one comment each for items 1/2, plus **35 immutable required receipt blobs**. The late-completed-uncertainty case publishes only tuple/comment 2, plus **24 blobs**. Both required artifact and selected-comment receipt phases independently add new blobs. Other scenarios exercise guarded artifact consumption without claiming live publication.

**Artifact binding (SHA-256):**

```text
baseline workflow  292af05d66908512f16d0b07579df31e16a944226871f57125a5dd2d73ae734c
candidate workflow 5c42ee81e8d9f92222526435af797abffac57eef1e8b2e0acb518a6410ecd86d
fixture            a75b63bfc6b8d99850de96a4eee0b544251e77c3d6736e939fca35f8cf45d5e8
harness            9bc462cfd12e29bffc84c8e04976a494084dfbbd2c4097042b50b064cbbd60a7
projection         8d229a27c612c7c5465a3ab3863b3aa1f6514d8df25f77a60e0ca3ca652cf05c
exact-head receipt edc1d232468b75e3b4e924882a553b1a128d263a5fed2ea31de03cd88abc1cf4
```

The executable receipt records head/base SHAs, these source hashes, actual request membership, producer/recovery exits, retained report names, published tuple/comment identities, required blob counts, and terminal-exclusion verdicts. Focused CLI tests additionally reject each foreign producer identity field, corrupted canonical bytes, and report symlinks.

**Limits:** this is executable production command-boundary proof with synthetic transport responses, not hosted artifact/scheduling proof, model execution, scanner effectiveness, production queue admission, real storage durability, or public comments. Existing publisher guards and receipts are preserved. Early harness setup failures were corrected before the successful matrix and are not counted as proof; no live write was used to repair them. No performance or throughput improvement is claimed.
