### PR TITLE
fix(queue): retry control-plane 5xx and propagate retryable admission failures

### DIFF
--- a/.github/workflows/exact-review-dead-letter-reconcile.yml
+++ b/.github/workflows/exact-review-dead-letter-reconcile.yml
@@ -106,8 +106,9 @@ jobs:
       - name: Verify live recovery guards
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           expected_deploy_sha="$(git rev-parse HEAD)"
-          live_deploy_sha="$(curl --fail --silent --show-error "$EXACT_REVIEW_QUEUE_URL/api/health" | jq -er '.deployment_sha')"
+          live_deploy_sha="$(control_plane_curl --fail --silent --show-error "$EXACT_REVIEW_QUEUE_URL/api/health" | jq -er '.deployment_sha')"
           if [[ "$live_deploy_sha" != "$expected_deploy_sha" ]]; then
             if ! [[ "$live_deploy_sha" =~ ^[0-9a-f]{40}$ ]]; then
               echo "Live Worker returned an invalid deployment revision; refusing unguarded reconciliation" >&2

--- a/.github/workflows/exact-review-reconcile-run.yml
+++ b/.github/workflows/exact-review-reconcile-run.yml
@@ -34,9 +34,16 @@ jobs:
     needs: cooldown
     if: ${{ needs.cooldown.outputs.reconcile == 'true' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions: {}
+    timeout-minutes: 12
+    permissions:
+      contents: read
     steps:
+      - name: Check out control-plane retry helper
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          sparse-checkout-cone-mode: false
+          sparse-checkout: scripts/control-plane-curl.sh
       - name: Reconcile terminal run
         env:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
@@ -45,6 +52,7 @@ jobs:
           SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           test -n "$CLAWSWEEPER_WEBHOOK_SECRET"
           queue_url="${QUEUE_URL%/}"
           payload="$(node -e '
@@ -59,17 +67,12 @@ jobs:
             }));
           ')"
           signature="$(PAYLOAD="$payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
-          for attempt in 1 2 3; do
-            if curl --fail --silent --show-error --connect-timeout 5 --max-time 120 \
-              --request POST \
-              --header "content-type: application/json" \
-              --header "x-clawsweeper-exact-review-signature: $signature" \
-              --data-binary "$payload" \
-              "$queue_url/internal/exact-review/reconcile" >/dev/null; then
-              exit 0
-            fi
-            if [ "$attempt" -lt 3 ]; then
-              sleep "$((attempt * 5))"
-            fi
-          done
+          if control_plane_curl --fail --silent --show-error --connect-timeout 5 --max-time 120 \
+            --request POST \
+            --header "content-type: application/json" \
+            --header "x-clawsweeper-exact-review-signature: $signature" \
+            --data-binary "$payload" \
+            "$queue_url/internal/exact-review/reconcile" >/dev/null; then
+            exit 0
+          fi
           exit 1

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -281,6 +281,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Check out control-plane retry helper
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          sparse-checkout-cone-mode: false
+          sparse-checkout: scripts/control-plane-curl.sh
       - name: Enqueue legacy event through the durable control plane
         env:
           CLIENT_PAYLOAD: ${{ toJson(github.event.client_payload) }}
@@ -288,6 +294,7 @@ jobs:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           test -n "$CLAWSWEEPER_WEBHOOK_SECRET"
           queue_url="${QUEUE_URL%/}"
           mapfile -d '' -t legacy_intake_fields < <(node <<'NODE'
@@ -459,7 +466,7 @@ jobs:
           NODE
           )"
           signature="$(PAYLOAD="$payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
-          curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+          control_plane_curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
             --request POST \
             --header "content-type: application/json" \
             --header "x-clawsweeper-exact-review-signature: $signature" \
@@ -482,6 +489,12 @@ jobs:
       pull-requests: read
       statuses: read
     steps:
+      - name: Check out control-plane retry helper
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          sparse-checkout-cone-mode: false
+          sparse-checkout: scripts/control-plane-curl.sh
       - name: Claim exact-review queue lease
         id: claim-exact-review-queue
         env:
@@ -493,6 +506,7 @@ jobs:
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           test -n "$QUEUE_LEASE_ID"
           printf 'claimed=false\ndecision={}\n' >> "$GITHUB_OUTPUT"
           queue_url="${QUEUE_URL%/}"
@@ -514,160 +528,151 @@ jobs:
             }));
           ')"
           response_file="$(mktemp)"
-          error_file="$(mktemp)"
-          trap 'rm -f "$response_file" "$error_file"' EXIT
-          for attempt in 1 2 3; do
-            : > "$response_file"
-            : > "$error_file"
-            if status="$(curl --silent --show-error --connect-timeout 5 --max-time 20 \
-              --output "$response_file" \
-              --write-out '%{http_code}' \
-              --request POST \
-              --header "content-type: application/json" \
-              --data "$payload" \
-              "$queue_url/internal/exact-review/claim" 2>"$error_file")"; then
-              response="$(<"$response_file")"
-              if [ "$status" = "409" ]; then
-                conflict_reason="$(RESPONSE="$response" node <<'NODE'
-                  const response = JSON.parse(process.env.RESPONSE || "{}");
-                  const safeConflicts = new Set([
-                    "lease_not_active",
-                    "lease_already_claimed",
-                    "lease_decision_unavailable",
-                    "stale_run_attempt",
-                  ]);
-                  if (!safeConflicts.has(response.error)) process.exit(1);
-                  process.stdout.write(response.error);
-          NODE
-                )" || {
-                  echo "Unexpected exact-review lease conflict: $response" >&2
-                  exit 1
-                }
-                echo "::notice::Skipping exact review because lease claim lost safely: $conflict_reason"
-                exit 0
-              fi
-              if [ "$status" != "200" ]; then
-                if [[ "$status" != 5* ]]; then
-                  echo "Exact-review lease claim returned HTTP $status: $response" >&2
-                  exit 1
-                fi
-              elif RESPONSE="$response" node <<'NODE'
-                const fs = require("node:fs");
+          trap 'rm -f "$response_file"' EXIT
+          : > "$response_file"
+          if status="$(control_plane_curl --silent --show-error --connect-timeout 5 --max-time 20 \
+            --output "$response_file" \
+            --write-out '%{http_code}' \
+            --request POST \
+            --header "content-type: application/json" \
+            --data "$payload" \
+            "$queue_url/internal/exact-review/claim")"; then
+            response="$(<"$response_file")"
+            if [ "$status" = "409" ]; then
+              conflict_reason="$(RESPONSE="$response" node <<'NODE'
                 const response = JSON.parse(process.env.RESPONSE || "{}");
-                const dispatch = JSON.parse(process.env.DISPATCH_PAYLOAD || "{}");
-                const requestedItemKey = String(process.env.ITEM_KEY || "").trim();
-                const requestedLeaseRevision = Number(process.env.QUEUE_LEASE_REVISION);
-                const responseProtocol = Number(response.protocol_version || 1);
-                if (responseProtocol !== 1 && responseProtocol !== 2) process.exit(1);
-                if (response.claimed !== true) process.exit(1);
-
-                const reviewOptions =
-                  dispatch.review_options && typeof dispatch.review_options === "object"
-                    ? dispatch.review_options
-                    : {};
-                const legacyDecision = {
-                  targetRepo: String(dispatch.target_repo || ""),
-                  targetBranch: String(dispatch.target_branch || "main"),
-                  itemNumber: Number(dispatch.item_number),
-                  itemKind: String(dispatch.item_kind || ""),
-                  sourceEvent: String(dispatch.source_event || ""),
-                  sourceAction: String(dispatch.source_action || "legacy_dispatch"),
-                  supersedesInProgress: dispatch.supersedes_in_progress === true,
-                  ...(/^[0-9a-f]{40}$/.test(String(dispatch.queue_claim?.source_head_sha || dispatch.source_head_sha || "").trim().toLowerCase())
-                    ? { sourceHeadSha: String(dispatch.queue_claim?.source_head_sha || dispatch.source_head_sha).trim().toLowerCase() }
-                    : {}),
-                  ...(Number.isFinite(Number(reviewOptions.codex_timeout_ms))
-                    ? { codexTimeoutMs: Number(reviewOptions.codex_timeout_ms) }
-                    : {}),
-                  ...(Number.isFinite(Number(reviewOptions.media_proof_timeout_ms))
-                    ? { mediaProofTimeoutMs: Number(reviewOptions.media_proof_timeout_ms) }
-                    : {}),
-                  ...(Object.hasOwn(reviewOptions, "command_status_marker")
-                    ? { commandStatusMarker: reviewOptions.command_status_marker }
-                    : {}),
-                  ...(Object.hasOwn(reviewOptions, "status_comment_id")
-                    ? { statusCommentId: reviewOptions.status_comment_id }
-                    : {}),
-                  ...(Number.isSafeInteger(
-                    Number(reviewOptions.review_acknowledgement_comment_id),
-                  ) && Number(reviewOptions.review_acknowledgement_comment_id) > 0
-                    ? {
-                        reviewAcknowledgementCommentId: Number(
-                          reviewOptions.review_acknowledgement_comment_id,
-                        ),
-                      }
-                    : {}),
-                  ...(Object.hasOwn(reviewOptions, "additional_prompt")
-                    ? { additionalPrompt: reviewOptions.additional_prompt }
-                    : {}),
-                };
-                const decision =
-                  response.decision && typeof response.decision === "object"
-                    ? response.decision
-                    : legacyDecision;
-                const targetRepo = String(decision?.targetRepo || "");
-                const itemNumber = Number(decision?.itemNumber);
-                const itemKey = `${targetRepo}#${itemNumber}`;
-                const leaseRevision =
-                  responseProtocol === 2
-                    ? Number(response.lease_revision)
-                    : Number(
-                        response.revision ||
-                          response.lease_revision ||
-                          process.env.QUEUE_LEASE_REVISION,
-                      );
-                const claimGeneration = Number(response.claim_generation);
-                const repeatRevision = response.repeat_revision;
-                if (
-                  !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(targetRepo) ||
-                  !Number.isInteger(itemNumber) ||
-                  itemNumber < 1 ||
-                  (decision.itemKind !== "issue" && decision.itemKind !== "pull_request") ||
-                  (decision.sourceEvent !== "issues" && decision.sourceEvent !== "pull_request") ||
-                  typeof decision.sourceAction !== "string" ||
-                  !decision.sourceAction
-                ) {
-                  process.exit(1);
-                }
-                if (response.item_key && response.item_key !== itemKey) process.exit(1);
-                if (requestedItemKey && requestedItemKey !== itemKey) process.exit(1);
-                if (
-                  responseProtocol === 2 &&
-                  (!response.decision ||
-                    typeof response.decision !== "object" ||
-                    response.item_key !== requestedItemKey ||
-                    response.lease_revision !== requestedLeaseRevision ||
-                    !Number.isInteger(claimGeneration) ||
-                    claimGeneration < 1 ||
-                    typeof repeatRevision !== "boolean")
-                ) {
-                  process.exit(1);
-                }
-                const output = [
-                  "claimed=true",
-                  `lease_id=${process.env.QUEUE_LEASE_ID}`,
-                  `item_key=${itemKey}`,
-                  `lease_revision=${Number.isInteger(leaseRevision) ? leaseRevision : ""}`,
-                  `claim_generation=${responseProtocol === 2 ? claimGeneration : ""}`,
-                  `repeat_revision=${responseProtocol === 2 ? repeatRevision : false}`,
-                  `protocol_version=${responseProtocol}`,
-                  `decision=${JSON.stringify(decision)}`,
-                ];
-                fs.appendFileSync(process.env.GITHUB_OUTPUT, `${output.join("\n")}\n`);
+                const safeConflicts = new Set([
+                  "lease_not_active",
+                  "lease_already_claimed",
+                  "lease_decision_unavailable",
+                  "stale_run_attempt",
+                ]);
+                if (!safeConflicts.has(response.error)) process.exit(1);
+                process.stdout.write(response.error);
           NODE
-              then
-                exit 0
-              else
-                echo "Exact-review lease claim returned an invalid success payload." >&2
+              )" || {
+                echo "Unexpected exact-review lease conflict: $response" >&2
+                exit 1
+              }
+              echo "::notice::Skipping exact review because lease claim lost safely: $conflict_reason"
+              exit 0
+            fi
+            if [ "$status" != "200" ]; then
+              if [[ "$status" != 5* ]]; then
+                echo "Exact-review lease claim returned HTTP $status: $response" >&2
                 exit 1
               fi
