### PR TITLE
fix(queue): retry control-plane 5xx and propagate retryable admission failures (re-land)

### DIFF
--- a/.github/workflows/exact-review-dead-letter-reconcile.yml
+++ b/.github/workflows/exact-review-dead-letter-reconcile.yml
@@ -106,8 +106,9 @@ jobs:
       - name: Verify live recovery guards
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           expected_deploy_sha="$(git rev-parse HEAD)"
-          live_deploy_sha="$(curl --fail --silent --show-error "$EXACT_REVIEW_QUEUE_URL/api/health" | jq -er '.deployment_sha')"
+          live_deploy_sha="$(control_plane_curl --fail --silent --show-error "$EXACT_REVIEW_QUEUE_URL/api/health" | jq -er '.deployment_sha')"
           if [[ "$live_deploy_sha" != "$expected_deploy_sha" ]]; then
             if ! [[ "$live_deploy_sha" =~ ^[0-9a-f]{40}$ ]]; then
               echo "Live Worker returned an invalid deployment revision; refusing unguarded reconciliation" >&2

--- a/.github/workflows/exact-review-reconcile-run.yml
+++ b/.github/workflows/exact-review-reconcile-run.yml
@@ -38,12 +38,14 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Check out control-plane retry helper
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-          sparse-checkout-cone-mode: false
-          sparse-checkout: scripts/control-plane-curl.sh
+      - name: Fetch control-plane retry helper
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL --retry 3 "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/scripts/control-plane-curl.sh" -o "$RUNNER_TEMP/control-plane-curl.sh"
+          test -s "$RUNNER_TEMP/control-plane-curl.sh"
+          source "$RUNNER_TEMP/control-plane-curl.sh"
+          declare -F control_plane_curl > /dev/null
       - name: Reconcile terminal run
         env:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
@@ -52,7 +54,7 @@ jobs:
           SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
         run: |
           set -euo pipefail
-          source scripts/control-plane-curl.sh
+          source "$RUNNER_TEMP/control-plane-curl.sh"
           test -n "$CLAWSWEEPER_WEBHOOK_SECRET"
           queue_url="${QUEUE_URL%/}"
           payload="$(node -e '

--- a/.github/workflows/exact-review-reconcile-run.yml
+++ b/.github/workflows/exact-review-reconcile-run.yml
@@ -34,9 +34,16 @@ jobs:
     needs: cooldown
     if: ${{ needs.cooldown.outputs.reconcile == 'true' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions: {}
+    timeout-minutes: 12
+    permissions:
+      contents: read
     steps:
+      - name: Check out control-plane retry helper
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          sparse-checkout-cone-mode: false
+          sparse-checkout: scripts/control-plane-curl.sh
       - name: Reconcile terminal run
         env:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
@@ -45,6 +52,7 @@ jobs:
           SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           test -n "$CLAWSWEEPER_WEBHOOK_SECRET"
           queue_url="${QUEUE_URL%/}"
           payload="$(node -e '
@@ -59,17 +67,12 @@ jobs:
             }));
           ')"
           signature="$(PAYLOAD="$payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
-          for attempt in 1 2 3; do
-            if curl --fail --silent --show-error --connect-timeout 5 --max-time 120 \
-              --request POST \
-              --header "content-type: application/json" \
-              --header "x-clawsweeper-exact-review-signature: $signature" \
-              --data-binary "$payload" \
-              "$queue_url/internal/exact-review/reconcile" >/dev/null; then
-              exit 0
-            fi
-            if [ "$attempt" -lt 3 ]; then
-              sleep "$((attempt * 5))"
-            fi
-          done
+          if control_plane_curl --fail --silent --show-error --connect-timeout 5 --max-time 120 \
+            --request POST \
+            --header "content-type: application/json" \
+            --header "x-clawsweeper-exact-review-signature: $signature" \
+            --data-binary "$payload" \
+            "$queue_url/internal/exact-review/reconcile" >/dev/null; then
+            exit 0
+          fi
           exit 1

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -680,6 +680,7 @@ jobs:
           exit 1
 
       - uses: actions/checkout@v7
+        id: source-checkout
         if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' }}
         with:
           filter: blob:none
@@ -2261,6 +2262,7 @@ jobs:
         if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && always() && (steps.direct-exact-review-publication.outputs.accepted != 'true' || steps.finalize-direct-exact-review-lifecycle.outcome == 'success') }}
         continue-on-error: true
         env:
+          SOURCE_CHECKOUT_OUTCOME: ${{ steps.source-checkout.outcome }}
           PRIMARY_OUTCOME: ${{ steps.exact-review-generation-result.outputs.outcome || 'failure' }}
           CLAIM_GENERATION: ${{ steps.claim-exact-review-queue.outputs.claim_generation }}
           ITEM_KEY: ${{ steps.claim-exact-review-queue.outputs.item_key }}
@@ -2289,7 +2291,11 @@ jobs:
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
-          source scripts/control-plane-curl.sh
+          if [[ "$SOURCE_CHECKOUT_OUTCOME" == "success" ]]; then
+            source scripts/control-plane-curl.sh
+          else
+            source "$RUNNER_TEMP/control-plane-curl.sh"
+          fi
           test -n "$QUEUE_LEASE_ID"
           queue_url="${QUEUE_URL%/}"
           payload="$(node -e '
@@ -2866,6 +2872,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v7
+        id: source-checkout
         if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.publication-context.outputs.direct_lifecycle_recovery != 'true' }}
         with:
           # The artifact validator binds the producer SHA. The publisher itself
@@ -3629,6 +3636,7 @@ jobs:
         if: ${{ steps.publication-context.outputs.claimed == 'true' && always() }}
         continue-on-error: true
         env:
+          SOURCE_CHECKOUT_OUTCOME: ${{ steps.source-checkout.outcome }}
           CLAIM_GENERATION: ${{ steps.publication-context.outputs.publisher_claim_generation }}
           ITEM_KEY: ${{ steps.publication-context.outputs.publisher_item_key }}
           LEASE_REVISION: ${{ steps.publication-context.outputs.publisher_lease_revision }}
@@ -3654,7 +3662,11 @@ jobs:
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
-          source scripts/control-plane-curl.sh
+          if [[ "$SOURCE_CHECKOUT_OUTCOME" == "success" ]]; then
+            source scripts/control-plane-curl.sh
+          else
+            source "$RUNNER_TEMP/control-plane-curl.sh"
+          fi
           queue_url="${QUEUE_URL%/}"
           payload="$(node -e '
             const leaseRevision = Number(process.env.LEASE_REVISION);
@@ -3891,6 +3903,7 @@ jobs:
           NODE
 
       - uses: actions/checkout@v7
+        id: source-checkout
         if: ${{ steps.finalization-context.outputs.claimed == 'true' }}
         with:
           # Fetch blobs during the retryable fetch instead of lazily fetching
@@ -4139,6 +4152,7 @@ jobs:
       - name: Requeue unobserved terminal acknowledgement
         if: ${{ always() && steps.finalization-context.outputs.claimed == 'true' && steps.observe-verified-terminal-acknowledgement.outcome != 'success' && !((steps.update-final-command-status.outputs.locked_conversation == 'true' || steps.update-final-command-status.outputs.missing_status_comment == 'true') && steps.complete-locked-terminal-acknowledgement.outcome == 'success') }}
         env:
+          SOURCE_CHECKOUT_OUTCOME: ${{ steps.source-checkout.outcome }}
           ITEM_KEY: ${{ steps.finalization-context.outputs.item_key }}
           QUEUE_LEASE_ID: ${{ github.event.client_payload.queue_lease_id }}
           LEASE_REVISION: ${{ steps.finalization-context.outputs.lease_revision }}
@@ -4147,7 +4161,11 @@ jobs:
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
-          source scripts/control-plane-curl.sh
+          if [[ "$SOURCE_CHECKOUT_OUTCOME" == "success" ]]; then
+            source scripts/control-plane-curl.sh
+          else
+            source "$RUNNER_TEMP/control-plane-curl.sh"
+          fi
           payload="$(node -e '
             const leaseRevision = Number(process.env.LEASE_REVISION);
             const claimGeneration = Number(process.env.CLAIM_GENERATION);

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -281,6 +281,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Check out control-plane retry helper
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          sparse-checkout-cone-mode: false
+          sparse-checkout: scripts/control-plane-curl.sh
       - name: Enqueue legacy event through the durable control plane
         env:
           CLIENT_PAYLOAD: ${{ toJson(github.event.client_payload) }}
@@ -288,6 +294,7 @@ jobs:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           test -n "$CLAWSWEEPER_WEBHOOK_SECRET"
           queue_url="${QUEUE_URL%/}"
           mapfile -d '' -t legacy_intake_fields < <(node <<'NODE'
@@ -459,7 +466,7 @@ jobs:
           NODE
           )"
           signature="$(PAYLOAD="$payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
-          curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+          control_plane_curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
             --request POST \
             --header "content-type: application/json" \
             --header "x-clawsweeper-exact-review-signature: $signature" \
@@ -482,6 +489,12 @@ jobs:
       pull-requests: read
       statuses: read
     steps:
+      - name: Check out control-plane retry helper
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          sparse-checkout-cone-mode: false
+          sparse-checkout: scripts/control-plane-curl.sh
       - name: Claim exact-review queue lease
         id: claim-exact-review-queue
         env:
@@ -493,6 +506,7 @@ jobs:
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           test -n "$QUEUE_LEASE_ID"
           printf 'claimed=false\ndecision={}\n' >> "$GITHUB_OUTPUT"
           queue_url="${QUEUE_URL%/}"
@@ -514,160 +528,151 @@ jobs:
             }));
           ')"
           response_file="$(mktemp)"
-          error_file="$(mktemp)"
-          trap 'rm -f "$response_file" "$error_file"' EXIT
-          for attempt in 1 2 3; do
-            : > "$response_file"
-            : > "$error_file"
-            if status="$(curl --silent --show-error --connect-timeout 5 --max-time 20 \
-              --output "$response_file" \
-              --write-out '%{http_code}' \
-              --request POST \
-              --header "content-type: application/json" \
-              --data "$payload" \
-              "$queue_url/internal/exact-review/claim" 2>"$error_file")"; then
-              response="$(<"$response_file")"
-              if [ "$status" = "409" ]; then
-                conflict_reason="$(RESPONSE="$response" node <<'NODE'
-                  const response = JSON.parse(process.env.RESPONSE || "{}");
-                  const safeConflicts = new Set([
-                    "lease_not_active",
-                    "lease_already_claimed",
-                    "lease_decision_unavailable",
-                    "stale_run_attempt",
-                  ]);
-                  if (!safeConflicts.has(response.error)) process.exit(1);
-                  process.stdout.write(response.error);
-          NODE
-                )" || {
-                  echo "Unexpected exact-review lease conflict: $response" >&2
-                  exit 1
-                }
-                echo "::notice::Skipping exact review because lease claim lost safely: $conflict_reason"
-                exit 0
-              fi
-              if [ "$status" != "200" ]; then
-                if [[ "$status" != 5* ]]; then
-                  echo "Exact-review lease claim returned HTTP $status: $response" >&2
-                  exit 1
-                fi
-              elif RESPONSE="$response" node <<'NODE'
-                const fs = require("node:fs");
+          trap 'rm -f "$response_file"' EXIT
+          : > "$response_file"
+          if status="$(control_plane_curl --silent --show-error --connect-timeout 5 --max-time 20 \
+            --output "$response_file" \
+            --write-out '%{http_code}' \
+            --request POST \
+            --header "content-type: application/json" \
+            --data "$payload" \
+            "$queue_url/internal/exact-review/claim")"; then
+            response="$(<"$response_file")"
+            if [ "$status" = "409" ]; then
+              conflict_reason="$(RESPONSE="$response" node <<'NODE'
                 const response = JSON.parse(process.env.RESPONSE || "{}");
-                const dispatch = JSON.parse(process.env.DISPATCH_PAYLOAD || "{}");
-                const requestedItemKey = String(process.env.ITEM_KEY || "").trim();
-                const requestedLeaseRevision = Number(process.env.QUEUE_LEASE_REVISION);
-                const responseProtocol = Number(response.protocol_version || 1);
-                if (responseProtocol !== 1 && responseProtocol !== 2) process.exit(1);
-                if (response.claimed !== true) process.exit(1);
-
-                const reviewOptions =
-                  dispatch.review_options && typeof dispatch.review_options === "object"
-                    ? dispatch.review_options
-                    : {};
-                const legacyDecision = {
-                  targetRepo: String(dispatch.target_repo || ""),
-                  targetBranch: String(dispatch.target_branch || "main"),
-                  itemNumber: Number(dispatch.item_number),
-                  itemKind: String(dispatch.item_kind || ""),
-                  sourceEvent: String(dispatch.source_event || ""),
-                  sourceAction: String(dispatch.source_action || "legacy_dispatch"),
-                  supersedesInProgress: dispatch.supersedes_in_progress === true,
-                  ...(/^[0-9a-f]{40}$/.test(String(dispatch.queue_claim?.source_head_sha || dispatch.source_head_sha || "").trim().toLowerCase())
-                    ? { sourceHeadSha: String(dispatch.queue_claim?.source_head_sha || dispatch.source_head_sha).trim().toLowerCase() }
-                    : {}),
-                  ...(Number.isFinite(Number(reviewOptions.codex_timeout_ms))
-                    ? { codexTimeoutMs: Number(reviewOptions.codex_timeout_ms) }
-                    : {}),
-                  ...(Number.isFinite(Number(reviewOptions.media_proof_timeout_ms))
-                    ? { mediaProofTimeoutMs: Number(reviewOptions.media_proof_timeout_ms) }
-                    : {}),
-                  ...(Object.hasOwn(reviewOptions, "command_status_marker")
-                    ? { commandStatusMarker: reviewOptions.command_status_marker }
-                    : {}),
-                  ...(Object.hasOwn(reviewOptions, "status_comment_id")
-                    ? { statusCommentId: reviewOptions.status_comment_id }
-                    : {}),
-                  ...(Number.isSafeInteger(
-                    Number(reviewOptions.review_acknowledgement_comment_id),
-                  ) && Number(reviewOptions.review_acknowledgement_comment_id) > 0
-                    ? {
-                        reviewAcknowledgementCommentId: Number(
-                          reviewOptions.review_acknowledgement_comment_id,
-                        ),
-                      }
-                    : {}),
-                  ...(Object.hasOwn(reviewOptions, "additional_prompt")
-                    ? { additionalPrompt: reviewOptions.additional_prompt }
-                    : {}),
-                };
-                const decision =
-                  response.decision && typeof response.decision === "object"
-                    ? response.decision
-                    : legacyDecision;
-                const targetRepo = String(decision?.targetRepo || "");
-                const itemNumber = Number(decision?.itemNumber);
-                const itemKey = `${targetRepo}#${itemNumber}`;
-                const leaseRevision =
-                  responseProtocol === 2
-                    ? Number(response.lease_revision)
-                    : Number(
-                        response.revision ||
-                          response.lease_revision ||
-                          process.env.QUEUE_LEASE_REVISION,
-                      );
-                const claimGeneration = Number(response.claim_generation);
-                const repeatRevision = response.repeat_revision;
-                if (
-                  !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(targetRepo) ||
-                  !Number.isInteger(itemNumber) ||
-                  itemNumber < 1 ||
-                  (decision.itemKind !== "issue" && decision.itemKind !== "pull_request") ||
-                  (decision.sourceEvent !== "issues" && decision.sourceEvent !== "pull_request") ||
-                  typeof decision.sourceAction !== "string" ||
-                  !decision.sourceAction
-                ) {
-                  process.exit(1);
-                }
-                if (response.item_key && response.item_key !== itemKey) process.exit(1);
-                if (requestedItemKey && requestedItemKey !== itemKey) process.exit(1);
-                if (
-                  responseProtocol === 2 &&
-                  (!response.decision ||
-                    typeof response.decision !== "object" ||
-                    response.item_key !== requestedItemKey ||
-                    response.lease_revision !== requestedLeaseRevision ||
-                    !Number.isInteger(claimGeneration) ||
-                    claimGeneration < 1 ||
-                    typeof repeatRevision !== "boolean")
-                ) {
-                  process.exit(1);
-                }
-                const output = [
-                  "claimed=true",
-                  `lease_id=${process.env.QUEUE_LEASE_ID}`,
-                  `item_key=${itemKey}`,
-                  `lease_revision=${Number.isInteger(leaseRevision) ? leaseRevision : ""}`,
-                  `claim_generation=${responseProtocol === 2 ? claimGeneration : ""}`,
-                  `repeat_revision=${responseProtocol === 2 ? repeatRevision : false}`,
-                  `protocol_version=${responseProtocol}`,
-                  `decision=${JSON.stringify(decision)}`,
-                ];
-                fs.appendFileSync(process.env.GITHUB_OUTPUT, `${output.join("\n")}\n`);
+                const safeConflicts = new Set([
+                  "lease_not_active",
+                  "lease_already_claimed",
+                  "lease_decision_unavailable",
+                  "stale_run_attempt",
+                ]);
+                if (!safeConflicts.has(response.error)) process.exit(1);
+                process.stdout.write(response.error);
           NODE
-              then
-                exit 0
-              else
-                echo "Exact-review lease claim returned an invalid success payload." >&2
+              )" || {
+                echo "Unexpected exact-review lease conflict: $response" >&2
+                exit 1
+              }
+              echo "::notice::Skipping exact review because lease claim lost safely: $conflict_reason"
+              exit 0
+            fi
+            if [ "$status" != "200" ]; then
+              if [[ "$status" != 5* ]]; then
+                echo "Exact-review lease claim returned HTTP $status: $response" >&2
                 exit 1
               fi
