### PR TITLE
fix(review): accept mixed-case target repos in the PR admission handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@ checkpoint, and status-only commits are intentionally omitted.
 - Generated live-proof plans now receive the effective cold-checkout setup contract and guidance to supply missing build or code-generation prerequisites before dependent commands.
 
 ### Fixed
+- Accept the exact-event PR admission handoff for mixed-case target repositories such as fallback-profile repos, whose profile slug is lowercased; the strict repo comparison failed every review of such pull requests after the oversized-PR policy landed.
 
 - Recheck current close policies and known same-author counterparts before close mutations, keeping the parent open when a counterpart locks, reopens, or cannot be refreshed; thanks @vincentkoc.
 - Bound cluster dispatch and target cloning with operator-configured deadlines, useful timeout errors, and clone process-tree cleanup; thanks @SebTardif.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,8 +120,8 @@ checkpoint, and status-only commits are intentionally omitted.
 - Generated live-proof plans now receive the effective cold-checkout setup contract and guidance to supply missing build or code-generation prerequisites before dependent commands.
 
 ### Fixed
-- Accept the exact-event PR admission handoff for mixed-case target repositories such as fallback-profile repos, whose profile slug is lowercased; the strict repo comparison failed every review of such pull requests after the oversized-PR policy landed.
 
+- Accept the exact-event PR admission handoff for mixed-case target repositories such as fallback-profile repos, whose profile slug is lowercased; the strict repo comparison failed every review of such pull requests after the oversized-PR policy landed.
 - Recheck current close policies and known same-author counterparts before close mutations, keeping the parent open when a counterpart locks, reopens, or cannot be refreshed; thanks @vincentkoc.
 - Bound cluster dispatch and target cloning with operator-configured deadlines, useful timeout errors, and clone process-tree cleanup; thanks @SebTardif.
 - Bound cluster-selector model and GitHub requests through response completion, failing without new selection output on stalled transports; thanks @SebTardif.