+            elif RESPONSE="$response" node <<'NODE'
+              const fs = require("node:fs");
+              const response = JSON.parse(process.env.RESPONSE || "{}");
+              const dispatch = JSON.parse(process.env.DISPATCH_PAYLOAD || "{}");
+              const requestedItemKey = String(process.env.ITEM_KEY || "").trim();
+              const requestedLeaseRevision = Number(process.env.QUEUE_LEASE_REVISION);
+              const responseProtocol = Number(response.protocol_version || 1);
+              if (responseProtocol !== 1 && responseProtocol !== 2) process.exit(1);
+              if (response.claimed !== true) process.exit(1);
+
+              const reviewOptions =
+                dispatch.review_options && typeof dispatch.review_options === "object"
+                  ? dispatch.review_options
+                  : {};
+              const legacyDecision = {
+                targetRepo: String(dispatch.target_repo || ""),
+                targetBranch: String(dispatch.target_branch || "main"),
+                itemNumber: Number(dispatch.item_number),
+                itemKind: String(dispatch.item_kind || ""),
+                sourceEvent: String(dispatch.source_event || ""),
+                sourceAction: String(dispatch.source_action || "legacy_dispatch"),
+                supersedesInProgress: dispatch.supersedes_in_progress === true,
+                ...(/^[0-9a-f]{40}$/.test(String(dispatch.queue_claim?.source_head_sha || dispatch.source_head_sha || "").trim().toLowerCase())
+                  ? { sourceHeadSha: String(dispatch.queue_claim?.source_head_sha || dispatch.source_head_sha).trim().toLowerCase() }
+                  : {}),
+                ...(Number.isFinite(Number(reviewOptions.codex_timeout_ms))
+                  ? { codexTimeoutMs: Number(reviewOptions.codex_timeout_ms) }
+                  : {}),
+                ...(Number.isFinite(Number(reviewOptions.media_proof_timeout_ms))
+                  ? { mediaProofTimeoutMs: Number(reviewOptions.media_proof_timeout_ms) }
+                  : {}),
+                ...(Object.hasOwn(reviewOptions, "command_status_marker")
+                  ? { commandStatusMarker: reviewOptions.command_status_marker }
+                  : {}),
+                ...(Object.hasOwn(reviewOptions, "status_comment_id")
+                  ? { statusCommentId: reviewOptions.status_comment_id }
+                  : {}),
+                ...(Number.isSafeInteger(
+                  Number(reviewOptions.review_acknowledgement_comment_id),
+                ) && Number(reviewOptions.review_acknowledgement_comment_id) > 0
+                  ? {
+                      reviewAcknowledgementCommentId: Number(
+                        reviewOptions.review_acknowledgement_comment_id,
+                      ),
+                    }
+                  : {}),
+                ...(Object.hasOwn(reviewOptions, "additional_prompt")
+                  ? { additionalPrompt: reviewOptions.additional_prompt }
+                  : {}),
+              };
+              const decision =
+                response.decision && typeof response.decision === "object"
+                  ? response.decision
+                  : legacyDecision;
+              const targetRepo = String(decision?.targetRepo || "");
+              const itemNumber = Number(decision?.itemNumber);
+              const itemKey = `${targetRepo}#${itemNumber}`;
+              const leaseRevision =
+                responseProtocol === 2
+                  ? Number(response.lease_revision)
+                  : Number(
+                      response.revision ||
+                        response.lease_revision ||
+                        process.env.QUEUE_LEASE_REVISION,
+                    );
+              const claimGeneration = Number(response.claim_generation);
+              const repeatRevision = response.repeat_revision;
+              if (
+                !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(targetRepo) ||
+                !Number.isInteger(itemNumber) ||
+                itemNumber < 1 ||
+                (decision.itemKind !== "issue" && decision.itemKind !== "pull_request") ||
+                (decision.sourceEvent !== "issues" && decision.sourceEvent !== "pull_request") ||
+                typeof decision.sourceAction !== "string" ||
+                !decision.sourceAction
+              ) {
+                process.exit(1);
+              }
+              if (response.item_key && response.item_key !== itemKey) process.exit(1);
+              if (requestedItemKey && requestedItemKey !== itemKey) process.exit(1);
+              if (
+                responseProtocol === 2 &&
+                (!response.decision ||
+                  typeof response.decision !== "object" ||
+                  response.item_key !== requestedItemKey ||
+                  response.lease_revision !== requestedLeaseRevision ||
+                  !Number.isInteger(claimGeneration) ||
+                  claimGeneration < 1 ||
+                  typeof repeatRevision !== "boolean")
+              ) {
+                process.exit(1);
+              }
+              const output = [
+                "claimed=true",
+                `lease_id=${process.env.QUEUE_LEASE_ID}`,
+                `item_key=${itemKey}`,
+                `lease_revision=${Number.isInteger(leaseRevision) ? leaseRevision : ""}`,
+                `claim_generation=${responseProtocol === 2 ? claimGeneration : ""}`,
+                `repeat_revision=${responseProtocol === 2 ? repeatRevision : false}`,
+                `protocol_version=${responseProtocol}`,
+                `decision=${JSON.stringify(decision)}`,
+              ];
+              fs.appendFileSync(process.env.GITHUB_OUTPUT, `${output.join("\n")}\n`);
+          NODE
+            then
+              exit 0
             else
-              cat "$error_file" >&2
+              echo "Exact-review lease claim returned an invalid success payload." >&2
+              exit 1
             fi
-            if [ "$attempt" -lt 3 ]; then
-              sleep "$((attempt * 5))"
-            fi
-          done
+          fi
           exit 1
 
       - uses: actions/checkout@v7
@@ -1234,6 +1239,7 @@ jobs:
           REVIEW_ACKNOWLEDGEMENT_COMMENT_ID: ${{ steps.automatic-review-status.outputs.status_comment_id }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           echo "authorized=false" >> "$GITHUB_OUTPUT"
           payload="$(node -e '
             const sourceHeadSha = String(process.env.EXACT_REVIEW_SOURCE_HEAD_SHA || "").trim().toLowerCase();
@@ -1251,7 +1257,7 @@ jobs:
           ')"
           response="$(mktemp)"
           trap 'rm -f "$response"' EXIT
-          status="$(curl --silent --show-error --connect-timeout 5 --max-time 20 \
+          status="$(control_plane_curl --silent --show-error --connect-timeout 5 --max-time 20 \
             --output "$response" --write-out '%{http_code}' --request POST \
             --header "content-type: application/json" --data-binary "$payload" \
             "${QUEUE_URL%/}/internal/exact-review/heartbeat")" || status=""
@@ -1292,6 +1298,7 @@ jobs:
           EXACT_REVIEW_SOURCE_HEAD_SHA: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).sourceHeadSha || '' }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           echo "authorized=false" >> "$GITHUB_OUTPUT"
           payload="$(node -e '
             const sourceHeadSha = String(process.env.EXACT_REVIEW_SOURCE_HEAD_SHA || "").trim().toLowerCase();
@@ -1308,7 +1315,7 @@ jobs:
           ')"
           response="$(mktemp)"
           trap 'rm -f "$response"' EXIT
-          status="$(curl --silent --show-error --connect-timeout 5 --max-time 20 \
+          status="$(control_plane_curl --silent --show-error --connect-timeout 5 --max-time 20 \
             --output "$response" --write-out '%{http_code}' --request POST \
             --header "content-type: application/json" --data-binary "$payload" \
             "${QUEUE_URL%/}/internal/exact-review/heartbeat")" || status=""
@@ -1345,6 +1352,7 @@ jobs:
           EXACT_REVIEW_DECISION: ${{ steps.claim-exact-review-queue.outputs.decision }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           test -n "$GH_TOKEN"
           heartbeat_pid=""
           review_pid=""
@@ -1375,13 +1383,13 @@ jobs:
           }
           heartbeat_loop() {
             while true; do
-              heartbeat_status="$(curl --silent --connect-timeout 5 --max-time 20 \
+              heartbeat_status="$(control_plane_curl --silent --connect-timeout 5 --max-time 20 \
                 --output /dev/null \
                 --write-out '%{http_code}' \
                 --request POST \
                 --header "content-type: application/json" \
                 --data-binary "$heartbeat_payload" \
-                "${QUEUE_URL%/}/internal/exact-review/heartbeat" 2>/dev/null)" || heartbeat_status=""
+                "${QUEUE_URL%/}/internal/exact-review/heartbeat")" || heartbeat_status=""
               if [ "$heartbeat_status" = "409" ]; then
                 echo "::notice::Exact-review heartbeat lost its lease tuple."
                 : > "$superseded_marker"
@@ -1427,26 +1435,22 @@ jobs:
               const payload = JSON.parse(process.env.HEARTBEAT_PAYLOAD || "{}");
               process.stdout.write(JSON.stringify({ ...payload, phase: "finalizing" }));
             ')" || return 1
-            for attempt in 1 2 3; do
-              finalizing_status="$(curl --silent --connect-timeout 5 --max-time 20 \
-                --output /dev/null \
-                --write-out '%{http_code}' \
-                --request POST \
-                --header "content-type: application/json" \
-                --data-binary "$finalizing_payload" \
-                "${QUEUE_URL%/}/internal/exact-review/heartbeat" 2>/dev/null)" || finalizing_status=""
-              if [ "$finalizing_status" = "200" ]; then
-                return 0
-              fi
-              if [ "$finalizing_status" = "409" ]; then
-                echo "::notice::Exact-review finalization lost its lease tuple."
-                : > "$superseded_marker"
-                return 0
-              fi
-              if [ "$attempt" -lt 3 ]; then
-                sleep "$((attempt * 5))"
-              fi
-            done
+            finalizing_status="$(control_plane_curl --silent --connect-timeout 5 --max-time 20 \
+              --output /dev/null \
+              --write-out '%{http_code}' \
+              --request POST \
+              --header "content-type: application/json" \
+              --data-binary "$finalizing_payload" \
+              "${QUEUE_URL%/}/internal/exact-review/heartbeat")" || finalizing_status=""
+            if [ "$finalizing_status" = "200" ]; then
+              return 0
+            fi
+            if [ "$finalizing_status" = "409" ]; then
+              echo "::notice::Exact-review finalization lost its lease tuple."
+              : > "$superseded_marker"
+              return 0
+            fi
+            echo "control_plane_unavailable=true" >> "$GITHUB_OUTPUT"
             echo "::error::Exact-review lease could not enter finalization."
             return 1
           }
@@ -1593,6 +1597,7 @@ jobs:
           REVIEW_ACKNOWLEDGEMENT_COMMENT_ID: ${{ steps.automatic-review-status.outputs.status_comment_id }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           echo "authorized=false" >> "$GITHUB_OUTPUT"
           payload="$(node -e '
             const sourceHeadSha = String(process.env.EXACT_REVIEW_SOURCE_HEAD_SHA || "").trim().toLowerCase();
@@ -1610,7 +1615,7 @@ jobs:
           ')"
           response="$(mktemp)"
           trap 'rm -f "$response"' EXIT
-          status="$(curl --silent --show-error --connect-timeout 5 --max-time 20 \
+          status="$(control_plane_curl --silent --show-error --connect-timeout 5 --max-time 20 \
             --output "$response" --write-out '%{http_code}' --request POST \
             --header "content-type: application/json" --data-binary "$payload" \
             "${QUEUE_URL%/}/internal/exact-review/heartbeat")" || status=""
@@ -1648,6 +1653,7 @@ jobs:
           EXACT_REVIEW_SOURCE_HEAD_SHA: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).sourceHeadSha || '' }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           echo "authorized=false" >> "$GITHUB_OUTPUT"
           payload="$(node -e '
             const sourceHeadSha = String(process.env.EXACT_REVIEW_SOURCE_HEAD_SHA || "").trim().toLowerCase();
@@ -1664,7 +1670,7 @@ jobs:
           ')"
           response="$(mktemp)"
           trap 'rm -f "$response"' EXIT
-          status="$(curl --silent --show-error --connect-timeout 5 --max-time 20 \
+          status="$(control_plane_curl --silent --show-error --connect-timeout 5 --max-time 20 \
             --output "$response" --write-out '%{http_code}' --request POST \
             --header "content-type: application/json" --data-binary "$payload" \
             "${QUEUE_URL%/}/internal/exact-review/heartbeat")" || status=""
@@ -1799,6 +1805,7 @@ jobs:
           CLAWSWEEPER_COMMENT_MAX_COMMENTS: ${{ vars.CLAWSWEEPER_COMMENT_MAX_COMMENTS || '1000' }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           test -s "$DIRECT_OUTCOME"
           jq -e '.kind == "eligible" and .disposition != null' "$DIRECT_OUTCOME" >/dev/null
           test -n "$CLAWSWEEPER_WEBHOOK_SECRET"
@@ -1862,7 +1869,7 @@ jobs:
               }));
             ')"
             lifecycle_signature="$(PAYLOAD="$lifecycle_payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
-            lifecycle_response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+            lifecycle_response="$(control_plane_curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
               --request POST \
               --header "content-type: application/json" \
               --header "x-clawsweeper-exact-review-signature: $lifecycle_signature" \
@@ -1882,7 +1889,7 @@ jobs:
               }));
             ')"
             lifecycle_signature="$(PAYLOAD="$lifecycle_payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
-            lifecycle_response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+            lifecycle_response="$(control_plane_curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
               --request POST \
               --header "content-type: application/json" \
               --header "x-clawsweeper-exact-review-signature: $lifecycle_signature" \
@@ -1940,6 +1947,7 @@ jobs:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           test -n "$CLAWSWEEPER_WEBHOOK_SECRET"
           queue_url="${QUEUE_URL%/}"
           payload="$(node <<'NODE'
@@ -1981,26 +1989,21 @@ jobs:
           NODE
           )"
           signature="$(PAYLOAD="$payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
-          for attempt in 1 2 3; do
-            response="$(
-              curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
-                --request POST \
-                --header "content-type: application/json" \
-                --header "x-clawsweeper-exact-review-signature: $signature" \
-                --data "$payload" \
-                "$queue_url/internal/exact-review/enqueue" || true
-            )"
-            if jq -e '.superseded == true' <<< "$response" >/dev/null 2>&1; then
-              echo "::notice::Exact-review publication revision $(jq -r '.publication_revision // "unknown"' <<< "$response") was superseded by revision $(jq -r '.superseded_by_revision // "unknown"' <<< "$response"); the newer publisher owns final delivery."
-              exit 0
-            fi
-            if jq -e '.ok == true and (.queued == true or .deduped == true)' <<< "$response" >/dev/null; then
-              exit 0
-            fi
-            if [ "$attempt" -lt 3 ]; then
-              sleep "$((attempt * 5))"
-            fi
-          done
+          response="$(
+            control_plane_curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+              --request POST \
+              --header "content-type: application/json" \
+              --header "x-clawsweeper-exact-review-signature: $signature" \
+              --data "$payload" \
+              "$queue_url/internal/exact-review/enqueue" || true
+          )"
+          if jq -e '.superseded == true' <<< "$response" >/dev/null 2>&1; then
+            echo "::notice::Exact-review publication revision $(jq -r '.publication_revision // "unknown"' <<< "$response") was superseded by revision $(jq -r '.superseded_by_revision // "unknown"' <<< "$response"); the newer publisher owns final delivery."
+            exit 0
+          fi
+          if jq -e '.ok == true and (.queued == true or .deduped == true)' <<< "$response" >/dev/null; then
+            exit 0
+          fi
           exit 1
 
       - name: Expire queued exact review lease
