### PR TITLE
fix(review): treat non-retryable scanner refusals as terminal queue failures

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2401,45 +2401,56 @@ jobs:
           error_file="$(mktemp)"
           trap 'rm -f "$response_file" "$error_file"' EXIT
           for attempt in 1 2 3; do
-            : > "$response_file"
-            : > "$error_file"
-            if status="$(curl --silent --show-error --connect-timeout 5 --max-time 20 \
-              --output "$response_file" \
-              --write-out '%{http_code}' \
-              --request POST \
-              --header "content-type: application/json" \
-              --data "$payload" \
-              "$queue_url/internal/exact-review/complete" 2>"$error_file")"; then
-              response="$(<"$response_file")"
-              if [[ "$status" == 2* ]]; then
-                exit 0
-              fi
-              # Only this completion-specific conflict is emitted after the
-              # durable queue verifies that this exact v2 lease tuple was fenced
-              # by a newer source revision. Every generic ownership conflict
-              # stays visible so a malformed or mismatched callback cannot turn
-              # a failed completion into a green workflow.
-              if [ "$status" = "409" ]; then
-                conflict_reason="$(RESPONSE="$response" node <<'NODE'
-                  const response = JSON.parse(process.env.RESPONSE || "{}");
-                  const safeConflicts = new Set(["lease_superseded"]);
-                  if (!safeConflicts.has(response.error)) process.exit(1);
-                  process.stdout.write(response.error);
+            while true; do
+              : > "$response_file"
+              : > "$error_file"
+              if status="$(curl --silent --show-error --connect-timeout 5 --max-time 20 \
+                --output "$response_file" \
+                --write-out '%{http_code}' \
+                --request POST \
+                --header "content-type: application/json" \
+                --data "$payload" \
+                "$queue_url/internal/exact-review/complete" 2>"$error_file")"; then
+                response="$(<"$response_file")"
+                if [[ "$status" == 2* ]]; then
+                  exit 0
+                fi
+                if [ "$status" = "400" ] &&
+                  jq -e '.error == "invalid_review_failure_reason"' "$response_file" >/dev/null 2>&1 &&
+                  jq -e 'has("review_failure_reason")' <<< "$payload" >/dev/null; then
+                  # Status is valid only alongside a terminal reason; retain diagnostic detail.
+                  payload="$(jq -c 'del(.review_failure_reason, .review_failure_status)' <<< "$payload")"
+                  echo "::warning::Exact-review completion detected Worker/workflow deploy skew (invalid_review_failure_reason); retrying once without terminal reason/status, retaining review_failure detail."
+                  continue
+                fi
+                # Only this completion-specific conflict is emitted after the
+                # durable queue verifies that this exact v2 lease tuple was fenced
+                # by a newer source revision. Every generic ownership conflict
+                # stays visible so a malformed or mismatched callback cannot turn
+                # a failed completion into a green workflow.
+                if [ "$status" = "409" ]; then
+                  conflict_reason="$(RESPONSE="$response" node <<'NODE'
+                    const response = JSON.parse(process.env.RESPONSE || "{}");
+                    const safeConflicts = new Set(["lease_superseded"]);
+                    if (!safeConflicts.has(response.error)) process.exit(1);
+                    process.stdout.write(response.error);
           NODE
-                )" || {
-                  echo "Unexpected exact-review completion conflict: $response" >&2
+                  )" || {
+                    echo "Unexpected exact-review completion conflict: $response" >&2
+                    exit 1
+                  }
+                  echo "::notice::Exact-review completion skipped because its lease was superseded: $conflict_reason"
+                  exit 0
+                fi
+                echo "Exact-review completion returned HTTP $status: $response" >&2
+                if [[ "$status" != 5* ]]; then
                   exit 1
-                }
-                echo "::notice::Exact-review completion skipped because its lease was superseded: $conflict_reason"
-                exit 0
+                fi
+              else
+                cat "$error_file" >&2
               fi
-              echo "Exact-review completion returned HTTP $status: $response" >&2
-              if [[ "$status" != 5* ]]; then
-                exit 1
-              fi
-            else
-              cat "$error_file" >&2
-            fi
+              break
+            done
             if [ "$attempt" -lt 3 ]; then
               sleep "$((attempt * 5))"
             fi

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1522,6 +1522,9 @@ jobs:
           elif [ "$review_exit_code" -eq 79 ]; then
             echo "failure_reason=findings" >> "$GITHUB_OUTPUT"
           elif [ "$review_exit_code" -ne 0 ] && [ -f artifacts/event/failure-diagnostics/manifest.json ] &&
+            jq -e '.failure.stage == "agent_input_scan" and .retryable == false' artifacts/event/failure-diagnostics/manifest.json >/dev/null; then
+            echo "failure_reason=$(jq -r '.failure.reason_code' artifacts/event/failure-diagnostics/manifest.json)" >> "$GITHUB_OUTPUT"
+          elif [ "$review_exit_code" -ne 0 ] && [ -f artifacts/event/failure-diagnostics/manifest.json ] &&
             jq -e '
               .classification == "source_preparation" and
               .retryable == false and
@@ -2067,6 +2070,8 @@ jobs:
             detail="The input scanner refused the reviewed source. The durable queue will not retry this unchanged revision."
           elif [ "$REVIEW_FAILURE_REASON" = "source_incompatible" ]; then
             detail="The reviewed source does not contain a valid exact Codex version pin. The durable queue will not retry this unchanged revision; update or rebase it before requesting review again."
+          elif [ -n "$REVIEW_FAILURE_REASON" ]; then
+            detail="The input scanner could not safely complete review. The durable queue will not retry this unchanged revision. Maintainers should inspect the linked workflow run."
           elif [ "$RESERVATION_STATUS" = "superseded" ] || [ "$REVIEW_SUPERSEDED" = "true" ]; then
             state="Waiting"
             detail="A newer exact-review queue owner superseded this run. This run completed as a no-op."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,8 @@ checkpoint, and status-only commits are intentionally omitted.
 - Mask credentialed URLs in supplementary review context and ignore foreign timeline issue numbers; thanks @yetval.
 - Bound app-server CrabFleet status updates so a stalled endpoint cannot block the review turn indefinitely; thanks @Yigtwxx.
 - Accept direct local `.sh` validation through shared guarded Bash normalization for command strings and resolved arguments; thanks @Jhacarreiro.