+            elif RESPONSE="$response" node <<'NODE'
+              const fs = require("node:fs");
+              const response = JSON.parse(process.env.RESPONSE || "{}");
+              const dispatch = JSON.parse(process.env.DISPATCH_PAYLOAD || "{}");
+              const requestedItemKey = String(process.env.ITEM_KEY || "").trim();
+              const requestedLeaseRevision = Number(process.env.QUEUE_LEASE_REVISION);
+              const responseProtocol = Number(response.protocol_version || 1);
+              if (responseProtocol !== 1 && responseProtocol !== 2) process.exit(1);
+              if (response.claimed !== true) process.exit(1);
+
+              const reviewOptions =
+                dispatch.review_options && typeof dispatch.review_options === "object"
+                  ? dispatch.review_options
+                  : {};
+              const legacyDecision = {
+                targetRepo: String(dispatch.target_repo || ""),
+                targetBranch: String(dispatch.target_branch || "main"),
+                itemNumber: Number(dispatch.item_number),
+                itemKind: String(dispatch.item_kind || ""),
+                sourceEvent: String(dispatch.source_event || ""),
+                sourceAction: String(dispatch.source_action || "legacy_dispatch"),
+                supersedesInProgress: dispatch.supersedes_in_progress === true,
+                ...(/^[0-9a-f]{40}$/.test(String(dispatch.queue_claim?.source_head_sha || dispatch.source_head_sha || "").trim().toLowerCase())
+                  ? { sourceHeadSha: String(dispatch.queue_claim?.source_head_sha || dispatch.source_head_sha).trim().toLowerCase() }
+                  : {}),
+                ...(Number.isFinite(Number(reviewOptions.codex_timeout_ms))
+                  ? { codexTimeoutMs: Number(reviewOptions.codex_timeout_ms) }
+                  : {}),
+                ...(Number.isFinite(Number(reviewOptions.media_proof_timeout_ms))
+                  ? { mediaProofTimeoutMs: Number(reviewOptions.media_proof_timeout_ms) }
+                  : {}),
+                ...(Object.hasOwn(reviewOptions, "command_status_marker")
+                  ? { commandStatusMarker: reviewOptions.command_status_marker }
+                  : {}),
+                ...(Object.hasOwn(reviewOptions, "status_comment_id")
+                  ? { statusCommentId: reviewOptions.status_comment_id }
+                  : {}),
+                ...(Number.isSafeInteger(
+                  Number(reviewOptions.review_acknowledgement_comment_id),
+                ) && Number(reviewOptions.review_acknowledgement_comment_id) > 0
+                  ? {
+                      reviewAcknowledgementCommentId: Number(
+                        reviewOptions.review_acknowledgement_comment_id,
+                      ),
+                    }
+                  : {}),
+                ...(Object.hasOwn(reviewOptions, "additional_prompt")
+                  ? { additionalPrompt: reviewOptions.additional_prompt }
+                  : {}),
+              };
+              const decision =
+                response.decision && typeof response.decision === "object"
+                  ? response.decision
+                  : legacyDecision;
+              const targetRepo = String(decision?.targetRepo || "");
+              const itemNumber = Number(decision?.itemNumber);
+              const itemKey = `${targetRepo}#${itemNumber}`;
+              const leaseRevision =
+                responseProtocol === 2
+                  ? Number(response.lease_revision)
+                  : Number(
+                      response.revision ||
+                        response.lease_revision ||
+                        process.env.QUEUE_LEASE_REVISION,
+                    );
+              const claimGeneration = Number(response.claim_generation);
+              const repeatRevision = response.repeat_revision;
+              if (
+                !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(targetRepo) ||
+                !Number.isInteger(itemNumber) ||
+                itemNumber < 1 ||
+                (decision.itemKind !== "issue" && decision.itemKind !== "pull_request") ||
+                (decision.sourceEvent !== "issues" && decision.sourceEvent !== "pull_request") ||
+                typeof decision.sourceAction !== "string" ||
+                !decision.sourceAction
+              ) {
+                process.exit(1);
+              }
+              if (response.item_key && response.item_key !== itemKey) process.exit(1);
+              if (requestedItemKey && requestedItemKey !== itemKey) process.exit(1);
+              if (
+                responseProtocol === 2 &&
+                (!response.decision ||
+                  typeof response.decision !== "object" ||
+                  response.item_key !== requestedItemKey ||
+                  response.lease_revision !== requestedLeaseRevision ||
+                  !Number.isInteger(claimGeneration) ||
+                  claimGeneration < 1 ||
+                  typeof repeatRevision !== "boolean")
+              ) {
+                process.exit(1);
+              }
+              const output = [
+                "claimed=true",
+                `lease_id=${process.env.QUEUE_LEASE_ID}`,
+                `item_key=${itemKey}`,
+                `lease_revision=${Number.isInteger(leaseRevision) ? leaseRevision : ""}`,
+                `claim_generation=${responseProtocol === 2 ? claimGeneration : ""}`,
+                `repeat_revision=${responseProtocol === 2 ? repeatRevision : false}`,
+                `protocol_version=${responseProtocol}`,
+                `decision=${JSON.stringify(decision)}`,
+              ];
+              fs.appendFileSync(process.env.GITHUB_OUTPUT, `${output.join("\n")}\n`);
+          NODE
+            then
+              exit 0
             else
-              cat "$error_file" >&2
+              echo "Exact-review lease claim returned an invalid success payload." >&2
+              exit 1
             fi
-            if [ "$attempt" -lt 3 ]; then
-              sleep "$((attempt * 5))"
-            fi
-          done
+          fi
           exit 1
 
       - uses: actions/checkout@v7
@@ -1234,6 +1239,7 @@ jobs:
           REVIEW_ACKNOWLEDGEMENT_COMMENT_ID: ${{ steps.automatic-review-status.outputs.status_comment_id }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           echo "authorized=false" >> "$GITHUB_OUTPUT"
           payload="$(node -e '
             const sourceHeadSha = String(process.env.EXACT_REVIEW_SOURCE_HEAD_SHA || "").trim().toLowerCase();
@@ -1251,7 +1257,7 @@ jobs:
           ')"
           response="$(mktemp)"
           trap 'rm -f "$response"' EXIT
-          status="$(curl --silent --show-error --connect-timeout 5 --max-time 20 \
+          status="$(control_plane_curl --silent --show-error --connect-timeout 5 --max-time 20 \
             --output "$response" --write-out '%{http_code}' --request POST \
             --header "content-type: application/json" --data-binary "$payload" \
             "${QUEUE_URL%/}/internal/exact-review/heartbeat")" || status=""
@@ -1292,6 +1298,7 @@ jobs:
           EXACT_REVIEW_SOURCE_HEAD_SHA: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).sourceHeadSha || '' }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           echo "authorized=false" >> "$GITHUB_OUTPUT"
           payload="$(node -e '
             const sourceHeadSha = String(process.env.EXACT_REVIEW_SOURCE_HEAD_SHA || "").trim().toLowerCase();
@@ -1308,7 +1315,7 @@ jobs:
           ')"
           response="$(mktemp)"
           trap 'rm -f "$response"' EXIT
-          status="$(curl --silent --show-error --connect-timeout 5 --max-time 20 \
+          status="$(control_plane_curl --silent --show-error --connect-timeout 5 --max-time 20 \
             --output "$response" --write-out '%{http_code}' --request POST \
             --header "content-type: application/json" --data-binary "$payload" \
             "${QUEUE_URL%/}/internal/exact-review/heartbeat")" || status=""
@@ -1345,6 +1352,7 @@ jobs:
           EXACT_REVIEW_DECISION: ${{ steps.claim-exact-review-queue.outputs.decision }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           test -n "$GH_TOKEN"
           heartbeat_pid=""
           review_pid=""
@@ -1375,13 +1383,13 @@ jobs:
           }
           heartbeat_loop() {
             while true; do
-              heartbeat_status="$(curl --silent --connect-timeout 5 --max-time 20 \
+              heartbeat_status="$(control_plane_curl --silent --connect-timeout 5 --max-time 20 \
                 --output /dev/null \
                 --write-out '%{http_code}' \
                 --request POST \
                 --header "content-type: application/json" \
                 --data-binary "$heartbeat_payload" \
-                "${QUEUE_URL%/}/internal/exact-review/heartbeat" 2>/dev/null)" || heartbeat_status=""
+                "${QUEUE_URL%/}/internal/exact-review/heartbeat")" || heartbeat_status=""
               if [ "$heartbeat_status" = "409" ]; then
                 echo "::notice::Exact-review heartbeat lost its lease tuple."
                 : > "$superseded_marker"
@@ -1427,26 +1435,22 @@ jobs:
               const payload = JSON.parse(process.env.HEARTBEAT_PAYLOAD || "{}");
               process.stdout.write(JSON.stringify({ ...payload, phase: "finalizing" }));
             ')" || return 1
-            for attempt in 1 2 3; do
-              finalizing_status="$(curl --silent --connect-timeout 5 --max-time 20 \
-                --output /dev/null \
-                --write-out '%{http_code}' \
-                --request POST \
-                --header "content-type: application/json" \
-                --data-binary "$finalizing_payload" \
-                "${QUEUE_URL%/}/internal/exact-review/heartbeat" 2>/dev/null)" || finalizing_status=""
-              if [ "$finalizing_status" = "200" ]; then
-                return 0
-              fi
-              if [ "$finalizing_status" = "409" ]; then
-                echo "::notice::Exact-review finalization lost its lease tuple."
-                : > "$superseded_marker"
-                return 0
-              fi
-              if [ "$attempt" -lt 3 ]; then
-                sleep "$((attempt * 5))"
-              fi
-            done
+            finalizing_status="$(control_plane_curl --silent --connect-timeout 5 --max-time 20 \
+              --output /dev/null \
+              --write-out '%{http_code}' \
+              --request POST \
+              --header "content-type: application/json" \
+              --data-binary "$finalizing_payload" \
+              "${QUEUE_URL%/}/internal/exact-review/heartbeat")" || finalizing_status=""
+            if [ "$finalizing_status" = "200" ]; then
+              return 0
+            fi
+            if [ "$finalizing_status" = "409" ]; then
+              echo "::notice::Exact-review finalization lost its lease tuple."
+              : > "$superseded_marker"
+              return 0
+            fi
+            echo "control_plane_unavailable=true" >> "$GITHUB_OUTPUT"
             echo "::error::Exact-review lease could not enter finalization."
             return 1
           }
@@ -1593,6 +1597,7 @@ jobs:
           REVIEW_ACKNOWLEDGEMENT_COMMENT_ID: ${{ steps.automatic-review-status.outputs.status_comment_id }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           echo "authorized=false" >> "$GITHUB_OUTPUT"
           payload="$(node -e '
             const sourceHeadSha = String(process.env.EXACT_REVIEW_SOURCE_HEAD_SHA || "").trim().toLowerCase();
@@ -1610,7 +1615,7 @@ jobs:
           ')"
           response="$(mktemp)"
           trap 'rm -f "$response"' EXIT
-          status="$(curl --silent --show-error --connect-timeout 5 --max-time 20 \
+          status="$(control_plane_curl --silent --show-error --connect-timeout 5 --max-time 20 \
             --output "$response" --write-out '%{http_code}' --request POST \
             --header "content-type: application/json" --data-binary "$payload" \
             "${QUEUE_URL%/}/internal/exact-review/heartbeat")" || status=""
@@ -1648,6 +1653,7 @@ jobs:
           EXACT_REVIEW_SOURCE_HEAD_SHA: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).sourceHeadSha || '' }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           echo "authorized=false" >> "$GITHUB_OUTPUT"
           payload="$(node -e '
             const sourceHeadSha = String(process.env.EXACT_REVIEW_SOURCE_HEAD_SHA || "").trim().toLowerCase();
@@ -1664,7 +1670,7 @@ jobs:
           ')"
           response="$(mktemp)"
           trap 'rm -f "$response"' EXIT
-          status="$(curl --silent --show-error --connect-timeout 5 --max-time 20 \
+          status="$(control_plane_curl --silent --show-error --connect-timeout 5 --max-time 20 \
             --output "$response" --write-out '%{http_code}' --request POST \
             --header "content-type: application/json" --data-binary "$payload" \
             "${QUEUE_URL%/}/internal/exact-review/heartbeat")" || status=""
@@ -1799,6 +1805,7 @@ jobs:
           CLAWSWEEPER_COMMENT_MAX_COMMENTS: ${{ vars.CLAWSWEEPER_COMMENT_MAX_COMMENTS || '1000' }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           test -s "$DIRECT_OUTCOME"
           jq -e '.kind == "eligible" and .disposition != null' "$DIRECT_OUTCOME" >/dev/null
           test -n "$CLAWSWEEPER_WEBHOOK_SECRET"
@@ -1862,7 +1869,7 @@ jobs:
               }));
             ')"
             lifecycle_signature="$(PAYLOAD="$lifecycle_payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
-            lifecycle_response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+            lifecycle_response="$(control_plane_curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
               --request POST \
               --header "content-type: application/json" \
               --header "x-clawsweeper-exact-review-signature: $lifecycle_signature" \
@@ -1882,7 +1889,7 @@ jobs:
               }));
             ')"
             lifecycle_signature="$(PAYLOAD="$lifecycle_payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
-            lifecycle_response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+            lifecycle_response="$(control_plane_curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
               --request POST \
               --header "content-type: application/json" \
               --header "x-clawsweeper-exact-review-signature: $lifecycle_signature" \
@@ -1940,6 +1947,7 @@ jobs:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           test -n "$CLAWSWEEPER_WEBHOOK_SECRET"
           queue_url="${QUEUE_URL%/}"
           payload="$(node <<'NODE'
@@ -1981,26 +1989,21 @@ jobs:
           NODE
           )"
           signature="$(PAYLOAD="$payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
-          for attempt in 1 2 3; do
-            response="$(
-              curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
-                --request POST \
-                --header "content-type: application/json" \
-                --header "x-clawsweeper-exact-review-signature: $signature" \
-                --data "$payload" \
-                "$queue_url/internal/exact-review/enqueue" || true
-            )"
-            if jq -e '.superseded == true' <<< "$response" >/dev/null 2>&1; then
-              echo "::notice::Exact-review publication revision $(jq -r '.publication_revision // "unknown"' <<< "$response") was superseded by revision $(jq -r '.superseded_by_revision // "unknown"' <<< "$response"); the newer publisher owns final delivery."
-              exit 0
-            fi
-            if jq -e '.ok == true and (.queued == true or .deduped == true)' <<< "$response" >/dev/null; then
-              exit 0
-            fi
-            if [ "$attempt" -lt 3 ]; then
-              sleep "$((attempt * 5))"
-            fi
-          done
+          response="$(
+            control_plane_curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+              --request POST \
+              --header "content-type: application/json" \
+              --header "x-clawsweeper-exact-review-signature: $signature" \
+              --data "$payload" \
+              "$queue_url/internal/exact-review/enqueue" || true
+          )"
+          if jq -e '.superseded == true' <<< "$response" >/dev/null 2>&1; then
+            echo "::notice::Exact-review publication revision $(jq -r '.publication_revision // "unknown"' <<< "$response") was superseded by revision $(jq -r '.superseded_by_revision // "unknown"' <<< "$response"); the newer publisher owns final delivery."
+            exit 0
+          fi
+          if jq -e '.ok == true and (.queued == true or .deduped == true)' <<< "$response" >/dev/null; then
+            exit 0
+          fi
           exit 1
 
       - name: Expire queued exact review lease
@@ -2105,6 +2108,7 @@ jobs:
           REVIEW_ACKNOWLEDGEMENT_COMMENT_ID: ${{ steps.automatic-review-status.outputs.status_comment_id }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           echo "authorized=false" >> "$GITHUB_OUTPUT"
           payload="$(node -e '
             const leaseRevision = Number(process.env.EXACT_REVIEW_LEASE_REVISION);
@@ -2128,24 +2132,21 @@ jobs:
               phase: "status",
             }));
           ')"
-          for attempt in 1 2 3; do
-            status="$(curl --silent --show-error --connect-timeout 5 --max-time 20 \
-              --output /dev/null \
-              --write-out '%{http_code}' \
-              --request POST \
-              --header "content-type: application/json" \
-              --data-binary "$payload" \
-              "${QUEUE_URL%/}/internal/exact-review/heartbeat")" || status=""
-            if [ "$status" = "200" ]; then
-              echo "authorized=true" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-            if [ "$status" = "409" ]; then
-              echo "::notice::Skipping terminal review status because the queue lease was superseded."
-              exit 0
-            fi
-            if [ "$attempt" -lt 3 ]; then sleep "$((attempt * 5))"; fi
-          done
+          status="$(control_plane_curl --silent --show-error --connect-timeout 5 --max-time 20 \
+            --output /dev/null \
+            --write-out '%{http_code}' \
+            --request POST \
+            --header "content-type: application/json" \
+            --data-binary "$payload" \
+            "${QUEUE_URL%/}/internal/exact-review/heartbeat")" || status=""
+          if [ "$status" = "200" ]; then
+            echo "authorized=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$status" = "409" ]; then
+            echo "::notice::Skipping terminal review status because the queue lease was superseded."
+            exit 0
+          fi
           echo "Unable to fence terminal review status against the active queue lease." >&2
           exit 1
 
@@ -2180,6 +2181,7 @@ jobs:
           EXACT_REVIEW_CLAIM_GENERATION: ${{ steps.claim-exact-review-queue.outputs.claim_generation }}
           EXACT_REVIEW_SOURCE_HEAD_SHA: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).sourceHeadSha || '' }}
         run: |
+          source scripts/control-plane-curl.sh
           payload="$(node -e '
             const sourceHeadSha = String(process.env.EXACT_REVIEW_SOURCE_HEAD_SHA || "").trim().toLowerCase();
             process.stdout.write(JSON.stringify({
@@ -2193,7 +2195,7 @@ jobs:
               phase: "finalizing",
             }));
           ')"
-          curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+          control_plane_curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
             --request POST --header "content-type: application/json" --data-binary "$payload" \
             "${QUEUE_URL%/}/internal/exact-review/heartbeat" >/dev/null
 
@@ -2283,6 +2285,7 @@ jobs:
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           test -n "$QUEUE_LEASE_ID"
           queue_url="${QUEUE_URL%/}"
           payload="$(node -e '
@@ -2398,64 +2401,54 @@ jobs:
             }));
           ')"
           response_file="$(mktemp)"