@@ -2105,6 +2108,7 @@ jobs:
           REVIEW_ACKNOWLEDGEMENT_COMMENT_ID: ${{ steps.automatic-review-status.outputs.status_comment_id }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           echo "authorized=false" >> "$GITHUB_OUTPUT"
           payload="$(node -e '
             const leaseRevision = Number(process.env.EXACT_REVIEW_LEASE_REVISION);
@@ -2128,24 +2132,21 @@ jobs:
               phase: "status",
             }));
           ')"
-          for attempt in 1 2 3; do
-            status="$(curl --silent --show-error --connect-timeout 5 --max-time 20 \
-              --output /dev/null \
-              --write-out '%{http_code}' \
-              --request POST \
-              --header "content-type: application/json" \
-              --data-binary "$payload" \
-              "${QUEUE_URL%/}/internal/exact-review/heartbeat")" || status=""
-            if [ "$status" = "200" ]; then
-              echo "authorized=true" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-            if [ "$status" = "409" ]; then
-              echo "::notice::Skipping terminal review status because the queue lease was superseded."
-              exit 0
-            fi
-            if [ "$attempt" -lt 3 ]; then sleep "$((attempt * 5))"; fi
-          done
+          status="$(control_plane_curl --silent --show-error --connect-timeout 5 --max-time 20 \
+            --output /dev/null \
+            --write-out '%{http_code}' \
+            --request POST \
+            --header "content-type: application/json" \
+            --data-binary "$payload" \
+            "${QUEUE_URL%/}/internal/exact-review/heartbeat")" || status=""
+          if [ "$status" = "200" ]; then
+            echo "authorized=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$status" = "409" ]; then
+            echo "::notice::Skipping terminal review status because the queue lease was superseded."
+            exit 0
+          fi
           echo "Unable to fence terminal review status against the active queue lease." >&2
           exit 1
 
@@ -2180,6 +2181,7 @@ jobs:
           EXACT_REVIEW_CLAIM_GENERATION: ${{ steps.claim-exact-review-queue.outputs.claim_generation }}
           EXACT_REVIEW_SOURCE_HEAD_SHA: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).sourceHeadSha || '' }}
         run: |
+          source scripts/control-plane-curl.sh
           payload="$(node -e '
             const sourceHeadSha = String(process.env.EXACT_REVIEW_SOURCE_HEAD_SHA || "").trim().toLowerCase();
             process.stdout.write(JSON.stringify({
@@ -2193,7 +2195,7 @@ jobs:
               phase: "finalizing",
             }));
           ')"
-          curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+          control_plane_curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
             --request POST --header "content-type: application/json" --data-binary "$payload" \
             "${QUEUE_URL%/}/internal/exact-review/heartbeat" >/dev/null
 
@@ -2283,6 +2285,7 @@ jobs:
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           test -n "$QUEUE_LEASE_ID"
           queue_url="${QUEUE_URL%/}"
           payload="$(node -e '
@@ -2398,64 +2401,54 @@ jobs:
             }));
           ')"
           response_file="$(mktemp)"
-          error_file="$(mktemp)"
-          trap 'rm -f "$response_file" "$error_file"' EXIT
-          for attempt in 1 2 3; do
-            while true; do
-              : > "$response_file"
-              : > "$error_file"
-              if status="$(curl --silent --show-error --connect-timeout 5 --max-time 20 \
-                --output "$response_file" \
-                --write-out '%{http_code}' \
-                --request POST \
-                --header "content-type: application/json" \
-                --data "$payload" \
-                "$queue_url/internal/exact-review/complete" 2>"$error_file")"; then
-                response="$(<"$response_file")"
-                if [[ "$status" == 2* ]]; then
-                  exit 0
-                fi
-                if [ "$status" = "400" ] &&
-                  jq -e '.error == "invalid_review_failure_reason"' "$response_file" >/dev/null 2>&1 &&
-                  jq -e 'has("review_failure_reason")' <<< "$payload" >/dev/null; then
-                  # Status is valid only alongside a terminal reason; retain diagnostic detail.
-                  payload="$(jq -c 'del(.review_failure_reason, .review_failure_status)' <<< "$payload")"
-                  echo "::warning::Exact-review completion detected Worker/workflow deploy skew (invalid_review_failure_reason); retrying once without terminal reason/status, retaining review_failure detail."
-                  continue
-                fi
-                # Only this completion-specific conflict is emitted after the
-                # durable queue verifies that this exact v2 lease tuple was fenced
-                # by a newer source revision. Every generic ownership conflict
-                # stays visible so a malformed or mismatched callback cannot turn
-                # a failed completion into a green workflow.
-                if [ "$status" = "409" ]; then
-                  conflict_reason="$(RESPONSE="$response" node <<'NODE'
-                    const response = JSON.parse(process.env.RESPONSE || "{}");
-                    const safeConflicts = new Set(["lease_superseded"]);
-                    if (!safeConflicts.has(response.error)) process.exit(1);
-                    process.stdout.write(response.error);
-          NODE
-                  )" || {
-                    echo "Unexpected exact-review completion conflict: $response" >&2
-                    exit 1
-                  }
-                  echo "::notice::Exact-review completion skipped because its lease was superseded: $conflict_reason"
-                  exit 0
-                fi
-                echo "Exact-review completion returned HTTP $status: $response" >&2
-                if [[ "$status" != 5* ]]; then
-                  exit 1
-                fi
-              else
-                cat "$error_file" >&2
+          trap 'rm -f "$response_file"' EXIT
+          while true; do
+            : > "$response_file"
+            if status="$(control_plane_curl --silent --show-error --connect-timeout 5 --max-time 20 \
+              --output "$response_file" \
+              --write-out '%{http_code}' \
+              --request POST \
+              --header "content-type: application/json" \
+              --data "$payload" \
+              "$queue_url/internal/exact-review/complete")"; then
+              response="$(<"$response_file")"
+              if [[ "$status" == 2* ]]; then
+                exit 0
               fi
-              break
-            done
-            if [ "$attempt" -lt 3 ]; then
-              sleep "$((attempt * 5))"
+              if [ "$status" = "400" ] &&
+                jq -e '.error == "invalid_review_failure_reason"' "$response_file" >/dev/null 2>&1 &&
+                jq -e 'has("review_failure_reason")' <<< "$payload" >/dev/null; then
+                # Status is valid only alongside a terminal reason; retain diagnostic detail.
+                payload="$(jq -c 'del(.review_failure_reason, .review_failure_status)' <<< "$payload")"
+                echo "::warning::Exact-review completion detected Worker/workflow deploy skew (invalid_review_failure_reason); retrying once without terminal reason/status, retaining review_failure detail."
+                continue
+              fi
+              # Only this completion-specific conflict is emitted after the
+              # durable queue verifies that this exact v2 lease tuple was fenced
+              # by a newer source revision. Every generic ownership conflict
+              # stays visible so a malformed or mismatched callback cannot turn
+              # a failed completion into a green workflow.
+              if [ "$status" = "409" ]; then
+                conflict_reason="$(RESPONSE="$response" node <<'NODE'
+                  const response = JSON.parse(process.env.RESPONSE || "{}");
+                  const safeConflicts = new Set(["lease_superseded"]);
+                  if (!safeConflicts.has(response.error)) process.exit(1);
+                  process.stdout.write(response.error);
+          NODE
+                )" || {
+                  echo "Unexpected exact-review completion conflict: $response" >&2
+                  exit 1
+                }
+                echo "::notice::Exact-review completion skipped because its lease was superseded: $conflict_reason"
+                exit 0
+              fi
+              echo "Exact-review completion returned HTTP $status: $response" >&2
+              if [[ "$status" != 5* ]]; then
+                exit 1
+              fi
             fi
+            exit 1
           done
-          exit 1
 
       - name: Submit direct GitHub egress telemetry
         if: ${{ always() && steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.direct-github-egress-observer.outcome == 'success' }}
@@ -2508,7 +2501,14 @@ jobs:
         env:
           CLASSIFICATION: >-
             ${{
-              (steps.review-complete-status-fence.outcome == 'failure' || steps.release-review-complete-status-fence.outcome == 'failure') && 'review_status_delivery_failure' ||
+              (
+                steps.reserve-exact-review-lease.outcome == 'failure' ||
+                steps.review-status-fence.outcome == 'failure' ||
+                steps.release-review-status-fence.outcome == 'failure' ||
+                steps.review-complete-status-fence.outcome == 'failure' ||
+                steps.release-review-complete-status-fence.outcome == 'failure' ||
+                steps.review-exact-event-item.outputs.control_plane_unavailable == 'true'
+              ) && 'queue_completion_failure' ||
               (
                 steps.exact-review-generation-result.outputs.outcome != 'success' &&
                 steps.exact-review-generation-result.outputs.retry_kind == '' &&
@@ -2536,6 +2536,12 @@ jobs:
       pull-requests: write
       statuses: read
     steps:
+      - name: Check out control-plane retry helper
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          sparse-checkout-cone-mode: false
+          sparse-checkout: scripts/control-plane-curl.sh
       - name: Claim durable exact review publication
         id: publication-context
         env:
@@ -2546,6 +2552,7 @@ jobs:
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           printf 'claimed=false\ndecision={}\n' >> "$GITHUB_OUTPUT"
           queue_url="${QUEUE_URL%/}"
           payload="$(node -e '
@@ -2563,163 +2570,154 @@ jobs:
             }));
           ')"
           response_file="$(mktemp)"
-          error_file="$(mktemp)"
-          trap 'rm -f "$response_file" "$error_file"' EXIT
-          for attempt in 1 2 3; do
-            : > "$response_file"
-            : > "$error_file"
-            if status="$(curl --silent --show-error --connect-timeout 5 --max-time 20 \
-              --output "$response_file" \
-              --write-out '%{http_code}' \
-              --request POST \
-              --header "content-type: application/json" \
-              --data "$payload" \
-              "$queue_url/internal/exact-review/claim" 2>"$error_file")"; then
-              response="$(<"$response_file")"
-              if [ "$status" = "409" ]; then
-                conflict_reason="$(RESPONSE="$response" node <<'NODE'
-                  const response = JSON.parse(process.env.RESPONSE || "{}");
-                  const safeConflicts = new Set([
-                    "lease_not_active",
-                    "lease_already_claimed",
-                    "lease_decision_unavailable",
-                    "stale_run_attempt",
-                  ]);
-                  if (!safeConflicts.has(response.error)) process.exit(1);
-                  process.stdout.write(response.error);
-          NODE
-                )" || {
-                  echo "Unexpected exact-review publication conflict: $response" >&2
-                  exit 1
-                }
-                echo "::notice::Skipping exact review publication because lease claim lost safely: $conflict_reason"
-                exit 0
-              fi
-              if [ "$status" != "200" ]; then
-                if [[ "$status" != 5* ]]; then
-                  echo "Exact-review publication claim returned HTTP $status: $response" >&2
-                  exit 1
-                fi
-              elif RESPONSE="$response" node <<'NODE'
-                const fs = require("node:fs");
+          trap 'rm -f "$response_file"' EXIT
+          : > "$response_file"
+          if status="$(control_plane_curl --silent --show-error --connect-timeout 5 --max-time 20 \
+            --output "$response_file" \
+            --write-out '%{http_code}' \
+            --request POST \
+            --header "content-type: application/json" \
+            --data "$payload" \
+            "$queue_url/internal/exact-review/claim")"; then
+            response="$(<"$response_file")"
+            if [ "$status" = "409" ]; then
+              conflict_reason="$(RESPONSE="$response" node <<'NODE'
                 const response = JSON.parse(process.env.RESPONSE || "{}");