+- Complete exact-review leases during Worker/workflow deploy skew by retrying rejected terminal reasons once without the reason/status, preserving diagnostics and warning operators.
+
 - Stop exact-review retries for every non-retryable scanner refusal, including scan deadlines, and retain terminal guidance for the unchanged revision.
 
 - Prepare GitHub user-attachment and legacy repository asset proof locally, resolving image/video types after download and reserving bounded preprocessing time for attachments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@ checkpoint, and status-only commits are intentionally omitted.
 - Mask credentialed URLs in supplementary review context and ignore foreign timeline issue numbers; thanks @yetval.
 - Bound app-server CrabFleet status updates so a stalled endpoint cannot block the review turn indefinitely; thanks @Yigtwxx.
 - Accept direct local `.sh` validation through shared guarded Bash normalization for command strings and resolved arguments; thanks @Jhacarreiro.
+- Stop exact-review retries for every non-retryable scanner refusal, including scan deadlines, and retain terminal guidance for the unchanged revision.
 
 - Prepare GitHub user-attachment and legacy repository asset proof locally, resolving image/video types after download and reserving bounded preprocessing time for attachments.
 

--- a/dashboard/exact-review-failure-telemetry.ts
+++ b/dashboard/exact-review-failure-telemetry.ts
@@ -1,5 +1,6 @@
 import type { ExactReviewDecision } from "./exact-review-decision.ts";
 import { stableJson } from "../src/stable-json.ts";
+import type { TerminalReviewFailureReason } from "../src/exact-review-failure-reason.ts";
 
 export const EXACT_REVIEW_FAILURE_TELEMETRY_TABLE = "exact_review_failure_attempts_v1";
 export const EXACT_REVIEW_FAILURE_TELEMETRY_STATE_TABLE = "exact_review_failure_telemetry_state_v1";