-          error_file="$(mktemp)"
-          trap 'rm -f "$response_file" "$error_file"' EXIT
-          for attempt in 1 2 3; do
-            while true; do
-              : > "$response_file"
-              : > "$error_file"
-              if status="$(curl --silent --show-error --connect-timeout 5 --max-time 20 \
-                --output "$response_file" \
-                --write-out '%{http_code}' \
-                --request POST \
-                --header "content-type: application/json" \
-                --data "$payload" \
-                "$queue_url/internal/exact-review/complete" 2>"$error_file")"; then
-                response="$(<"$response_file")"
-                if [[ "$status" == 2* ]]; then
-                  exit 0
-                fi
-                if [ "$status" = "400" ] &&
-                  jq -e '.error == "invalid_review_failure_reason"' "$response_file" >/dev/null 2>&1 &&
-                  jq -e 'has("review_failure_reason")' <<< "$payload" >/dev/null; then
-                  # Status is valid only alongside a terminal reason; retain diagnostic detail.
-                  payload="$(jq -c 'del(.review_failure_reason, .review_failure_status)' <<< "$payload")"
-                  echo "::warning::Exact-review completion detected Worker/workflow deploy skew (invalid_review_failure_reason); retrying once without terminal reason/status, retaining review_failure detail."
-                  continue
-                fi
-                # Only this completion-specific conflict is emitted after the
-                # durable queue verifies that this exact v2 lease tuple was fenced
-                # by a newer source revision. Every generic ownership conflict
-                # stays visible so a malformed or mismatched callback cannot turn
-                # a failed completion into a green workflow.
-                if [ "$status" = "409" ]; then
-                  conflict_reason="$(RESPONSE="$response" node <<'NODE'
-                    const response = JSON.parse(process.env.RESPONSE || "{}");
-                    const safeConflicts = new Set(["lease_superseded"]);
-                    if (!safeConflicts.has(response.error)) process.exit(1);
-                    process.stdout.write(response.error);
-          NODE
-                  )" || {
-                    echo "Unexpected exact-review completion conflict: $response" >&2
-                    exit 1
-                  }
-                  echo "::notice::Exact-review completion skipped because its lease was superseded: $conflict_reason"
-                  exit 0
-                fi
-                echo "Exact-review completion returned HTTP $status: $response" >&2
-                if [[ "$status" != 5* ]]; then
-                  exit 1
-                fi
-              else
-                cat "$error_file" >&2
+          trap 'rm -f "$response_file"' EXIT
+          while true; do
+            : > "$response_file"
+            if status="$(control_plane_curl --silent --show-error --connect-timeout 5 --max-time 20 \
+              --output "$response_file" \
+              --write-out '%{http_code}' \
+              --request POST \
+              --header "content-type: application/json" \
+              --data "$payload" \
+              "$queue_url/internal/exact-review/complete")"; then
+              response="$(<"$response_file")"
+              if [[ "$status" == 2* ]]; then
+                exit 0
               fi
-              break
-            done
-            if [ "$attempt" -lt 3 ]; then
-              sleep "$((attempt * 5))"
+              if [ "$status" = "400" ] &&
+                jq -e '.error == "invalid_review_failure_reason"' "$response_file" >/dev/null 2>&1 &&
+                jq -e 'has("review_failure_reason")' <<< "$payload" >/dev/null; then
+                # Status is valid only alongside a terminal reason; retain diagnostic detail.
+                payload="$(jq -c 'del(.review_failure_reason, .review_failure_status)' <<< "$payload")"
+                echo "::warning::Exact-review completion detected Worker/workflow deploy skew (invalid_review_failure_reason); retrying once without terminal reason/status, retaining review_failure detail."
+                continue
+              fi
+              # Only this completion-specific conflict is emitted after the
+              # durable queue verifies that this exact v2 lease tuple was fenced
+              # by a newer source revision. Every generic ownership conflict
+              # stays visible so a malformed or mismatched callback cannot turn
+              # a failed completion into a green workflow.
+              if [ "$status" = "409" ]; then
+                conflict_reason="$(RESPONSE="$response" node <<'NODE'
+                  const response = JSON.parse(process.env.RESPONSE || "{}");
+                  const safeConflicts = new Set(["lease_superseded"]);
+                  if (!safeConflicts.has(response.error)) process.exit(1);
+                  process.stdout.write(response.error);
+          NODE
+                )" || {
+                  echo "Unexpected exact-review completion conflict: $response" >&2
+                  exit 1
+                }
+                echo "::notice::Exact-review completion skipped because its lease was superseded: $conflict_reason"
+                exit 0
+              fi
+              echo "Exact-review completion returned HTTP $status: $response" >&2
+              if [[ "$status" != 5* ]]; then
+                exit 1
+              fi
             fi
+            exit 1
           done
-          exit 1
 
       - name: Submit direct GitHub egress telemetry
         if: ${{ always() && steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.direct-github-egress-observer.outcome == 'success' }}
@@ -2508,7 +2501,14 @@ jobs:
         env:
           CLASSIFICATION: >-
             ${{
-              (steps.review-complete-status-fence.outcome == 'failure' || steps.release-review-complete-status-fence.outcome == 'failure') && 'review_status_delivery_failure' ||
+              (
+                steps.reserve-exact-review-lease.outcome == 'failure' ||
+                steps.review-status-fence.outcome == 'failure' ||
+                steps.release-review-status-fence.outcome == 'failure' ||
+                steps.review-complete-status-fence.outcome == 'failure' ||
+                steps.release-review-complete-status-fence.outcome == 'failure' ||
+                steps.review-exact-event-item.outputs.control_plane_unavailable == 'true'
+              ) && 'queue_completion_failure' ||
               (
                 steps.exact-review-generation-result.outputs.outcome != 'success' &&
                 steps.exact-review-generation-result.outputs.retry_kind == '' &&
@@ -2536,6 +2536,12 @@ jobs:
       pull-requests: write
       statuses: read
     steps:
+      - name: Check out control-plane retry helper
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          sparse-checkout-cone-mode: false
+          sparse-checkout: scripts/control-plane-curl.sh
       - name: Claim durable exact review publication
         id: publication-context
         env:
@@ -2546,6 +2552,7 @@ jobs:
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           printf 'claimed=false\ndecision={}\n' >> "$GITHUB_OUTPUT"
           queue_url="${QUEUE_URL%/}"
           payload="$(node -e '
@@ -2563,163 +2570,154 @@ jobs:
             }));
           ')"
           response_file="$(mktemp)"
-          error_file="$(mktemp)"
-          trap 'rm -f "$response_file" "$error_file"' EXIT
-          for attempt in 1 2 3; do
-            : > "$response_file"
-            : > "$error_file"
-            if status="$(curl --silent --show-error --connect-timeout 5 --max-time 20 \
-              --output "$response_file" \
-              --write-out '%{http_code}' \
-              --request POST \
-              --header "content-type: application/json" \
-              --data "$payload" \
-              "$queue_url/internal/exact-review/claim" 2>"$error_file")"; then
-              response="$(<"$response_file")"
-              if [ "$status" = "409" ]; then
-                conflict_reason="$(RESPONSE="$response" node <<'NODE'
-                  const response = JSON.parse(process.env.RESPONSE || "{}");
-                  const safeConflicts = new Set([
-                    "lease_not_active",
-                    "lease_already_claimed",
-                    "lease_decision_unavailable",
-                    "stale_run_attempt",
-                  ]);
-                  if (!safeConflicts.has(response.error)) process.exit(1);
-                  process.stdout.write(response.error);
-          NODE
-                )" || {
-                  echo "Unexpected exact-review publication conflict: $response" >&2
-                  exit 1
-                }
-                echo "::notice::Skipping exact review publication because lease claim lost safely: $conflict_reason"
-                exit 0
-              fi
-              if [ "$status" != "200" ]; then
-                if [[ "$status" != 5* ]]; then
-                  echo "Exact-review publication claim returned HTTP $status: $response" >&2
-                  exit 1
-                fi
-              elif RESPONSE="$response" node <<'NODE'
-                const fs = require("node:fs");
+          trap 'rm -f "$response_file"' EXIT
+          : > "$response_file"
+          if status="$(control_plane_curl --silent --show-error --connect-timeout 5 --max-time 20 \
+            --output "$response_file" \
+            --write-out '%{http_code}' \
+            --request POST \
+            --header "content-type: application/json" \
+            --data "$payload" \
+            "$queue_url/internal/exact-review/claim")"; then
+            response="$(<"$response_file")"
+            if [ "$status" = "409" ]; then
+              conflict_reason="$(RESPONSE="$response" node <<'NODE'
                 const response = JSON.parse(process.env.RESPONSE || "{}");
-                const decision = response.decision;
-                const publication = decision?.publication;
-                const producerDecision = publication?.producerDecision;
-                const leaseRevision = Number(response.lease_revision);
-                const claimGeneration = Number(response.claim_generation);
-                const repeatRevision = response.repeat_revision;
-                const publicationLeaseRevision = Number(publication?.leaseRevision);
-                const directItemKey = `${decision?.targetRepo}#${decision?.itemNumber}`;
-                const expectedDeferredItemKey = `${directItemKey}@publish:${publication?.producerRunId}:${publication?.producerRunAttempt}`;
-                // Direct publication converts its already-leased base item into a
-                // recoverable publication. Its saved revision must still match
-                // this publisher lease before any external router handoff;
-                // deferred publication has its own key.
-                const directLifecycleRecovery =
-                  response.item_key === directItemKey &&
-                  publication?.itemKey === directItemKey &&
-                  Number.isInteger(publicationLeaseRevision) &&
-                  publicationLeaseRevision === leaseRevision;
-                const directLifecycle = directLifecycleRecovery ? publication?.directLifecycle : null;
-                const directLifecyclePlan = directLifecycle?.plan;
-                const directLifecycleReceiptOutcome = directLifecycle?.receiptOutcome;
-                const directLifecycleKinds = new Set([
-                  "router",
-                  "router_deferred_coverage",
-                  "router_not_required",
-                  "requeue",
-                  "target_missing",
-                  "target_closed",
-                  "guarded_open",
-                  "policy_noop",
+                const safeConflicts = new Set([
+                  "lease_not_active",
+                  "lease_already_claimed",
+                  "lease_decision_unavailable",
+                  "stale_run_attempt",
                 ]);
-                // Pre-projection rows have no saved post-effect intent. They
-                // deliberately retain artifact recovery rather than inferring a
-                // router or terminal result from a newer publisher run.
-                const directLifecycleRecoveryReady =
-                  directLifecycleRecovery &&
-                  directLifecyclePlan &&
-                  typeof directLifecyclePlan === "object" &&
-                  !Array.isArray(directLifecyclePlan) &&
-                  Object.keys(directLifecyclePlan).length === 1 &&
-                  directLifecycleKinds.has(directLifecyclePlan.kind) &&
-                  ["accepted", "deduped", "superseded"].includes(directLifecycleReceiptOutcome);
-                const deferredPublication = response.item_key === expectedDeferredItemKey;
-                if (
-                  response.claimed !== true ||
-                  response.protocol_version !== 2 ||
-                  typeof repeatRevision !== "boolean" ||
-                  response.item_key !== process.env.ITEM_KEY ||
-                  (!deferredPublication && !directLifecycleRecovery) ||
-                  decision?.sourceAction !== "exact_review_artifact_publish" ||
-                  !publication ||
-                  !producerDecision ||
-                  producerDecision.targetRepo !== decision.targetRepo ||
-                  producerDecision.targetBranch !== decision.targetBranch ||
-                  producerDecision.itemNumber !== decision.itemNumber ||
-                  producerDecision.itemKind !== decision.itemKind
-                ) process.exit(1);
-                if (!Number.isInteger(leaseRevision) || leaseRevision < 1) process.exit(1);
-                if (!Number.isInteger(claimGeneration) || claimGeneration < 1) process.exit(1);
-                const targetRepo = String(decision.targetRepo);
-                const [targetRepoOwner, targetRepoName] = targetRepo.split("/");
-                const targetSlug = targetRepo.trim().toLowerCase().replace(/[^a-z0-9_.-]+/g, "-");
-                const values = {
-                  artifact_name: publication.artifactName,
-                  generation_attempt: publication.producerRunAttempt,
-                  producer_run_id: publication.producerRunId,
-                  source_sha: publication.sourceSha,
-                  decision: JSON.stringify(producerDecision),
-                  item_key: publication.itemKey,
-                  protocol_version: publication.protocolVersion,
-                  lease_revision: publication.leaseRevision ?? "",
-                  claim_generation: publication.claimGeneration ?? "",
-                  target_repo: targetRepo,
-                  target_repo_owner: targetRepoOwner,
-                  target_repo_name: targetRepoName,
-                  target_slug: targetSlug,
-                  target_branch: decision.targetBranch,
-                  item_number: decision.itemNumber,
-                  item_kind: decision.itemKind,
-                  has_command_context: Boolean(
-                    producerDecision.commandStatusMarker || producerDecision.statusCommentId,
-                  ),
-                  live_proceeded: publication.liveProceeded,
-                  live_terminal_noop: publication.liveTerminalNoop,
-                  live_terminal_missing: publication.liveTerminalMissing,
-                  live_guarded_open: publication.liveGuardedOpen,
-                  publisher_lease_id: process.env.QUEUE_LEASE_ID,
-                  publisher_item_key: response.item_key,
-                  publisher_lease_revision: leaseRevision,
-                  publisher_claim_generation: claimGeneration,
-                  repeat_revision: repeatRevision,
-                  direct_lifecycle_recovery: directLifecycleRecoveryReady,
-                  direct_lifecycle_plan: directLifecycleRecoveryReady
-                    ? JSON.stringify(directLifecyclePlan)
-                    : "",
-                  direct_lifecycle_receipt_outcome: directLifecycleRecoveryReady
-                    ? directLifecycleReceiptOutcome
-                    : "",
-                };
-                fs.appendFileSync(process.env.GITHUB_OUTPUT, "claimed=true\n");
-                for (const [key, value] of Object.entries(values)) {
-                  fs.appendFileSync(process.env.GITHUB_OUTPUT, `${key}=${value}\n`);
-                }
+                if (!safeConflicts.has(response.error)) process.exit(1);
+                process.stdout.write(response.error);
           NODE
-              then
-                exit 0
-              else
-                echo "Exact-review publication claim returned an invalid success payload." >&2
+              )" || {
+                echo "Unexpected exact-review publication conflict: $response" >&2
+                exit 1
+              }
+              echo "::notice::Skipping exact review publication because lease claim lost safely: $conflict_reason"
+              exit 0
+            fi
+            if [ "$status" != "200" ]; then
+              if [[ "$status" != 5* ]]; then
+                echo "Exact-review publication claim returned HTTP $status: $response" >&2
                 exit 1
               fi
+            elif RESPONSE="$response" node <<'NODE'
+              const fs = require("node:fs");
+              const response = JSON.parse(process.env.RESPONSE || "{}");
+              const decision = response.decision;
+              const publication = decision?.publication;
+              const producerDecision = publication?.producerDecision;
+              const leaseRevision = Number(response.lease_revision);
+              const claimGeneration = Number(response.claim_generation);
+              const repeatRevision = response.repeat_revision;
+              const publicationLeaseRevision = Number(publication?.leaseRevision);
+              const directItemKey = `${decision?.targetRepo}#${decision?.itemNumber}`;
+              const expectedDeferredItemKey = `${directItemKey}@publish:${publication?.producerRunId}:${publication?.producerRunAttempt}`;
+              // Direct publication converts its already-leased base item into a
+              // recoverable publication. Its saved revision must still match
+              // this publisher lease before any external router handoff;
+              // deferred publication has its own key.
+              const directLifecycleRecovery =
+                response.item_key === directItemKey &&
+                publication?.itemKey === directItemKey &&
+                Number.isInteger(publicationLeaseRevision) &&
+                publicationLeaseRevision === leaseRevision;
+              const directLifecycle = directLifecycleRecovery ? publication?.directLifecycle : null;
+              const directLifecyclePlan = directLifecycle?.plan;
+              const directLifecycleReceiptOutcome = directLifecycle?.receiptOutcome;
+              const directLifecycleKinds = new Set([
+                "router",
+                "router_deferred_coverage",
+                "router_not_required",
+                "requeue",
+                "target_missing",
+                "target_closed",
+                "guarded_open",
+                "policy_noop",
+              ]);
+              // Pre-projection rows have no saved post-effect intent. They
+              // deliberately retain artifact recovery rather than inferring a
+              // router or terminal result from a newer publisher run.
+              const directLifecycleRecoveryReady =
+                directLifecycleRecovery &&
+                directLifecyclePlan &&
+                typeof directLifecyclePlan === "object" &&
+                !Array.isArray(directLifecyclePlan) &&
+                Object.keys(directLifecyclePlan).length === 1 &&
+                directLifecycleKinds.has(directLifecyclePlan.kind) &&
+                ["accepted", "deduped", "superseded"].includes(directLifecycleReceiptOutcome);
+              const deferredPublication = response.item_key === expectedDeferredItemKey;
+              if (
+                response.claimed !== true ||
+                response.protocol_version !== 2 ||
+                typeof repeatRevision !== "boolean" ||
+                response.item_key !== process.env.ITEM_KEY ||
+                (!deferredPublication && !directLifecycleRecovery) ||
+                decision?.sourceAction !== "exact_review_artifact_publish" ||
+                !publication ||
+                !producerDecision ||
+                producerDecision.targetRepo !== decision.targetRepo ||
+                producerDecision.targetBranch !== decision.targetBranch ||
+                producerDecision.itemNumber !== decision.itemNumber ||
+                producerDecision.itemKind !== decision.itemKind
+              ) process.exit(1);
+              if (!Number.isInteger(leaseRevision) || leaseRevision < 1) process.exit(1);
+              if (!Number.isInteger(claimGeneration) || claimGeneration < 1) process.exit(1);
+              const targetRepo = String(decision.targetRepo);
+              const [targetRepoOwner, targetRepoName] = targetRepo.split("/");
+              const targetSlug = targetRepo.trim().toLowerCase().replace(/[^a-z0-9_.-]+/g, "-");
+              const values = {
+                artifact_name: publication.artifactName,
+                generation_attempt: publication.producerRunAttempt,
+                producer_run_id: publication.producerRunId,
+                source_sha: publication.sourceSha,
+                decision: JSON.stringify(producerDecision),
+                item_key: publication.itemKey,
+                protocol_version: publication.protocolVersion,
+                lease_revision: publication.leaseRevision ?? "",
+                claim_generation: publication.claimGeneration ?? "",
+                target_repo: targetRepo,
+                target_repo_owner: targetRepoOwner,
+                target_repo_name: targetRepoName,
+                target_slug: targetSlug,
+                target_branch: decision.targetBranch,
+                item_number: decision.itemNumber,
+                item_kind: decision.itemKind,
+                has_command_context: Boolean(
+                  producerDecision.commandStatusMarker || producerDecision.statusCommentId,
+                ),
+                live_proceeded: publication.liveProceeded,
+                live_terminal_noop: publication.liveTerminalNoop,
+                live_terminal_missing: publication.liveTerminalMissing,
+                live_guarded_open: publication.liveGuardedOpen,
+                publisher_lease_id: process.env.QUEUE_LEASE_ID,
+                publisher_item_key: response.item_key,
+                publisher_lease_revision: leaseRevision,
+                publisher_claim_generation: claimGeneration,
+                repeat_revision: repeatRevision,
+                direct_lifecycle_recovery: directLifecycleRecoveryReady,
+                direct_lifecycle_plan: directLifecycleRecoveryReady
+                  ? JSON.stringify(directLifecyclePlan)
+                  : "",
+                direct_lifecycle_receipt_outcome: directLifecycleRecoveryReady
+                  ? directLifecycleReceiptOutcome
+                  : "",
+              };
+              fs.appendFileSync(process.env.GITHUB_OUTPUT, "claimed=true\n");
+              for (const [key, value] of Object.entries(values)) {
+                fs.appendFileSync(process.env.GITHUB_OUTPUT, `${key}=${value}\n`);
+              }
+          NODE
+            then
+              exit 0
             else