-                const decision = response.decision;
-                const publication = decision?.publication;
-                const producerDecision = publication?.producerDecision;
-                const leaseRevision = Number(response.lease_revision);
-                const claimGeneration = Number(response.claim_generation);
-                const repeatRevision = response.repeat_revision;
-                const publicationLeaseRevision = Number(publication?.leaseRevision);
-                const directItemKey = `${decision?.targetRepo}#${decision?.itemNumber}`;
-                const expectedDeferredItemKey = `${directItemKey}@publish:${publication?.producerRunId}:${publication?.producerRunAttempt}`;
-                // Direct publication converts its already-leased base item into a
-                // recoverable publication. Its saved revision must still match
-                // this publisher lease before any external router handoff;
-                // deferred publication has its own key.
-                const directLifecycleRecovery =
-                  response.item_key === directItemKey &&
-                  publication?.itemKey === directItemKey &&
-                  Number.isInteger(publicationLeaseRevision) &&
-                  publicationLeaseRevision === leaseRevision;
-                const directLifecycle = directLifecycleRecovery ? publication?.directLifecycle : null;
-                const directLifecyclePlan = directLifecycle?.plan;
-                const directLifecycleReceiptOutcome = directLifecycle?.receiptOutcome;
-                const directLifecycleKinds = new Set([
-                  "router",
-                  "router_deferred_coverage",
-                  "router_not_required",
-                  "requeue",
-                  "target_missing",
-                  "target_closed",
-                  "guarded_open",
-                  "policy_noop",
+                const safeConflicts = new Set([
+                  "lease_not_active",
+                  "lease_already_claimed",
+                  "lease_decision_unavailable",
+                  "stale_run_attempt",
                 ]);
-                // Pre-projection rows have no saved post-effect intent. They
-                // deliberately retain artifact recovery rather than inferring a
-                // router or terminal result from a newer publisher run.
-                const directLifecycleRecoveryReady =
-                  directLifecycleRecovery &&
-                  directLifecyclePlan &&
-                  typeof directLifecyclePlan === "object" &&
-                  !Array.isArray(directLifecyclePlan) &&
-                  Object.keys(directLifecyclePlan).length === 1 &&
-                  directLifecycleKinds.has(directLifecyclePlan.kind) &&
-                  ["accepted", "deduped", "superseded"].includes(directLifecycleReceiptOutcome);
-                const deferredPublication = response.item_key === expectedDeferredItemKey;
-                if (
-                  response.claimed !== true ||
-                  response.protocol_version !== 2 ||
-                  typeof repeatRevision !== "boolean" ||
-                  response.item_key !== process.env.ITEM_KEY ||
-                  (!deferredPublication && !directLifecycleRecovery) ||
-                  decision?.sourceAction !== "exact_review_artifact_publish" ||
-                  !publication ||
-                  !producerDecision ||
-                  producerDecision.targetRepo !== decision.targetRepo ||
-                  producerDecision.targetBranch !== decision.targetBranch ||
-                  producerDecision.itemNumber !== decision.itemNumber ||
-                  producerDecision.itemKind !== decision.itemKind
-                ) process.exit(1);
-                if (!Number.isInteger(leaseRevision) || leaseRevision < 1) process.exit(1);
-                if (!Number.isInteger(claimGeneration) || claimGeneration < 1) process.exit(1);
-                const targetRepo = String(decision.targetRepo);
-                const [targetRepoOwner, targetRepoName] = targetRepo.split("/");
-                const targetSlug = targetRepo.trim().toLowerCase().replace(/[^a-z0-9_.-]+/g, "-");
-                const values = {
-                  artifact_name: publication.artifactName,
-                  generation_attempt: publication.producerRunAttempt,
-                  producer_run_id: publication.producerRunId,
-                  source_sha: publication.sourceSha,
-                  decision: JSON.stringify(producerDecision),
-                  item_key: publication.itemKey,
-                  protocol_version: publication.protocolVersion,
-                  lease_revision: publication.leaseRevision ?? "",
-                  claim_generation: publication.claimGeneration ?? "",
-                  target_repo: targetRepo,
-                  target_repo_owner: targetRepoOwner,
-                  target_repo_name: targetRepoName,
-                  target_slug: targetSlug,
-                  target_branch: decision.targetBranch,
-                  item_number: decision.itemNumber,
-                  item_kind: decision.itemKind,
-                  has_command_context: Boolean(
-                    producerDecision.commandStatusMarker || producerDecision.statusCommentId,
-                  ),
-                  live_proceeded: publication.liveProceeded,
-                  live_terminal_noop: publication.liveTerminalNoop,
-                  live_terminal_missing: publication.liveTerminalMissing,
-                  live_guarded_open: publication.liveGuardedOpen,
-                  publisher_lease_id: process.env.QUEUE_LEASE_ID,
-                  publisher_item_key: response.item_key,
-                  publisher_lease_revision: leaseRevision,
-                  publisher_claim_generation: claimGeneration,
-                  repeat_revision: repeatRevision,
-                  direct_lifecycle_recovery: directLifecycleRecoveryReady,
-                  direct_lifecycle_plan: directLifecycleRecoveryReady
-                    ? JSON.stringify(directLifecyclePlan)
-                    : "",
-                  direct_lifecycle_receipt_outcome: directLifecycleRecoveryReady
-                    ? directLifecycleReceiptOutcome
-                    : "",
-                };
-                fs.appendFileSync(process.env.GITHUB_OUTPUT, "claimed=true\n");
-                for (const [key, value] of Object.entries(values)) {
-                  fs.appendFileSync(process.env.GITHUB_OUTPUT, `${key}=${value}\n`);
-                }
+                if (!safeConflicts.has(response.error)) process.exit(1);
+                process.stdout.write(response.error);
           NODE
-              then
-                exit 0
-              else
-                echo "Exact-review publication claim returned an invalid success payload." >&2
+              )" || {
+                echo "Unexpected exact-review publication conflict: $response" >&2
+                exit 1
+              }
+              echo "::notice::Skipping exact review publication because lease claim lost safely: $conflict_reason"
+              exit 0
+            fi
+            if [ "$status" != "200" ]; then
+              if [[ "$status" != 5* ]]; then
+                echo "Exact-review publication claim returned HTTP $status: $response" >&2
                 exit 1
               fi
+            elif RESPONSE="$response" node <<'NODE'
+              const fs = require("node:fs");
+              const response = JSON.parse(process.env.RESPONSE || "{}");
+              const decision = response.decision;
+              const publication = decision?.publication;
+              const producerDecision = publication?.producerDecision;
+              const leaseRevision = Number(response.lease_revision);
+              const claimGeneration = Number(response.claim_generation);
+              const repeatRevision = response.repeat_revision;
+              const publicationLeaseRevision = Number(publication?.leaseRevision);
+              const directItemKey = `${decision?.targetRepo}#${decision?.itemNumber}`;
+              const expectedDeferredItemKey = `${directItemKey}@publish:${publication?.producerRunId}:${publication?.producerRunAttempt}`;
+              // Direct publication converts its already-leased base item into a
+              // recoverable publication. Its saved revision must still match
+              // this publisher lease before any external router handoff;
+              // deferred publication has its own key.
+              const directLifecycleRecovery =
+                response.item_key === directItemKey &&
+                publication?.itemKey === directItemKey &&
+                Number.isInteger(publicationLeaseRevision) &&
+                publicationLeaseRevision === leaseRevision;
+              const directLifecycle = directLifecycleRecovery ? publication?.directLifecycle : null;
+              const directLifecyclePlan = directLifecycle?.plan;
+              const directLifecycleReceiptOutcome = directLifecycle?.receiptOutcome;
+              const directLifecycleKinds = new Set([
+                "router",
+                "router_deferred_coverage",
+                "router_not_required",
+                "requeue",
+                "target_missing",
+                "target_closed",
+                "guarded_open",
+                "policy_noop",
+              ]);
+              // Pre-projection rows have no saved post-effect intent. They
+              // deliberately retain artifact recovery rather than inferring a
+              // router or terminal result from a newer publisher run.
+              const directLifecycleRecoveryReady =
+                directLifecycleRecovery &&
+                directLifecyclePlan &&
+                typeof directLifecyclePlan === "object" &&
+                !Array.isArray(directLifecyclePlan) &&
+                Object.keys(directLifecyclePlan).length === 1 &&
+                directLifecycleKinds.has(directLifecyclePlan.kind) &&
+                ["accepted", "deduped", "superseded"].includes(directLifecycleReceiptOutcome);
+              const deferredPublication = response.item_key === expectedDeferredItemKey;
+              if (
+                response.claimed !== true ||
+                response.protocol_version !== 2 ||
+                typeof repeatRevision !== "boolean" ||
+                response.item_key !== process.env.ITEM_KEY ||
+                (!deferredPublication && !directLifecycleRecovery) ||
+                decision?.sourceAction !== "exact_review_artifact_publish" ||
+                !publication ||
+                !producerDecision ||
+                producerDecision.targetRepo !== decision.targetRepo ||
+                producerDecision.targetBranch !== decision.targetBranch ||
+                producerDecision.itemNumber !== decision.itemNumber ||
+                producerDecision.itemKind !== decision.itemKind
+              ) process.exit(1);
+              if (!Number.isInteger(leaseRevision) || leaseRevision < 1) process.exit(1);
+              if (!Number.isInteger(claimGeneration) || claimGeneration < 1) process.exit(1);
+              const targetRepo = String(decision.targetRepo);
+              const [targetRepoOwner, targetRepoName] = targetRepo.split("/");
+              const targetSlug = targetRepo.trim().toLowerCase().replace(/[^a-z0-9_.-]+/g, "-");
+              const values = {
+                artifact_name: publication.artifactName,
+                generation_attempt: publication.producerRunAttempt,
+                producer_run_id: publication.producerRunId,
+                source_sha: publication.sourceSha,
+                decision: JSON.stringify(producerDecision),
+                item_key: publication.itemKey,
+                protocol_version: publication.protocolVersion,
+                lease_revision: publication.leaseRevision ?? "",
+                claim_generation: publication.claimGeneration ?? "",
+                target_repo: targetRepo,
+                target_repo_owner: targetRepoOwner,
+                target_repo_name: targetRepoName,
+                target_slug: targetSlug,
+                target_branch: decision.targetBranch,
+                item_number: decision.itemNumber,
+                item_kind: decision.itemKind,
+                has_command_context: Boolean(
+                  producerDecision.commandStatusMarker || producerDecision.statusCommentId,
+                ),
+                live_proceeded: publication.liveProceeded,
+                live_terminal_noop: publication.liveTerminalNoop,
+                live_terminal_missing: publication.liveTerminalMissing,
+                live_guarded_open: publication.liveGuardedOpen,
+                publisher_lease_id: process.env.QUEUE_LEASE_ID,
+                publisher_item_key: response.item_key,
+                publisher_lease_revision: leaseRevision,
+                publisher_claim_generation: claimGeneration,
+                repeat_revision: repeatRevision,
+                direct_lifecycle_recovery: directLifecycleRecoveryReady,
+                direct_lifecycle_plan: directLifecycleRecoveryReady
+                  ? JSON.stringify(directLifecyclePlan)
+                  : "",
+                direct_lifecycle_receipt_outcome: directLifecycleRecoveryReady
+                  ? directLifecycleReceiptOutcome
+                  : "",
+              };
+              fs.appendFileSync(process.env.GITHUB_OUTPUT, "claimed=true\n");
+              for (const [key, value] of Object.entries(values)) {
+                fs.appendFileSync(process.env.GITHUB_OUTPUT, `${key}=${value}\n`);
+              }
+          NODE
+            then
+              exit 0
             else
-              cat "$error_file" >&2
+              echo "Exact-review publication claim returned an invalid success payload." >&2
+              exit 1
             fi
-            if [ "$attempt" -lt 3 ]; then
-              sleep "$((attempt * 5))"
-            fi
-          done
+          fi
           exit 1
 
       - name: Replay committed direct lifecycle handoff
@@ -2744,6 +2742,7 @@ jobs:
           CLAWSWEEPER_COMMENT_MAX_COMMENTS: ${{ vars.CLAWSWEEPER_COMMENT_MAX_COMMENTS || '1000' }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           test -n "$CLAWSWEEPER_WEBHOOK_SECRET"
           queue_url="${QUEUE_URL%/}"
           lifecycle_kind="$(DIRECT_LIFECYCLE_PLAN="$DIRECT_LIFECYCLE_PLAN" node -e '
@@ -2780,7 +2779,7 @@ jobs:
               }));
             ')"
             lifecycle_signature="$(PAYLOAD="$lifecycle_payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
-            lifecycle_response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+            lifecycle_response="$(control_plane_curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
               --request POST \
               --header "content-type: application/json" \
               --header "x-clawsweeper-exact-review-signature: $lifecycle_signature" \
@@ -2801,7 +2800,7 @@ jobs:
               }));
             ')"
             lifecycle_signature="$(PAYLOAD="$lifecycle_payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
-            lifecycle_response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+            lifecycle_response="$(control_plane_curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
               --request POST \
               --header "content-type: application/json" \
               --header "x-clawsweeper-exact-review-signature: $lifecycle_signature" \
@@ -3197,6 +3196,7 @@ jobs:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           payload="$(node -e '
             const revision = Number(process.env.REVISION);
             if (!Number.isInteger(revision) || revision < 1 || !process.env.FENCE_KEY) process.exit(1);
@@ -3210,7 +3210,7 @@ jobs:
           ')"
           signature="$(PAYLOAD="$payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
           queue_url="${QUEUE_URL%/}"
-          curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+          control_plane_curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
             --request POST \
             --header "content-type: application/json" \
             --header "x-clawsweeper-exact-review-signature: $signature" \
@@ -3234,6 +3234,7 @@ jobs:
           CLAWSWEEPER_COMMENT_LOOKBACK_MINUTES: ${{ vars.CLAWSWEEPER_COMMENT_LOOKBACK_MINUTES || '180' }}
           CLAWSWEEPER_COMMENT_MAX_COMMENTS: ${{ vars.CLAWSWEEPER_COMMENT_MAX_COMMENTS || '1000' }}
         run: |
+          source scripts/control-plane-curl.sh
           gh workflow run repair-comment-router.yml \
             --repo "$GITHUB_REPOSITORY" \
             --ref main \
@@ -3256,7 +3257,7 @@ jobs:
           ')"
           signature="$(PAYLOAD="$payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
           queue_url="${QUEUE_URL%/}"
-          curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+          control_plane_curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
             --request POST \
             --header "content-type: application/json" \
             --header "x-clawsweeper-exact-review-signature: $signature" \
@@ -3275,6 +3276,7 @@ jobs:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           payload="$(node -e '
             const revision = Number(process.env.REVISION);
             if (!Number.isInteger(revision) || revision < 1 || !process.env.FENCE_KEY) process.exit(1);
@@ -3288,7 +3290,7 @@ jobs:
           ')"
           signature="$(PAYLOAD="$payload" node -e 'const crypto=require("node:crypto"); process.stdout.write("sha256="+crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex"))')"
           queue_url="${QUEUE_URL%/}"
-          curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+          control_plane_curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
             --request POST \
             --header "content-type: application/json" \
             --header "x-clawsweeper-exact-review-signature: $signature" \
