### PR TITLE
refactor(process): share output option normalization

### DIFF
--- a/src/codex-output-capture.ts
+++ b/src/codex-output-capture.ts
@@ -73,9 +73,14 @@ function normalizedMaxFileBytes(value: number | undefined): number {
   return Math.max(TRUNCATION_MARKER.length, normalized);
 }
 
-function normalizedTailBytes(value: number | undefined): number {
+export function normalizedTailBytes(value: number | undefined): number {
   if (value === undefined) return DEFAULT_CODEX_OUTPUT_TAIL_BYTES;
   return Math.max(0, Number.isFinite(value) ? Math.floor(value) : DEFAULT_CODEX_OUTPUT_TAIL_BYTES);
+}
+
+export function normalizedOutputFileBytes(value: number | undefined): number {
+  if (value === undefined) return DEFAULT_CODEX_OUTPUT_FILE_BYTES;
+  return Math.max(0, Number.isFinite(value) ? Math.floor(value) : DEFAULT_CODEX_OUTPUT_FILE_BYTES);
 }
 
 function availableTailBytes(maxFileBytes: number): number {

--- a/src/codex-process.ts
+++ b/src/codex-process.ts
@@ -3,10 +3,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "no
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import {
-  DEFAULT_CODEX_OUTPUT_FILE_BYTES,
-  DEFAULT_CODEX_OUTPUT_TAIL_BYTES,
-} from "./codex-output-capture.js";
+import { normalizedOutputFileBytes, normalizedTailBytes } from "./codex-output-capture.js";
 import { codexProcessCommand } from "./codex-spawn.js";
 import type { ReviewProofCapability } from "./review-proof-client.js";
 
@@ -140,16 +137,6 @@ export function codexProcessErrorCode(error: Error | undefined): string | null {
   if (!error || !("code" in error)) return null;
   const code = (error as NodeJS.ErrnoException).code;
   return typeof code === "string" ? code : null;
-}
-
-function normalizedTailBytes(value: number | undefined): number {
-  if (value === undefined) return DEFAULT_CODEX_OUTPUT_TAIL_BYTES;
-  return Math.max(0, Number.isFinite(value) ? Math.floor(value) : DEFAULT_CODEX_OUTPUT_TAIL_BYTES);
-}
-
-function normalizedOutputFileBytes(value: number | undefined): number {
-  if (value === undefined) return DEFAULT_CODEX_OUTPUT_FILE_BYTES;
-  return Math.max(0, Number.isFinite(value) ? Math.floor(value) : DEFAULT_CODEX_OUTPUT_FILE_BYTES);
 }
 
 function failedProcessResult(

--- a/src/openclaw-process.ts
+++ b/src/openclaw-process.ts
@@ -5,10 +5,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "no
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import {
-  DEFAULT_CODEX_OUTPUT_FILE_BYTES,
-  DEFAULT_CODEX_OUTPUT_TAIL_BYTES,
-} from "./codex-output-capture.js";
+import { normalizedOutputFileBytes, normalizedTailBytes } from "./codex-output-capture.js";
 import type { CodexProcessResult } from "./codex-process.js";
 
 const OPENCLAW_PROCESS_WORKER_PATH = fileURLToPath(
@@ -487,16 +484,6 @@ function openclawSessionId(label: string): string {
     .replace(/[^a-z0-9_-]+/g, "-")
     .slice(0, 48);
   return `${safeLabel || "clawsweeper"}-${randomUUID()}`;
-}
-
-function normalizedTailBytes(value: number | undefined): number {
-  if (value === undefined) return DEFAULT_CODEX_OUTPUT_TAIL_BYTES;
-  return Math.max(0, Number.isFinite(value) ? Math.floor(value) : DEFAULT_CODEX_OUTPUT_TAIL_BYTES);
-}
-
-function normalizedOutputFileBytes(value: number | undefined): number {
-  if (value === undefined) return DEFAULT_CODEX_OUTPUT_FILE_BYTES;
-  return Math.max(0, Number.isFinite(value) ? Math.floor(value) : DEFAULT_CODEX_OUTPUT_FILE_BYTES);
 }
 
 function failedResult(


### PR DESCRIPTION
## What Problem This Solves

Codex and OpenClaw process launchers duplicate output-byte normalization, making their shared defaults and numeric edge cases easier to drift apart.

## Why This Change Was Made

Reuse the capture owner's zero-permitting normalizers in both launchers while keeping its capture-only truncation-marker minimum separate. This is a three-file refactor (+8/-29), with no changes to invocation, environment filtering, timeouts, or worker behavior.

Related overlap: https://github.com/openclaw/clawsweeper/pull/1488. Its retained-output policy changes are not included here.

## User Impact

No intended user-visible change. Output limits, defaults, truncation, and failure behavior remain the same.

## OpenClaw Bay Impact

None: no lifecycle, publication, queue, telemetry, dashboard, or observer contract changes.

## Documentation Impact

Reviewed `README.md`, `docs/README.md`, and `CONTRIBUTING.md`. No documentation changes are needed because the public options, defaults, and security boundaries are unchanged.

## Evidence

Fresh native Codex reviews completed without actionable findings before the commit (September 8, 2026, 22:42:31 UTC) and on the committed head against its base (22:57:34 UTC). These are local reviews, not a current ClawSweeper review.

The validation run below passed both complete diagnostics (23/23 and 3/3), then one unchanged `pnpm run check`: changed coverage 13/13; full coverage 5,691 total, 5,673 passed, 18 skipped, zero failures/cancellations/todos. Skips were seven macOS cases, four opt-in benchmarks, and seven unavailable delegated-containment cases, not executed coverage.

## Real Behavior Proof

**Source:** base `e4c2d57ad229dc8cef15dd5ef3d613386ced664b`; signed head `f1aaacd9ef96674ec8e1a11247ea4718e9f9822f`; tree `0436da5a006d2edf4c14627903302902339900ca`.

Patch SHA-256: `b3759e58f6b654e26753e99c36f642c4f2d1751aaf1fcb72641578e89620e680`.

**Claim and scenario:** the compiled `runCodexProcess` and `runOpenclawProcess`, their real workers, and controlled CLI/filesystem fixtures preserve normalized options, results, arguments/environment, and durable output bytes. Each launcher exercised undefined, 9.75, zero, negative, NaN, and both infinities. Zero/negative file limits retained the capture truncation marker. The retained Node parity harness ran against independently built base/candidate dist roots; its private invocation paths are omitted.

Committed parity command, with only private paths redacted: `$HARNESS` denotes the private `process-proof.mjs` path; `$BASE_DIST` and `$CANDIDATE_DIST` denote the actual independently built roots. Argument order and the head argument are unchanged.

```sh
/usr/local/bin/node "$HARNESS" "$BASE_DIST" "$CANDIDATE_DIST" f1aaacd9ef96674ec8e1a11247ea4718e9f9822f
```

Harness SHA-256: `e5d5bb0404c8a0a9260b31a1930f4809bd70dd18f9c5f0c749f94548bf0cd29a`. The precommit invocation used the same path arguments without the final head argument. Neither invocation had an output argument.

**Actual bindings:** Linux, Crabbox `local-container`, Node v24.20.0. Image digests identify local images, not publicly pullable artifacts.

- Image A: `sha256:569efea9fb325a09883b85180d8c48fd9234ae925b35d18a5298a451a5bfdd44`.
- Image B: `sha256:3048a4f17551cbdd1c10ae10356588d3e858e13199d1f5955231a0c014946ed8`.

| Evidence | Actual lease / run | Observed result on September 8, 2026 (UTC) |
| --- | --- | --- |
| Precommit, image A, base plus exact dirty patch; no candidate commit yet | `cbx_8b6b35b22f96` / `run_2ea58d5683c1` | 22:38:28-22:39:39: focused tests 25/25 per root; 14 parity comparisons / 28 real launcher invocations passed. |
| Committed pair, image A | `cbx_8b6b35b22f96` / `run_7018fc747e82` | 22:48:19-22:50:22: fresh 14/28 parity and its pre/post dist checks passed. Later diagnostics were 23/23 and 2/3 with a Bash startup failure; this enclosing run failed and did not start the full check. |
| Corrected-environment validation, image B, exact signed head | `cbx_6d4fe4bc4ae2` / `run_dfe2f20abdfd` | 23:41:58-23:53:45: pinned pnpm 11.10.0 qualification, both diagnostics, full check, and post-validation source/Git and package-manager metadata checks passed. No parity replay or relabeling of image A proof. |

The validation commands were:

```sh
node --test --test-concurrency=1 --test-reporter=tap test/live-proof-review-environment.test.ts
node --test --test-concurrency=1 --test-reporter=tap test/repair/exact-review-queue-maintenance-workflow.test.ts
pnpm run check
```

**Important result boundary:** the full check exited **0**, signal null, at 23:53:44.292 UTC, taking 582.513s within its 639.221s cap and original 23:54:41 deadline. The outer validation envelope subsequently exited **1**, signal null: its final whole-dist comparison failed with expected `dist/docs-site` additions produced by the check's documentation tests. The abbreviated assertion was retained, but no post-check dist manifest was written. We do **not** claim that only docs changed, that all compiled files remained identical after the check, or that the whole envelope passed.

All 374 freshly built candidate dist entries matched the retained committed proof before validation. The separate committed parity retained its own pre/post dist integrity. Independent review accepted these composed results against the original proof contract; the failed stronger post-check assertion remains recorded. The validation lease was stopped and verified absent at 23:54:25.879 UTC.

**Artifacts:** retained private result SHA-256 values, not hashes of public attachments:

- Precommit: `ba38e781811b007d2f66d6b3ab0b1fbfd9c76087a5478613b3704601d43cc85a`.
- Committed parity/diagnostics: `cc3329675b2bc2a17487b0f536e15ba925e585fa62661d03a013fcccd70dd4dd`.
- Corrected-environment validation: `77183bef4a74ddee9df29fc146e451c279c5f521d521004bb21344b18b901604`.

**Limits:** controlled launcher/worker/filesystem proof, not authenticated Codex/OpenClaw or external-provider execution. Earlier transport and environment failures remain separate retained evidence, not passes. First contact used TOFU, followed by an owned-container public-key comparison before product upload, not strict first-contact verification. No complete post-check dist, whole dependency-tree equality, skipped-platform coverage, or escaped-descendant absence claim. Current-head/body ClawSweeper review, CI, and landing gates remain separate.