-              cat "$error_file" >&2
+              echo "Exact-review publication claim returned an invalid success payload." >&2
+              exit 1
             fi
-            if [ "$attempt" -lt 3 ]; then
-              sleep "$((attempt * 5))"
-            fi
-          done
+          fi
           exit 1
 
       - name: Replay committed direct lifecycle handoff
@@ -2744,6 +2742,7 @@ jobs:
           CLAWSWEEPER_COMMENT_MAX_COMMENTS: ${{ vars.CLAWSWEEPER_COMMENT_MAX_COMMENTS || '1000' }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           test -n "$CLAWSWEEPER_WEBHOOK_SECRET"
           queue_url="${QUEUE_URL%/}"
           lifecycle_kind="$(DIRECT_LIFECYCLE_PLAN="$DIRECT_LIFECYCLE_PLAN" node -e '
@@ -2780,7 +2779,7 @@ jobs:
               }));
             ')"
             lifecycle_signature="$(PAYLOAD="$lifecycle_payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
-            lifecycle_response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+            lifecycle_response="$(control_plane_curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
               --request POST \
               --header "content-type: application/json" \
               --header "x-clawsweeper-exact-review-signature: $lifecycle_signature" \
@@ -2801,7 +2800,7 @@ jobs:
               }));
             ')"
             lifecycle_signature="$(PAYLOAD="$lifecycle_payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
-            lifecycle_response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+            lifecycle_response="$(control_plane_curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
               --request POST \
               --header "content-type: application/json" \
               --header "x-clawsweeper-exact-review-signature: $lifecycle_signature" \
@@ -3197,6 +3196,7 @@ jobs:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           payload="$(node -e '
             const revision = Number(process.env.REVISION);
             if (!Number.isInteger(revision) || revision < 1 || !process.env.FENCE_KEY) process.exit(1);
@@ -3210,7 +3210,7 @@ jobs:
           ')"
           signature="$(PAYLOAD="$payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
           queue_url="${QUEUE_URL%/}"
-          curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+          control_plane_curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
             --request POST \
             --header "content-type: application/json" \
             --header "x-clawsweeper-exact-review-signature: $signature" \
@@ -3234,6 +3234,7 @@ jobs:
           CLAWSWEEPER_COMMENT_LOOKBACK_MINUTES: ${{ vars.CLAWSWEEPER_COMMENT_LOOKBACK_MINUTES || '180' }}
           CLAWSWEEPER_COMMENT_MAX_COMMENTS: ${{ vars.CLAWSWEEPER_COMMENT_MAX_COMMENTS || '1000' }}
         run: |
+          source scripts/control-plane-curl.sh
           gh workflow run repair-comment-router.yml \
             --repo "$GITHUB_REPOSITORY" \
             --ref main \
@@ -3256,7 +3257,7 @@ jobs:
           ')"
           signature="$(PAYLOAD="$payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
           queue_url="${QUEUE_URL%/}"
-          curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+          control_plane_curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
             --request POST \
             --header "content-type: application/json" \
             --header "x-clawsweeper-exact-review-signature: $signature" \
@@ -3275,6 +3276,7 @@ jobs:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           payload="$(node -e '
             const revision = Number(process.env.REVISION);
             if (!Number.isInteger(revision) || revision < 1 || !process.env.FENCE_KEY) process.exit(1);
@@ -3288,7 +3290,7 @@ jobs:
           ')"
           signature="$(PAYLOAD="$payload" node -e 'const crypto=require("node:crypto"); process.stdout.write("sha256="+crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex"))')"
           queue_url="${QUEUE_URL%/}"
-          curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+          control_plane_curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
             --request POST \
             --header "content-type: application/json" \
             --header "x-clawsweeper-exact-review-signature: $signature" \
@@ -3307,6 +3309,7 @@ jobs:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           payload="$(node -e '
             const revision = Number(process.env.REVISION);
             if (!Number.isInteger(revision) || revision < 1 || !process.env.FENCE_KEY) process.exit(1);
@@ -3320,7 +3323,7 @@ jobs:
           ')"
           signature="$(PAYLOAD="$payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
           queue_url="${QUEUE_URL%/}"
-          curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+          control_plane_curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
             --request POST \
             --header "content-type: application/json" \
             --header "x-clawsweeper-exact-review-signature: $signature" \
@@ -3352,6 +3355,7 @@ jobs:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           test -n "$CLAWSWEEPER_WEBHOOK_SECRET"
           queue_url="${QUEUE_URL%/}"
           payload="$(node <<'NODE'
@@ -3370,7 +3374,7 @@ jobs:
           NODE
           )"
           signature="$(PAYLOAD="$payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
-          response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+          response="$(control_plane_curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
             --request POST \
             --header "content-type: application/json" \
             --header "x-clawsweeper-exact-review-signature: $signature" \
@@ -3644,6 +3648,7 @@ jobs:
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           queue_url="${QUEUE_URL%/}"
           payload="$(node -e '
             const leaseRevision = Number(process.env.LEASE_REVISION);
@@ -3715,18 +3720,13 @@ jobs:
               ...(stateWriter ? { state_writer: stateWriter } : {}),
             }));
           ')"
-          for attempt in 1 2 3; do
-            if curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
-              --request POST \
-              --header "content-type: application/json" \
-              --data "$payload" \
-              "$queue_url/internal/exact-review/complete" >/dev/null; then
-              exit 0
-            fi
-            if [ "$attempt" -lt 3 ]; then
-              sleep "$((attempt * 5))"
-            fi
-          done
+          if control_plane_curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+            --request POST \
+            --header "content-type: application/json" \
+            --data "$payload" \
+            "$queue_url/internal/exact-review/complete" >/dev/null; then
+            exit 0
+          fi
           exit 1
 
       - name: Mark active lease retry waiting
@@ -3770,6 +3770,12 @@ jobs:
       issues: write
       pull-requests: write
     steps:
+      - name: Check out control-plane retry helper
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          sparse-checkout-cone-mode: false
+          sparse-checkout: scripts/control-plane-curl.sh
       - name: Claim committed terminal finalization
         id: finalization-context
         env:
@@ -3780,6 +3786,7 @@ jobs:
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           printf 'claimed=false\n' >> "$GITHUB_OUTPUT"
           queue_url="${QUEUE_URL%/}"
           payload="$(node -e '
@@ -3797,50 +3804,40 @@ jobs:
             }));
           ')"
           response_file="$(mktemp)"
-          error_file="$(mktemp)"
-          trap 'rm -f "$response_file" "$error_file"' EXIT
-          for attempt in 1 2 3; do
-            : > "$response_file"
-            : > "$error_file"
-            if status="$(curl --silent --show-error --connect-timeout 5 --max-time 20 \
-              --output "$response_file" --write-out '%{http_code}' \
-              --request POST --header "content-type: application/json" --data "$payload" \
-              "$queue_url/internal/exact-review/claim" 2>"$error_file")"; then
-              response="$(<"$response_file")"
-              if [ "$status" = "409" ]; then
-                conflict_reason="$(RESPONSE="$response" node <<'NODE'
-                  const response = JSON.parse(process.env.RESPONSE || "{}");
-                  const safeConflicts = new Set([
-                    "lease_not_active",
-                    "lease_already_claimed",
-                    "lease_decision_unavailable",
-                    "stale_run_attempt",
-                  ]);
-                  if (!safeConflicts.has(response.error)) process.exit(1);
-                  process.stdout.write(response.error);
+          trap 'rm -f "$response_file"' EXIT
+          : > "$response_file"
+          if status="$(control_plane_curl --silent --show-error --connect-timeout 5 --max-time 20 \
+            --output "$response_file" --write-out '%{http_code}' \
+            --request POST --header "content-type: application/json" --data "$payload" \
+            "$queue_url/internal/exact-review/claim")"; then
+            response="$(<"$response_file")"
+            if [ "$status" = "409" ]; then
+              conflict_reason="$(RESPONSE="$response" node <<'NODE'
+                const response = JSON.parse(process.env.RESPONSE || "{}");
+                const safeConflicts = new Set([
+                  "lease_not_active",
+                  "lease_already_claimed",
+                  "lease_decision_unavailable",
+                  "stale_run_attempt",
+                ]);
+                if (!safeConflicts.has(response.error)) process.exit(1);
+                process.stdout.write(response.error);
           NODE
-                )" || {
-                  echo "Unexpected terminal-finalization claim conflict: $response" >&2
-                  exit 1
-                }
-                echo "::notice::Skipping terminal finalization because lease claim lost safely: $conflict_reason"
-                exit 0
-              fi
-              if [ "$status" = "200" ]; then
-                break
-              fi
-              if [[ "$status" != 5* ]]; then
-                echo "Terminal-finalization claim returned HTTP $status: $response" >&2
+              )" || {
+                echo "Unexpected terminal-finalization claim conflict: $response" >&2
                 exit 1
-              fi
+              }
+              echo "::notice::Skipping terminal finalization because lease claim lost safely: $conflict_reason"
+              exit 0
             fi
-            if [ "$attempt" = "3" ]; then
-              cat "$error_file" >&2
-              echo "Terminal-finalization claim failed after retries" >&2
+            if [ "$status" != "200" ]; then
+              echo "Terminal-finalization claim returned HTTP $status: $response" >&2
               exit 1
             fi
-            sleep "$attempt"
-          done
+          else
+            echo "Terminal-finalization claim failed after retries" >&2
+            exit 1
+          fi
           RESPONSE="$response" node <<'NODE'
           const fs = require("node:fs");
           const response = JSON.parse(process.env.RESPONSE || "{}");
@@ -3911,6 +3908,7 @@ jobs:
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           payload="$(node -e '
             const leaseRevision = Number(process.env.LEASE_REVISION);
             const claimGeneration = Number(process.env.CLAIM_GENERATION);
@@ -3930,7 +3928,7 @@ jobs:
           ')"
           response_file="$(mktemp)"
           trap 'rm -f "$response_file"' EXIT
-          response_status="$(curl --silent --show-error --connect-timeout 5 --max-time 20 \
+          response_status="$(control_plane_curl --silent --show-error --connect-timeout 5 --max-time 20 \
             --output "$response_file" --write-out '%{http_code}' \
             --request POST --header "content-type: application/json" --data "$payload" \
             "${QUEUE_URL%/}/internal/exact-review/terminal-finalization/attempt")"
@@ -3990,6 +3988,7 @@ jobs:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           update_log="$(mktemp)"
           trap 'rm -f "$update_log"' EXIT
           pnpm run repair:update-command-status -- \
@@ -4016,7 +4015,7 @@ jobs:
                 }));
               ')"
               signature="$(PAYLOAD="$failure_payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
-              curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+              control_plane_curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
                 --request POST --header "content-type: application/json" \
                 --header "x-clawsweeper-exact-review-signature: $signature" \
                 --data "$failure_payload" \
@@ -4042,6 +4041,7 @@ jobs:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           payload="$(node -e '
             const fenceKey = process.env.FENCE_KEY || "";
             const revision = Number(process.env.REVISION);
@@ -4073,7 +4073,7 @@ jobs:
             }));
           ')"
           signature="$(PAYLOAD="$payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
-          response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+          response="$(control_plane_curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
             --request POST --header "content-type: application/json" \
             --header "x-clawsweeper-exact-review-signature: $signature" \
             --data "$payload" \
@@ -4096,6 +4096,7 @@ jobs:
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           skip_reason="locked_conversation"
           expected_state="skipped_locked"
           if [ "$MISSING_STATUS_COMMENT" = "true" ]; then
@@ -4121,7 +4122,7 @@ jobs:
               ...(statusCommentId === null ? {} : { status_comment_id: statusCommentId }),
             }));
           ')"
-          response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+          response="$(control_plane_curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
             --request POST --header "content-type: application/json" --data "$payload" \
             "${QUEUE_URL%/}/internal/exact-review/terminal-finalization/skip")"
           jq -e --arg state "$expected_state" \
@@ -4138,6 +4139,7 @@ jobs:
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           payload="$(node -e '
             const leaseRevision = Number(process.env.LEASE_REVISION);
             const claimGeneration = Number(process.env.CLAIM_GENERATION);
@@ -4151,7 +4153,7 @@ jobs:
           ')"
           response_file="$(mktemp)"
           trap 'rm -f "$response_file"' EXIT
-          response_status="$(curl --silent --show-error --connect-timeout 5 --max-time 20 \
+          response_status="$(control_plane_curl --silent --show-error --connect-timeout 5 --max-time 20 \
             --write-out '%{http_code}' --output "$response_file" \
             --request POST --header "content-type: application/json" --data "$payload" \
             "${QUEUE_URL%/}/internal/exact-review/terminal-finalization/retry")"
@@ -5851,6 +5853,12 @@ jobs:
       actions: read
       contents: read
     steps:
+      - name: Check out control-plane retry helper
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          sparse-checkout-cone-mode: false
+          sparse-checkout: scripts/control-plane-curl.sh
       - uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -5886,6 +5894,7 @@ jobs:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
         run: |
           set -euo pipefail
+          source scripts/control-plane-curl.sh
           test -n "$CLAWSWEEPER_WEBHOOK_SECRET"
           queue_url="${QUEUE_URL%/}"
           recovery_marker="[clawsweeper-recovery-attempt=1]"
@@ -5971,34 +5980,28 @@ jobs:
                 }
               }')"
             queued=false
-            for attempt in 1 2 3; do
-              # shellcheck disable=SC2016 # The Node source must retain its literal template expression.
-              signature="$(PAYLOAD="$payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
-              response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
-                --request POST \
-                --header "content-type: application/json" \
-                --header "x-clawsweeper-exact-review-signature: $signature" \
-                --data "$payload" \
-                "$queue_url/internal/exact-review/enqueue")" || response=""
-              if jq -e '.ok == true and (.queued == true or .deduped == true or .shed == true or .accepted == false)' <<<"$response" >/dev/null; then
-                if jq -e '.accepted == false' <<<"$response" >/dev/null; then
-                  echo "Item #$item_number: Recovery skipped because the target is disabled." | tee -a "$GITHUB_STEP_SUMMARY"
-                elif jq -e '.shed == true' <<<"$response" >/dev/null; then
-                  echo "Item #$item_number: Recovery shed by exact-review queue backpressure." | tee -a "$GITHUB_STEP_SUMMARY"
-                elif jq -e '.deduped == true' <<<"$response" >/dev/null; then
-                  echo "Item #$item_number: recovery admission deduplicated." | tee -a "$GITHUB_STEP_SUMMARY"
-                else
-                  echo "Item #$item_number: recovery admission queued." | tee -a "$GITHUB_STEP_SUMMARY"
-                fi
-                queued=true
-                break
+            # shellcheck disable=SC2016 # The Node source must retain its literal template expression.
+            signature="$(PAYLOAD="$payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
+            response="$(control_plane_curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+              --request POST \
+              --header "content-type: application/json" \
+              --header "x-clawsweeper-exact-review-signature: $signature" \
+              --data "$payload" \
+              "$queue_url/internal/exact-review/enqueue")" || response=""
+            if jq -e '.ok == true and (.queued == true or .deduped == true or .shed == true or .accepted == false)' <<<"$response" >/dev/null; then
+              if jq -e '.accepted == false' <<<"$response" >/dev/null; then
+                echo "Item #$item_number: Recovery skipped because the target is disabled." | tee -a "$GITHUB_STEP_SUMMARY"
+              elif jq -e '.shed == true' <<<"$response" >/dev/null; then
+                echo "Item #$item_number: Recovery shed by exact-review queue backpressure." | tee -a "$GITHUB_STEP_SUMMARY"
+              elif jq -e '.deduped == true' <<<"$response" >/dev/null; then
+                echo "Item #$item_number: recovery admission deduplicated." | tee -a "$GITHUB_STEP_SUMMARY"
+              else
+                echo "Item #$item_number: recovery admission queued." | tee -a "$GITHUB_STEP_SUMMARY"
               fi
-              echo "Recovery queue acknowledgement was not accepted on attempt $attempt." >&2
-              if [ "$attempt" -lt 3 ]; then
-                sleep "$((attempt * 5))"
-              fi
-            done
+              queued=true
+            fi
             if [ "$queued" != "true" ]; then