@@ -3307,6 +3309,7 @@ jobs:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           payload="$(node -e '
             const revision = Number(process.env.REVISION);
             if (!Number.isInteger(revision) || revision < 1 || !process.env.FENCE_KEY) process.exit(1);
@@ -3320,7 +3323,7 @@ jobs:
           ')"
           signature="$(PAYLOAD="$payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
           queue_url="${QUEUE_URL%/}"
-          curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+          control_plane_curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
             --request POST \
             --header "content-type: application/json" \
             --header "x-clawsweeper-exact-review-signature: $signature" \
@@ -3352,6 +3355,7 @@ jobs:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           test -n "$CLAWSWEEPER_WEBHOOK_SECRET"
           queue_url="${QUEUE_URL%/}"
           payload="$(node <<'NODE'
@@ -3370,7 +3374,7 @@ jobs:
           NODE
           )"
           signature="$(PAYLOAD="$payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
-          response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+          response="$(control_plane_curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
             --request POST \
             --header "content-type: application/json" \
             --header "x-clawsweeper-exact-review-signature: $signature" \
@@ -3644,6 +3648,7 @@ jobs:
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           queue_url="${QUEUE_URL%/}"
           payload="$(node -e '
             const leaseRevision = Number(process.env.LEASE_REVISION);
@@ -3715,18 +3720,13 @@ jobs:
               ...(stateWriter ? { state_writer: stateWriter } : {}),
             }));
           ')"
-          for attempt in 1 2 3; do
-            if curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
-              --request POST \
-              --header "content-type: application/json" \
-              --data "$payload" \
-              "$queue_url/internal/exact-review/complete" >/dev/null; then
-              exit 0
-            fi
-            if [ "$attempt" -lt 3 ]; then
-              sleep "$((attempt * 5))"
-            fi
-          done
+          if control_plane_curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+            --request POST \
+            --header "content-type: application/json" \
+            --data "$payload" \
+            "$queue_url/internal/exact-review/complete" >/dev/null; then
+            exit 0
+          fi
           exit 1
 
       - name: Mark active lease retry waiting
@@ -3770,6 +3770,12 @@ jobs:
       issues: write
       pull-requests: write
     steps:
+      - name: Check out control-plane retry helper
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          sparse-checkout-cone-mode: false
+          sparse-checkout: scripts/control-plane-curl.sh
       - name: Claim committed terminal finalization
         id: finalization-context
         env:
@@ -3780,6 +3786,7 @@ jobs:
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           printf 'claimed=false\n' >> "$GITHUB_OUTPUT"
           queue_url="${QUEUE_URL%/}"
           payload="$(node -e '
@@ -3797,50 +3804,40 @@ jobs:
             }));
           ')"
           response_file="$(mktemp)"
-          error_file="$(mktemp)"
-          trap 'rm -f "$response_file" "$error_file"' EXIT
-          for attempt in 1 2 3; do
-            : > "$response_file"
-            : > "$error_file"
-            if status="$(curl --silent --show-error --connect-timeout 5 --max-time 20 \
-              --output "$response_file" --write-out '%{http_code}' \
-              --request POST --header "content-type: application/json" --data "$payload" \
-              "$queue_url/internal/exact-review/claim" 2>"$error_file")"; then
-              response="$(<"$response_file")"
-              if [ "$status" = "409" ]; then
-                conflict_reason="$(RESPONSE="$response" node <<'NODE'
-                  const response = JSON.parse(process.env.RESPONSE || "{}");
-                  const safeConflicts = new Set([
-                    "lease_not_active",
-                    "lease_already_claimed",
-                    "lease_decision_unavailable",
-                    "stale_run_attempt",
-                  ]);
-                  if (!safeConflicts.has(response.error)) process.exit(1);
-                  process.stdout.write(response.error);
+          trap 'rm -f "$response_file"' EXIT
+          : > "$response_file"
+          if status="$(control_plane_curl --silent --show-error --connect-timeout 5 --max-time 20 \
+            --output "$response_file" --write-out '%{http_code}' \
+            --request POST --header "content-type: application/json" --data "$payload" \
+            "$queue_url/internal/exact-review/claim")"; then
+            response="$(<"$response_file")"
+            if [ "$status" = "409" ]; then
+              conflict_reason="$(RESPONSE="$response" node <<'NODE'
+                const response = JSON.parse(process.env.RESPONSE || "{}");
+                const safeConflicts = new Set([
+                  "lease_not_active",
+                  "lease_already_claimed",
+                  "lease_decision_unavailable",
+                  "stale_run_attempt",
+                ]);
+                if (!safeConflicts.has(response.error)) process.exit(1);
+                process.stdout.write(response.error);
           NODE
-                )" || {
-                  echo "Unexpected terminal-finalization claim conflict: $response" >&2
-                  exit 1
-                }
-                echo "::notice::Skipping terminal finalization because lease claim lost safely: $conflict_reason"
-                exit 0
-              fi
-              if [ "$status" = "200" ]; then
-                break
-              fi
-              if [[ "$status" != 5* ]]; then
-                echo "Terminal-finalization claim returned HTTP $status: $response" >&2
+              )" || {
+                echo "Unexpected terminal-finalization claim conflict: $response" >&2
                 exit 1
-              fi
+              }
+              echo "::notice::Skipping terminal finalization because lease claim lost safely: $conflict_reason"
+              exit 0
             fi
-            if [ "$attempt" = "3" ]; then
-              cat "$error_file" >&2
-              echo "Terminal-finalization claim failed after retries" >&2
+            if [ "$status" != "200" ]; then
+              echo "Terminal-finalization claim returned HTTP $status: $response" >&2
               exit 1
             fi
-            sleep "$attempt"
-          done
+          else
+            echo "Terminal-finalization claim failed after retries" >&2
+            exit 1
+          fi
           RESPONSE="$response" node <<'NODE'
           const fs = require("node:fs");
           const response = JSON.parse(process.env.RESPONSE || "{}");
@@ -3911,6 +3908,7 @@ jobs:
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           payload="$(node -e '
             const leaseRevision = Number(process.env.LEASE_REVISION);
             const claimGeneration = Number(process.env.CLAIM_GENERATION);
@@ -3930,7 +3928,7 @@ jobs:
           ')"
           response_file="$(mktemp)"
           trap 'rm -f "$response_file"' EXIT
-          response_status="$(curl --silent --show-error --connect-timeout 5 --max-time 20 \
+          response_status="$(control_plane_curl --silent --show-error --connect-timeout 5 --max-time 20 \
             --output "$response_file" --write-out '%{http_code}' \
             --request POST --header "content-type: application/json" --data "$payload" \
             "${QUEUE_URL%/}/internal/exact-review/terminal-finalization/attempt")"
@@ -3990,6 +3988,7 @@ jobs:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           update_log="$(mktemp)"
           trap 'rm -f "$update_log"' EXIT
           pnpm run repair:update-command-status -- \
@@ -4016,7 +4015,7 @@ jobs:
                 }));
               ')"
               signature="$(PAYLOAD="$failure_payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
-              curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+              control_plane_curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
                 --request POST --header "content-type: application/json" \
                 --header "x-clawsweeper-exact-review-signature: $signature" \
                 --data "$failure_payload" \
@@ -4042,6 +4041,7 @@ jobs:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           payload="$(node -e '
             const fenceKey = process.env.FENCE_KEY || "";
             const revision = Number(process.env.REVISION);
@@ -4073,7 +4073,7 @@ jobs:
             }));
           ')"
           signature="$(PAYLOAD="$payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
-          response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+          response="$(control_plane_curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
             --request POST --header "content-type: application/json" \
             --header "x-clawsweeper-exact-review-signature: $signature" \
             --data "$payload" \
@@ -4096,6 +4096,7 @@ jobs:
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           skip_reason="locked_conversation"
           expected_state="skipped_locked"
           if [ "$MISSING_STATUS_COMMENT" = "true" ]; then
@@ -4121,7 +4122,7 @@ jobs:
               ...(statusCommentId === null ? {} : { status_comment_id: statusCommentId }),
             }));
           ')"
-          response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+          response="$(control_plane_curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
             --request POST --header "content-type: application/json" --data "$payload" \
             "${QUEUE_URL%/}/internal/exact-review/terminal-finalization/skip")"
           jq -e --arg state "$expected_state" \
@@ -4138,6 +4139,7 @@ jobs:
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           payload="$(node -e '
             const leaseRevision = Number(process.env.LEASE_REVISION);
             const claimGeneration = Number(process.env.CLAIM_GENERATION);
@@ -4151,7 +4153,7 @@ jobs:
           ')"
           response_file="$(mktemp)"
           trap 'rm -f "$response_file"' EXIT
-          response_status="$(curl --silent --show-error --connect-timeout 5 --max-time 20 \
+          response_status="$(control_plane_curl --silent --show-error --connect-timeout 5 --max-time 20 \
             --write-out '%{http_code}' --output "$response_file" \
             --request POST --header "content-type: application/json" --data "$payload" \
             "${QUEUE_URL%/}/internal/exact-review/terminal-finalization/retry")"
@@ -5851,6 +5853,12 @@ jobs:
       actions: read
       contents: read
     steps:
+      - name: Check out control-plane retry helper
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          sparse-checkout-cone-mode: false
+          sparse-checkout: scripts/control-plane-curl.sh
       - uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -5886,6 +5894,7 @@ jobs:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           test -n "$CLAWSWEEPER_WEBHOOK_SECRET"
           queue_url="${QUEUE_URL%/}"
           recovery_marker="[clawsweeper-recovery-attempt=1]"
@@ -5971,34 +5980,28 @@ jobs:
                 }
               }')"
             queued=false
-            for attempt in 1 2 3; do
-              # shellcheck disable=SC2016 # The Node source must retain its literal template expression.
-              signature="$(PAYLOAD="$payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
-              response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
-                --request POST \
-                --header "content-type: application/json" \
-                --header "x-clawsweeper-exact-review-signature: $signature" \
-                --data "$payload" \
-                "$queue_url/internal/exact-review/enqueue")" || response=""
-              if jq -e '.ok == true and (.queued == true or .deduped == true or .shed == true or .accepted == false)' <<<"$response" >/dev/null; then
-                if jq -e '.accepted == false' <<<"$response" >/dev/null; then
-                  echo "Item #$item_number: Recovery skipped because the target is disabled." | tee -a "$GITHUB_STEP_SUMMARY"
-                elif jq -e '.shed == true' <<<"$response" >/dev/null; then
-                  echo "Item #$item_number: Recovery shed by exact-review queue backpressure." | tee -a "$GITHUB_STEP_SUMMARY"
-                elif jq -e '.deduped == true' <<<"$response" >/dev/null; then
-                  echo "Item #$item_number: recovery admission deduplicated." | tee -a "$GITHUB_STEP_SUMMARY"
-                else
-                  echo "Item #$item_number: recovery admission queued." | tee -a "$GITHUB_STEP_SUMMARY"
-                fi
-                queued=true
-                break
+            # shellcheck disable=SC2016 # The Node source must retain its literal template expression.
+            signature="$(PAYLOAD="$payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
+            response="$(control_plane_curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+              --request POST \
+              --header "content-type: application/json" \
+              --header "x-clawsweeper-exact-review-signature: $signature" \
+              --data "$payload" \
+              "$queue_url/internal/exact-review/enqueue")" || response=""
+            if jq -e '.ok == true and (.queued == true or .deduped == true or .shed == true or .accepted == false)' <<<"$response" >/dev/null; then
+              if jq -e '.accepted == false' <<<"$response" >/dev/null; then
+                echo "Item #$item_number: Recovery skipped because the target is disabled." | tee -a "$GITHUB_STEP_SUMMARY"
+              elif jq -e '.shed == true' <<<"$response" >/dev/null; then
+                echo "Item #$item_number: Recovery shed by exact-review queue backpressure." | tee -a "$GITHUB_STEP_SUMMARY"
+              elif jq -e '.deduped == true' <<<"$response" >/dev/null; then
+                echo "Item #$item_number: recovery admission deduplicated." | tee -a "$GITHUB_STEP_SUMMARY"
+              else
+                echo "Item #$item_number: recovery admission queued." | tee -a "$GITHUB_STEP_SUMMARY"
               fi
-              echo "Recovery queue acknowledgement was not accepted on attempt $attempt." >&2
-              if [ "$attempt" -lt 3 ]; then
-                sleep "$((attempt * 5))"
-              fi
-            done
+              queued=true
+            fi
             if [ "$queued" != "true" ]; then
+              echo "Recovery queue acknowledgement was not accepted after control-plane retries." >&2
               failed_recovery_dispatches+=("$item_number")
             fi
           done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@ checkpoint, and status-only commits are intentionally omitted.
 - Complete exact-review leases during Worker/workflow deploy skew by retrying rejected terminal reasons once without the reason/status, preserving diagnostics and warning operators.
 
 - Stop exact-review retries for every non-retryable scanner refusal, including scan deadlines, and retain terminal guidance for the unchanged revision.
+- Retry transient control-plane failures across exact-review workflow calls, preserve retryable admission 503 responses and Retry-After headers through webhook/internal ingress, and attribute failed fences and reservations to queue infrastructure.
 
 - Prepare GitHub user-attachment and legacy repository asset proof locally, resolving image/video types after download and reserving bounded preprocessing time for attachments.
 

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -4142,6 +4142,7 @@ async function githubWebhook(request, env, ctx) {
       ingress,
     });
     if (!queued) return json({ error: "exact_review_queue_not_configured" }, 503);
