### PR TITLE
docs: record batch two triage fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ## 0.3.1 - Unreleased
 
-**Highlights:** Preserve later review evidence, keep quoted report prose from forging findings, and prevent stalled status updates from blocking review starts.
+**Highlights:** Preserve later review evidence, reject forged report findings, bound stalled repair calls, and recheck paired-close eligibility before mutations.
 
 ### Removed
 
@@ -119,6 +119,10 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Recheck current close policies and known same-author counterparts before close mutations, keeping the parent open when a counterpart locks, reopens, or cannot be refreshed; thanks @vincentkoc.
+- Bound cluster dispatch and target cloning with operator-configured deadlines, useful timeout errors, and clone process-tree cleanup; thanks @SebTardif.
+- Bound cluster-selector model and GitHub requests through response completion, failing without new selection output on stalled transports; thanks @SebTardif.
+- Show later PR review revisions beside the freshness timestamp while preserving same-review resyncs and lifetime history counts; thanks @elijahfriedman.
 - Prevent quoted finding and security-concern prose from adding findings or replacing confidence when durable reviews are parsed again; thanks @Yigtwxx.
 - Preserve later discussion evidence and invalidate cached reviews when omitted inline-comment text changes instead of silently dropping comment tails; thanks @TommyLei666.
 - Mask credentialed URLs in supplementary review context and ignore foreign timeline issue numbers; thanks @yetval.


### PR DESCRIPTION
## What Problem This Solves

Collect the second triage batch's release notes in one PR so the independently prepared code PRs do not conflict in CHANGELOG.md.

## Changes

Update Highlights and record the paired-close repair, both repair timeout fixes, and review-revision display, retaining contributor credit. Released sections are unchanged.

Land after these code PRs:

- https://github.com/openclaw/clawsweeper/pull/1483
- https://github.com/openclaw/clawsweeper/pull/1446
- https://github.com/openclaw/clawsweeper/pull/1382
- https://github.com/openclaw/clawsweeper/pull/1499 (replacement for https://github.com/openclaw/clawsweeper/pull/1042)

The queue-retry entry already on main is not edited here. Its revert and corrected re-land are owned by https://github.com/openclaw/clawsweeper/pull/1498 and that repair lane.

## Evidence

`git diff --check` and `pnpm run check:docs` pass. Local and committed-branch Codex autoreview are clean through P2. Exact head: `a8fa43d0c538978a457aa7999eedcb2f446a613f`; CI: https://github.com/openclaw/clawsweeper/actions/runs/34248097685. This is documentation-only; executable runtime proofs belong to the linked code PRs.

`pnpm outdated --format json` found only the coordinated Oxc/tsgolint tooling refresh already tracked in https://github.com/openclaw/clawsweeper/pull/1318 and newer Node typings outside the Node 24 runtime floor. No additional dependency bump is included. The 2,880-minute release-age policy is retained.

## Release and OpenClaw Bay Impact

These batch changes fit a patch. This PR does not authorize a tag, release, publication or deployment. Release preparation remains gated on the remaining autonomous queue and restoration of exact-review workflows after https://github.com/openclaw/clawsweeper/pull/1497. No Bay data or observer contract changes.

## Real Behavior Proof: Rendered Documentation

The exact committed changelog was rendered with the installed `markdown-it` 15.0.1, the repository's documentation parser, on Node 24.20.0. This exercises the changed documentation artifact; runtime behavior remains proved in the four linked code PRs.

Reproduction from an installed checkout:

```sh
git show a8fa43d0c538978a457aa7999eedcb2f446a613f:CHANGELOG.md > "$TMPDIR/batch-two-changelog.md"
node --input-type=module -e 'import fs from "node:fs"; import MarkdownIt from "markdown-it"; process.stdout.write(new MarkdownIt().render(fs.readFileSync(process.argv[1], "utf8")))' "$TMPDIR/batch-two-changelog.md" > "$TMPDIR/batch-two-changelog.html"
```

Observed after rendering: the heading is `<h2>0.3.1 - Unreleased</h2>`. All four added notes render as list items with intact contributor credit: paired-close revalidation (@vincentkoc), dispatch/clone deadlines (@SebTardif), selector deadlines (@SebTardif), and revision labels (@elijahfriedman). No note text is lost or interpreted as markup. Comparing the entire released suffix starting at `## 0.3.0 -` with parent `9da27d076a542b06751a879eace475ccc134fbff` is byte-identical.

Before/after standalone HTML files were generated locally. A separate Git merge-tree check against the post-revert main is conflict-free and does not restore the removed queue-retry entry. Exact-head CI passed: https://github.com/openclaw/clawsweeper/actions/runs/34248097685.

Limits: this proves the release-note artifact renders correctly; it does not claim the four implementation PRs have already merged. The explicit notes-last landing order remains required. No public website deployment, release or publication occurred.