+              echo "Recovery queue acknowledgement was not accepted after control-plane retries." >&2
               failed_recovery_dispatches+=("$item_number")
             fi
           done

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -281,12 +281,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Check out control-plane retry helper
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-          sparse-checkout-cone-mode: false
-          sparse-checkout: scripts/control-plane-curl.sh
+      - name: Fetch control-plane retry helper
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL --retry 3 "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/scripts/control-plane-curl.sh" -o "$RUNNER_TEMP/control-plane-curl.sh"
+          test -s "$RUNNER_TEMP/control-plane-curl.sh"
+          source "$RUNNER_TEMP/control-plane-curl.sh"
+          declare -F control_plane_curl > /dev/null
       - name: Enqueue legacy event through the durable control plane
         env:
           CLIENT_PAYLOAD: ${{ toJson(github.event.client_payload) }}
@@ -294,7 +296,7 @@ jobs:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
         run: |
           set -euo pipefail
-          source scripts/control-plane-curl.sh
+          source "$RUNNER_TEMP/control-plane-curl.sh"
           test -n "$CLAWSWEEPER_WEBHOOK_SECRET"
           queue_url="${QUEUE_URL%/}"
           mapfile -d '' -t legacy_intake_fields < <(node <<'NODE'
@@ -489,12 +491,14 @@ jobs:
       pull-requests: read
       statuses: read
     steps:
-      - name: Check out control-plane retry helper
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-          sparse-checkout-cone-mode: false
-          sparse-checkout: scripts/control-plane-curl.sh
+      - name: Fetch control-plane retry helper
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL --retry 3 "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/scripts/control-plane-curl.sh" -o "$RUNNER_TEMP/control-plane-curl.sh"
+          test -s "$RUNNER_TEMP/control-plane-curl.sh"
+          source "$RUNNER_TEMP/control-plane-curl.sh"
+          declare -F control_plane_curl > /dev/null
       - name: Claim exact-review queue lease
         id: claim-exact-review-queue
         env:
@@ -506,7 +510,7 @@ jobs:
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
-          source scripts/control-plane-curl.sh
+          source "$RUNNER_TEMP/control-plane-curl.sh"
           test -n "$QUEUE_LEASE_ID"
           printf 'claimed=false\ndecision={}\n' >> "$GITHUB_OUTPUT"
           queue_url="${QUEUE_URL%/}"
@@ -2536,12 +2540,14 @@ jobs:
       pull-requests: write
       statuses: read
     steps:
-      - name: Check out control-plane retry helper
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-          sparse-checkout-cone-mode: false
-          sparse-checkout: scripts/control-plane-curl.sh
+      - name: Fetch control-plane retry helper
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL --retry 3 "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/scripts/control-plane-curl.sh" -o "$RUNNER_TEMP/control-plane-curl.sh"
+          test -s "$RUNNER_TEMP/control-plane-curl.sh"
+          source "$RUNNER_TEMP/control-plane-curl.sh"
+          declare -F control_plane_curl > /dev/null
       - name: Claim durable exact review publication
         id: publication-context
         env:
@@ -2552,7 +2558,7 @@ jobs:
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
-          source scripts/control-plane-curl.sh
+          source "$RUNNER_TEMP/control-plane-curl.sh"
           printf 'claimed=false\ndecision={}\n' >> "$GITHUB_OUTPUT"
           queue_url="${QUEUE_URL%/}"
           payload="$(node -e '
@@ -2742,7 +2748,7 @@ jobs:
           CLAWSWEEPER_COMMENT_MAX_COMMENTS: ${{ vars.CLAWSWEEPER_COMMENT_MAX_COMMENTS || '1000' }}
         run: |
           set -euo pipefail
-          source scripts/control-plane-curl.sh
+          source "$RUNNER_TEMP/control-plane-curl.sh"
           test -n "$CLAWSWEEPER_WEBHOOK_SECRET"
           queue_url="${QUEUE_URL%/}"
           lifecycle_kind="$(DIRECT_LIFECYCLE_PLAN="$DIRECT_LIFECYCLE_PLAN" node -e '
@@ -3770,12 +3776,14 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - name: Check out control-plane retry helper
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-          sparse-checkout-cone-mode: false
-          sparse-checkout: scripts/control-plane-curl.sh
+      - name: Fetch control-plane retry helper
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL --retry 3 "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/scripts/control-plane-curl.sh" -o "$RUNNER_TEMP/control-plane-curl.sh"
+          test -s "$RUNNER_TEMP/control-plane-curl.sh"
+          source "$RUNNER_TEMP/control-plane-curl.sh"
+          declare -F control_plane_curl > /dev/null
       - name: Claim committed terminal finalization
         id: finalization-context
         env:
@@ -3786,7 +3794,7 @@ jobs:
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
-          source scripts/control-plane-curl.sh
+          source "$RUNNER_TEMP/control-plane-curl.sh"
           printf 'claimed=false\n' >> "$GITHUB_OUTPUT"
           queue_url="${QUEUE_URL%/}"
           payload="$(node -e '
@@ -5853,12 +5861,14 @@ jobs:
       actions: read
       contents: read
     steps:
-      - name: Check out control-plane retry helper
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-          sparse-checkout-cone-mode: false
-          sparse-checkout: scripts/control-plane-curl.sh
+      - name: Fetch control-plane retry helper
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL --retry 3 "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/scripts/control-plane-curl.sh" -o "$RUNNER_TEMP/control-plane-curl.sh"
+          test -s "$RUNNER_TEMP/control-plane-curl.sh"
+          source "$RUNNER_TEMP/control-plane-curl.sh"
+          declare -F control_plane_curl > /dev/null
       - uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -5894,7 +5904,7 @@ jobs:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
         run: |
           set -euo pipefail
-          source scripts/control-plane-curl.sh
+          source "$RUNNER_TEMP/control-plane-curl.sh"
           test -n "$CLAWSWEEPER_WEBHOOK_SECRET"
           queue_url="${QUEUE_URL%/}"
           recovery_marker="[clawsweeper-recovery-attempt=1]"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@ checkpoint, and status-only commits are intentionally omitted.
 - Complete exact-review leases during Worker/workflow deploy skew by retrying rejected terminal reasons once without the reason/status, preserving diagnostics and warning operators.
 
 - Stop exact-review retries for every non-retryable scanner refusal, including scan deadlines, and retain terminal guidance for the unchanged revision.
+- Retry transient control-plane failures across exact-review workflow calls, preserve retryable admission 503 responses and Retry-After headers through webhook/internal ingress, and attribute failed fences and reservations to queue infrastructure.
 
 - Prepare GitHub user-attachment and legacy repository asset proof locally, resolving image/video types after download and reserving bounded preprocessing time for attachments.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,7 +127,7 @@ checkpoint, and status-only commits are intentionally omitted.
 - Complete exact-review leases during Worker/workflow deploy skew by retrying rejected terminal reasons once without the reason/status, preserving diagnostics and warning operators.
 
 - Stop exact-review retries for every non-retryable scanner refusal, including scan deadlines, and retain terminal guidance for the unchanged revision.
-- Retry transient control-plane failures across exact-review workflow calls, preserve retryable admission 503 responses and Retry-After headers through webhook/internal ingress, and attribute failed fences and reservations to queue infrastructure.
+- Retry transient control-plane failures across exact-review workflow calls, preserve retryable admission 503 responses and Retry-After headers through webhook/internal ingress, and attribute failed fences and reservations to queue infrastructure. Bootstrap pre-checkout helpers with commit-pinned downloads so later full checkouts retain local setup actions.
 
 - Prepare GitHub user-attachment and legacy repository asset proof locally, resolving image/video types after download and reserving bounded preprocessing time for attachments.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,7 +127,7 @@ checkpoint, and status-only commits are intentionally omitted.
 - Complete exact-review leases during Worker/workflow deploy skew by retrying rejected terminal reasons once without the reason/status, preserving diagnostics and warning operators.
 
 - Stop exact-review retries for every non-retryable scanner refusal, including scan deadlines, and retain terminal guidance for the unchanged revision.
-- Retry transient control-plane failures across exact-review workflow calls, preserve retryable admission 503 responses and Retry-After headers through webhook/internal ingress, and attribute failed fences and reservations to queue infrastructure. Bootstrap pre-checkout helpers with commit-pinned downloads so later full checkouts retain local setup actions.
+- Retry transient control-plane failures across exact-review workflow calls, preserve retryable admission 503 responses and Retry-After headers through webhook/internal ingress, and attribute failed fences and reservations to queue infrastructure. Bootstrap pre-checkout helpers with commit-pinned downloads so later full checkouts retain local setup actions, and keep lease cleanup working when checkout is skipped or fails.
 
 - Prepare GitHub user-attachment and legacy repository asset proof locally, resolving image/video types after download and reserving bounded preprocessing time for attachments.
 

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -4142,6 +4142,7 @@ async function githubWebhook(request, env, ctx) {
       ingress,
     });
     if (!queued) return json({ error: "exact_review_queue_not_configured" }, 503);
+    if (queued instanceof Response) return queued;
     if (sourceAuthoritySeq !== null) {
       await completeExactReviewSourceAuthority(
         env,
@@ -7183,7 +7184,13 @@ async function enqueueExactReview({
       body: JSON.stringify({ delivery_id: deliveryId, decision, ...(ingress ? { ingress } : {}) }),
     }),
   );
-  const body = objectValue(await response.json().catch(() => null));
+  const body = objectValue(
+    await response
+      .clone()
+      .json()
+      .catch(() => null),
+  );
+  if (response.status >= 500 && body.retryable === true) return response;
   if (!response.ok) throw new Error(String(body.error || "exact review queue rejected item"));
   return body;
 }

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -667,6 +667,16 @@ still-valid subset of the key/revision pairs checked before departure. Fresh
 arrivals wait for the next departure; changed or removed members are skipped.
 An empty subset retires that reservation and requests another preflight.
 
+The Worker preserves structured retryable Durable Object 5xx responses, including
+`503 {error: "target_visibility_unverified", retryable: true}`, through both
+`/github/webhook` item enqueue and the `/internal/exact-review/*` proxies. The
+status, JSON body, and optional `Retry-After` header reach the caller unchanged;
+unexpected exceptions still produce 500 and the structured server-response
+telemetry remains intact. Visibility admission precedes delivery persistence,
+so a refused admission does not consume its enqueue delivery ID. Credential-bearing
+paths continue to require live visibility probes. Workflow shell retries are
+documented in [the scheduler](scheduler.md#control-plane-workflow-retries).
+
 Only signed intake (`/enqueue`, `/command-intake`, `/branch-authority`,
 `/source-authority`) may reuse durable KV public-admission observations;
 credential-bearing paths require live probes. `EXACT_REVIEW_HOSTED_TARGET_ADMISSION_FRESH_MS`

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -89,6 +89,9 @@ Before a job's source checkout, the workflow downloads this single helper from
 with three curl retries into `RUNNER_TEMP`. The bootstrap fails if the download
 fails, is empty, or does not define `control_plane_curl`. These steps source the
 temporary copy; after the full checkout, steps source the repository copy.
+Claimed-lease completion and terminal retry steps select the repository copy
+only when the source checkout succeeded. They use the validated temporary copy
+when checkout failed or was skipped, including direct-lifecycle recovery.
 The bootstrap never changes workspace Git configuration: an early sparse
 checkout can otherwise leave later checkouts sparse and omit local actions.
 

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -67,6 +67,23 @@ content caches. Changed PR content goes to Codex, including source comments
 and formatting. See [Review Cache](review-cache.md) for admission, freshness,
 and runtime packaging rules.
 
+### Control-plane workflow retries
+
+Shell calls to the control plane in `sweep.yml`, `exact-review-reconcile-run.yml`,
+and `exact-review-dead-letter-reconcile.yml` use
+`scripts/control-plane-curl.sh`. Each request retries connection failures and
+HTTP 5xx up to four attempts. A valid `Retry-After` delay (seconds or HTTP-date)
+is capped at 60 seconds; otherwise the waits are 2, 4, and 8 seconds. Each
+attempt emits a notice. The helper preserves the caller's final curl exit code,
+HTTP status output, and body handling. HTTP 4xx responses are not retried;
+callers retain their explicit lease-conflict, supersession, and deployment-skew handling.
+This includes enqueue, claims, review/status heartbeats, completion, lifecycle
+receipts, terminal-finalization operations, reconciliation, and the DLQ health
+probe. Existing typed batch clients retain their separate lease-aware retry
+policy. Fence and reservation failures are attributed to the existing
+`queue_completion_failure` infrastructure category, including a review that
+never starts because its status fence is unavailable.
+
 ## Workflow
 
 Explicit `workflow_dispatch` `item_number`/`item_numbers` selections, excluding

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -84,6 +84,14 @@ policy. Fence and reservation failures are attributed to the existing
 `queue_completion_failure` infrastructure category, including a review that
 never starts because its status fence is unavailable.
 
+Before a job's source checkout, the workflow downloads this single helper from
+`raw.githubusercontent.com`, pinned to `GITHUB_REPOSITORY` and `GITHUB_SHA`,
+with three curl retries into `RUNNER_TEMP`. The bootstrap fails if the download
+fails, is empty, or does not define `control_plane_curl`. These steps source the
+temporary copy; after the full checkout, steps source the repository copy.
+The bootstrap never changes workspace Git configuration: an early sparse
+checkout can otherwise leave later checkouts sparse and omit local actions.
+
 ## Workflow
 
 Explicit `workflow_dispatch` `item_number`/`item_numbers` selections, excluding

--- a/scripts/control-plane-curl.sh
+++ b/scripts/control-plane-curl.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Preserve curl's stdout, output file, and exit code; only the last attempt escapes.
+# A subshell keeps scratch cleanup separate from the caller's traps and shell options.
+control_plane_curl() (
+  local scratch attempt curl_exit http_status retryable delay
+  scratch="$(mktemp -d)" || return 1
+  trap 'rm -rf "$scratch"' EXIT
+  for attempt in 1 2 3 4; do
+    : > "$scratch/headers"
+    curl_exit=0
+    curl --dump-header "$scratch/headers" "$@" > "$scratch/stdout" || curl_exit=$?
+    http_status="$(awk '/^HTTP\// { code=$2 } END { print code }' "$scratch/headers")"
+    echo "::notice::Control-plane request attempt $attempt/4: HTTP ${http_status:-000}, curl exit $curl_exit" >&2
+    retryable=false
+    if [[ "$http_status" == 5[0-9][0-9] ]]; then
+      retryable=true
+    elif [[ -z "$http_status" || "$http_status" != 4[0-9][0-9] ]]; then
+      case "$curl_exit" in
+        5|6|7|16|18|28|35|52|55|56|92) retryable=true ;;
+      esac
+    fi
+    if [[ "$retryable" != true || "$attempt" == 4 ]]; then
+      cat "$scratch/stdout"
+      return "$curl_exit"
+    fi
+    delay="$(node - "$scratch/headers" "$attempt" <<'NODE'
+const fs = require("node:fs");
+const blocks = fs.readFileSync(process.argv[2], "utf8").split(/(?=^HTTP\/)/m);
+const value = blocks.at(-1)?.match(/^retry-after:\s*([^\r\n]*)/im)?.[1]?.trim();
+const seconds = value && /^\d+$/.test(value)
+  ? Number(value)
+  : value ? Math.ceil((Date.parse(value) - Date.now()) / 1000) : NaN;
+process.stdout.write(String(Number.isFinite(seconds)
+  ? Math.min(60, Math.max(0, seconds))
+  : 2 ** Number(process.argv[3])));
+NODE
+    )" || return 1
+    echo "::notice::Control-plane request retry in ${delay}s" >&2
+    sleep "$delay"
+  done
+)