+    if (queued instanceof Response) return queued;
     if (sourceAuthoritySeq !== null) {
       await completeExactReviewSourceAuthority(
         env,
@@ -7183,7 +7184,13 @@ async function enqueueExactReview({
       body: JSON.stringify({ delivery_id: deliveryId, decision, ...(ingress ? { ingress } : {}) }),
     }),
   );
-  const body = objectValue(await response.json().catch(() => null));
+  const body = objectValue(
+    await response
+      .clone()
+      .json()
+      .catch(() => null),
+  );
+  if (response.status >= 500 && body.retryable === true) return response;
   if (!response.ok) throw new Error(String(body.error || "exact review queue rejected item"));
   return body;
 }

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -667,6 +667,16 @@ still-valid subset of the key/revision pairs checked before departure. Fresh
 arrivals wait for the next departure; changed or removed members are skipped.
 An empty subset retires that reservation and requests another preflight.
 
+The Worker preserves structured retryable Durable Object 5xx responses, including
+`503 {error: "target_visibility_unverified", retryable: true}`, through both
+`/github/webhook` item enqueue and the `/internal/exact-review/*` proxies. The
+status, JSON body, and optional `Retry-After` header reach the caller unchanged;
+unexpected exceptions still produce 500 and the structured server-response
+telemetry remains intact. Visibility admission precedes delivery persistence,
+so a refused admission does not consume its enqueue delivery ID. Credential-bearing
+paths continue to require live visibility probes. Workflow shell retries are
+documented in [the scheduler](scheduler.md#control-plane-workflow-retries).
+
 Only signed intake (`/enqueue`, `/command-intake`, `/branch-authority`,
 `/source-authority`) may reuse durable KV public-admission observations;
 credential-bearing paths require live probes. `EXACT_REVIEW_HOSTED_TARGET_ADMISSION_FRESH_MS`

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -67,6 +67,23 @@ content caches. Changed PR content goes to Codex, including source comments
 and formatting. See [Review Cache](review-cache.md) for admission, freshness,
 and runtime packaging rules.
 
+### Control-plane workflow retries
+
+Shell calls to the control plane in `sweep.yml`, `exact-review-reconcile-run.yml`,
+and `exact-review-dead-letter-reconcile.yml` use
+`scripts/control-plane-curl.sh`. Each request retries connection failures and
+HTTP 5xx up to four attempts. A valid `Retry-After` delay (seconds or HTTP-date)
+is capped at 60 seconds; otherwise the waits are 2, 4, and 8 seconds. Each
+attempt emits a notice. The helper preserves the caller's final curl exit code,
+HTTP status output, and body handling. HTTP 4xx responses are not retried;
+callers retain their explicit lease-conflict, supersession, and deployment-skew handling.
+This includes enqueue, claims, review/status heartbeats, completion, lifecycle
+receipts, terminal-finalization operations, reconciliation, and the DLQ health
+probe. Existing typed batch clients retain their separate lease-aware retry
+policy. Fence and reservation failures are attributed to the existing
+`queue_completion_failure` infrastructure category, including a review that
+never starts because its status fence is unavailable.
+
 ## Workflow
 
 Explicit `workflow_dispatch` `item_number`/`item_numbers` selections, excluding

--- a/scripts/control-plane-curl.sh
+++ b/scripts/control-plane-curl.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Preserve curl's stdout, output file, and exit code; only the last attempt escapes.
+# A subshell keeps scratch cleanup separate from the caller's traps and shell options.
+control_plane_curl() (
+  local scratch attempt curl_exit http_status retryable delay
+  scratch="$(mktemp -d)" || return 1
+  trap 'rm -rf "$scratch"' EXIT
+  for attempt in 1 2 3 4; do
+    : > "$scratch/headers"
+    curl_exit=0
+    curl --dump-header "$scratch/headers" "$@" > "$scratch/stdout" || curl_exit=$?
+    http_status="$(awk '/^HTTP\// { code=$2 } END { print code }' "$scratch/headers")"
+    echo "::notice::Control-plane request attempt $attempt/4: HTTP ${http_status:-000}, curl exit $curl_exit" >&2
+    retryable=false
+    if [[ "$http_status" == 5[0-9][0-9] ]]; then
+      retryable=true
+    elif [[ -z "$http_status" || "$http_status" != 4[0-9][0-9] ]]; then
+      case "$curl_exit" in
+        5|6|7|16|18|28|35|52|55|56|92) retryable=true ;;
+      esac
+    fi
+    if [[ "$retryable" != true || "$attempt" == 4 ]]; then
+      cat "$scratch/stdout"
+      return "$curl_exit"
+    fi
+    delay="$(node - "$scratch/headers" "$attempt" <<'NODE'
+const fs = require("node:fs");
+const blocks = fs.readFileSync(process.argv[2], "utf8").split(/(?=^HTTP\/)/m);
+const value = blocks.at(-1)?.match(/^retry-after:\s*([^\r\n]*)/im)?.[1]?.trim();
+const seconds = value && /^\d+$/.test(value)
+  ? Number(value)
+  : value ? Math.ceil((Date.parse(value) - Date.now()) / 1000) : NaN;
+process.stdout.write(String(Number.isFinite(seconds)
+  ? Math.min(60, Math.max(0, seconds))
+  : 2 ** Number(process.argv[3])));
+NODE
+    )" || return 1
+    echo "::notice::Control-plane request retry in ${delay}s" >&2
+    sleep "$delay"
+  done
+)

--- a/scripts/e2e/apply-drift-refresh.ts
+++ b/scripts/e2e/apply-drift-refresh.ts
@@ -186,7 +186,11 @@ process.stdout.write(args.includes('--jq') ? (pr ? 'pull_request' : 'issue') : J
       entry.uses?.endsWith("/.github/actions/setup-state"),
     ),
   );
