### PR TITLE
fix: preserve safe diagnostics when review command intake fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Preserve bounded, recognized command-intake HTTP failure codes in review-request diagnostics without exposing raw responses or changing retry behavior.
+
 - Refresh markdown-it to 15.0.1 and Playwright to 1.63.0, retaining the repository's release-age policy and Node 24 runtime floor.
 
 - Recover failed aggregate review shards only from recognized retryable item terminals in the complete exact-attempt ledger. Keep completed, nonretryable, uncertain, and unstarted items out of recovery, and retain identity- and digest-verified completed reports for normal guarded publication.

--- a/src/repair/exact-review-batch-queue-client.ts
+++ b/src/repair/exact-review-batch-queue-client.ts
@@ -1,6 +1,7 @@
 import { createHmac } from "node:crypto";
 import {
   ExactReviewBatchQueueTransportError,
+  responseErrorCode,
   type TransportFailureReason,
 } from "./exact-review-queue-transport-error.js";
 
@@ -579,29 +580,6 @@ export class ExactReviewBatchQueueClient implements ExactReviewBatchQueue {
       await new Promise<void>((resolve) => setTimeout(resolve, delay));
     }
     throw new Error(`Batch queue ${path} retry attempts exhausted`);
-  }
-}
-
-async function responseErrorCode(response: Response): Promise<string | undefined> {
-  const reader = response.body?.getReader();
-  if (!reader) return undefined;
-  try {
-    const bytes = new Uint8Array(512);
-    let length = 0;
-    while (length < bytes.length) {
-      const { value, done } = await reader.read();
-      if (done) break;
-      const chunk = value.subarray(0, bytes.length - length);
-      bytes.set(chunk, length);
-      length += chunk.length;
-    }
-    const parsed: unknown = JSON.parse(new TextDecoder().decode(bytes.subarray(0, length)));
-    const error = objectValue(parsed).error;
-    return typeof error === "string" && /^[a-z0-9_]{1,64}$/.test(error) ? error : undefined;
-  } catch {
-    return undefined;
-  } finally {
-    void reader.cancel().catch(() => {});
   }
 }
 

--- a/src/repair/exact-review-command-queue.ts
+++ b/src/repair/exact-review-command-queue.ts
@@ -2,9 +2,19 @@ import { spawnSync } from "node:child_process";
 import { createHmac } from "node:crypto";
 
 import type { DirectReReviewIntake } from "./direct-re-review-admission.js";
+import { queueResponseErrorCode, responseErrorCode } from "./exact-review-queue-transport-error.js";
 
 const COMMAND_INTAKE_PATH = "/internal/exact-review/command-intake";
 const REQUEST_TIMEOUT_MS = 15_000;
+const COMMAND_INTAKE_ERROR_CODES = new Set([
+  "webhook_not_configured",
+  "invalid_signature",
+  "exact_review_queue_not_configured",
+  "exact_review_queue_unavailable",
+  "private_target_unsupported",
+  "target_visibility_unverified",
+  "invalid_command_intake",
+]);
 
 export type CommandIntakeAdmissionResult =
   | { kind: "accepted"; deduped: boolean; commandVersionId: string }