--- a/scripts/e2e/apply-drift-refresh.ts
+++ b/scripts/e2e/apply-drift-refresh.ts
@@ -25,7 +25,10 @@ export async function proveApplyDriftRefresh() {
   const artifacts = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-drift-refresh-"));
   const bin = path.join(artifacts, "bin");
   fs.mkdirSync(bin);
-  fs.symlinkSync(path.join(sourceRoot, "scripts"), path.join(artifacts, "scripts"));
+  fs.copyFileSync(
+    path.join(sourceRoot, "scripts/control-plane-curl.sh"),
+    path.join(artifacts, "control-plane-curl.sh"),
+  );
   const workflow = YAML.parse(
     fs.readFileSync(path.join(sourceRoot, ".github/workflows/sweep.yml"), "utf8"),
   );
@@ -101,6 +104,7 @@ process.stdout.write(args.includes('--jq') ? (pr ? 'pull_request' : 'issue') : J
   fs.symlinkSync(process.execPath, path.join(bin, "node"));
   const env = {
     PATH: `${bin}${path.delimiter}${process.env.PATH}`,
+    RUNNER_TEMP: artifacts,
     TRACE: requests,
     DISPATCHES: dispatches,
     ENQUEUE: enqueue,
@@ -186,11 +190,7 @@ process.stdout.write(args.includes('--jq') ? (pr ? 'pull_request' : 'issue') : J
       entry.uses?.endsWith("/.github/actions/setup-state"),
     ),
   );
-  assert.ok(
-    workflow.jobs["legacy-event-queue-intake"].steps.every(
-      (entry: Step) => !entry.uses || entry.name === "Check out control-plane retry helper",
-    ),
-  );
+  assert.ok(workflow.jobs["legacy-event-queue-intake"].steps.every((entry: Step) => !entry.uses));
   const envelopes: Envelope[] = rows(enqueue);
   assert.equal(envelopes.length, 5);
   for (const [index, envelope] of envelopes.entries()) {

--- a/scripts/e2e/apply-drift-refresh.ts
+++ b/scripts/e2e/apply-drift-refresh.ts
@@ -186,7 +186,11 @@ process.stdout.write(args.includes('--jq') ? (pr ? 'pull_request' : 'issue') : J
       entry.uses?.endsWith("/.github/actions/setup-state"),
     ),
   );
-  assert.ok(workflow.jobs["legacy-event-queue-intake"].steps.every((entry: Step) => !entry.uses));
+  assert.ok(
+    workflow.jobs["legacy-event-queue-intake"].steps.every(
+      (entry: Step) => !entry.uses || entry.name === "Check out control-plane retry helper",
+    ),
+  );
   const envelopes: Envelope[] = rows(enqueue);
   assert.equal(envelopes.length, 5);
   for (const [index, envelope] of envelopes.entries()) {

--- a/scripts/e2e/control-plane-checkout-cleanup.mjs
+++ b/scripts/e2e/control-plane-checkout-cleanup.mjs
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { parse } from "yaml";
+
+const execute = promisify(execFile);
+const workflow = parse(await readFile(".github/workflows/sweep.yml", "utf8"));
+const helper = await readFile("scripts/control-plane-curl.sh", "utf8");
+const cases = [];
+for (const [jobName, stepName, endpoint] of [
+  ["event-review-apply", "Complete exact-review queue lease", "/internal/exact-review/complete"],
+  [
+    "event-review-publish",
+    "Complete durable exact review publication",
+    "/internal/exact-review/complete",
+  ],
+  [
+    "event-review-terminal-finalization",
+    "Requeue unobserved terminal acknowledgement",
+    "/internal/exact-review/terminal-finalization/retry",
+  ],
+]) {
+  const job = workflow.jobs[jobName];
+  const step = job.steps.find((entry) => entry.name === stepName);
+  assert.ok(step?.run);
+  assert.match(step.if, /always\(\)/);
+  for (const checkoutOutcome of ["success", "skipped", "failure"]) {
+    const root = await mkdtemp(join(tmpdir(), "control-plane-cleanup-"));
+    const runnerTemp = join(root, "runner-temp");
+    const requests = [];
+    const server = createServer(async (request, response) => {
+      let raw = "";
+      for await (const chunk of request) raw += chunk;
+      requests.push({ method: request.method, path: request.url, body: JSON.parse(raw) });
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ ok: true, requeued: true }));
+    });
+    await new Promise((ready) => server.listen(0, "127.0.0.1", ready));
+    try {
+      await mkdir(runnerTemp);
+      await writeFile(
+        join(runnerTemp, "control-plane-curl.sh"),
+        checkoutOutcome === "success" ? "exit 91\n" : helper,
+      );
+      if (checkoutOutcome !== "skipped") {
+        await mkdir(join(root, "scripts"));
+        // A failed checkout's partial tree must not override the validated bootstrap.
+        await writeFile(
+          join(root, "scripts/control-plane-curl.sh"),
+          checkoutOutcome === "success" ? helper : "exit 92\n",
+        );
+      }
+      await execute("bash", ["-c", step.run], {
+        cwd: root,
+        timeout: 15_000,
+        env: {
+          ...Object.fromEntries(Object.keys(step.env ?? {}).map((key) => [key, ""])),
+          PATH: process.env.PATH,
+          RUNNER_TEMP: runnerTemp,
+          SOURCE_CHECKOUT_OUTCOME: checkoutOutcome,
+          QUEUE_URL: `http://127.0.0.1:${server.address().port}`,
+          GITHUB_OUTPUT: join(root, "output"),
+          GITHUB_RUN_ID: "123",
+          RUN_ATTEMPT: "1",
+          QUEUE_LEASE_ID: "synthetic-lease",
+          ITEM_KEY: "synthetic/repo#42",
+          PROTOCOL_VERSION: "2",
+          QUEUE_LEASE_REVISION: "1",
+          LEASE_REVISION: "1",
+          CLAIM_GENERATION: "1",
+          PRIMARY_OUTCOME: "failure",
+          OUTCOME: "failure",
+          COMPLETION_KIND: "retryable_failure",
+          REASON_CODE: "unknown_failure",
+          DIRECT_PUBLICATION_ACCEPTED: "false",
+          DIRECT_LIFECYCLE_REQUEUE: jobName === "event-review-publish" ? "true" : "false",
+        },
+      });
+      assert.equal(requests.length, 1, `${jobName}/${checkoutOutcome}`);
+      const request = requests[0];
+      assert.equal(request.method, "POST");
+      assert.equal(request.path, endpoint);
+      assert.equal(request.body.lease_id, "synthetic-lease");
+      assert.equal(request.body.claim_generation, 1);
+      if (jobName === "event-review-publish") {
+        assert.equal(request.body.direct_lifecycle_requeue, true);
+        assert.equal(request.body.lifecycle_terminal_disposition, "requeue");
+      }
+      cases.push({
+        job: jobName,
+        checkout: checkoutOutcome,
+        helper: checkoutOutcome === "success" ? "checkout" : "runner-temp",
+        endpoint,
+        requests: requests.length,
+        directLifecycleRequeue: request.body.direct_lifecycle_requeue === true,
+      });
+    } finally {
+      await new Promise((closed) => server.close(closed));
+      await rm(root, { recursive: true, force: true });
+    }
+  }
+}
+console.log(
+  JSON.stringify(
+    {
+      ok: true,
+      provider: "local-shell-loopback-http",
+      cases,
+      limits:
+        "Extracted cleanup steps and real HTTP; synthetic leases, no GitHub or production queue mutations.",
+    },
+    null,
+    2,
+  ),
+);

--- a/scripts/e2e/control-plane-checkout.mjs
+++ b/scripts/e2e/control-plane-checkout.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { parse } from "yaml";
+
+// Before publication, pass a published commit with byte-identical helper content.
+// After pushing, omit the argument to prove the current committed head's raw URL.
+const root = resolve(".");
+const head = execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+const helperRef = process.argv[2] ?? head;
+const scratch = mkdtempSync(join(tmpdir(), "control-plane-checkout-"));
+const output = resolve(".artifacts/control-plane-checkout-proof.txt");
+const transcript = [];
+const record = (line) => {
+  console.log(line);
+  transcript.push(line);
+};
+const git = (cwd, ...args) =>
+  execFileSync("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+const source = git(root, "rev-parse", "--path-format=absolute", "--git-common-dir");
+const action = ".github/actions/setup-pnpm/action.yml";
+try {
+  record(
+    `provider=local-git-shell; head=${head}; helper_ref=${helperRef}; Node=${process.version}`,
+  );
+  const old = join(scratch, "old");
+  git(root, "clone", "--shared", "--no-checkout", "--quiet", source, old);
+  git(old, "sparse-checkout", "set", "--no-cone", "scripts/control-plane-curl.sh");
+  git(old, "checkout", "--force", "--detach", head);
+  // actions/checkout's subsequent clean/reset/fetch/checkout does not disable sparse mode.
+  git(old, "clean", "-ffdx");
+  git(old, "reset", "--hard", "HEAD");
+  git(old, "fetch", "--quiet", "origin", head);
+  git(old, "checkout", "--force", "--detach", head);
+  assert.equal(git(old, "config", "--bool", "core.sparseCheckout"), "true");
+  assert.equal(existsSync(join(old, action)), false);
+  record(
+    `OLD: sparse-checkout set --no-cone scripts/control-plane-curl.sh; checkout; clean/reset/fetch/checkout => core.sparseCheckout=true; ${action}=MISSING`,
+  );
+
+  for (const file of ["sweep.yml", "exact-review-reconcile-run.yml"]) {
+    const workflow = parse(readFileSync(join(root, ".github/workflows", file), "utf8"));
+    for (const [jobName, job] of Object.entries(workflow.jobs)) {
+      const bootstrap = job.steps?.find((step) => step.name === "Fetch control-plane retry helper");
+      if (!bootstrap) continue;
+      const workspace = join(scratch, jobName);
+      const runnerTemp = join(scratch, `${jobName}-temp`);
+      mkdirSync(runnerTemp);
+      git(root, "clone", "--shared", "--no-checkout", "--quiet", source, workspace);
+      const configBefore = git(workspace, "config", "--local", "--list");
+      execFileSync("bash", ["-c", bootstrap.run], {
+        cwd: workspace,
+        env: {
+          ...process.env,
+          RUNNER_TEMP: runnerTemp,
+          GITHUB_REPOSITORY: "openclaw/clawsweeper",
+          GITHUB_SHA: helperRef,
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      assert.equal(git(workspace, "config", "--local", "--list"), configBefore);
+      const downloaded = readFileSync(join(runnerTemp, "control-plane-curl.sh"));
+      assert.deepEqual(downloaded, readFileSync(join(root, "scripts/control-plane-curl.sh")));
+      git(workspace, "checkout", "--force", "--detach", head);
+      assert.ok(existsSync(join(workspace, action)));
+      assert.equal(git(workspace, "ls-files", "-t", action), `H ${action}`);
+      record(
+        `NEW ${file}:${jobName}: actual bootstrap curl --retry 3 + source succeeded; Git config unchanged; full checkout => ${action}=PRESENT; helper_sha256=${createHash("sha256").update(downloaded).digest("hex")}`,
+      );
+    }
+  }
+  record(
+    "PASS; limits=Git checkout shell simulation, not act or hosted Actions; raw helper downloads only; no live control-plane calls.",
+  );
+} finally {
+  mkdirSync(resolve(".artifacts"), { recursive: true });
+  writeFileSync(output, `${transcript.join("\n")}\n`);
+  rmSync(scratch, { recursive: true, force: true });
+}

--- a/scripts/e2e/control-plane-retries.mjs
+++ b/scripts/e2e/control-plane-retries.mjs
@@ -1,0 +1,200 @@
+import assert from "node:assert/strict";
+import { execFile, execFileSync, spawn } from "node:child_process";
+import { createHmac } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { join, resolve } from "node:path";
+import { promisify } from "node:util";
+
+const execute = promisify(execFile);
+const root = resolve(".artifacts/control-plane-proof");
+await mkdir(root, { recursive: true });
+const transcript = [];
+const record = (value) => {
+  console.log(value);
+  transcript.push(value);
+};
+let wrangler;
+let server;
+try {
+  for (const statuses of [[503, 503, 200], [400]]) {
+    let count = 0;
+    const times = [];
+    server = createServer((_req, res) => {
+      times.push(Date.now());
+      const status = statuses[count++] ?? 500;
+      res.writeHead(status, { "content-type": "application/json", "retry-after": "1" });
+      res.end(JSON.stringify({ attempt: count, status }));
+    });
+    await new Promise((ready) => server.listen(0, "127.0.0.1", ready));
+    const result = await execute(
+      "bash",
+      [
+        "-c",
+        `source scripts/control-plane-curl.sh
+control_plane_curl --silent --show-error --output "$PROOF_BODY" --write-out '%{http_code}' "$PROOF_URL"`,
+      ],
+      {
+        env: {
+          ...process.env,
+          PROOF_BODY: join(root, "curl-body.json"),
+          PROOF_URL: `http://127.0.0.1:${server.address().port}/enqueue`,
+        },
+      },
+    );
+    const body = await readFile(join(root, "curl-body.json"), "utf8");
+    record(
+      `HTTP fixture ${statuses.join(" -> ")}\n${result.stderr.trim()}\nFinal HTTP ${result.stdout}; body ${body}; requests ${count}; elapsed gaps ${times
+        .slice(1)
+        .map((time, index) => time - times[index])
+        .join(",")} ms`,
+    );
+    assert.equal(count, statuses.length);
+    assert.equal(result.stdout, String(statuses.at(-1)));
+    for (let index = 1; index < times.length; index++)
+      assert.ok(times[index] - times[index - 1] >= 1000);
+    await new Promise((done) => server.close(done));
+    server = null;
+  }
+  const secret = "synthetic-control-plane-proof-secret";
+  await writeFile(
+    join(root, "entry.ts"),
+    `
+import worker, { ExactReviewQueue } from ${JSON.stringify(resolve("dashboard/worker.ts"))};
+export class ProofQueue extends ExactReviewQueue {
+  constructor(state, env) {
+    super(state, { ...env, hostedTargetPredicate: () => true, hostedPublicTargetProbe: async () => ({ outcome: "retryable", retryAt: Date.now() + 30_000 }) });
+  }
+  async fetch(request) {
+    if (new URL(request.url).pathname === "/enqueue" && (await request.clone().json()).decision?.itemNumber === 43) throw new Error("synthetic unexpected failure");
+    return super.fetch(request);
+  }
+}
+globalThis.fetch = async () => { throw new Error("proof forbids outbound network"); };
+export default { fetch(request, env, ctx) { return worker.fetch(request, { ...env, hostedTargetPredicate: () => true, hostedPublicTargetProbe: async () => "public" }, ctx); } };
+`,
+  );
+  const portServer = createServer();
+  await new Promise((ready) => portServer.listen(0, "127.0.0.1", ready));
+  const port = portServer.address().port;
+  await new Promise((done) => portServer.close(done));
+  await writeFile(
+    join(root, "wrangler.json"),
+    JSON.stringify({
+      name: "control-plane-retries-proof",
+      main: "entry.ts",
+      compatibility_date: "2026-05-11",
+      durable_objects: { bindings: [{ name: "EXACT_REVIEW_QUEUE", class_name: "ProofQueue" }] },
+      migrations: [{ tag: "v1", new_sqlite_classes: ["ProofQueue"] }],
+      vars: { CLAWSWEEPER_WEBHOOK_SECRET: secret },
+    }),
+  );
+  let workerLog = "";
+  wrangler = spawn(
+    "corepack",
+    [
+      "pnpm",
+      "dlx",
+      "wrangler@4.107.0",
+      "dev",
+      "--config",
+      join(root, "wrangler.json"),
+      "--local",
+      "--ip",
+      "127.0.0.1",
+      "--port",
+      String(port),
+      "--persist-to",
+      join(root, "state"),
+      "--show-interactive-dev-session=false",
+    ],
+    { env: { ...process.env, WRANGLER_SEND_METRICS: "false" }, stdio: ["ignore", "pipe", "pipe"] },
+  );
+  wrangler.stdout.on("data", (chunk) => {
+    workerLog += chunk;
+  });
+  wrangler.stderr.on("data", (chunk) => {
+    workerLog += chunk;
+  });
+  const url = `http://127.0.0.1:${port}`;
+  let ready = false;
+  for (let attempt = 0; attempt < 120; attempt++) {
+    if (
+      await fetch(`${url}/api/health`)
+        .then((response) => response.ok)
+        .catch(() => false)
+    ) {
+      ready = true;
+      break;
+    }
+    if (wrangler.exitCode !== null) break;
+    await new Promise((done) => setTimeout(done, 1000));
+  }
+  await writeFile(join(root, "workerd.log"), workerLog);
+  assert.ok(ready, "local workerd startup; inspect workerd.log");
+  for (const itemNumber of [42, 43]) {
+    for (const path of ["/github/webhook", "/internal/exact-review/enqueue"]) {
+      const webhook = path === "/github/webhook";
+      const body = JSON.stringify(
+        webhook
+          ? {
+              action: "opened",
+              repository: { full_name: "openclaw/gogcli", default_branch: "main", private: false },
+              issue: { number: itemNumber },
+              installation: { id: 123 },
+            }
+          : {
+              delivery_id: `synthetic-internal-${itemNumber}`,
+              decision: {
+                targetRepo: "openclaw/gogcli",
+                targetBranch: "main",
+                supersedesInProgress: false,
+                itemNumber,
+                itemKind: "issue",
+                sourceEvent: "issues",
+                sourceAction: "opened",
+              },
+            },
+      );
+      const signature = `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
+      const response = await fetch(url + path, {
+        method: "POST",
+        body,
+        headers: {
+          "content-type": "application/json",
+          ...(webhook
+            ? {
+                "x-github-event": "issues",
+                "x-github-delivery": `synthetic-webhook-${itemNumber}`,
+                "x-hub-signature-256": signature,
+              }
+            : { "x-clawsweeper-exact-review-signature": signature }),
+        },
+      });
+      const text = await response.text();
+      record(
+        `workerd POST ${path} fixture=${itemNumber === 42 ? "probe-retryable" : "unexpected-exception"}: HTTP ${response.status}; retry-after=${response.headers.get("retry-after")}; ${itemNumber === 42 || !webhook ? text : "workerd internal error response"}`,
+      );
+      assert.equal(response.status, itemNumber === 42 ? 503 : 500);
+      if (itemNumber === 42) {
+        assert.match(response.headers.get("retry-after") ?? "", /^\d+$/);
+        assert.deepEqual(JSON.parse(text), {
+          error: "target_visibility_unverified",
+          retryable: true,
+        });
+      } else assert.equal(response.headers.get("retry-after"), null);
+    }
+  }
+  await writeFile(join(root, "workerd.log"), workerLog);
+  assert.match(workerLog, /exact_review_queue_structured_server_response/);
+  record(
+    `PASS; provider=local-workerd; Node=${process.version}; head=${execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim()}; limits=synthetic admission, no production or GitHub calls`,
+  );
+} finally {
+  if (server) await new Promise((done) => server.close(done));
+  if (wrangler && wrangler.exitCode === null) {
+    wrangler.kill("SIGTERM");
+    await new Promise((done) => wrangler.once("exit", done));
+  }
+  await writeFile(join(root, "transcript.txt"), transcript.join("\n") + "\n");
+}

--- a/test/automatic-review-status-fence.test.ts
+++ b/test/automatic-review-status-fence.test.ts
@@ -41,9 +41,11 @@ test("automatic status fences distinguish stale handoffs from operational failur
   const outputPath = join(root, "outputs");
   const generationPath = join(root, "generation");
   const fixture = [
+    "sleep() { :; }",
     "curl() {",
     '  while [ "$#" -gt 0 ]; do',
     '    if [ "$1" = "--output" ]; then shift; printf "%s" "$MOCK_BODY" > "$1"; fi',
+    '    if [ "$1" = "--dump-header" ]; then shift; printf "HTTP/1.1 %s\\r\\n\\r\\n" "$MOCK_STATUS" > "$1"; fi',
     "    shift",
     "  done",
     '  printf "%s" "$MOCK_STATUS"',
@@ -161,9 +163,11 @@ test("completion-fence outages fail the workflow without changing successful que
   const root = mkdtempSync(join(tmpdir(), "completion-status-fence-"));
   const outputPath = join(root, "outputs");
   const fixture = [
+    "sleep() { :; }",
     "curl() {",
     '  while [ "$#" -gt 0 ]; do',
     '    if [ "$1" = "--output" ]; then shift; printf "%s" "$MOCK_BODY" > "$1"; fi',
+    '    if [ "$1" = "--dump-header" ]; then shift; printf "HTTP/1.1 %s\\r\\n\\r\\n" "$MOCK_STATUS" > "$1"; fi',
     "    shift",
     "  done",
     '  printf "%s" "$MOCK_STATUS"',
@@ -216,10 +220,7 @@ test("completion-fence outages fail the workflow without changing successful que
       };
       assert.equal(evaluate(failure.if, values), scenario.failed);
       if (scenario.failed) {
-        assert.equal(
-          evaluate(failure.env.CLASSIFICATION, values),
-          "review_status_delivery_failure",
-        );
+        assert.equal(evaluate(failure.env.CLASSIFICATION, values), "queue_completion_failure");
       }
     }
   } finally {
@@ -234,4 +235,27 @@ test("a new revision during completion status blocks the obsolete artifact and p
   assert.equal(result.generation_outcome, "success");
   assert.equal(result.requeue_latest, false);
   assert.equal(result.blocked_steps.length, 8);
+});
+
+test("failed reservation and review fences retain infrastructure attribution when review is skipped", () => {
+  const steps = YAML.parse(readFileSync(".github/workflows/sweep.yml", "utf8")).jobs[
+    "event-review-apply"
+  ].steps;
+  const failure = steps.find((step) => step.name === "Fail unsuccessful exact review generation");
+  for (const step of [
+    "reserve-exact-review-lease",
+    "review-status-fence",
+    "release-review-status-fence",
+    "review-complete-status-fence",
+    "release-review-complete-status-fence",
+  ]) {
+    const values = {
+      "claim-exact-review-queue.claimed": "true",
+      "exact-review-generation-result.outcome": "failure",
+      "review-exact-event-item.outcome": "skipped",
+      [`${step}.outcome`]: "failure",
+    };
+    assert.equal(evaluate(failure.if, values), true, step);
+    assert.equal(evaluate(failure.env.CLASSIFICATION, values), "queue_completion_failure", step);
+  }
 });

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2626,7 +2626,7 @@ test("sweep review recovery uses explicit failed shard artifacts", () => {
   );
   assert.match(recoveryJob, /Recovery skipped because the target is disabled/);
   assert.match(recoveryJob, /Recovery shed by exact-review queue backpressure/);
-  assert.match(recoveryJob, /for attempt in 1 2 3/);
+  assert.match(recoveryJob, /control_plane_curl/);
   assert.match(recoveryJob, /failed_recovery_dispatches/);
   assert.match(
     recoveryJob,

--- a/test/control-plane-curl.test.ts
+++ b/test/control-plane-curl.test.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { createServer } from "node:http";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { promisify } from "node:util";
+import test from "node:test";
+
+const execute = promisify(execFile);
+const helper = resolve("scripts/control-plane-curl.sh");
+
+test("control-plane curl preserves final output and bounded retry semantics over HTTP", async (t) => {
+  for (const scenario of [
+    { name: "503 then 200", statuses: [503, 503, 200], retryAfter: "1", waits: [1, 1], final: 200 },
+    { name: "400 is terminal", statuses: [400], waits: [], final: 400 },
+    { name: "429 is terminal", statuses: [429], retryAfter: "1", waits: [], final: 429 },
+    { name: "exhausted 5xx", statuses: [500, 502, 503, 504], waits: [2, 4, 8], final: 504 },
+    {
+      name: "retry-after seconds capped",
+      statuses: [503, 200],
+      retryAfter: "120",
+      waits: [60],
+      final: 200,
+    },
+    {
+      name: "retry-after date capped",
+      statuses: [503, 200],
+      retryAfter: new Date(Date.now() + 120_000).toUTCString(),
+      waits: [60],
+      final: 200,
+    },
+    {
+      name: "invalid retry-after",
+      statuses: [503, 200],
+      retryAfter: "invalid",
+      waits: [2],
+      final: 200,
+    },
+    { name: "connection reset", statuses: [0, 200], waits: [2], final: 200 },
+    { name: "HTTP/2 transport error", statuses: [200], waits: [2], final: 200, transportExit: 16 },
+    { name: "HTTP/2 stream reset", statuses: [200], waits: [2], final: 200, transportExit: 92 },
+    {
+      name: "fail exit preserved",
+      statuses: [503, 503, 503, 503],
+      waits: [2, 4, 8],
+      final: 503,
+      fail: true,
+    },
+  ]) {
+    await t.test(scenario.name, async () => {
+      const root = await mkdtemp(join(tmpdir(), "control-plane-curl-"));
+      const requests: string[] = [];
+      const server = createServer(async (req, res) => {
+        let body = "";
+        for await (const chunk of req) body += chunk;
+        requests.push(body);
+        const code = scenario.statuses[requests.length - 1] ?? 500;
+        if (!code) {
+          req.socket.destroy();
+          return;
+        }
+        res.writeHead(code, {
+          "content-type": "application/json",
+          ...(scenario.retryAfter ? { "retry-after": scenario.retryAfter } : {}),
+        });
+        res.end(JSON.stringify({ attempt: requests.length }));
+      });
+      await new Promise<void>((ready) => server.listen(0, "127.0.0.1", ready));
+      const address = server.address();
+      assert.ok(address && typeof address !== "string");
+      try {
+        const result = await execute(
+          "bash",
+          [
+            "-c",
+            `
+source "$HELPER"
+${
+  scenario.transportExit
+    ? `calls=0
+curl() { calls=$((calls + 1)); if [ "$calls" = 1 ]; then return ${scenario.transportExit}; fi; command curl "$@"; }`
+    : ""
+}
+sleep() { printf '%s\\n' "$1" >> "$WAITS"; }
+rc=0
+control_plane_curl --silent --show-error ${scenario.fail ? "--fail" : ""} --max-time 2 --request POST --data-binary 'same signed bytes' --output "$BODY" --write-out '%{http_code}' "$URL" || rc=$?
+printf '\\nexit=%s\\n' "$rc"
+`,
+          ],
+          {
+            env: {
+              ...process.env,
+              PATH: `${dirname(process.execPath)}:${process.env.PATH}`,
+              HELPER: helper,
+              WAITS: join(root, "waits"),
+              BODY: join(root, "body"),
+              URL: `http://127.0.0.1:${address.port}/enqueue`,
+            },
+          },
+        );
+        assert.equal(result.stdout, `${scenario.final}\nexit=${scenario.fail ? 22 : 0}\n`);
+        assert.equal(requests.length, scenario.statuses.length);
+        assert.ok(requests.every((body) => body === "same signed bytes"));
+        assert.equal(
+          (result.stderr.match(/::notice::Control-plane request attempt/g) ?? []).length,
+          requests.length + (scenario.transportExit ? 1 : 0),
+        );
+        const waits = await readFile(join(root, "waits"), "utf8").catch(() => "");
+        assert.deepEqual(waits.trim() ? waits.trim().split("\n").map(Number) : [], scenario.waits);
+        if (!scenario.fail)
+          assert.deepEqual(JSON.parse(await readFile(join(root, "body"), "utf8")), {
+            attempt: requests.length,
+          });
+      } finally {
+        await new Promise<void>((done) => server.close(() => done()));
+        await rm(root, { recursive: true, force: true });
+      }
+    });
+  }
+});