--- a/scripts/proof-pr-admission-repo-case.mjs
+++ b/scripts/proof-pr-admission-repo-case.mjs
@@ -1,0 +1,144 @@
+// Proof: the built `review` entrypoint accepts the exact-event PR admission handoff when the
+// workflow spells the target repo in mixed case (steipete/CodexBar) while the fallback
+// repository profile carries the lowercased slug. Git/GitHub/model boundaries are synthetic.
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const root = resolve(process.argv[2] || ".artifacts/pr-admission-repo-case-proof");
+mkdirSync(root, { recursive: true });
+const calls = join(root, "calls.jsonl");
+const fake = join(root, "boundary.mjs");
+writeFileSync(
+  fake,
+  `import { appendFileSync } from 'node:fs';
+const [kind, ...args] = process.argv.slice(2);
+appendFileSync(process.env.PROOF_CALLS, JSON.stringify({kind,args})+'\\n');
+if (kind === 'git') {
+  if (args.includes('--is-shallow-repository')) console.log('false');
+  else if (args[0] === 'symbolic-ref' || args.includes('--abbrev-ref')) console.log('main');
+  else if (args[0] !== 'fetch') console.log('a'.repeat(40));
+} else if (kind === 'gh' && args.includes('release')) console.log('[]');
+else { console.error('CONTROL_REACHED_NORMAL_HYDRATION'); process.exit(91); }
+`,
+);
+const repo = "steipete/CodexBar";
+const pull = {
+  number: 3246,
+  title: "Synthetic mixed-case repo PR",
+  body: "Synthetic body",
+  comments: 0,
+  review_comments: 0,
+  state: "open",
+  locked: false,
+  additions: 1200,
+  deletions: 839,
+  changed_files: 12,
+  head: { sha: "a881c63d08d36e3926aaa7b97a2eef2e438cd53b" },
+  base: { ref: "main", sha: "a".repeat(40) },
+  user: { login: "synthetic-contributor" },
+  author_association: "CONTRIBUTOR",
+  draft: false,
+  created_at: "2026-09-01T00:00:00Z",
+  updated_at: "2026-09-09T14:52:19Z",
+  labels: [],
+};
+const environment = {
+  ...process.env,
+  CLAWSWEEPER_OVERSIZED_PR_CLOSE_ENABLED: "false",
+  CLAWSWEEPER_MAX_PR_CHANGED_LINES: "50000",
+  PROOF_CALLS: calls,
+};
+for (const kind of ["gh", "git", "codex"]) {
+  environment[`${kind.toUpperCase()}_BIN`] = process.execPath;
+  environment[`${kind.toUpperCase()}_BIN_ARGS`] = JSON.stringify([fake, kind]);
+}
+const transcript = [];
+const run = (label, args) => {
+  const result = spawnSync(process.execPath, ["dist/clawsweeper.js", ...args], {
+    env: environment,
+    encoding: "utf8",
+  });
+  const normalized = `${result.stdout}${result.stderr}`
+    .replaceAll(root, "<proof>")
+    .replaceAll(process.cwd(), "<checkout>")
+    .replaceAll(process.execPath, "<node>");
+  transcript.push(
+    `$ node dist/clawsweeper.js ${args.join(" ").replaceAll(root, "<proof>")}\nexit=${result.status}\n${normalized.trim()}`,
+  );
+  writeFileSync(join(root, `${label}.log`), normalized);
+  return result;
+};
+// Mirrors the production exact-event invocation: --target-repo as GitHub spells it, --item-numbers, handoff file.
+const reviewArgs = (admission, artifactDir) => [
+  "review",
+  "--target-repo",
+  repo,
+  "--item-numbers",
+  String(pull.number),
+  "--skip-start-comment",
+  "--artifact-dir",
+  artifactDir,
+  "--target-dir",
+  root,
+  "--pr-admission-file",
+  admission,
+];
+
+writeFileSync(calls, "");
+const admitted = join(root, "admitted.json");
+writeFileSync(
+  admitted,
+  JSON.stringify({ repo, observedAt: "2026-09-09T15:11:31.000Z", pull }, null, 2),
+);
+const admittedResult = run("admitted", reviewArgs(admitted, join(root, "admitted")));
+const admittedOutput = `${admittedResult.stdout}${admittedResult.stderr}`;
+assert.doesNotMatch(
+  admittedOutput,
+  /PR admission metadata does not match/,
+  "mixed-case handoff must not be rejected as a repo mismatch",
+);
+assert.match(
+  admittedOutput,
+  /CONTROL_REACHED_NORMAL_HYDRATION/,
+  "admitted PR must proceed past admission into normal hydration",
+);
+const observed = readFileSync(calls, "utf8").trim().split("\n").filter(Boolean).map(JSON.parse);
+assert.ok(observed.length > 0, "admitted PR must reach the synthetic Git/GitHub boundary");
+transcript.push(
+  `Admitted mixed-case handoff: passed readPrAdmissionInput and stopped at the synthetic boundary after ${observed.length} git/gh calls.`,
+);
+
+writeFileSync(calls, "");
+const oversized = join(root, "oversized.json");
+writeFileSync(
+  oversized,
+  JSON.stringify(
+    {
+      repo,
+      observedAt: "2026-09-09T15:11:31.000Z",
+      pull: { ...pull, additions: 60000, deletions: 1 },
+    },
+    null,
+    2,
+  ),
+);
+const oversizedItems = join(root, "oversized-items");
+const oversizedResult = run("oversized", reviewArgs(oversized, oversizedItems));
+assert.equal(oversizedResult.status, 0, oversizedResult.stderr);
+assert.equal(readFileSync(calls, "utf8"), "", "oversized admission must not invoke subprocesses");
+const report = readFileSync(join(oversizedItems, `${pull.number}.md`), "utf8");
+assert.match(report, /^close_reason: oversized_pull_request$/m);
+assert.match(report, /^review_model: none$/m);
+// Fallback repository profiles do not list oversized_pull_request in their apply close rules,
+// so the metadata-only decision is recorded but not proposed for close.
+assert.match(report, /^action_taken: skipped_invalid_decision$/m);
+transcript.push(
+  "Oversized mixed-case handoff: metadata-only oversized decision written with zero git/gh/codex calls; the fallback profile's apply policy does not allow that close reason, so action_taken is skipped_invalid_decision.",
+);
+transcript.push(
+  "Limits: synthetic Git/GitHub/model boundaries; no live GitHub reads or mutations. The admitted case deliberately stops at hydration entry.",
+);
+writeFileSync(join(root, "transcript.txt"), transcript.join("\n\n"));
+console.log(transcript.join("\n\n"));