@@ -43,6 +53,8 @@ export function postExactReviewCommandIntakeSync(options: {
       "--silent",
       "--show-error",
       "--fail-with-body",
+      "--write-out",
+      "%{stderr}\n%{http_code}",
       "--max-time",
       String(REQUEST_TIMEOUT_MS / 1_000),
       ...headerArgs,
@@ -52,8 +64,15 @@ export function postExactReviewCommandIntakeSync(options: {
     ],
     { encoding: "utf8", input: request.body },
   );
-  if (response.status !== 0) {
-    throw new Error(`exact re-review command intake failed: ${response.stderr || response.stdout}`);
+  if (response.status !== 0 || response.error) {
+    // Curl owns this final numeric field; its earlier stderr can contain private details.
+    const status = Number(response.stderr?.match(/\n(\d{3})$/)?.[1]);
+    if (!response.error && response.status === 22 && status >= 400 && status <= 599) {
+      throw commandIntakeHttpError(status, queueResponseErrorCode(Buffer.from(response.stdout)));
+    }
+    throw new Error(
+      `exact-review command intake failed (curl exit ${response.status ?? "unknown"})`,
+    );
   }
   return commandIntakeAdmissionResult(JSON.parse(response.stdout || "null"));
 }
@@ -71,11 +90,17 @@ export async function postExactReviewCommandIntake(options: {
     body: request.body,
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
-  const result = await response.json().catch(() => null);
   if (!response.ok) {
-    throw new Error(`exact-review command intake failed (HTTP ${response.status})`);
+    throw commandIntakeHttpError(response.status, await responseErrorCode(response));
   }
+  const result = await response.json().catch(() => null);
   return commandIntakeAdmissionResult(result);
+}
+
+function commandIntakeHttpError(status: number, code: string | undefined) {
+  return new Error(
+    `exact-review command intake failed (HTTP ${status})${code && COMMAND_INTAKE_ERROR_CODES.has(code) ? `: ${code}` : ""}`,
+  );
 }
 
 export function commandIntakeAdmissionResult(value: unknown): CommandIntakeAdmissionResult {

--- a/src/repair/exact-review-queue-transport-error.ts
+++ b/src/repair/exact-review-queue-transport-error.ts
@@ -1,3 +1,5 @@
+import { isJsonObject } from "./json-types.js";
+
 export type TransportFailureReason = "network_error" | "timeout" | `HTTP_${number}`;
 
 export class ExactReviewBatchQueueTransportError extends Error {
@@ -6,5 +8,40 @@ export class ExactReviewBatchQueueTransportError extends Error {
     message: string,
   ) {
     super(message);
+  }
+}
+
+const ERROR_DIAGNOSTIC_BYTES = 512;
+
+export function queueResponseErrorCode(bytes: Uint8Array): string | undefined {
+  try {
+    const parsed: unknown = JSON.parse(
+      new TextDecoder().decode(bytes.subarray(0, ERROR_DIAGNOSTIC_BYTES)),
+    );
+    const error = isJsonObject(parsed) ? parsed.error : undefined;
+    return typeof error === "string" && /^[a-z0-9_]{1,64}$/.test(error) ? error : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function responseErrorCode(response: Response): Promise<string | undefined> {
+  const reader = response.body?.getReader();
+  if (!reader) return undefined;
+  try {
+    const bytes = new Uint8Array(ERROR_DIAGNOSTIC_BYTES);
+    let length = 0;
+    while (length < bytes.length) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      const chunk = value.subarray(0, bytes.length - length);
+      bytes.set(chunk, length);
+      length += chunk.length;
+    }
+    return queueResponseErrorCode(bytes.subarray(0, length));
+  } catch {
+    return undefined;
+  } finally {
+    void reader.cancel().catch(() => {});
   }
 }

--- a/test/helpers/command-intake-fixture.mjs
+++ b/test/helpers/command-intake-fixture.mjs
@@ -1,0 +1,167 @@
+import { fork } from "node:child_process";
+import { createHmac, generateKeyPairSync } from "node:crypto";
+import { once } from "node:events";
+import http from "node:http";
+import { fileURLToPath } from "node:url";
+import { directReReviewIntake } from "../../dist/repair/direct-re-review-admission.js";
+
+export const secret = "synthetic-intake-secret";
+export const intake = directReReviewIntake({
+  targetRepo: "openclaw/openclaw",
+  targetBranch: "main",
+  itemNumber: 42,
+  itemKind: "pull_request",
+  installationId: 123,
+  sourceCommentId: 456,
+  sourceCommentUpdatedAt: "2026-09-08T12:00:00Z",
+  commandBodyDigest: "a".repeat(64),
+  commandOrigin: "comment_router",
+  additionalPrompt: "",
+});
+
+export async function startIntakeFixture(webhook = false) {
+  const child = fork(fileURLToPath(import.meta.url), ["serve", ...(webhook ? ["webhook"] : [])], {
+    execArgv: [],
+    env: { PATH: process.env.PATH },
+    stdio: ["ignore", "ignore", "pipe", "ipc"],
+  });
+  let stderr = "";
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+  let ready;
+  try {
+    [ready] = await once(child, "message", { signal: AbortSignal.timeout(10_000) });
+  } catch (error) {
+    child.kill("SIGTERM");
+    throw error;
+  }
+  const rpc = async (message) => {
+    const reply = once(child, "message");
+    child.send(message);
+    return (await reply)[0];
+  };
+  return {
+    runtime: ready.runtime,
+    options: { queueUrl: ready.origin, secret, intake },
+    setResponse: (status, body, close = false) => rpc({ status, body, close }),
+    requests: () => rpc({ inspect: true }),
+    async webhook() {
+      const body = JSON.stringify({
+        action: "created",
+        repository: { full_name: "openclaw/openclaw", default_branch: "main", private: false },
+        installation: { id: 123 },
+        issue: { number: 42, state: "open", pull_request: {} },
+        comment: {
+          id: 456,
+          body: "@clawsweeper re-review",
+          updated_at: "2026-09-08T12:00:00Z",
+          author_association: "MEMBER",
+          user: { login: "maintainer" },
+        },
+      });
+      return fetch(`${ready.webhookOrigin}/github/webhook`, {
+        method: "POST",
+        headers: { "x-github-event": "issue_comment", "x-hub-signature-256": signature(body) },
+        body,
+      });
+    },
+    stderr: () => stderr,
+    async close() {
+      if (child.exitCode !== null || child.signalCode !== null) return;
+      const exited = once(child, "exit");
+      child.kill("SIGTERM");
+      return await exited;
+    },
+  };
+}
+
+function signature(body) {
+  return `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
+}
+
+if (process.argv[2] === "serve") {
+  let response = {
+    status: 202,
+    body: { ok: true, accepted: true, deduped: false, command_version_id: intake.commandVersionId },
+  };
+  let requests = [];
+  const server = http.createServer(async (request, reply) => {
+    const chunks = [];
+    for await (const chunk of request) chunks.push(chunk);
+    const body = Buffer.concat(chunks).toString("utf8");
+    const json = (value) => reply.end(JSON.stringify(value));
+    if (request.method === "GET" && request.url === "/repos/openclaw/clawsweeper/installation")
+      return json({ id: 999 });
+    if (request.method === "POST" && request.url === "/app/installations/999/access_tokens")
+      return json({ token: "synthetic-token" });
+    if (request.method === "GET" && request.url === "/repos/openclaw/openclaw")
+      return json({ full_name: "openclaw/openclaw", private: false, visibility: "public" });
+    requests.push({
+      path: request.url,
+      method: request.method,
+      body,
+      signed: request.headers["x-clawsweeper-exact-review-signature"] === signature(body),
+    });
+    if (request.method !== "POST" || request.url !== "/internal/exact-review/command-intake") {
+      reply.writeHead(404);
+      return json({ error: "unexpected_fixture_request" });
+    }
+    if (response.close === true) return request.socket.destroy();
+    if (response.close === "partial") {
+      const partial = JSON.stringify(response.body);
+      reply.writeHead(response.status, { "content-length": Buffer.byteLength(partial) + 100 });
+      return reply.write(partial, () => reply.destroy());
+    }
+    reply.writeHead(response.status, { "content-type": "application/json" });
+    reply.end(typeof response.body === "string" ? response.body : JSON.stringify(response.body));
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const origin = `http://127.0.0.1:${server.address().port}`;
+  let webhookOrigin;
+  if (process.argv.includes("webhook")) {
+    process.env.CLAWSWEEPER_WEBHOOK_SECRET = secret;
+    process.env.CLAWSWEEPER_APP_ID = "12345";
+    process.env.CLAWSWEEPER_APP_PRIVATE_KEY = generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+      privateKeyEncoding: { type: "pkcs8", format: "pem" },
+      publicKeyEncoding: { type: "spki", format: "pem" },
+    }).privateKey;
+    process.env.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL = origin;
+    const fetchImpl = globalThis.fetch;
+    globalThis.fetch = (input, init) => {
+      const url = new URL(String(input));
+      if (url.origin === "https://api.github.com")
+        return fetchImpl(`${origin}${url.pathname}`, init);
+      if (url.origin === origin) return fetchImpl(input, init);
+      throw new Error("unexpected outbound fixture destination");
+    };
+    // Only socket placement changes: the compiled HTTP handler still owns the request.
+    const listen = http.Server.prototype.listen;
+    const listening = new Promise((resolve) => {
+      http.Server.prototype.listen = function (_port, callback) {
+        return listen.call(this, 0, "127.0.0.1", () => {
+          callback();
+          resolve(`http://127.0.0.1:${this.address().port}`);
+        });
+      };
+    });
+    const { startServer } = await import("../../dist/repair/comment-webhook.js");
+    startServer();
+    http.Server.prototype.listen = listen;
+    webhookOrigin = await listening;
+  }
+  process.on("message", (message) => {
+    if (message.inspect) return process.send(requests);
+    response = message;
+    requests = [];
+    process.send({ configured: true });
+  });
+  process.on("disconnect", () => process.exit(0));
+  process.send({
+    origin,
+    webhookOrigin,
+    runtime: { version: process.version, execPath: process.execPath },
+  });
+}

--- a/test/repair/comment-webhook.test.ts
+++ b/test/repair/comment-webhook.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import crypto from "node:crypto";
 import http from "node:http";
 import test from "node:test";
+import { startIntakeFixture } from "../helpers/command-intake-fixture.mjs";
 
 import {
   adaptiveCodexTimeoutMsForTest,
@@ -1491,6 +1492,34 @@ test("webhook GitHub requests have a deadline through the response body", async 
       }
     });
   }
+});
+
+test("standalone HTTP webhook preserves intake failure classification", async (t) => {
+  const fixture = await startIntakeFixture(true);
+  t.after(() => fixture.close());
+  for (const status of [429, 503, 422]) {
+    await fixture.setResponse(status, {
+      error: "target_visibility_unverified",
+      message: "synthetic-private-sentinel",
+    });
+    const response = await fixture.webhook();
+    assert.equal(response.status, status === 422 ? 400 : 503);
+    assert.deepEqual(
+      await response.json(),
+      status === 422
+        ? {
+            ok: false,
+            error: "exact-review command intake failed (HTTP 422): target_visibility_unverified",
+          }
+        : { ok: false, retryable: true },
+    );
+    const requests = await fixture.requests();
+    assert.equal(requests.length, 1);
+    assert.equal(requests[0].path, "/internal/exact-review/command-intake");
+    assert.equal(requests[0].method, "POST");
+    assert.equal(requests[0].signed, true);
+  }
+  assert.doesNotMatch(fixture.stderr(), /synthetic-private-sentinel/);
 });
 
 function commandWebhookPayload(commandBody: string, targetRepo = "openclaw/openclaw") {

--- a/test/repair/exact-review-batch-queue-client.test.ts
+++ b/test/repair/exact-review-batch-queue-client.test.ts
@@ -228,6 +228,16 @@ test("post-effect stops reading error bodies at 512 bytes and cancels the stream
   assert.equal(cancelled, true);
 });
 