--- a/test/dashboard-worker-durable-object-error.test.ts
+++ b/test/dashboard-worker-durable-object-error.test.ts
@@ -318,3 +318,101 @@ test("exact-review Worker preserves intentional non-JSON 4xx responses", async (
   assert.equal(response.headers.get("content-type"), "text/plain");
   assert.equal(await response.text(), "intentional conflict");
 });
+
+test("webhook and internal enqueue preserve retryable admission responses before delivery deduplication", async (t) => {
+  const { signedGithubWebhookRequest } = await import("./dashboard-worker-harness.ts");
+  const secret = "synthetic-admission-secret";
+  const errors: unknown[][] = [];
+  t.mock.method(console, "error", (...values: unknown[]) => errors.push(values));
+  for (const route of ["webhook", "internal"]) {
+    const storage = new MemoryDurableStorage();
+    const queue = new ExactReviewQueue(
+      { storage },
+      {
+        hostedTargetPredicate: () => true,
+        hostedPublicTargetProbe: async () => ({
+          outcome: "retryable" as const,
+          retryAt: Date.now() + 30_000,
+        }),
+      },
+    );
+    const body = JSON.stringify({
+      delivery_id: "synthetic-admission",
+      decision: {
+        targetRepo: "openclaw/gogcli",
+        targetBranch: "main",
+        supersedesInProgress: false,
+        itemNumber: 42,
+        itemKind: "issue",
+        sourceEvent: "issues",
+        sourceAction: "opened",
+      },
+    });
+    const request = () =>
+      route === "webhook"
+        ? signedGithubWebhookRequest({
+            event: "issues",
+            secret,
+            payload: {
+              action: "opened",
+              repository: { full_name: "openclaw/gogcli", default_branch: "main", private: false },
+              issue: { number: 42 },
+              installation: { id: 123 },
+            },
+          })
+        : new Request("https://clawsweeper.openclaw.ai/internal/exact-review/enqueue", {
+            method: "POST",
+            body,
+            headers: {
+              "x-clawsweeper-exact-review-signature": `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`,
+            },
+          });
+    const env = {
+      CLAWSWEEPER_WEBHOOK_SECRET: secret,
+      hostedTargetPredicate: () => true,
+      hostedPublicTargetProbe: async () => "public" as const,
+      EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+    };
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const response = await worker.fetch(request(), env);
+      assert.equal(response.status, 503, route);
+      assert.match(response.headers.get("retry-after") ?? "", /^\d+$/);
+      assert.deepEqual(await response.json(), {
+        error: "target_visibility_unverified",
+        retryable: true,
+      });
+    }
+    assert.equal(
+      Number(
+        Array.from(
+          storage.sql.exec("SELECT COUNT(*) AS count FROM exact_review_queue_deliveries"),
+        )[0]?.count,
+      ),
+      0,
+    );
+    assert.ok(
+      errors.some(
+        ([event, metadata]) =>
+          event === "exact_review_queue_structured_server_response" &&
+          (metadata as Record<string, unknown>).endpoint === "enqueue",
+      ),
+    );
+    const failingEnv = {
+      ...env,
+      EXACT_REVIEW_QUEUE: new MemoryDurableNamespace({
+        async fetch() {
+          throw new Error("unexpected fixture exception");
+        },
+      }),
+    };
+    if (route === "webhook") {
+      // workerd maps the unhandled exception to HTTP 500, rather than a retryable response.
+      await assert.rejects(worker.fetch(request(), failingEnv), /unexpected fixture exception/);
+    } else {
+      const response = await worker.fetch(request(), failingEnv);
+      assert.equal(response.status, 500);
+      assert.equal(response.headers.get("retry-after"), null);
+      assert.deepEqual(await response.json(), { error: "exact_review_queue_unavailable" });
+    }
+  }
+});