-  assert.ok(workflow.jobs["legacy-event-queue-intake"].steps.every((entry: Step) => !entry.uses));
+  assert.ok(
+    workflow.jobs["legacy-event-queue-intake"].steps.every(
+      (entry: Step) => !entry.uses || entry.name === "Check out control-plane retry helper",
+    ),
+  );
   const envelopes: Envelope[] = rows(enqueue);
   assert.equal(envelopes.length, 5);
   for (const [index, envelope] of envelopes.entries()) {

--- a/scripts/e2e/control-plane-retries.mjs
+++ b/scripts/e2e/control-plane-retries.mjs
@@ -1,0 +1,200 @@
+import assert from "node:assert/strict";
+import { execFile, execFileSync, spawn } from "node:child_process";
+import { createHmac } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { join, resolve } from "node:path";
+import { promisify } from "node:util";
+
+const execute = promisify(execFile);
+const root = resolve(".artifacts/control-plane-proof");
+await mkdir(root, { recursive: true });
+const transcript = [];
+const record = (value) => {
+  console.log(value);
+  transcript.push(value);
+};
+let wrangler;
+let server;
+try {
+  for (const statuses of [[503, 503, 200], [400]]) {
+    let count = 0;
+    const times = [];
+    server = createServer((_req, res) => {
+      times.push(Date.now());
+      const status = statuses[count++] ?? 500;
+      res.writeHead(status, { "content-type": "application/json", "retry-after": "1" });
+      res.end(JSON.stringify({ attempt: count, status }));
+    });
+    await new Promise((ready) => server.listen(0, "127.0.0.1", ready));
+    const result = await execute(
+      "bash",
+      [
+        "-c",
+        `source scripts/control-plane-curl.sh
+control_plane_curl --silent --show-error --output "$PROOF_BODY" --write-out '%{http_code}' "$PROOF_URL"`,
+      ],
+      {
+        env: {
+          ...process.env,
+          PROOF_BODY: join(root, "curl-body.json"),
+          PROOF_URL: `http://127.0.0.1:${server.address().port}/enqueue`,
+        },
+      },
+    );
+    const body = await readFile(join(root, "curl-body.json"), "utf8");
+    record(
+      `HTTP fixture ${statuses.join(" -> ")}\n${result.stderr.trim()}\nFinal HTTP ${result.stdout}; body ${body}; requests ${count}; elapsed gaps ${times
+        .slice(1)
+        .map((time, index) => time - times[index])
+        .join(",")} ms`,
+    );
+    assert.equal(count, statuses.length);
+    assert.equal(result.stdout, String(statuses.at(-1)));
+    for (let index = 1; index < times.length; index++)
+      assert.ok(times[index] - times[index - 1] >= 1000);
+    await new Promise((done) => server.close(done));
+    server = null;
+  }
+  const secret = "synthetic-control-plane-proof-secret";
+  await writeFile(
+    join(root, "entry.ts"),
+    `
+import worker, { ExactReviewQueue } from ${JSON.stringify(resolve("dashboard/worker.ts"))};
+export class ProofQueue extends ExactReviewQueue {
+  constructor(state, env) {
+    super(state, { ...env, hostedTargetPredicate: () => true, hostedPublicTargetProbe: async () => ({ outcome: "retryable", retryAt: Date.now() + 30_000 }) });
+  }
+  async fetch(request) {
+    if (new URL(request.url).pathname === "/enqueue" && (await request.clone().json()).decision?.itemNumber === 43) throw new Error("synthetic unexpected failure");
+    return super.fetch(request);
+  }
+}
+globalThis.fetch = async () => { throw new Error("proof forbids outbound network"); };
+export default { fetch(request, env, ctx) { return worker.fetch(request, { ...env, hostedTargetPredicate: () => true, hostedPublicTargetProbe: async () => "public" }, ctx); } };
+`,
+  );
+  const portServer = createServer();
+  await new Promise((ready) => portServer.listen(0, "127.0.0.1", ready));
+  const port = portServer.address().port;
+  await new Promise((done) => portServer.close(done));
+  await writeFile(
+    join(root, "wrangler.json"),
+    JSON.stringify({
+      name: "control-plane-retries-proof",
+      main: "entry.ts",
+      compatibility_date: "2026-05-11",
+      durable_objects: { bindings: [{ name: "EXACT_REVIEW_QUEUE", class_name: "ProofQueue" }] },
+      migrations: [{ tag: "v1", new_sqlite_classes: ["ProofQueue"] }],
+      vars: { CLAWSWEEPER_WEBHOOK_SECRET: secret },
+    }),
+  );
+  let workerLog = "";
+  wrangler = spawn(
+    "corepack",
+    [
+      "pnpm",
+      "dlx",
+      "wrangler@4.107.0",
+      "dev",
+      "--config",
+      join(root, "wrangler.json"),
+      "--local",
+      "--ip",
+      "127.0.0.1",
+      "--port",
+      String(port),
+      "--persist-to",
+      join(root, "state"),
+      "--show-interactive-dev-session=false",
+    ],
+    { env: { ...process.env, WRANGLER_SEND_METRICS: "false" }, stdio: ["ignore", "pipe", "pipe"] },
+  );
+  wrangler.stdout.on("data", (chunk) => {
+    workerLog += chunk;
+  });
+  wrangler.stderr.on("data", (chunk) => {
+    workerLog += chunk;
+  });
+  const url = `http://127.0.0.1:${port}`;
+  let ready = false;
+  for (let attempt = 0; attempt < 120; attempt++) {
+    if (
+      await fetch(`${url}/api/health`)
+        .then((response) => response.ok)
+        .catch(() => false)
+    ) {
+      ready = true;
+      break;
+    }
+    if (wrangler.exitCode !== null) break;
+    await new Promise((done) => setTimeout(done, 1000));
+  }
+  await writeFile(join(root, "workerd.log"), workerLog);
+  assert.ok(ready, "local workerd startup; inspect workerd.log");
+  for (const itemNumber of [42, 43]) {
+    for (const path of ["/github/webhook", "/internal/exact-review/enqueue"]) {
+      const webhook = path === "/github/webhook";
+      const body = JSON.stringify(
+        webhook
+          ? {
+              action: "opened",
+              repository: { full_name: "openclaw/gogcli", default_branch: "main", private: false },
+              issue: { number: itemNumber },
+              installation: { id: 123 },
+            }
+          : {
+              delivery_id: `synthetic-internal-${itemNumber}`,
+              decision: {
+                targetRepo: "openclaw/gogcli",
+                targetBranch: "main",
+                supersedesInProgress: false,
+                itemNumber,
+                itemKind: "issue",
+                sourceEvent: "issues",
+                sourceAction: "opened",
+              },
+            },
+      );
+      const signature = `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
+      const response = await fetch(url + path, {
+        method: "POST",
+        body,
+        headers: {
+          "content-type": "application/json",
+          ...(webhook
+            ? {
+                "x-github-event": "issues",
+                "x-github-delivery": `synthetic-webhook-${itemNumber}`,
+                "x-hub-signature-256": signature,
+              }
+            : { "x-clawsweeper-exact-review-signature": signature }),
+        },
+      });
+      const text = await response.text();
+      record(
+        `workerd POST ${path} fixture=${itemNumber === 42 ? "probe-retryable" : "unexpected-exception"}: HTTP ${response.status}; retry-after=${response.headers.get("retry-after")}; ${itemNumber === 42 || !webhook ? text : "workerd internal error response"}`,
+      );
+      assert.equal(response.status, itemNumber === 42 ? 503 : 500);
+      if (itemNumber === 42) {
+        assert.match(response.headers.get("retry-after") ?? "", /^\d+$/);
+        assert.deepEqual(JSON.parse(text), {
+          error: "target_visibility_unverified",
+          retryable: true,
+        });
+      } else assert.equal(response.headers.get("retry-after"), null);
+    }
+  }
+  await writeFile(join(root, "workerd.log"), workerLog);
+  assert.match(workerLog, /exact_review_queue_structured_server_response/);
+  record(
+    `PASS; provider=local-workerd; Node=${process.version}; head=${execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim()}; limits=synthetic admission, no production or GitHub calls`,
+  );
+} finally {
+  if (server) await new Promise((done) => server.close(done));
+  if (wrangler && wrangler.exitCode === null) {
+    wrangler.kill("SIGTERM");
+    await new Promise((done) => wrangler.once("exit", done));
+  }
+  await writeFile(join(root, "transcript.txt"), transcript.join("\n") + "\n");
+}

--- a/test/automatic-review-status-fence.test.ts
+++ b/test/automatic-review-status-fence.test.ts
@@ -41,9 +41,11 @@ test("automatic status fences distinguish stale handoffs from operational failur
   const outputPath = join(root, "outputs");
   const generationPath = join(root, "generation");
   const fixture = [
+    "sleep() { :; }",
     "curl() {",
     '  while [ "$#" -gt 0 ]; do',
     '    if [ "$1" = "--output" ]; then shift; printf "%s" "$MOCK_BODY" > "$1"; fi',
+    '    if [ "$1" = "--dump-header" ]; then shift; printf "HTTP/1.1 %s\\r\\n\\r\\n" "$MOCK_STATUS" > "$1"; fi',
     "    shift",
     "  done",
     '  printf "%s" "$MOCK_STATUS"',
@@ -161,9 +163,11 @@ test("completion-fence outages fail the workflow without changing successful que
   const root = mkdtempSync(join(tmpdir(), "completion-status-fence-"));
   const outputPath = join(root, "outputs");
   const fixture = [
+    "sleep() { :; }",
     "curl() {",
     '  while [ "$#" -gt 0 ]; do',
     '    if [ "$1" = "--output" ]; then shift; printf "%s" "$MOCK_BODY" > "$1"; fi',
+    '    if [ "$1" = "--dump-header" ]; then shift; printf "HTTP/1.1 %s\\r\\n\\r\\n" "$MOCK_STATUS" > "$1"; fi',
     "    shift",
     "  done",
     '  printf "%s" "$MOCK_STATUS"',
@@ -216,10 +220,7 @@ test("completion-fence outages fail the workflow without changing successful que
       };
       assert.equal(evaluate(failure.if, values), scenario.failed);
       if (scenario.failed) {
-        assert.equal(
-          evaluate(failure.env.CLASSIFICATION, values),
-          "review_status_delivery_failure",
-        );
+        assert.equal(evaluate(failure.env.CLASSIFICATION, values), "queue_completion_failure");
       }
     }
   } finally {
@@ -234,4 +235,27 @@ test("a new revision during completion status blocks the obsolete artifact and p
   assert.equal(result.generation_outcome, "success");
   assert.equal(result.requeue_latest, false);
   assert.equal(result.blocked_steps.length, 8);
+});
+
+test("failed reservation and review fences retain infrastructure attribution when review is skipped", () => {
+  const steps = YAML.parse(readFileSync(".github/workflows/sweep.yml", "utf8")).jobs[
+    "event-review-apply"
+  ].steps;
+  const failure = steps.find((step) => step.name === "Fail unsuccessful exact review generation");
+  for (const step of [
+    "reserve-exact-review-lease",
+    "review-status-fence",
+    "release-review-status-fence",
+    "review-complete-status-fence",
+    "release-review-complete-status-fence",
+  ]) {
+    const values = {
+      "claim-exact-review-queue.claimed": "true",
+      "exact-review-generation-result.outcome": "failure",
+      "review-exact-event-item.outcome": "skipped",
+      [`${step}.outcome`]: "failure",
+    };
+    assert.equal(evaluate(failure.if, values), true, step);
+    assert.equal(evaluate(failure.env.CLASSIFICATION, values), "queue_completion_failure", step);
+  }
 });

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2626,7 +2626,7 @@ test("sweep review recovery uses explicit failed shard artifacts", () => {
   );
   assert.match(recoveryJob, /Recovery skipped because the target is disabled/);
   assert.match(recoveryJob, /Recovery shed by exact-review queue backpressure/);
-  assert.match(recoveryJob, /for attempt in 1 2 3/);
+  assert.match(recoveryJob, /control_plane_curl/);
   assert.match(recoveryJob, /failed_recovery_dispatches/);
   assert.match(
     recoveryJob,

--- a/test/control-plane-curl.test.ts
+++ b/test/control-plane-curl.test.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { createServer } from "node:http";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { promisify } from "node:util";
+import test from "node:test";
+
+const execute = promisify(execFile);
+const helper = resolve("scripts/control-plane-curl.sh");
+
+test("control-plane curl preserves final output and bounded retry semantics over HTTP", async (t) => {
+  for (const scenario of [
+    { name: "503 then 200", statuses: [503, 503, 200], retryAfter: "1", waits: [1, 1], final: 200 },
+    { name: "400 is terminal", statuses: [400], waits: [], final: 400 },
+    { name: "429 is terminal", statuses: [429], retryAfter: "1", waits: [], final: 429 },
+    { name: "exhausted 5xx", statuses: [500, 502, 503, 504], waits: [2, 4, 8], final: 504 },
+    {
+      name: "retry-after seconds capped",
+      statuses: [503, 200],
+      retryAfter: "120",
+      waits: [60],
+      final: 200,
+    },
+    {
+      name: "retry-after date capped",
+      statuses: [503, 200],
+      retryAfter: new Date(Date.now() + 120_000).toUTCString(),
+      waits: [60],
+      final: 200,
+    },
+    {
+      name: "invalid retry-after",
+      statuses: [503, 200],
+      retryAfter: "invalid",
+      waits: [2],
+      final: 200,
+    },
+    { name: "connection reset", statuses: [0, 200], waits: [2], final: 200 },
+    { name: "HTTP/2 transport error", statuses: [200], waits: [2], final: 200, transportExit: 16 },
+    { name: "HTTP/2 stream reset", statuses: [200], waits: [2], final: 200, transportExit: 92 },
+    {
+      name: "fail exit preserved",
+      statuses: [503, 503, 503, 503],
+      waits: [2, 4, 8],
+      final: 503,
+      fail: true,
+    },
+  ]) {
+    await t.test(scenario.name, async () => {
+      const root = await mkdtemp(join(tmpdir(), "control-plane-curl-"));
+      const requests: string[] = [];
+      const server = createServer(async (req, res) => {
+        let body = "";
+        for await (const chunk of req) body += chunk;
+        requests.push(body);
+        const code = scenario.statuses[requests.length - 1] ?? 500;
+        if (!code) {
+          req.socket.destroy();
+          return;
+        }
+        res.writeHead(code, {
+          "content-type": "application/json",
+          ...(scenario.retryAfter ? { "retry-after": scenario.retryAfter } : {}),
+        });
+        res.end(JSON.stringify({ attempt: requests.length }));
+      });
+      await new Promise<void>((ready) => server.listen(0, "127.0.0.1", ready));
+      const address = server.address();
+      assert.ok(address && typeof address !== "string");
+      try {
+        const result = await execute(
+          "bash",
+          [
+            "-c",
+            `
+source "$HELPER"
+${
+  scenario.transportExit
+    ? `calls=0
+curl() { calls=$((calls + 1)); if [ "$calls" = 1 ]; then return ${scenario.transportExit}; fi; command curl "$@"; }`
+    : ""
+}
+sleep() { printf '%s\\n' "$1" >> "$WAITS"; }
+rc=0
+control_plane_curl --silent --show-error ${scenario.fail ? "--fail" : ""} --max-time 2 --request POST --data-binary 'same signed bytes' --output "$BODY" --write-out '%{http_code}' "$URL" || rc=$?
+printf '\\nexit=%s\\n' "$rc"
+`,
+          ],
+          {
+            env: {
+              ...process.env,
+              PATH: `${dirname(process.execPath)}:${process.env.PATH}`,
+              HELPER: helper,
+              WAITS: join(root, "waits"),
+              BODY: join(root, "body"),
+              URL: `http://127.0.0.1:${address.port}/enqueue`,
+            },
+          },
+        );
+        assert.equal(result.stdout, `${scenario.final}\nexit=${scenario.fail ? 22 : 0}\n`);
+        assert.equal(requests.length, scenario.statuses.length);
+        assert.ok(requests.every((body) => body === "same signed bytes"));
+        assert.equal(
+          (result.stderr.match(/::notice::Control-plane request attempt/g) ?? []).length,
+          requests.length + (scenario.transportExit ? 1 : 0),
+        );
+        const waits = await readFile(join(root, "waits"), "utf8").catch(() => "");
+        assert.deepEqual(waits.trim() ? waits.trim().split("\n").map(Number) : [], scenario.waits);
+        if (!scenario.fail)
+          assert.deepEqual(JSON.parse(await readFile(join(root, "body"), "utf8")), {
+            attempt: requests.length,
+          });
+      } finally {
+        await new Promise<void>((done) => server.close(() => done()));
+        await rm(root, { recursive: true, force: true });
+      }
+    });
+  }
+});

--- a/test/dashboard-worker-durable-object-error.test.ts
+++ b/test/dashboard-worker-durable-object-error.test.ts
@@ -318,3 +318,101 @@ test("exact-review Worker preserves intentional non-JSON 4xx responses", async (
   assert.equal(response.headers.get("content-type"), "text/plain");
   assert.equal(await response.text(), "intentional conflict");
 });
+
+test("webhook and internal enqueue preserve retryable admission responses before delivery deduplication", async (t) => {
+  const { signedGithubWebhookRequest } = await import("./dashboard-worker-harness.ts");
+  const secret = "synthetic-admission-secret";
+  const errors: unknown[][] = [];
+  t.mock.method(console, "error", (...values: unknown[]) => errors.push(values));
+  for (const route of ["webhook", "internal"]) {
+    const storage = new MemoryDurableStorage();
+    const queue = new ExactReviewQueue(
+      { storage },
+      {
+        hostedTargetPredicate: () => true,
+        hostedPublicTargetProbe: async () => ({
+          outcome: "retryable" as const,
+          retryAt: Date.now() + 30_000,
+        }),
+      },
+    );
+    const body = JSON.stringify({
+      delivery_id: "synthetic-admission",
+      decision: {
+        targetRepo: "openclaw/gogcli",
+        targetBranch: "main",
+        supersedesInProgress: false,
+        itemNumber: 42,
+        itemKind: "issue",
+        sourceEvent: "issues",
+        sourceAction: "opened",
+      },
+    });
+    const request = () =>
+      route === "webhook"
+        ? signedGithubWebhookRequest({
+            event: "issues",
+            secret,
+            payload: {
+              action: "opened",
+              repository: { full_name: "openclaw/gogcli", default_branch: "main", private: false },
+              issue: { number: 42 },
+              installation: { id: 123 },
+            },
+          })
+        : new Request("https://clawsweeper.openclaw.ai/internal/exact-review/enqueue", {
+            method: "POST",
+            body,
+            headers: {
+              "x-clawsweeper-exact-review-signature": `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`,
+            },
+          });
+    const env = {
+      CLAWSWEEPER_WEBHOOK_SECRET: secret,
+      hostedTargetPredicate: () => true,
+      hostedPublicTargetProbe: async () => "public" as const,
+      EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+    };
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const response = await worker.fetch(request(), env);
+      assert.equal(response.status, 503, route);
+      assert.match(response.headers.get("retry-after") ?? "", /^\d+$/);
+      assert.deepEqual(await response.json(), {
+        error: "target_visibility_unverified",
+        retryable: true,
+      });
+    }
+    assert.equal(
+      Number(
+        Array.from(
+          storage.sql.exec("SELECT COUNT(*) AS count FROM exact_review_queue_deliveries"),
+        )[0]?.count,
+      ),
+      0,
+    );
+    assert.ok(
+      errors.some(
+        ([event, metadata]) =>
+          event === "exact_review_queue_structured_server_response" &&
+          (metadata as Record<string, unknown>).endpoint === "enqueue",
+      ),
+    );
+    const failingEnv = {
+      ...env,
+      EXACT_REVIEW_QUEUE: new MemoryDurableNamespace({
+        async fetch() {
+          throw new Error("unexpected fixture exception");
+        },
+      }),
+    };
+    if (route === "webhook") {
+      // workerd maps the unhandled exception to HTTP 500, rather than a retryable response.
+      await assert.rejects(worker.fetch(request(), failingEnv), /unexpected fixture exception/);
+    } else {
+      const response = await worker.fetch(request(), failingEnv);
+      assert.equal(response.status, 500);
+      assert.equal(response.headers.get("retry-after"), null);
+      assert.deepEqual(await response.json(), { error: "exact_review_queue_unavailable" });
+    }
+  }
+});

--- a/test/repair/exact-review-reconcile-workflow.test.ts
+++ b/test/repair/exact-review-reconcile-workflow.test.ts
@@ -217,7 +217,11 @@ else process.exit(2);
       assert.equal(admitted, scenario !== "recent");
       const before = requests.length;
       if (admitted)
-        await run("bash", ["-e", "-c", eventWorkflow.jobs.reconcile.steps[0].run], { env });
+        await run(
+          "bash",
+          ["-e", "-c", eventWorkflow.jobs.reconcile.steps.find((step) => step.run)?.run],
+          { env },
+        );
       assert.equal(requests.length - before, admitted ? 1 : 0);
       results.push({ scenario, admitted, queueWrites: requests.length - before });
     }