+test("batch diagnostics retain codes outside the command-intake allowlist", async (t) => {
+  const { client, calls } = fixture(t, () =>
+    Response.json({ error: "batch_lease_expired" }, { status: 409 }),
+  );
+  await assert.rejects(client.postEffect("enqueue", payload), {
+    message: "Batch queue /internal/exact-review/enqueue failed (HTTP 409): batch_lease_expired",
+  });
+  assert.equal(calls.length, 1);
+});
+
 test("heartbeat retries 500 with unchanged signed bytes and returns the renewed expiry", async (t) => {
   const batch = {
     batch_id: heartbeat.batchId,

--- a/test/repair/exact-review-command-queue.test.ts
+++ b/test/repair/exact-review-command-queue.test.ts
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  postExactReviewCommandIntake,
+  postExactReviewCommandIntakeSync,
+} from "../../dist/repair/exact-review-command-queue.js";
+import { startIntakeFixture } from "../helpers/command-intake-fixture.mjs";
+
+for (const [mode, invoke] of [
+  ["sync", postExactReviewCommandIntakeSync],
+  ["async", postExactReviewCommandIntake],
+] as const) {
+  test(`${mode} intake preserves signed admission and closed HTTP diagnostics`, async (t) => {
+    const fixture = await startIntakeFixture();
+    t.after(() => fixture.close());
+    const commandVersionId = fixture.options.intake.commandVersionId;
+    for (const [status, code, suffix] of [
+      [503, "target_visibility_unverified", ": target_visibility_unverified"],
+      [422, "private_target_unsupported", ": private_target_unsupported"],
+      [503, "synthetic_private_token", ""],
+    ] as const) {
+      await t.test(`HTTP ${status} ${code}`, async () => {
+        await fixture.setResponse(status, {
+          error: code,
+          retryable: true,
+          message: "synthetic-private-sentinel",
+        });
+        await assert.rejects(async () => invoke(fixture.options), {
+          message: `exact-review command intake failed (HTTP ${status})${suffix}`,
+        });
+        await assertSignedOnce(fixture);
+      });
+    }
+    for (const deduped of [false, true]) {
+      await fixture.setResponse(202, {
+        ok: true,
+        accepted: true,
+        deduped,
+        command_version_id: commandVersionId,
+      });
+      assert.deepEqual(await invoke(fixture.options), {
+        kind: "accepted",
+        deduped,
+        commandVersionId,
+      });
+      await assertSignedOnce(fixture);
+    }
+    await fixture.setResponse(202, {
+      ok: true,
+      accepted: false,
+      reason: "superseded",
+      command_version_id: commandVersionId,
+    });
+    assert.deepEqual(await invoke(fixture.options), {
+      kind: "stale",
+      reason: "superseded",
+      commandVersionId,
+    });
+    await assertSignedOnce(fixture);
+    await fixture.setResponse(202, null);
+    await assert.rejects(async () => invoke(fixture.options), {
+      message: "exact-review command intake returned an invalid result",
+    });
+    await assertSignedOnce(fixture);
+    for (const close of [true, "partial"]) {
+      await fixture.setResponse(
+        202,
+        {
+          ok: true,
+          accepted: true,
+          deduped: false,
+          command_version_id: commandVersionId,
+        },
+        close,
+      );
+      await assert.rejects(async () => invoke(fixture.options));
+      await assertSignedOnce(fixture);
+    }
+  });
+}
+
+test("intake omits malformed and over-bound diagnostics", async (t) => {
+  const fixture = await startIntakeFixture();
+  t.after(() => fixture.close());
+  for (const body of [
+    "{",
+    null,
+    [],
+    123,
+    { error: 123 },
+    { error: "https://private.example.test/token" },
+    "synthetic-private-sentinel",
+  ]) {
+    await fixture.setResponse(503, body);
+    await assert.rejects(postExactReviewCommandIntake(fixture.options), {
+      message: "exact-review command intake failed (HTTP 503)",
+    });
+    await assertSignedOnce(fixture);
+  }
+  // UTF-8 reaches the byte cap while the JSON is still fewer than 512 characters.
+  const body = JSON.stringify({
+    padding: "\u00e9".repeat(230),
+    error: "target_visibility_unverified",
+  });
+  assert.ok(body.length < 512 && Buffer.byteLength(body) > 512);
+  for (const invoke of [postExactReviewCommandIntakeSync, postExactReviewCommandIntake]) {
+    await fixture.setResponse(503, body);
+    await assert.rejects(async () => invoke(fixture.options), {
+      message: "exact-review command intake failed (HTTP 503)",
+    });
+    await assertSignedOnce(fixture);
+    const code = JSON.stringify({ error: "target_visibility_unverified" });
+    await fixture.setResponse(503, code.padStart(512));
+    await assert.rejects(async () => invoke(fixture.options), {
+      message: "exact-review command intake failed (HTTP 503): target_visibility_unverified",
+    });
+    await assertSignedOnce(fixture);
+  }
+});
+
+async function assertSignedOnce(fixture) {
+  const requests = await fixture.requests();
+  assert.deepEqual(requests, [
+    {
+      method: "POST",
+      path: "/internal/exact-review/command-intake",
+      signed: true,
+      body: JSON.stringify(fixture.options.intake),
+    },
+  ]);
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users requesting a review would lose the service's
structured failure reason when command intake returned an HTTP error.

## Why This Change Was Made

The sync client preferred curl's generic stderr over the structured body; the
async client retained only the HTTP status. Both now reuse the bounded queue
decoder and expose only seven recognized intake codes, with numeric curl status
kept separate from untrusted stderr.

Batch error identity, diagnostic policy and retries are unchanged. This adds
no retries, longer deadlines, admission/state changes, configuration, schema,
dependencies or deployment changes.

## User Impact

Known HTTP failures now retain a safe reason, for example
`exact-review command intake failed (HTTP 503): target_visibility_unverified`.
Unknown or malformed HTTP error bodies produce status-only diagnostics.
Accepted, deduplicated and stale results retain their existing behavior.

## OpenClaw Bay Impact

Unaffected: no observer API, queue record, status projection or dashboard
contract changes.

## Documentation Impact

Reviewed command routing in `docs/repair/operations.md` and durable intake
markers in `docs/pr-review-comments.md`. Those contracts remain unchanged;
`CHANGELOG.md` records the diagnostics improvement.

## Evidence

- Base: `2690dafa8c3382d05e733af9dfdc31c804b7305d`.
- Candidate commit: `612c8b55261fc879172e4b306908cc5618038708`.
- Independent precommit and exact committed-range reviews: both accepted,
  no P0-P2 findings.
- Both real-client structured-503 assertions failed on the compiled base before
  production edits, then the unchanged assertions passed on the candidate.
- Focused client/batch/webhook suite: 78 passed, zero failed/cancelled/skipped.
- One normal `pnpm run check`: 5,642 passed, 13 existing skips, zero failures
  or cancellations. Changed-coverage stage: 13 passed. Full coverage: 86.79%
  lines, 77.06% branches, 90.18% functions.
- Production +67/-27 (net +40) across three existing modules, including the
  absorbed reader move. Growth supplies bounded shared decoding, numeric
  status observation and closed intake diagnostics. Tests/support +337 use
  one child fixture for blocking curl and real standalone HTTP; changelog +2.

## Real Behavior Proof

**Claim and surface:** compiled sync curl and async fetch clients preserve
known HTTP failure codes without exposing other response fields. The actual
standalone HTTP handler retains its upstream-error classification.

**Fixture and command:** a controlled Node process invoked both compiled
clients and the exported standalone server entry point, sharing
`test/helpers/command-intake-fixture.mjs`. Its responder ran in an owned child
so blocking curl could make real HTTP requests. Synthetic GitHub dependencies
were routed exclusively to loopback; the production handler and classifier
were not replaced.

The test/helper paths retain the same boundary cases:

```sh
pnpm run build:all
node --test test/repair/exact-review-command-queue.test.ts test/repair/exact-review-batch-queue-client.test.ts test/repair/comment-webhook.test.ts
```

**Environment:** approved local macOS; caller and responder both Node 24.18.0,
pnpm 11.10.0, Bash 5.3.15 and curl 8.7.1. The check child did not inherit
`TMUX`, `TMUX_PANE` or `TMUX_TMPDIR`, protecting interactive sessions from
existing terminal fixtures. No test selection or threshold was changed.

**Observed process trace:**

| Surface | Upstream Response | Result |
| --- | --- | --- |
| Sync curl and async fetch | 503, known code | `exact-review command intake failed (HTTP 503): target_visibility_unverified` |
| Sync curl and async fetch | 422, known code | `exact-review command intake failed (HTTP 422): private_target_unsupported` |
| Sync curl and async fetch | 503, unknown token-shaped code | `exact-review command intake failed (HTTP 503)` |
| Standalone HTTP | 429 | HTTP 503, `{"ok":false,"retryable":true}` |
| Standalone HTTP | 503 | HTTP 503, `{"ok":false,"retryable":true}` |
| Standalone HTTP | 422 | HTTP 400 with the bounded known-code error |

All nine invocations produced exactly one POST to
`/internal/exact-review/command-intake`, with independently verified
received-byte HMACs. No private sentinel escaped. The owned child exited and
both listeners refused connections after cleanup.

Controlled trace SHA256:
`9088d112b12f6669961afeccabd5ed624bfece6b17b8e90de1a896c07c94ac12`.
The frozen source and compiled module hashes remained unchanged after the
full check.

**Limits:** 512 bytes bounds diagnostic decoding; async also cancels the error
stream. Sync retains its existing buffering and 15-second deadline, not a
512-byte transfer cap. No live queue traffic or cloud/container allocation.
The historical 503 body is unavailable, so its original cause is not claimed.
Rejected intake propagation through router outcomes and the separate
ledger-write 500 remain follow-ups. This source/test-only change does not
automatically deploy the Worker.