@@ -123,7 +124,7 @@ export function normalizeExactReviewFailureDetail(value: unknown): ExactReviewFa
 
 export function exactReviewFailureDetail(options: {
   outcome: "failure" | "cancelled";
-  terminalReason?: "findings" | "incomplete_source" | "source_incompatible";
+  terminalReason?: TerminalReviewFailureReason;
   supplied?: ExactReviewFailureDetail;
 }): ExactReviewFailureDetail {
   if (options.supplied) return options.supplied;

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -1,4 +1,8 @@
 import { stableJson } from "../src/stable-json.ts";
+import {
+  terminalReviewFailureReason,
+  type TerminalReviewFailureReason as ExactReviewFailureReason,
+} from "../src/exact-review-failure-reason.ts";
 import { REVIEW_PROOF_RESULT_MAX_BYTES } from "../src/review-proof-limits.ts";
 import { CommandProofRequestStore } from "./command-proof-requests.ts";
 import {
@@ -376,7 +380,6 @@ export type ExactReviewReviewRecoveryReason =
   | "workflow_cancelled"
   | "workflow_failed";
 type ExactReviewRetryKind = "coordination" | "throttle";
-type ExactReviewFailureReason = "findings" | "incomplete_source" | "source_incompatible";
 type ExactReviewPublicationFailureKind = "github_rate_limit" | "github_transient";
 type ExactReviewDispatchFailureClass =
   | "permanent_rejection"
@@ -2923,11 +2926,7 @@ export class ExactReviewQueue {
       const reviewFailureReason =
         body.review_failure_reason === undefined
           ? undefined
-          : body.review_failure_reason === "findings" ||
-              body.review_failure_reason === "incomplete_source" ||
-              body.review_failure_reason === "source_incompatible"
-            ? (body.review_failure_reason as ExactReviewFailureReason)
-            : null;
+          : terminalReviewFailureReason(body.review_failure_reason);
       if (body.review_failure_reason !== undefined && !reviewFailureReason) {
         return json({ error: "invalid_review_failure_reason" }, 400);
       }

--- a/docs/pr-review-comments.md
+++ b/docs/pr-review-comments.md
@@ -87,7 +87,7 @@ version twice.
 
 Automatically received pull requests keep their lightweight
 `clawsweeper-pr-ack` receipt separate from command status. When a deterministic
-input refusal (`findings`, `incomplete_source`, or `source_incompatible`) stops
+input refusal (any non-retryable agent-input scan reason, or `source_incompatible`) stops
 review, ClawSweeper edits that exact trusted-bot receipt with bounded,
 reason-specific guidance. It never reproduces scanner findings, detected values,
 paths, or source excerpts. The failure ledger records whether the edit was

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -32,7 +32,13 @@ The shared allowlist lives in `src/exact-review-failure-reason.ts`. Exit codes
 78 and 79 still identify `incomplete_source` and `findings` without a manifest.
 A matching non-retryable `review_failure` detail is accepted; retryable or
 mismatched detail is rejected. Diagnostic detail alone does not suppress retry:
-without `review_failure_reason`, failed completion still retries. A terminal
+without `review_failure_reason`, failed completion still retries. During Worker/workflow deploy skew, an HTTP 400
+`invalid_review_failure_reason` response triggers one immediate compatibility
+retry without the terminal reason or its dependent status receipt, preserving
+`review_failure` diagnostic detail and emitting a workflow warning. An older
+Worker can then complete the lease under its existing retry policy; compatible
+Workers receive the terminal reason on the first request. Other errors retain
+the existing failure and retry handling. A terminal
 reason removes the unchanged queue revision while allowing an already queued
 newer revision to proceed; it does not turn the failed workflow green.
 

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -22,6 +22,24 @@ still override live-worker caps, but when they do not, `repair:dispatch` derives
 the priority lane from `job_intent` instead of relying on workflow-specific
 defaults.
 
+Exact-review completion sends `review_failure_reason` for every diagnostics
+manifest with `failure.stage: agent_input_scan` and `retryable: false`, using
+`failure.reason_code` verbatim. The accepted scanner reasons are
+`scanner_unavailable`, `scanner_failed`, `findings`, `deadline`, `staging_limit`,
+`incomplete_source`, `source_drift`, `unsafe_path`, and `unsupported_content`;
+`source_incompatible` remains a separate terminal source-preparation reason.
+The shared allowlist lives in `src/exact-review-failure-reason.ts`. Exit codes
+78 and 79 still identify `incomplete_source` and `findings` without a manifest.
+A matching non-retryable `review_failure` detail is accepted; retryable or
+mismatched detail is rejected. Diagnostic detail alone does not suppress retry:
+without `review_failure_reason`, failed completion still retries. A terminal
+reason removes the unchanged queue revision while allowing an already queued
+newer revision to proceed; it does not turn the failed workflow green.
+
+Scheduled and manual explicit queue admissions use the same exact-event review
+step. Aggregate shard recovery uses its per-item terminal ledger instead of
+producing a queue-level `failure_reason` from the shard's process exit.
+
 ClawSweeper has three issue/PR scheduler paths:
 
 - exact event review for one target issue or pull request

--- a/src/agent-input-scan.ts
+++ b/src/agent-input-scan.ts
@@ -19,6 +19,7 @@ import { tmpdir } from "node:os";
 import { basename, delimiter, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { reviewToolCacheRoot } from "./review-tool-bootstrap.js";
+import type { AgentInputScanFailureReason } from "./exact-review-failure-reason.js";
 import { readReviewGit, reviewMergeBase, type ReviewGitReadOptions } from "./pr-review-evidence.js";
 import {
   classifyReviewedFixtureScan,
@@ -47,16 +48,7 @@ export class AgentInputScanError extends Error {
   readonly retryable = false;
   reviewedHeadSha?: string;
   constructor(
-    readonly reason:
-      | "scanner_unavailable"
-      | "scanner_failed"
-      | "findings"
-      | "deadline"
-      | "staging_limit"
-      | "incomplete_source"
-      | "source_drift"
-      | "unsafe_path"
-      | "unsupported_content",
+    readonly reason: AgentInputScanFailureReason,
     readonly scanDiagnostic?: ScanRefusalDiagnostic,
   ) {
     super(

--- a/src/clawsweeper-review-failure-diagnostics.ts
+++ b/src/clawsweeper-review-failure-diagnostics.ts
@@ -2,6 +2,7 @@ import { stringOrEmpty as stringValue } from "./value-coerce.js";
 import { existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { AgentInputScanError } from "./agent-input-scan.js";
+import { agentInputScanFailureReason } from "./exact-review-failure-reason.js";
 import { codexJsonlFailureDetail } from "./codex-transient.js";
 
 const FILE_LIMITS = { "error.txt": 4096, "stdout.error.txt": 4096, "stderr.tail.txt": 12_288 };
@@ -48,10 +49,7 @@ export function writeExactReviewFailureDiagnostics(options: {
     ? "agent_input_scan"
     : safeCode(error.diagnosticStage, /^source_preparation$/);
   const diagnosticReason = scanFailure
-    ? safeCode(
-        error.reason,
-        /^(?:scanner_unavailable|scanner_failed|findings|deadline|staging_limit|incomplete_source|source_drift|unsafe_path|unsupported_content)$/,
-      )
+    ? agentInputScanFailureReason(error.reason)
     : diagnosticStage
       ? safeCode(
           error.diagnosticReason,

--- a/src/exact-review-failure-reason.ts
+++ b/src/exact-review-failure-reason.ts
@@ -1,0 +1,22 @@
+export const AGENT_INPUT_SCAN_FAILURE_REASONS = [
+  "scanner_unavailable",
+  "scanner_failed",
+  "findings",
+  "deadline",
+  "staging_limit",
+  "incomplete_source",
+  "source_drift",
+  "unsafe_path",
+  "unsupported_content",
+] as const;
+
+export type AgentInputScanFailureReason = (typeof AGENT_INPUT_SCAN_FAILURE_REASONS)[number];
+export type TerminalReviewFailureReason = AgentInputScanFailureReason | "source_incompatible";
+
+export function agentInputScanFailureReason(value: unknown): AgentInputScanFailureReason | null {
+  return AGENT_INPUT_SCAN_FAILURE_REASONS.find((reason) => reason === value) ?? null;
+}
+
+export function terminalReviewFailureReason(value: unknown): TerminalReviewFailureReason | null {
+  return value === "source_incompatible" ? value : agentInputScanFailureReason(value);
+}

--- a/src/repair/update-review-status.ts
+++ b/src/repair/update-review-status.ts
@@ -1,7 +1,11 @@
 #!/usr/bin/env node
 import { appendFileSync } from "node:fs";
 import { ghJsonWithRetry, ghText } from "./github-cli.js";
-import type { JsonValue, LooseRecord } from "./json-types.js";
+import type { LooseRecord } from "./json-types.js";
+import {
+  terminalReviewFailureReason,
+  type TerminalReviewFailureReason,
+} from "../exact-review-failure-reason.js";
 import { repoRoot } from "./paths.js";
 import { DEFAULT_TRUSTED_BOTS } from "./config.js";
 import {
@@ -14,7 +18,7 @@ import {
 const REVIEW_PROGRESS_START = "<!-- clawsweeper-review-progress:start -->";
 const REVIEW_PROGRESS_END = "<!-- clawsweeper-review-progress:end -->";
 
-export type TerminalReviewFailureReason = "findings" | "incomplete_source" | "source_incompatible";
+export type { TerminalReviewFailureReason } from "../exact-review-failure-reason.js";
 
 type Options = {
   repo: string;
@@ -46,6 +50,11 @@ export function terminalReviewStatusCopy(reason: TerminalReviewFailureReason) {
     case "incomplete_source":
       return {
         reason: "ClawSweeper could not verify the complete source for this revision.",
+        next: "No contributor action is requested. Maintainers should inspect the linked workflow run.",
+      };
+    default:
+      return {
+        reason: "The input-safety check could not safely complete for this revision.",
         next: "No contributor action is requested. Maintainers should inspect the linked workflow run.",
       };
   }
@@ -233,10 +242,4 @@ export function parseOptions(argv: string[]): Options {
     failureReason,
     runUrl,
   };
-}
-
-function terminalReviewFailureReason(value: JsonValue): TerminalReviewFailureReason | null {
-  return value === "findings" || value === "incomplete_source" || value === "source_incompatible"
-    ? value
-    : null;
 }

--- a/test/dashboard-worker-queue-runtime.test.ts
+++ b/test/dashboard-worker-queue-runtime.test.ts
@@ -32,6 +32,7 @@ import {
   unclaimedExactReviewQueueItem,
 } from "./dashboard-worker-harness.ts";
 import type { HostedPublicTargetProbe } from "../dashboard/exact-review-queue.ts";
+import { AGENT_INPUT_SCAN_FAILURE_REASONS } from "../src/exact-review-failure-reason.ts";
 import {
   HOSTED_TARGET_ELIGIBILITY_HEADER,
   isHostedTargetEligible,
@@ -13060,6 +13061,46 @@ test("exact-review queue terminates deterministic refusals only for the unchange
   assert.equal(sourceState.items["openclaw/openclaw#714"].revision, 2);
 });
 
+test("exact-review queue terminates every scanner refusal and retries missing terminal reasons", async () => {
+  for (const reason of [...AGENT_INPUT_SCAN_FAILURE_REASONS, undefined]) {
+    const storage = new MemoryDurableStorage();
+    const item = leasedExactReviewQueueItem(718, "7180");
+    await storage.put("exact-review-queue", { deliveries: {}, items: { [item.key]: item } });
+    const queue = new ExactReviewQueue({ storage }, {});
+    const response = await queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/complete", {
+        method: "POST",
+        body: JSON.stringify({
+          lease_id: item.leaseId,
+          item_key: item.key,
+          lease_revision: 1,
+          claim_generation: 1,
+          run_id: "7180",
+          run_attempt: 1,
+          outcome: "failure",
+          ...(reason ? { review_failure_reason: reason } : {}),
+          review_failure: {
+            stage: "agent_input_scan",
+            reason_code: reason ?? "deadline",
+            retryable: false,
+          },
+        }),
+      }),
+    );
+    assert.equal(response.status, 200, reason);
+    assert.deepEqual(await response.json(), { ok: true, requeued: reason === undefined });
+    const state = (await storage.get("exact-review-queue")) as {
+      items: Record<string, { state: string; reviewFailureAttempts: number }>;
+    };
+    if (reason) {
+      assert.equal(state.items[item.key], undefined, reason);
+    } else {
+      assert.equal(state.items[item.key].state, "pending");
+      assert.equal(state.items[item.key].reviewFailureAttempts, 1);
+    }
+  }
+});
+
 test("terminal PR refusals retain a verified explanation receipt without retrying", async () => {
   const storage = new MemoryDurableStorage();
   const item = leasedExactReviewQueueItem(718, "7180");
@@ -13127,7 +13168,7 @@ test("exact-review queue validates terminal review failure reasons", async () =>
   const queue = new ExactReviewQueue({ storage: new MemoryDurableStorage() }, {});
   for (const [body, error] of [
     [
-      { outcome: "failure", review_failure_reason: "scanner_failed" },
+      { outcome: "failure", review_failure_reason: "unknown_scanner_reason" },
       "invalid_review_failure_reason",
     ],
     [
@@ -13164,10 +13205,10 @@ test("exact-review queue validates terminal review failure reasons", async () =>
     [
       {
         outcome: "failure",
-        review_failure_reason: "findings",
+        review_failure_reason: "deadline",
         review_failure: {
           stage: "agent_input_scan",
-          reason_code: "findings",
+          reason_code: "deadline",
           retryable: true,
         },
       },

--- a/test/exact-review-failure-diagnostics.test.ts
+++ b/test/exact-review-failure-diagnostics.test.ts
@@ -7,6 +7,10 @@ import test from "node:test";
 import { ReviewGitError } from "../dist/clawsweeper-review-blobs.js";
 import { writeExactReviewFailureDiagnostics } from "../dist/clawsweeper-review-failure-diagnostics.js";
 import { AgentInputScanError, agentInputScanFailureExitCode } from "../dist/agent-input-scan.js";
+import {
+  AGENT_INPUT_SCAN_FAILURE_REASONS,
+  terminalReviewFailureReason,
+} from "../dist/exact-review-failure-reason.js";
 
 const expectedFiles = ["error.txt", "manifest.json", "stderr.tail.txt", "stdout.error.txt"];
 
@@ -174,7 +178,7 @@ test("source-preparation diagnostics survive unsafe raw detail", () => {
 test("scan diagnostics retain refusal identity without scanner output", () => {
   const root = mkdtempSync(join(tmpdir(), "clawsweeper-diagnostics-"));
   try {
-    for (const reason of ["findings", "incomplete_source"] as const) {
+    for (const reason of AGENT_INPUT_SCAN_FAILURE_REASONS) {
       const error = Object.assign(new AgentInputScanError(reason), {
         stdout: '{"type":"turn.failed","error":{"message":"raw scanner finding"}}',
         stderr: "raw scanner verification detail",
@@ -197,7 +201,12 @@ test("scan diagnostics retain refusal identity without scanner output", () => {
       assert.equal(manifest.classification, "agent_input_scan");
       assert.deepEqual(manifest.failure, { stage: "agent_input_scan", reason_code: reason });
       assert.equal(manifest.retryable, false);
-      assert.equal(manifest.process.workflow_exit, reason === "incomplete_source" ? 78 : 79);
+      assert.equal(error.retryable, false);
+      assert.equal(terminalReviewFailureReason(manifest.failure.reason_code), reason);
+      assert.equal(
+        manifest.process.workflow_exit,
+        reason === "incomplete_source" ? 78 : reason === "findings" ? 79 : 1,
+      );
       const text = expectedFiles.map((name) => readFileSync(join(output, name), "utf8")).join("\n");
       assert.doesNotMatch(text, /raw scanner/);
     }

--- a/test/repair/update-review-status.test.ts
+++ b/test/repair/update-review-status.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { AGENT_INPUT_SCAN_FAILURE_REASONS } from "../../dist/exact-review-failure-reason.js";
 import {
   mergeReviewProgressSection,
   parseOptions,
@@ -9,6 +10,27 @@ import {
 } from "../../dist/repair/update-review-status.js";
 
 const runUrl = "https://github.com/openclaw/clawsweeper/actions/runs/12345";
+
+test("all scanner refusals accept and render terminal review status", () => {
+  for (const reason of AGENT_INPUT_SCAN_FAILURE_REASONS) {
+    const options = parseOptions([
+      "--repo",
+      "openclaw/openclaw",
+      "--item-number",
+      "42",
+      "--status-comment-id",
+      "4200",
+      "--state",
+      "blocked",
+      "--failure-reason",
+      reason,
+    ]);
+    assert.equal(options.failureReason, reason);
+    const rendered = renderReviewProgressSection(options);
+    assert.match(rendered, /will not retry this unchanged revision/);
+    if (reason !== "findings") assert.match(rendered, /Maintainers should inspect/);
+  }
+});
 
 test("terminal review status renders bounded reason-specific guidance", () => {
   const findings = renderReviewProgressSection({

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -14,6 +14,7 @@ import {
 import { delimiter, dirname, join } from "node:path";
 import test from "node:test";
 import YAML from "yaml";
+import { AGENT_INPUT_SCAN_FAILURE_REASONS } from "../dist/exact-review-failure-reason.js";
 
 import { makeTreeReadOnlyForTest, restoreTreeModesForTest } from "../dist/clawsweeper.js";
 import {
@@ -25,6 +26,51 @@ import {
   workPlanCandidateReport,
 } from "./helpers.ts";
 import { scheduledReviewSemanticSourceRevision } from "../scripts/classify-scheduled-review-noop.ts";
+
+test("review workflow emits terminal reasons for non-retryable scanner manifests", () => {
+  const workflow = YAML.parse(readText(".github/workflows/sweep.yml"));
+  const producers = Object.values(workflow.jobs).flatMap((job: any) =>
+    (job.steps ?? []).filter((step: any) => /echo "failure_reason=/.test(step.run ?? "")),
+  );
+  assert.equal(producers.length, 1, "audit every terminal-reason producer when lanes change");
+  const root = mkdtempSync(`${tmpPrefix}terminal-scan-workflow-`);
+  try {
+    const manifestDir = join(root, "artifacts/event/failure-diagnostics");
+    mkdirSync(manifestDir, { recursive: true });
+    const output = join(root, "outputs");
+    for (const producer of producers) {
+      const body = producer.run as string;
+      const shell = body.slice(
+        body.indexOf('echo "exit_code=$review_exit_code"'),
+        body.indexOf('coordination_held_path="artifacts/event/coordination-held.json"'),
+      );
+      assert.ok(shell.includes('exit "$review_exit_code"'));
+      for (const reason of AGENT_INPUT_SCAN_FAILURE_REASONS) {
+        for (const retryable of [false, true]) {
+          writeFileSync(output, "");
+          writeFileSync(
+            join(manifestDir, "manifest.json"),
+            JSON.stringify({
+              classification: "codex_or_content_failure",
+              retryable,
+              failure: { stage: "agent_input_scan", reason_code: reason },
+            }),
+          );
+          const result = spawnSync("bash", ["-c", `set -euo pipefail\n${shell}`], {
+            cwd: root,
+            encoding: "utf8",
+            env: { ...process.env, review_exit_code: "1", GITHUB_OUTPUT: output },
+          });
+          assert.equal(result.status, 1, result.stderr);
+          const outputs = readFileSync(output, "utf8").split("\n");
+          assert.equal(outputs.includes(`failure_reason=${reason}`), !retryable, reason);
+        }
+      }
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
 
 function runCommentSyncShell(root: string, commands: string[]): string {
   return execFileSync(

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { execFileSync, spawnSync } from "node:child_process";
+import { execFileSync, spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
   chmodSync,
@@ -11,6 +11,7 @@ import {
   statSync,
   writeFileSync,
 } from "node:fs";
+import { createServer } from "node:http";
 import { delimiter, dirname, join } from "node:path";
 import test from "node:test";
 import YAML from "yaml";
@@ -69,6 +70,142 @@ test("review workflow emits terminal reasons for non-retryable scanner manifests
     }
   } finally {
     rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("queue completion tolerates only terminal-reason deploy skew", async (t) => {
+  const workflow = YAML.parse(readText(".github/workflows/sweep.yml"));
+  const producers = Object.values(workflow.jobs).flatMap((job: any) =>
+    (job.steps ?? []).filter((step: any) => /review_failure_reason:/.test(step.run ?? "")),
+  );
+  assert.equal(producers.length, 1, "audit every completion reason producer when lanes change");
+  const detail = { stage: "agent_input_scan", reason_code: "deadline", retryable: false };
+  const cases = [
+    { name: "compatible Worker", replies: [200], exit: 0, fallback: false },
+    { name: "old Worker", replies: [400, 200], exit: 0, fallback: true },
+    {
+      name: "unrelated bad request",
+      replies: [400],
+      error: "invalid_outcome",
+      exit: 1,
+      fallback: false,
+    },
+    { name: "malformed response", replies: [400], raw: "not JSON", exit: 1, fallback: false },
+    { name: "no reason sent", replies: [400], reason: "", exit: 1, fallback: false },
+    { name: "fallback rejected", replies: [400, 400], exit: 1, fallback: true },
+    {
+      name: "fallback superseded",
+      replies: [400, 409],
+      error409: "lease_superseded",
+      exit: 0,
+      fallback: true,
+    },
+    {
+      name: "fallback ownership conflict",
+      replies: [400, 409],
+      error409: "lease_not_active",
+      exit: 1,
+      fallback: true,
+    },
+  ];
+  for (const scenario of cases) {
+    await t.test(scenario.name, async () => {
+      const requests: Record<string, any>[] = [];
+      let completed = false;
+      const server = createServer(async (req, res) => {
+        let body = "";
+        for await (const chunk of req) body += chunk;
+        requests.push(JSON.parse(body));
+        const code = scenario.replies[requests.length - 1] ?? 500;
+        completed ||= code === 200;
+        res.writeHead(code, { "content-type": "application/json" });
+        res.end(
+          scenario.raw ??
+            JSON.stringify(
+              code === 200
+                ? { ok: true }
+                : {
+                    error:
+                      code === 409
+                        ? scenario.error409
+                        : (scenario.error ?? "invalid_review_failure_reason"),
+                  },
+            ),
+        );
+      });
+      await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+      try {
+        const address = server.address();
+        assert.ok(address && typeof address !== "string");
+        const child = spawn("bash", ["-c", producers[0].run], {
+          env: {
+            ...process.env,
+            QUEUE_URL: `http://127.0.0.1:${address.port}`,
+            QUEUE_LEASE_ID: "synthetic-lease",
+            PROTOCOL_VERSION: "2",
+            QUEUE_LEASE_REVISION: "1",
+            CLAIM_GENERATION: "1",
+            ITEM_KEY: "openclaw/clawsweeper#1",
+            GITHUB_RUN_ID: "100",
+            RUN_ATTEMPT: "1",
+            PRIMARY_OUTCOME: "failure",
+            REQUEUE_LATEST: "false",
+            RETRY_KIND: "",
+            RETRY_AT: "",
+            DIRECT_PUBLICATION_ACCEPTED: "false",
+            DIRECT_LIFECYCLE_OUTCOME: "",
+            REVIEW_FAILURE_REASON: scenario.reason ?? "deadline",
+            REVIEW_FAILURE_STAGE: detail.stage,
+            REVIEW_FAILURE_REASON_CODE: detail.reason_code,
+            REVIEW_FAILURE_RETRYABLE: "false",
+            HAS_COMMAND_CONTEXT: "false",
+            REVIEW_ITEM_KIND: "pull_request",
+            REVIEW_STATUS_VERIFIED: "false",
+            REVIEW_ACKNOWLEDGEMENT_COMMENT_ID: "123",
+          },
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+        let output = "";
+        child.stdout.on("data", (chunk) => {
+          output += chunk;
+        });
+        child.stderr.on("data", (chunk) => {
+          output += chunk;
+        });
+        const exit = await new Promise<number | null>((resolve, reject) => {
+          child.once("error", reject);
+          child.once("close", resolve);
+        });
+        assert.equal(exit, scenario.exit, output);
+        assert.equal(completed, scenario.replies.includes(200));
+        assert.equal(requests.length, scenario.replies.length);
+        assert.deepEqual(requests[0].review_failure, detail);
+        assert.equal(
+          requests[0].review_failure_reason,
+          scenario.reason === "" ? undefined : "deadline",
+        );
+        assert.equal(
+          (output.match(/::warning::/g) ?? []).length,
+          scenario.fallback ? 1 : 0,
+          output,
+        );
+        if (scenario.fallback) {
+          assert.match(output, /Worker\/workflow deploy skew/);
+          const { review_failure_reason, review_failure_status, ...expected } = requests[0];
+          assert.equal(review_failure_reason, "deadline");
+          assert.deepEqual(review_failure_status, { outcome: "failed", comment_id: 123 });
+          assert.deepEqual(
+            requests[1],
+            expected,
+            "only reason and its dependent status are removed",
+          );
+        }
+      } finally {
+        await new Promise<void>((resolve, reject) =>
+          server.close((error) => (error ? reject(error) : resolve())),
+        );
+      }
+    });
   }
 });
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where exact reviews repeatedly redispatch the same unchanged revision after the agent-input scanner refuses to proceed. A scan deadline could consume a runner on every retry even though the runtime and diagnostics already classify it as non-retryable.

Related observed case: https://github.com/openclaw/openclaw/pull/141913.

## Why This Change Was Made

The exact-event workflow now forwards `failure.reason_code` as its terminal `failure_reason` whenever the manifest reports `failure.stage == "agent_input_scan"` and `retryable == false`. Exit 78/79 handling, source-incompatible handling, workflow failure status, scanner policy, and the queue's retry transition algorithm are preserved.

The supplied base accepted only three terminal reasons at queue ingress; its broader allowlist applied to diagnostic detail. A workflow-only change would therefore reject `deadline` with HTTP 400. A shared bounded reason contract now aligns scanner errors, diagnostics, completion validation, failure telemetry typing, and automatic status guidance. Command status also explains that the unchanged revision will not retry. Missing terminal reasons still retry, and newer queued revisions remain eligible.

Audited every `failure_reason=` producer: this revision has one, in the exact-event review step. Scheduled and explicit manual queue admissions converge there; aggregate shard recovery uses its per-item terminal ledger rather than a queue-level reason derived from the aggregate exit code.

## User Impact

All nine existing non-retryable scanner refusals stop retrying the unchanged review revision, including `deadline`, `scanner_unavailable`, `scanner_failed`, `staging_limit`, `source_drift`, `unsafe_path`, and `unsupported_content`. Operators retain a failed workflow and bounded terminal guidance without exposing scanner output.

## OpenClaw Bay Impact

No Bay code or API schema change is needed. Bay continues to observe the existing terminal-failure lifecycle and review-failure telemetry; the queue validator accepts reason codes already recognized by diagnostic telemetry. Bay gains no actions or browser-side GitHub calls.

## Documentation Impact

Updated the active scheduler completion protocol in `docs/scheduler.md`, the active terminal receipt guidance in `docs/pr-review-comments.md`, and the Unreleased Fixed changelog entry. The scheduler's owning workflow and shared reason module are identified alongside the completion contract.

## Evidence

Final rebased-head hosted CI is green on `358138d4cbc08d628a8b21cf6269d726edb8063d`: [full pnpm check and CI](https://github.com/openclaw/clawsweeper/actions/runs/34241279253), [automerge integration](https://github.com/openclaw/clawsweeper/actions/runs/34241279297), and [CodeQL](https://github.com/openclaw/clawsweeper/actions/runs/34241279298/job/102111779387). Network smoke, sparse repair build, and Windows launcher passed. No failed core CI job or rerun was needed in either cycle.

Before the conflict-only rebase, hosted CI was green on `c080b2724a142061fcebc483c1c7b48c3fbb2c13`: [full pnpm check and CI](https://github.com/openclaw/clawsweeper/actions/runs/34238171658), [automerge integration](https://github.com/openclaw/clawsweeper/actions/runs/34238171668), and [CodeQL](https://github.com/openclaw/clawsweeper/actions/runs/34238171646/job/102101192778). Network smoke, sparse repair build, and Windows launcher also passed. No failed core CI job or rerun was needed. Conditional skips and superseded review-intake cancellations are not core CI failures.

Previous-head hosted CI was green on `cde576209b48fe4fc6235783f451ef2cb484b76b`: [CI run](https://github.com/openclaw/clawsweeper/actions/runs/34234268471) passed `pnpm check`, network smoke, sparse repair build, and Windows launcher; [automerge integration](https://github.com/openclaw/clawsweeper/actions/runs/34234268527) and [CodeQL](https://github.com/openclaw/clawsweeper/actions/runs/34234268459) also passed. Local broad-suite limitations below remain recorded.

- Focused validation: 377 tests passed across workflow, diagnostics, Durable Object queue, and review status tests.
- Pre-commit Codex review: `autoreview scoped-clean: no accepted/actionable findings in the selected Git scope and priority`; `overall: patch is correct (0.9)`.
- Node 24 build, repair/dashboard builds, formatting, static checks, lint, focused 13-test coverage gate, and `git diff --check` passed.
- `pnpm run test:unit` and `pnpm run check` were run but interrupted after approximately 17 minutes: both stopped reporting progress at the existing ledger import-race boundary while remaining active in filesystem work. The broad check also reported a failure in the existing CrabFleet projection fairness test (153 seconds). That test passed in the unit run and isolated rerun (32 seconds); the next import-race test passed separately (8 seconds). The broad local gates are **not green**; logs and a process sample are retained in `.artifacts/`.

## Initial Real Behavior Proof

**Head:** `cde576209b48fe4fc6235783f451ef2cb484b76b` (same reviewed and exercised file content; base `e1e4250868f1c6783d9570fd9a1f62d904487c4c`).

**Claim:** A non-retryable scanner deadline is terminal for the unchanged exact-review revision; omitting the terminal reason preserves retries.

**Surface:** The actual review-step shell parsed from `.github/workflows/sweep.yml`, followed by the actual `ExactReviewQueue.fetch()` completion path using the repository's in-memory Durable Object storage harness.

**Fixture:** `{"classification":"codex_or_content_failure","retryable":false,"failure":{"stage":"agent_input_scan","reason_code":"deadline"}}`, process exit 1, and a synthetic leased item with revision 1 / claim generation 1.

**Command and environment:** macOS arm64, Node 24.20.0, repository-pinned pnpm 11.10.0, Bash, jq 1.7.1. Ran `node .artifacts/terminal-scan-proof/run.mjs` with Node 24 on PATH. The harness parsed the old and current workflows with YAML, copied the review body verbatim from `echo "exit_code=$review_exit_code"` through its failure exit into `workflow-body.sh`, and ran `bash -euo pipefail workflow-body.sh` against the synthetic manifest with `review_exit_code=1`. It then POSTed both completion variants directly to the Durable Object. Also ran `node --test test/exact-review-failure-diagnostics.test.ts test/sweep-workflow.test.ts test/dashboard-worker-queue-runtime.test.ts test/repair/update-review-status.test.ts`.

**Observed:**

```text
before: workflow_exit=1
exit_code=1
failure_diagnostics=true
failure_stage=agent_input_scan
failure_reason_code=deadline
failure_retryable=false
after: workflow_exit=1
exit_code=1
failure_diagnostics=true
failure_stage=agent_input_scan
failure_reason_code=deadline
failure_retryable=false
failure_reason=deadline
queue deadline: {"ok":true,"requeued":false}, item=removed
queue missing reason: {"ok":true,"requeued":true}, item=pending
PASS: actual workflow shell and Durable Object completion; synthetic inputs; no GitHub calls
```

**Artifact:** Local `.artifacts/terminal-scan-proof/` contains the harness, copied shell bodies, fixture manifests, GitHub-output files, and `transcript.txt`; the transcript is reproduced above. Committed regression tests execute all nine scan reasons through the actual shell and queue completion, and reject retryable detail with a terminal deadline reason.

**Limits:** The initial shell/queue proof uses synthetic inputs and in-memory Durable Object persistence; the additional workerd proof below exercises local SQLite and the actual HTTP/binding boundary. No live scanner deadline, GitHub dispatch, production Worker deployment, or hosted storage was exercised. The queue completion API exposes `requeued`, not its internal `retried` value; removal of the unchanged item proves that no retry remains. The deploy-skew fallback below now covers a workflow running before the compatible Worker finishes deployment.

### Initial Worker-boundary proof (executed on the original head)

Addressed the queue-boundary proof request in the first ClawSweeper review with Wrangler 4.107.0 in local mode on macOS arm64. A temporary entrypoint imports the actual dashboard Worker and queue, adds only fixture-seeding and SQL-inspection routes, and disables all outbound fetches. Seeded leases enter real local Durable Object storage; completion requests traverse the unchanged Worker `/internal/exact-review/complete` HTTP route and its real Durable Object binding. Production completion methods are not overridden.

Command: `wrangler dev --config .artifacts/workerd-proof/wrangler.toml --local --ip 127.0.0.1 --port 18795 --env-file .artifacts/workerd-proof/.dev.vars --persist-to .artifacts/workerd-proof/state-second`, followed by `node .artifacts/workerd-proof/drive.mjs`. The process receives a minimal environment with disposable local fixture configuration and no production credentials. No Crabbox provider/image/lease is involved in this local macOS run.

```text
POST /internal/exact-review/complete deadline -> HTTP 200 {"ok":true,"requeued":false}
POST /internal/exact-review/complete missing reason -> HTTP 200 {"ok":true,"requeued":true}
SQLite inspection: deadline item removed; missing-reason item pending
PASS: real Worker HTTP + Durable Object binding + SQLite completion; signed requests; outbound network disabled
```

Artifacts: `.artifacts/workerd-proof/entry.ts`, `wrangler.toml`, `drive.mjs`, `wrangler-second.log`, and `transcript-final.txt`. The trace above records the observable results. Limits: synthetic pre-existing leases, local workerd SQLite, fixture-only seeding/inspection routes, no live GitHub or production deployment.

Finding disposition: the initial HTTP/Durable Object proof request was satisfied. The two remaining rollout items from the current ClawSweeper review are addressed below.

## Known Gaps

The broad local validation is incomplete and includes the reported ledger fairness failure; focused reruns do not replace a complete gate. Hosted CI was green on the original head, including the full `pnpm check` gate. Both the pre-rebase and final rebased-head hosted gates passed. No production mutation or deployment was performed. This PR stops before merge as requested. Current-head ClawSweeper review will be checked separately.


## Deploy-skew fix and current behavior proof

**Current head:** `358138d4cbc08d628a8b21cf6269d726edb8063d` (rebased onto `ecdeaf5561ac59a404a0c69a51db9543b6c50b20`).

The only completion payload producer now recognizes HTTP 400 with JSON `error == "invalid_review_failure_reason"` only when it sent `review_failure_reason`. It immediately retries once after removing that field and its dependent `review_failure_status` receipt. The Worker rejects status without a terminal reason, so removing both is required. `review_failure` diagnostics and the entire lease ownership tuple are retained. The run emits `::warning::` naming Worker/workflow deploy skew. Other 400s, malformed responses, 409 ownership conflicts, and the existing three-attempt transport/5xx policy retain their behavior.

**Claim/surface/scenario:** the actual completion-step Bash body and curl requests release the lease even while the old validator is serving; the compatible validator still terminates the unchanged revision on the first request. Run `node .artifacts/skew-proof/run.mjs` on macOS arm64 with Node 24.20.0, pnpm 11.10.0, Bash, jq 1.7.1, and Wrangler 4.107.0. This runs separate local workerd instances using the original base queue implementation (`e1e4250868f1c6783d9570fd9a1f62d904487c4c`, with only import paths relocated) and the current queue implementation. Both use the actual current Worker completion HTTP route, real Durable Object bindings and SQLite. A loopback recording proxy captures unchanged requests and responses. The temporary entrypoint only seeds synthetic leases, inspects SQLite and disables outbound requests; completion methods are unchanged. The pull-request fixtures include a correctly bound acknowledgement receipt.

```text
old: completion shell exit=0
::warning::Exact-review completion detected Worker/workflow deploy skew (invalid_review_failure_reason); retrying once without terminal reason/status, retaining review_failure detail.
old request 1: deadline + status + diagnostics -> HTTP 400 {"error":"invalid_review_failure_reason"}
old request 2: diagnostics, same lease tuple, no reason/status -> HTTP 200 {"ok":true,"requeued":true}
old: SQLite item pending with lease released
compatible: completion shell exit=0
compatible request 1: deadline + status + diagnostics -> HTTP 200 {"ok":true,"requeued":false}
compatible: SQLite unchanged item removed
PASS: unchanged completion shell, real curl HTTP, old/current queue implementations, real Durable Object bindings and SQLite; synthetic leases; no deployment or live queue mutation
```

**Artifacts/limits:** `.artifacts/skew-proof/` retains `run.mjs`, `completion.sh`, `old-queue.ts`, `entry.ts`, both Wrangler configurations/logs, HTTP/SQLite JSON traces, and `transcript.txt`. No external provider, container image, or Crabbox lease was used for this local macOS proof. Synthetic leases and local storage only; no live scanner refusal, hosted workflow dispatch, production mutation or deployment. During skew the older Worker may requeue under its existing policy: the fallback releases leases, and full terminal behavior begins once the compatible Worker serves. No Bay code/schema change is needed because existing retry/terminal observations remain the public contract.

**Regression:** the executable workflow-shell test covers compatible first-attempt completion, old-Worker fallback with warning, unrelated 400, malformed JSON, absent reason, rejected fallback, superseded lease, and unrelated ownership conflict. It verifies diagnostics and all other payload fields are preserved while only reason/status are removed.

## Rollout

The Worker auto-deploys from the same merge via `.github/workflows/dashboard.yml`. The compatibility fallback covers the interval in which the expanded sweep workflow is active and the older Worker is still serving. After landing, the coordinator will verify that `GET https://clawsweeper.openclaw.ai/api/health` reports the merge SHA as `deployment_sha`; this remains a post-landing coordinator check, not a claim of deployment in this PR. No deployment was performed for this work.

Disposition of ClawSweeper's two items: **P1 merge risk resolved** by the bounded compatibility fallback and the old/current Worker HTTP/SQLite proof above. **P2 deployment verification rescheduled to the coordinator's post-landing health check**, because the Worker is deployed by the same merge and safe activation no longer requires Worker-first ordering. The optional Rank-up move requesting Worker-first verification is superseded by the demonstrated skew-safe protocol and this explicit rollout check. This work stops before merge.

Current rebased validation: all 10 targeted scanner/fallback tests passed. The actual completion shell and old/current Worker HTTP/Durable Object/SQLite proof passed again on the committed rebased head with the updated base; artifact: `.artifacts/skew-proof/rebased-committed-transcript.txt`. Candidate and committed-branch Codex reviews are both `scoped-clean`, `overall: patch is correct (0.88)`, with no actionable P0–P2 defects. Static checks, all builds, lint and focused coverage passed. The full local check progressed beyond the long import-race pause and passed the fairness test, but reported failures in terminal proof, Telegram consumer, and three replacement-publication cases. It was interrupted after approximately 19 minutes before a final suite verdict; the local broad gate is not green, and interrupted target-validation output is not counted as an independent defect. The earlier local run also had a fairness failure before interruption. These limitations remain explicit; both complete hosted CI runs, including full `pnpm check`, passed on their respective heads.

## Conflict-only rebase

The first final-body re-review accepted the patch and rollout proof but reported that main had advanced and the branch conflicted. Used the permitted follow-up cycle to rebase the existing two commits onto `ecdeaf5561ac59a404a0c69a51db9543b6c50b20`. Both conflicts were changelog insertions; all entries from both sides were preserved. `git range-diff` shows only changelog placement/context changes between the old and rebased stack, with no semantic source changes. No third feature commit was added. `git merge-tree --write-tree HEAD ecdeaf5561ac59a404a0c69a51db9543b6c50b20` passed with no conflict; the pinned base is an ancestor of this head. Dependencies were refreshed with the frozen lockfile, and affected shell/Worker proof and reviews were rerun. The prior ClawSweeper P1 conflict and P2 refresh request are addressed by this rebase and the resulting-head proof; final-head CI is green and the final body is submitted for re-review. The earlier rebased-head ClawSweeper review already reported ready for maintainer review with no remaining blocker.