--- a/test/repair/workflow-sparse-checkout.test.ts
+++ b/test/repair/workflow-sparse-checkout.test.ts
@@ -108,9 +108,14 @@ test("every workflow job that runs the main bundle directly obtains it", () => {
       );
 
       // The main build reads tsconfig.json, so a curated checkout has to carry it.
-      const checkout = steps.find((step) =>
-        String(step.uses ?? "").startsWith("actions/checkout@"),
+      const buildIndex = steps.findIndex(
+        (step) =>
+          String(step.uses ?? "").includes("actions/setup-pnpm") &&
+          buildScriptEmitsMainBundle(String(step.with?.["build-script"] ?? "")),
       );
+      const checkout = steps
+        .slice(0, buildIndex)
+        .findLast((step) => String(step.uses ?? "").startsWith("actions/checkout@"));
       const sparseCheckout = checkout?.with?.["sparse-checkout"];
       if (typeof sparseCheckout === "string") {
         const entries = sparseCheckout

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1563,7 +1563,7 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
     /direct-exact-review-publication\.outputs\.accepted != 'true' \|\| steps\.finalize-direct-exact-review-lifecycle\.outcome != 'success'/,
   );
   assert.equal(upload.with?.["retention-days"], 90);
-  assert.match(queuePublication.run ?? "", /for attempt in 1 2 3/);
+  assert.match(queuePublication.run ?? "", /control_plane_curl/);
   assert.match(queuePublication.run ?? "", /\.queued == true or \.deduped == true/);
   assert.equal(queuePublication.env?.CLAIM_DECISION, "${{ steps.live-item.outputs.decision }}");
   assert.equal(
@@ -1806,7 +1806,7 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
     "${{ steps.publication-context.outputs.item_number }}",
   );
   const publisherCheckout = publisher.steps.find(
-    (candidate) => candidate.uses === "actions/checkout@v7",
+    (candidate) => candidate.uses === "actions/checkout@v7" && candidate.if,
   );
   assert.ok(publisherCheckout);
   assert.equal(publisherCheckout.with?.ref, "main");
@@ -2306,8 +2306,8 @@ test("exact event publication derives lifecycle receipt and final command acknow
   assert.doesNotMatch(complete.run ?? "", /outcome !== "success"\s*\?\s*"failure"/);
   assert.match(complete.run ?? "", /completionKind === "permanent_failure"\s*\? "failure"/);
   const finalizer = workflow.jobs["event-review-terminal-finalization"]!;
-  const finalizationCheckout = finalizer.steps.find((candidate) =>
-    candidate.uses?.startsWith("actions/checkout@"),
+  const finalizationCheckout = finalizer.steps.find(
+    (candidate) => candidate.uses?.startsWith("actions/checkout@") && candidate.if,
   );
   assert.equal(finalizationCheckout?.with?.filter, undefined);
   assert.equal(finalizationCheckout?.with?.["fetch-depth"], 1);
@@ -2562,7 +2562,7 @@ test("exact-review lease competition skips only known conflicts and gates both o
     ["event-review-apply", "claim-exact-review-queue"],
     ["event-review-publish", "publication-context"],
   ]) {
-    const steps = workflow.jobs[jobName]!.steps;
+    const steps = workflow.jobs[jobName]!.steps.slice(1);
     const claim = steps[0]!;
     const claimRun = claim.run ?? "";
     const gate = `steps.${claimId}.outputs.claimed == 'true'`;
@@ -6407,7 +6407,7 @@ test("failed review recovery waits for durable exact-review queue acknowledgemen
   assert.match(recoveryBlock, /Recovery shed by exact-review queue backpressure/);
   assert.doesNotMatch(recoveryBlock, /workflow run sweep\.yml/);
   assert.doesNotMatch(recoveryBlock, /repos\/\$GITHUB_REPOSITORY\/dispatches/);
-  assert.match(recoveryBlock, /for attempt in 1 2 3/);
+  assert.match(recoveryBlock, /control_plane_curl/);
 });
 
 test("target sweep dispatches preserve disabled ClawHub guard", () => {
@@ -7476,4 +7476,28 @@ test("apply job requeues drift-blocked close reviews only for default cursor run
   assert.match(step, /event_type: "clawsweeper_item"/);
   assert.match(step, /source_action: "source_drift_requeue"/);
   assert.match(step, /supersedes_in_progress: false/);
+});
+
+test("all workflow control-plane curls use the shared helper after checkout", () => {
+  for (const file of [
+    "sweep.yml",
+    "exact-review-reconcile-run.yml",
+    "exact-review-dead-letter-reconcile.yml",
+  ]) {
+    const workflow = YAML.parse(readText(`.github/workflows/${file}`));
+    for (const [jobName, job] of Object.entries(workflow.jobs) as [string, any][]) {
+      let checkedOut = false;
+      for (const step of job.steps ?? []) {
+        if (step.uses?.startsWith("actions/checkout@")) checkedOut = true;
+        const run = step.run ?? "";
+        assert.doesNotMatch(run, /\bcurl --/, `${file}: ${step.name}`);
+        if (!run.includes("control_plane_curl")) continue;
+        assert.ok(checkedOut, `${file}: ${jobName} has the helper before its first call`);
+        assert.match(run, /source scripts\/control-plane-curl.sh/);
+        assert.doesNotMatch(run, /for attempt in 1 2 3; do/);
+        const syntax = spawnSync("bash", ["-n"], { input: run, encoding: "utf8" });
+        assert.equal(syntax.status, 0, `${step.name}: ${syntax.stderr}`);
+      }
+    }
+  }
 });

--- a/test/terminal-finalization-cancellation-workflow.test.ts
+++ b/test/terminal-finalization-cancellation-workflow.test.ts
@@ -59,7 +59,7 @@ for (const [status, body, success] of [
         assert.match(result, status === 409 ? /allowed=false/ : /allowed=true/);
         if (status === 409) assert.match(result, /acknowledgement_state=unavailable/);
       } else await assert.rejects(run);
-      assert.equal(requests, 1);
+      assert.equal(requests, status >= 500 ? 4 : 1);
       assert.match(
         job.steps.find((step) => step.id === "update-final-command-status").if,
         /terminal-acknowledgement.outputs.allowed == .true./,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where exact-review workflows fail or skip review after a single transient control-plane 5xx, and visibility admission failures lose their retry signal at webhook ingress.

## Why This Change Was Made

The Worker now returns the Durable Object's structured retryable 5xx response intact at webhook enqueue; internal proxies already preserved it and now have explicit regression coverage. One shared shell helper retries connection failures and HTTP 5xx at most four times, honors Retry-After up to 60 seconds, and otherwise waits 2/4/8 seconds. Callers retain their final status, body, curl exit behavior, and explicit 409 handling and the existing one-time 400 deployment-skew fallback. Existing outer curl retry loops are removed.

Visibility admission and credential-bearing live probes are unchanged. Enqueue admission precedes delivery persistence, and earlier webhook gates already return 503; no GitHub redelivery contract depends on the previous opaque 500.

## User Impact

Transient control-plane failures can recover within the same workflow attempt. Exhausted reservation and status-fence failures use the existing queue_completion_failure category, so a skipped review is attributed to queue infrastructure.

## OpenClaw Bay Impact

No Bay code or public data-contract change is required. This corrects workflow failure attribution using an existing category; Bay's observer-only reads and canonical view links are unchanged. No browser calls or mutation controls are added.

## Documentation Impact

Updated the active scheduler reference with shell retry limits and classification, and the active live-dashboard protocol reference with structured admission response propagation. Reviewed webhook delivery/deduplication behavior and the separate batch-publication retry policy; batch clients retain their existing policy. Added the Unreleased changelog entry.

## Evidence

Node 24 / pnpm 11.10.0: build, build:repair, build:dashboard, static/documentation checks, formatting, lint, and diff checks passed. Focused Worker/helper/fence tests, loopback terminal-finalization/reconciliation tests, drift-refresh proof, and checkout audits passed.

The first full unit run reported 3 failures among 3,999 tests: stale curl/terminal-attempt fixture assumptions were corrected, and the separate locale/process-identity failure passed on an isolated rerun. The broader coverage check reported 5,608 passed, 13 skipped and 10 failures, including outdated checkout assumptions (now fixed) and separate subprocess/time-budget failures; every reported case has passed focused reruns. The rebased tree builds all bundles, passes 48 focused tests plus the 11-case completion/skew/classification audit, passes the committed-head real-behavior proof and static checks, and has a clean pre-commit review. The full-run failure summary is retained rather than described as a clean run. CI must validate the current head.

## Real Behavior Proof

- Claim: transient control-plane errors recover with bounded retries; admission 503 status, JSON, and Retry-After survive webhook and internal enqueue ingress; unexpected exceptions remain 500.
- Surface: actual Bash/curl over loopback HTTP, plus Worker fetch through a SQLite Durable Object in local workerd.
- Fixture: synthetic HTTP server returns 503 with Retry-After: 1 twice, then 200; separate 400 response. Workerd injects a retryable hosted-target probe with a retry timestamp, and separately an unexpected exception.
- Reviewed source: `166bc7bd77baa7fb6ecfdcf91e8adfc85916ab8e` (rebased onto current main; changelog entries and the existing terminal-reason deployment-skew fallback are retained).
- Command and environment: `node scripts/e2e/control-plane-retries.mjs`, Node 24.20.0 on macOS, local Wrangler 4.107.0/workerd, Bash/curl. No remote lease or container image; provider is local-workerd.
- Observed: 503/503/200 made exactly three requests with notices and at least one second between requests; 400 made exactly one request. Both ingress paths returned 503, the original target_visibility_unverified/retryable JSON, and Retry-After: 30. Both unexpected-exception cases returned 500 without Retry-After.
- Artifact: executable proof driver in `scripts/e2e/control-plane-retries.mjs`; generated transcript and workerd logs in `.artifacts/control-plane-proof/`. Compact executed output below.
- Limits: synthetic local failure, no production outage injection, external GitHub traffic, live redelivery exercise, or mutation.

```text
503 -> 503 -> 200: attempts 1/4, 2/4, 3/4; waits 1s, 1s; final HTTP 200
400: attempt 1/4; no retry; final HTTP 400
POST /github/webhook: HTTP 503; Retry-After: 30
POST /internal/exact-review/enqueue: HTTP 503; Retry-After: 30
JSON: {"error":"target_visibility_unverified","retryable":true}
Unexpected webhook exception: HTTP 500; Retry-After absent
Unexpected internal exception: HTTP 500; Retry-After absent
```

## Known Gaps

No production deployment or merge is performed by this PR. Shell retries do not add replay authority or change admission policy; the separately implemented batch clients remain outside this change.
Audited 32 control-plane curl sites.

| Workflow | Job | Step | Endpoint |
| --- | --- | --- | --- |
| sweep.yml | legacy-event-queue-intake | Enqueue legacy event through the durable control plane | /internal/exact-review/enqueue, /branch-authority, or /source-authority |
| sweep.yml | event-review-apply | Claim exact-review queue lease | /internal/exact-review/claim |
| sweep.yml | event-review-apply | Fence automatic review in progress | /internal/exact-review/heartbeat |
| sweep.yml | event-review-apply | Release automatic review status fence | /internal/exact-review/heartbeat |
| sweep.yml | event-review-apply | Review exact event item | /internal/exact-review/heartbeat |
| sweep.yml | event-review-apply | Review exact event item | /internal/exact-review/heartbeat |
| sweep.yml | event-review-apply | Fence automatic review completion | /internal/exact-review/heartbeat |
| sweep.yml | event-review-apply | Release automatic review completion fence | /internal/exact-review/heartbeat |
| sweep.yml | event-review-apply | Finalize direct exact review lifecycle | /internal/exact-review/lifecycle/router-receipt |
| sweep.yml | event-review-apply | Finalize direct exact review lifecycle | /internal/exact-review/lifecycle/terminal-disposition |
| sweep.yml | event-review-apply | Queue durable exact review publication | /internal/exact-review/enqueue |
| sweep.yml | event-review-apply | Fence terminal automatic review failure | /internal/exact-review/heartbeat |
| sweep.yml | event-review-apply | Release terminal automatic review status fence | /internal/exact-review/heartbeat |
| sweep.yml | event-review-apply | Complete exact-review queue lease | /internal/exact-review/complete |
| sweep.yml | event-review-publish | Claim durable exact review publication | /internal/exact-review/claim |
| sweep.yml | event-review-publish | Replay committed direct lifecycle handoff | /internal/exact-review/lifecycle/router-receipt |
| sweep.yml | event-review-publish | Replay committed direct lifecycle handoff | /internal/exact-review/lifecycle/terminal-disposition |
| sweep.yml | event-review-publish | Record fallback canonical exact review lifecycle receipt | /internal/exact-review/lifecycle/canonical-receipt |
| sweep.yml | event-review-publish | Queue deferred exact verdict router | /internal/exact-review/lifecycle/router-receipt |
| sweep.yml | event-review-publish | Record deferred close-proof exact review lifecycle receipt | /internal/exact-review/lifecycle/router-receipt |
| sweep.yml | event-review-publish | Record no-router exact review lifecycle receipt | /internal/exact-review/lifecycle/router-receipt |
| sweep.yml | event-review-publish | Queue fresh review after source drift | /internal/exact-review/enqueue |
| sweep.yml | event-review-publish | Complete durable exact review publication | /internal/exact-review/complete |
| sweep.yml | event-review-terminal-finalization | Claim committed terminal finalization | /internal/exact-review/claim |
| sweep.yml | event-review-terminal-finalization | Begin fenced terminal acknowledgement | /internal/exact-review/terminal-finalization/attempt |
| sweep.yml | event-review-terminal-finalization | Update final command status once | /internal/exact-review/lifecycle/command-ack/failed |
| sweep.yml | event-review-terminal-finalization | Record verified terminal acknowledgement receipt | /internal/exact-review/lifecycle/command-ack/observed |
| sweep.yml | event-review-terminal-finalization | Complete locked terminal acknowledgement skip | /internal/exact-review/terminal-finalization/skip |
| sweep.yml | event-review-terminal-finalization | Requeue unobserved terminal acknowledgement | /internal/exact-review/terminal-finalization/retry |
| sweep.yml | recover-review-failures | Requeue eligible item terminals once | /internal/exact-review/enqueue |
| exact-review-reconcile-run.yml | reconcile | Reconcile terminal run | /internal/exact-review/reconcile |
| exact-review-dead-letter-reconcile.yml | reconcile | Verify live recovery guards | /api/health |