--- a/src/clawsweeper-pr-admission-input.ts
+++ b/src/clawsweeper-pr-admission-input.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { oversizedPullRequestAdmission } from "./clawsweeper-oversized-pr-policy.js";
 import type { Item } from "./clawsweeper-types.js";
 import { labelNames } from "./clawsweeper-item-policy.js";
+import { normalizeRepo } from "./repository-profiles.js";
 import { recordOrEmpty, stringOrEmpty } from "./value-coerce.js";
 
 /** Workflow-owned handoff of the metadata already read during live admission. */
@@ -9,8 +10,11 @@ export function readPrAdmissionInput(path: string, repo: string, numbers: readon
   const input = recordOrEmpty(JSON.parse(readFileSync(path, "utf8")));
   const pull = recordOrEmpty(input.pull);
   const number = Number(pull.number);
+  // The workflow records the repo as GitHub spells it; fallback profiles carry
+  // the lowercased slug, so compare the normalized forms.
   if (
-    input.repo !== repo ||
+    typeof input.repo !== "string" ||
+    normalizeRepo(input.repo) !== normalizeRepo(repo) ||
     numbers.length !== 1 ||
     numbers[0] !== number ||
     pull.state !== "open"

--- a/test/pr-admission-input.test.ts
+++ b/test/pr-admission-input.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { readPrAdmissionInput } from "../dist/clawsweeper-pr-admission-input.js";
+import { repositoryProfileFor } from "../dist/repository-profiles.js";
+
+function admissionFile(repo: string, pull: Record<string, unknown>): string {
+  const dir = mkdtempSync(join(tmpdir(), "clawsweeper-pr-admission-"));
+  const path = join(dir, "exact-pr-admission.json");
+  writeFileSync(path, JSON.stringify({ repo, observedAt: "2026-09-09T15:11:31.000Z", pull }));
+  return path;
+}
+
+const pull = {
+  number: 3246,
+  state: "open",
+  title: "Example",
+  labels: [],
+  user: { login: "contributor" },
+  author_association: "CONTRIBUTOR",
+  additions: 1200,
+  deletions: 839,
+  changed_files: 12,
+  head: { sha: "a881c63d08d36e3926aaa7b97a2eef2e438cd53b" },
+};
+
+test("PR admission accepts the workflow's mixed-case repo against a lowercased fallback profile", () => {
+  // Fallback profiles carry the normalized slug; the workflow records the repo as GitHub spells it.
+  const profileRepo = repositoryProfileFor("steipete/CodexBar").targetRepo;
+  assert.equal(profileRepo, "steipete/codexbar");
+  const path = admissionFile("steipete/CodexBar", pull);
+  try {
+    const input = readPrAdmissionInput(path, profileRepo, [3246]);
+    assert.equal(input.item.repo, profileRepo);
+    assert.equal(input.item.number, 3246);
+    assert.equal(input.admission.admitted, true);
+  } finally {
+    rmSync(join(path, ".."), { recursive: true, force: true });
+  }
+});
+
+test("PR admission still rejects a different repo, item number, or closed pull request", () => {
+  const cases: Array<[string, string, number[], Record<string, unknown>]> = [
+    ["steipete/CodexBar", "steipete/camsnap", [3246], pull],
+    ["steipete/CodexBar", "steipete/codexbar", [3247], pull],
+    ["steipete/CodexBar", "steipete/codexbar", [3246, 3247], pull],
+    ["steipete/CodexBar", "steipete/codexbar", [3246], { ...pull, state: "closed" }],
+  ];
+  for (const [fileRepo, repo, numbers, filePull] of cases) {
+    const path = admissionFile(fileRepo, filePull);
+    try {
+      assert.throws(
+        () => readPrAdmissionInput(path, repo, numbers),
+        /does not match the selected open pull request/,
+      );
+    } finally {
+      rmSync(join(path, ".."), { recursive: true, force: true });
+    }
+  }
+});


### PR DESCRIPTION
## Problem

After #1496 landed, every exact review of `steipete/CodexBar#3246` failed at review start with `PR admission metadata does not match the selected open pull request` (three consecutive `source_drift_requeue` runs on merge head `aabbd983c`), while reviews on `openclaw/*` repositories passed.

## Root cause

The exact-event workflow writes `$TARGET_REPO` into `.artifacts/exact-pr-admission.json` as GitHub spells it (`steipete/CodexBar`). Repositories without a configured profile get a fallback profile whose `targetRepo` is the normalized lowercase slug (`steipete/codexbar`). `readPrAdmissionInput` compared the two with strict equality, so every mixed-case fallback repository was rejected before hydration.

## Fix

Compare both repository slugs through the existing `normalizeRepo` helper and require the recorded repo to be a string. Item number, single-item selection, and open state are still enforced.

## Proof

- New `test/pr-admission-input.test.ts`: the mixed-case handoff against the lowercased fallback profile is accepted, and different repo / different number / multi-item / closed inputs still throw. The mixed-case case fails on the pre-fix source (1 of 2 failing) and passes after the fix.
- `node --test test/pr-admission-input.test.ts test/oversized-pr-admission.test.ts test/oversized-pr-close.test.ts`: 24 passed, 0 failed.
- `pnpm run lint:src` clean; `oxfmt --check` clean on the changed files.

## Impact

Restores exact reviews for pull requests on mixed-case target repositories. No policy or threshold change.

## Real behavior proof (built review entrypoint)

Source head: `43efcddfd59f3000581bb9c4529c3399feb0a785`. `scripts/proof-pr-admission-repo-case.mjs` runs the built `dist/clawsweeper.js review` exactly as the exact-event job does (`--target-repo steipete/CodexBar --item-numbers 3246 --pr-admission-file …`) against a handoff file whose `repo` is the mixed-case `steipete/CodexBar`, with Git/GitHub/model boundaries replaced by a synthetic recorder.

- Before the fix, production runs on this head shape died at review start (`Error: PR admission metadata does not match the selected open pull request` in `readPrAdmissionInput`; runs 34368140928, 34368331456, 34368557241, 34370796444, and 34370823329 for `steipete/CodexBar#3246` and `#3527`).
- After the fix, the admitted case passes `readPrAdmissionInput` and proceeds into normal hydration, stopping at the synthetic boundary after 6 git/gh calls (`CONTROL_REACHED_NORMAL_HYDRATION`). The oversized variant (60,001 lines) writes the metadata-only `oversized_pull_request` decision with zero git/gh/codex calls; because fallback repository profiles do not list that close reason in their apply policy, its `action_taken` is `skipped_invalid_decision`, which is the existing profile behavior and unchanged here.

```text
$ node scripts/proof-pr-admission-repo-case.mjs
$ node dist/clawsweeper.js review --target-repo steipete/CodexBar --item-numbers 3246 --skip-start-comment --artifact-dir <proof>/admitted --target-dir <proof> --pr-admission-file <proof>/admitted.json
exit=1
CONTROL_REACHED_NORMAL_HYDRATION
Admitted mixed-case handoff: passed readPrAdmissionInput and stopped at the synthetic boundary after 6 git/gh calls.
$ node dist/clawsweeper.js review --target-repo steipete/CodexBar --item-numbers 3246 --skip-start-comment --artifact-dir <proof>/oversized-items --target-dir <proof> --pr-admission-file <proof>/oversized.json
exit=0
Oversized mixed-case handoff: metadata-only oversized decision written with zero git/gh/codex calls; the fallback profile's apply policy does not allow that close reason, so action_taken is skipped_invalid_decision.
Limits: synthetic Git/GitHub/model boundaries; no live GitHub reads or mutations. The admitted case deliberately stops at hydration entry.
```

Bay needs no change: this only alters how the review CLI validates the workflow's handoff file; no record schema, queue payload, or observer projection changes.