--- a/test/repair/exact-review-reconcile-workflow.test.ts
+++ b/test/repair/exact-review-reconcile-workflow.test.ts
@@ -155,6 +155,10 @@ test("guard CLI and workflow clients preserve cooldown and the scheduled termina
     const endpoint = `http://127.0.0.1:${(server.address() as import("node:net").AddressInfo).port}`;
     const bin = join(root, "bin");
     mkdirSync(bin);
+    writeFileSync(
+      join(root, "control-plane-curl.sh"),
+      readFileSync("scripts/control-plane-curl.sh"),
+    );
     const fixture = join(root, "history.json");
     writeFileSync(
       join(bin, "gh"),
@@ -178,6 +182,7 @@ else process.exit(2);
       ...process.env,
       PATH: `${bin}:${process.env.PATH}`,
       PROOF_HISTORY: fixture,
+      RUNNER_TEMP: root,
       GITHUB_REPOSITORY: "synthetic/reviews",
       GITHUB_RUN_ID: "99",
       GH_TOKEN: "synthetic",
@@ -219,7 +224,13 @@ else process.exit(2);
       if (admitted)
         await run(
           "bash",
-          ["-e", "-c", eventWorkflow.jobs.reconcile.steps.find((step) => step.run)?.run],
+          [
+            "-e",
+            "-c",
+            eventWorkflow.jobs.reconcile.steps.find(
+              (step) => step.name === "Reconcile terminal run",
+            )?.run,
+          ],
           { env },
         );
       assert.equal(requests.length - before, admitted ? 1 : 0);

--- a/test/repair/exact-review-reconcile-workflow.test.ts
+++ b/test/repair/exact-review-reconcile-workflow.test.ts
@@ -217,7 +217,11 @@ else process.exit(2);
       assert.equal(admitted, scenario !== "recent");
       const before = requests.length;
       if (admitted)
-        await run("bash", ["-e", "-c", eventWorkflow.jobs.reconcile.steps[0].run], { env });
+        await run(
+          "bash",
+          ["-e", "-c", eventWorkflow.jobs.reconcile.steps.find((step) => step.run)?.run],
+          { env },
+        );
       assert.equal(requests.length - before, admitted ? 1 : 0);
       results.push({ scenario, admitted, queueWrites: requests.length - before });
     }

--- a/test/repair/workflow-sparse-checkout.test.ts
+++ b/test/repair/workflow-sparse-checkout.test.ts
@@ -108,9 +108,14 @@ test("every workflow job that runs the main bundle directly obtains it", () => {
       );
 
       // The main build reads tsconfig.json, so a curated checkout has to carry it.
-      const checkout = steps.find((step) =>
-        String(step.uses ?? "").startsWith("actions/checkout@"),
+      const buildIndex = steps.findIndex(
+        (step) =>
+          String(step.uses ?? "").includes("actions/setup-pnpm") &&
+          buildScriptEmitsMainBundle(String(step.with?.["build-script"] ?? "")),
       );
+      const checkout = steps
+        .slice(0, buildIndex)
+        .findLast((step) => String(step.uses ?? "").startsWith("actions/checkout@"));
       const sparseCheckout = checkout?.with?.["sparse-checkout"];
       if (typeof sparseCheckout === "string") {
         const entries = sparseCheckout

--- a/test/repair/workflow-sparse-checkout.test.ts
+++ b/test/repair/workflow-sparse-checkout.test.ts
@@ -28,6 +28,80 @@ const REPAIR_RUNTIME_PATHS = [
 const MAIN_BUNDLE = "dist/clawsweeper.js";
 const RUNTIME_DIST_ARTIFACT = "clawsweeper-runtime-dist";
 
+type CheckoutAuditStep = { uses?: string; with?: Record<string, unknown> };
+
+function assertNoInheritedSparseCheckout(steps: CheckoutAuditStep[], site: string): void {
+  const checkouts = steps.filter((step) => step.uses?.startsWith("actions/checkout@"));
+  for (const checkout of checkouts.slice(0, -1)) {
+    assert.equal(
+      checkout.with?.["sparse-checkout"],
+      undefined,
+      `${site}: a sparse checkout before another checkout can leave inherited sparse configuration`,
+    );
+  }
+}
+
+test("workflow jobs never run a sparse checkout before another checkout", () => {
+  for (const workflowPath of fs.globSync(".github/workflows/*.yml").sort()) {
+    const workflow = parse(readText(workflowPath)) as {
+      jobs?: Record<string, { steps?: CheckoutAuditStep[] }>;
+    };
+    for (const [jobName, job] of Object.entries(workflow.jobs ?? {})) {
+      assertNoInheritedSparseCheckout(job.steps ?? [], `${workflowPath}:${jobName}`);
+    }
+  }
+});
+
+test("checkout audit rejects the early helper sparse checkout from the reverted landing", () => {
+  assert.throws(
+    () =>
+      assertNoInheritedSparseCheckout(
+        [
+          {
+            uses: "actions/checkout@v7",
+            with: {
+              "sparse-checkout": "scripts/control-plane-curl.sh",
+              "sparse-checkout-cone-mode": false,
+            },
+          },
+          { uses: "actions/checkout@v7" },
+          { uses: "./.github/actions/setup-pnpm" },
+        ],
+        "reverted sweep job",
+      ),
+    /inherited sparse configuration/,
+  );
+});
+
+test("every sweep setup-pnpm step follows a full checkout at its action path", () => {
+  const workflow = parse(readText(".github/workflows/sweep.yml")) as {
+    jobs: Record<string, { steps?: CheckoutAuditStep[] }>;
+  };
+  let audited = 0;
+  for (const [jobName, job] of Object.entries(workflow.jobs)) {
+    const steps = job.steps ?? [];
+    for (const [index, step] of steps.entries()) {
+      const actionPath = step.uses?.match(/^\.\/(.*)\.github\/actions\/setup-pnpm$/)?.[1];
+      if (actionPath === undefined) continue;
+      audited++;
+      const checkout = steps
+        .slice(0, index)
+        .findLast(
+          (candidate) =>
+            candidate.uses?.startsWith("actions/checkout@") &&
+            String(candidate.with?.path ?? "").replace(/\/$/, "") === actionPath.replace(/\/$/, ""),
+        );
+      assert.ok(checkout, `${jobName}: setup-pnpm requires a preceding source checkout`);
+      assert.equal(
+        checkout.with?.["sparse-checkout"],
+        undefined,
+        `${jobName}: setup-pnpm requires a full checkout`,
+      );
+    }
+  }
+  assert.ok(audited > 0, "must audit sweep setup-pnpm consumers");
+});
+
 test("repair planning and execution use a Node runtime accepted by current OpenClaw", () => {
   const workflow = parse(
     fs.readFileSync(".github/workflows/repair-cluster-worker.yml", "utf8"),

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -140,6 +140,7 @@ test("queue completion tolerates only terminal-reason deploy skew", async (t) =>
         const child = spawn("bash", ["-c", producers[0].run], {
           env: {
             ...process.env,
+            SOURCE_CHECKOUT_OUTCOME: "success",
             QUEUE_URL: `http://127.0.0.1:${address.port}`,
             QUEUE_LEASE_ID: "synthetic-lease",
             PROTOCOL_VERSION: "2",
@@ -7554,4 +7555,27 @@ test("pre-checkout helper bootstrap fails on download errors, empty files, and m
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
+});
+
+test("claimed-lease cleanup survives skipped and failed checkouts and uses source after success", () => {
+  const workflow = YAML.parse(readText(".github/workflows/sweep.yml"));
+  for (const [jobName, stepName] of [
+    ["event-review-apply", "Complete exact-review queue lease"],
+    ["event-review-publish", "Complete durable exact review publication"],
+    ["event-review-terminal-finalization", "Requeue unobserved terminal acknowledgement"],
+  ]) {
+    const steps = workflow.jobs[jobName].steps;
+    const checkout = steps.find((step: any) => step.id === "source-checkout");
+    assert.ok(checkout.uses.startsWith("actions/checkout@"));
+    const cleanup = steps.find((step: any) => step.name === stepName);
+    assert.equal(cleanup.env.SOURCE_CHECKOUT_OUTCOME, "${{ steps.source-checkout.outcome }}");
+    assert.match(cleanup.if, /always\(\)/);
+  }
+  const proof = JSON.parse(
+    execFileSync(process.execPath, ["scripts/e2e/control-plane-checkout-cleanup.mjs"], {
+      encoding: "utf8",
+    }),
+  );
+  assert.equal(proof.ok, true);
+  assert.equal(proof.cases.length, 9);
 });

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1563,7 +1563,7 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
     /direct-exact-review-publication\.outputs\.accepted != 'true' \|\| steps\.finalize-direct-exact-review-lifecycle\.outcome != 'success'/,
   );
   assert.equal(upload.with?.["retention-days"], 90);
-  assert.match(queuePublication.run ?? "", /for attempt in 1 2 3/);
+  assert.match(queuePublication.run ?? "", /control_plane_curl/);
   assert.match(queuePublication.run ?? "", /\.queued == true or \.deduped == true/);
   assert.equal(queuePublication.env?.CLAIM_DECISION, "${{ steps.live-item.outputs.decision }}");
   assert.equal(
@@ -1806,7 +1806,7 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
     "${{ steps.publication-context.outputs.item_number }}",
   );
   const publisherCheckout = publisher.steps.find(
-    (candidate) => candidate.uses === "actions/checkout@v7",
+    (candidate) => candidate.uses === "actions/checkout@v7" && candidate.if,
   );
   assert.ok(publisherCheckout);
   assert.equal(publisherCheckout.with?.ref, "main");
@@ -2306,8 +2306,8 @@ test("exact event publication derives lifecycle receipt and final command acknow
   assert.doesNotMatch(complete.run ?? "", /outcome !== "success"\s*\?\s*"failure"/);
   assert.match(complete.run ?? "", /completionKind === "permanent_failure"\s*\? "failure"/);
   const finalizer = workflow.jobs["event-review-terminal-finalization"]!;
-  const finalizationCheckout = finalizer.steps.find((candidate) =>
-    candidate.uses?.startsWith("actions/checkout@"),
+  const finalizationCheckout = finalizer.steps.find(
+    (candidate) => candidate.uses?.startsWith("actions/checkout@") && candidate.if,
   );
   assert.equal(finalizationCheckout?.with?.filter, undefined);
   assert.equal(finalizationCheckout?.with?.["fetch-depth"], 1);
@@ -2562,7 +2562,7 @@ test("exact-review lease competition skips only known conflicts and gates both o
     ["event-review-apply", "claim-exact-review-queue"],
     ["event-review-publish", "publication-context"],
   ]) {
-    const steps = workflow.jobs[jobName]!.steps;
+    const steps = workflow.jobs[jobName]!.steps.slice(1);
     const claim = steps[0]!;
     const claimRun = claim.run ?? "";
     const gate = `steps.${claimId}.outputs.claimed == 'true'`;
@@ -6407,7 +6407,7 @@ test("failed review recovery waits for durable exact-review queue acknowledgemen
   assert.match(recoveryBlock, /Recovery shed by exact-review queue backpressure/);
   assert.doesNotMatch(recoveryBlock, /workflow run sweep\.yml/);
   assert.doesNotMatch(recoveryBlock, /repos\/\$GITHUB_REPOSITORY\/dispatches/);
-  assert.match(recoveryBlock, /for attempt in 1 2 3/);
+  assert.match(recoveryBlock, /control_plane_curl/);
 });
 
 test("target sweep dispatches preserve disabled ClawHub guard", () => {
@@ -7476,4 +7476,28 @@ test("apply job requeues drift-blocked close reviews only for default cursor run
   assert.match(step, /event_type: "clawsweeper_item"/);
   assert.match(step, /source_action: "source_drift_requeue"/);
   assert.match(step, /supersedes_in_progress: false/);
+});
+
+test("all workflow control-plane curls use the shared helper after checkout", () => {
+  for (const file of [
+    "sweep.yml",
+    "exact-review-reconcile-run.yml",
+    "exact-review-dead-letter-reconcile.yml",
+  ]) {
+    const workflow = YAML.parse(readText(`.github/workflows/${file}`));
+    for (const [jobName, job] of Object.entries(workflow.jobs) as [string, any][]) {
+      let checkedOut = false;
+      for (const step of job.steps ?? []) {
+        if (step.uses?.startsWith("actions/checkout@")) checkedOut = true;
+        const run = step.run ?? "";
+        assert.doesNotMatch(run, /\bcurl --/, `${file}: ${step.name}`);
+        if (!run.includes("control_plane_curl")) continue;
+        assert.ok(checkedOut, `${file}: ${jobName} has the helper before its first call`);
+        assert.match(run, /source scripts\/control-plane-curl.sh/);
+        assert.doesNotMatch(run, /for attempt in 1 2 3; do/);
+        const syntax = spawnSync("bash", ["-n"], { input: run, encoding: "utf8" });
+        assert.equal(syntax.status, 0, `${step.name}: ${syntax.stderr}`);
+      }
+    }
+  }
 });

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -7478,7 +7478,7 @@ test("apply job requeues drift-blocked close reviews only for default cursor run
   assert.match(step, /supersedes_in_progress: false/);
 });
 
-test("all workflow control-plane curls use the shared helper after checkout", () => {
+test("all workflow control-plane curls use the shared helper after download or full checkout", () => {
   for (const file of [
     "sweep.yml",
     "exact-review-reconcile-run.yml",
@@ -7487,17 +7487,71 @@ test("all workflow control-plane curls use the shared helper after checkout", ()
     const workflow = YAML.parse(readText(`.github/workflows/${file}`));
     for (const [jobName, job] of Object.entries(workflow.jobs) as [string, any][]) {
       let checkedOut = false;
+      let downloaded = false;
       for (const step of job.steps ?? []) {
         if (step.uses?.startsWith("actions/checkout@")) checkedOut = true;
         const run = step.run ?? "";
         assert.doesNotMatch(run, /\bcurl --/, `${file}: ${step.name}`);
+        if (step.name === "Fetch control-plane retry helper") {
+          assert.match(
+            run,
+            /curl -fsSL --retry 3 "https:\/\/raw\.githubusercontent\.com\/\$\{GITHUB_REPOSITORY\}\/\$\{GITHUB_SHA\}\/scripts\/control-plane-curl\.sh"/,
+          );
+          assert.match(run, /test -s "\$RUNNER_TEMP\/control-plane-curl\.sh"/);
+          assert.match(run, /declare -F control_plane_curl/);
+          downloaded = true;
+          continue;
+        }
         if (!run.includes("control_plane_curl")) continue;
-        assert.ok(checkedOut, `${file}: ${jobName} has the helper before its first call`);
-        assert.match(run, /source scripts\/control-plane-curl.sh/);
+        assert.ok(
+          checkedOut || downloaded,
+          `${file}: ${jobName} has the helper before its first call`,
+        );
+        assert.match(
+          run,
+          checkedOut
+            ? /source scripts\/control-plane-curl.sh/
+            : /source "\$RUNNER_TEMP\/control-plane-curl.sh"/,
+        );
         assert.doesNotMatch(run, /for attempt in 1 2 3; do/);
         const syntax = spawnSync("bash", ["-n"], { input: run, encoding: "utf8" });
         assert.equal(syntax.status, 0, `${step.name}: ${syntax.stderr}`);
       }
     }
+  }
+});
+
+test("pre-checkout helper bootstrap fails on download errors, empty files, and missing functions", () => {
+  const workflow = YAML.parse(readText(".github/workflows/sweep.yml"));
+  const bootstrap = workflow.jobs["event-review-apply"].steps.find(
+    (step: any) => step.name === "Fetch control-plane retry helper",
+  ).run;
+  const root = mkdtempSync(`${tmpPrefix}helper-bootstrap-`);
+  try {
+    const bin = join(root, "bin");
+    mkdirSync(bin);
+    for (const [fixture, expected] of [
+      ["exit 22", 22],
+      ['while [ "$1" != "-o" ]; do shift; done; : > "$2"', 1],
+      ['while [ "$1" != "-o" ]; do shift; done; echo ":" > "$2"', 1],
+      ['while [ "$1" != "-o" ]; do shift; done; echo "control_plane_curl() { :; }" > "$2"', 0],
+    ] as const) {
+      writeFileSync(join(bin, "curl"), `#!/usr/bin/env bash\n${fixture}\n`, { mode: 0o755 });
+      const result = spawnSync("bash", ["-c", bootstrap], {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${bin}${delimiter}${process.env.PATH}`,
+          RUNNER_TEMP: root,
+          GITHUB_REPOSITORY: "openclaw/clawsweeper",
+          GITHUB_SHA: "synthetic-commit",
+        },
+      });
+      assert.equal(result.status, expected, `${fixture}: ${result.stderr}`);
+      assert.equal(existsSync(join(root, ".git")), false);
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
   }
 });

--- a/test/terminal-finalization-cancellation-workflow.test.ts
+++ b/test/terminal-finalization-cancellation-workflow.test.ts
@@ -59,7 +59,7 @@ for (const [status, body, success] of [
         assert.match(result, status === 409 ? /allowed=false/ : /allowed=true/);
         if (status === 409) assert.match(result, /acknowledgement_state=unavailable/);
       } else await assert.rejects(run);
-      assert.equal(requests, 1);
+      assert.equal(requests, status >= 500 ? 4 : 1);
       assert.match(
         job.steps.find((step) => step.id === "update-final-command-status").if,
         /terminal-acknowledgement.outputs.allowed == .true./,


### PR DESCRIPTION
Related: https://github.com/openclaw/clawsweeper/pull/1497

<details>
<summary>Additional instructions</summary>

This branch is in the same repository, so maintainers edit it through repository write permissions. GitHub rejects its fork-only “Allow edits from maintainers” toggle for same-repository PRs. This PR is prepared for maintainer review; merging and automerge are not authorized by this work order.

</details>

## What Problem This Solves

Resolves a problem where exact-review workflows fail on transient control-plane errors or lose the structured retryable admission response. Restores the retry fix while keeping local setup actions available when a job reaches its full checkout.

## Why This Change Was Made

All shell control-plane calls in sweep, run reconciliation, and dead-letter health reconciliation use the shared bounded retry helper. The Worker preserves structured retryable 5xx responses and Retry-After through webhook and internal admission, and failed fences/reservations retain their queue-infrastructure classification.

**Why the first landing was reverted:** https://github.com/openclaw/clawsweeper/pull/1497 added helper-only sparse checkouts before full source checkouts. The early checkout left `core.sparseCheckout=true` and the single-file sparse definition in the shared workspace; the later checkout inherited it and omitted `.github/actions/setup-pnpm/action.yml`. This caused the local action lookup failures in [run 34246655629](https://github.com/openclaw/clawsweeper/actions/runs/34246655629) and [run 34246581768](https://github.com/openclaw/clawsweeper/actions/runs/34246581768).

Every helper-only sparse checkout is replaced with `curl -fsSL --retry 3` from the public repository at `GITHUB_SHA` into `RUNNER_TEMP`. The bootstrap requires a nonempty file and a defined `control_plane_curl` function. Pre-checkout callers source that temporary copy; callers after full checkout source the repository copy. No bootstrap modifies Git configuration.

## User Impact

Transient infrastructure failures receive bounded retries and preserve their final response semantics. Retryable visibility admission remains retryable, and exact-review jobs can reach the local package setup action after claiming work.

## OpenClaw Bay Impact

No Bay code or contract change is needed. The existing queue-infrastructure failure category is preserved, and no observer field, route, lifecycle shape, or browser behavior changes. Bay remains an observer-only surface with no new controls.

## Documentation Impact

Updated active `docs/scheduler.md` with the retry contract and commit-pinned helper bootstrap, and active `docs/live-dashboard.md` with structured retryable admission response handling. Their ClawSweeper maintainer ownership, workflow/Worker sources of truth, and update triggers remain applicable; verification scope is this PR's implementation and executed local proofs. The Unreleased changelog records both retry behavior and the checkout correction.

## Finding disposition

The first ClawSweeper review identified a real checkout-free completion defect: direct-lifecycle recovery skips the publisher checkout, but completion still required its repository helper. The follow-up binds review completion, publication completion, and terminal retry to the actual `source-checkout` outcome. Successful checkout uses the repository helper; skipped, failed, or cancelled checkout uses the already validated temporary helper. Existing lease/admission guards are unchanged. Other always-run helper consumers require successful post-checkout fence, review, upload, or status outputs before they can run.

The new `scripts/e2e/control-plane-checkout-cleanup.mjs` driver executes all three cleanup paths over real loopback HTTP with successful, skipped, and failed checkout fixtures. The failed-checkout fixture contains a poisoned repository helper, and the successful-checkout fixture contains a poisoned temporary helper. All nine cases choose the intended source and submit one request; publication completion preserves `direct_lifecycle_requeue: true` and the requeue disposition without checkout. This addresses the source finding and both related merge-risk/rank-up requests.

## Evidence

- Checkout audit rejects any sparse `actions/checkout@` step preceding another checkout in the same job, across all workflows. A reverted-shape fixture proves the audit rejects the original sequence.
- Every sweep `setup-pnpm` consumer requires a preceding full checkout at its local action path, including the nested source checkout. Existing intentional single sparse repair checkouts retain their dependency audits.
- Executed bootstrap failure tests cover failed downloads, empty files, missing functions, and a valid helper.
- Original focused changed-behavior suite: 200 passed, 0 failed. Cleanup follow-up suite: 171 passed, 0 failed, including the nine real HTTP cleanup scenarios. The six reconciliation tests also passed independently after selecting the request step explicitly. The corrected apply-drift workflow proof passed independently in 4.2 seconds after receiving its temporary helper.
- The existing CI `pnpm check` path includes `test/sweep-workflow.test.ts` and `test/repair/workflow-sparse-checkout.test.ts` through the all-tests runner.
- Pre-commit Codex review: `autoreview scoped-clean: no accepted/actionable findings in the selected Git scope and priority`.

## Real Behavior Proof

**Claim:** The retry helper bootstrap cannot leave the workspace sparse, while transient control-plane retries and structured retryable admission responses remain intact.

**Surface:** Actual bootstrap shell extracted from workflow YAML; real Git configuration, index and worktree; curl over loopback HTTP; production Worker and queue code in local workerd with SQLite Durable Objects.

**Scenario / fixture:** The reverted sparse-first checkout followed by clean/reset/fetch/checkout in one temporary clone; every new bootstrap followed by a full checkout; 503/503/200 and 400 HTTP responses; signed synthetic admission requests returning retryable visibility failures or unexpected exceptions.

**Command and environment:** Executed at head `c96bd996e1c15d18fc5237a6138403b6c4ef1ebf` on macOS, Node 24.20.0, corepack pnpm 11.10.0, local Git shell and Wrangler 4.107.0/workerd. `act` is unavailable. Commands: `node scripts/e2e/control-plane-checkout.mjs`, `node scripts/e2e/control-plane-checkout-cleanup.mjs`, and `node scripts/e2e/control-plane-retries.mjs`. All three passed on this committed head. The checkout driver downloaded from the published current-head raw URL and verified byte equality with the repository helper; SHA-256 `2f9ab7096aa98b6d327242f7b5483a2c301ab69cf7ff640fc9b8532ea08bff92`. The pre-publication proof also passed using the byte-identical helper from the reverted commit.

**Observed result:** All six actual bootstrap steps passed: sweep legacy intake, review/apply, publication, terminal finalization, bounded recovery, and reusable run reconciliation. The old shape leaves `core.sparseCheckout=true` and `setup-pnpm/action.yml` missing. The new bootstrap preserves the entire local Git configuration, and the full checkout materializes `action.yml`. The helper retries 503 twice then returns HTTP 200 and the final body; 400 produces one request. Both webhook and internal ingress return `503 {error: "target_visibility_unverified", retryable: true}` with `Retry-After: 30`; unexpected exceptions remain 500 without Retry-After. Structured server-response telemetry is present.

**Artifact / trace:** Reproducible drivers are committed at `scripts/e2e/control-plane-checkout.mjs`, `scripts/e2e/control-plane-checkout-cleanup.mjs`, and `scripts/e2e/control-plane-retries.mjs`. Local transcripts are `.artifacts/control-plane-checkout-proof.txt` and `.artifacts/control-plane-proof/transcript.txt`; the latter driver also records `workerd.log`. The cleanup driver also emits a nine-case JSON transcript, including the actual completion/retry endpoints, selected helper source, and requeue flag. The main-body results above summarize the executed assertions.

**Limits:** The checkout proof simulates the relevant Git action sequence rather than running `act` or the full hosted sweep job. The Worker proof uses synthetic local admission fixtures and makes no production queue or GitHub mutation calls; it does not prove deployed Cloudflare behavior. Raw helper downloads are the checkout proof's only external requests.

## Known Gaps

The preliminary local full check reported 5,645 passed, 13 skipped, and five failures. Its apply-drift bootstrap fixture was corrected and passed; the producer-run telemetry case, replacement-publication case, and both proof-consumer timeout cases subsequently passed isolated rechecks without implementation changes. The unit rerun had 4,017 passes, six skips, and the same pre-correction apply-drift failure. These preliminary runs are not claimed green; the final-tree full check subsequently completed all 5,663 tests with 5,650 passes, zero failures, and 13 skips, but exited 1 because Node found an empty child-process coverage file. The cleanup follow-up is checked again; hosted CI establishes the complete current coverage result. Current-head ClawSweeper review is checked separately before the maintainer handoff. No live sweep, apply, close, deployment, merge, or automerge is performed by this work order.
