### PR TITLE
fix(review): hydrate blob sizes from bounded trees

### DIFF
--- a/src/clawsweeper-context-hydration.ts
+++ b/src/clawsweeper-context-hydration.ts
@@ -14,7 +14,6 @@ import { createRelatedContext } from "./clawsweeper-related-context.js";
 import {
   ensurePullRequestReviewHead,
   ensureReviewTreeCommit,
-  githubReviewBlobSizes,
   githubReviewTreeBlobSizes,
   hydratePullRequestReviewBlobs,
   hydratePullRequestReviewHistory,
@@ -978,17 +977,33 @@ export function createContextHydration(dependencies: CreateContextHydrationDepen
           "Could not establish complete review ancestry.",
         );
       }
+      const remoteTreeSizes = new Map<string, ReadonlyMap<string, number>>();
+      const treeSizes = (revision: string): ReadonlyMap<string, number> => {
+        const cached = remoteTreeSizes.get(revision);
+        if (cached) return cached;
+        const sizes = githubReviewTreeBlobSizes({
+          repository: targetRepo(),
+          headSha: revision,
+          request: (path) => ghJson(["api", path]),
+        });
+        remoteTreeSizes.set(revision, sizes);
+        return sizes;
+      };
       const hydrateBlobs = (revision: string) =>
         hydratePullRequestReviewBlobs({
           targetDir: options.targetDir,
           baseSha: revision,
           headSha,
-          resolveBlobSizes: (objectIds) =>
-            githubReviewBlobSizes({
-              repository: targetRepo(),
-              objectIds,
-              request: (query) => ghJson(["api", "graphql", "-f", `query=${query}`]),
-            }),
+          resolveBlobSizes: (objectIds) => {
+            const baseSizes = treeSizes(revision);
+            const headSizes = revision === headSha ? baseSizes : treeSizes(headSha);
+            return new Map(
+              objectIds.flatMap((objectId) => {
+                const bytes = headSizes.get(objectId) ?? baseSizes.get(objectId);
+                return bytes === undefined ? [] : [[objectId, bytes]];
+              }),
+            );
+          },
         });
       hydrateBlobs(mergeBaseSha);
       if (baseSha !== mergeBaseSha) {

--- a/test/review-blob-hydration.test.ts
+++ b/test/review-blob-hydration.test.ts
@@ -1510,18 +1510,20 @@ test("source preparation reports unavailable historical blobs before restricted 
         isSafeGitBranchName: (branch: string) => branch === "main",
         targetRepo: () => "fixture/repository",
         ghJson: (args: string[]) => {
-          const query = args.find((arg) => arg.startsWith("query="));
-          assert.ok(query);
-          const ids = [...query.matchAll(/b(\d+): object\(oid: "([0-9a-f]+)"\)/g)];
-          assert.ok(ids.length);
-          const sizes = resolveFixtureBlobSizes(fixture.source)(ids.map((match) => match[2]!));
-          return {
-            data: {
-              repository: Object.fromEntries(
-                ids.map((match) => ["b" + match[1], { byteSize: sizes.get(match[2]!) }]),
-              ),
-            },
-          };
+          assert.equal(args[0], "api");
+          const revision = args[1]?.match(/\/git\/trees\/([0-9a-f]+)\?recursive=1$/)?.[1];
+          assert.ok(revision);
+          const tree = git(fixture.source, "ls-tree", "-r", "-l", revision)
+            .split("\n")
+            .filter(Boolean)
+            .map((line) => {
+              const match = line.match(/^\d+ (\w+) ([0-9a-f]+)\s+(-|\d+)\t/);
+              assert.ok(match);
+              return match[1] === "blob"
+                ? { type: "blob", sha: match[2], size: Number(match[3]) }
+                : { type: match[1], sha: match[2] };
+            });
+          return { truncated: false, tree };
         },
       },
       { get: (target, key) => Reflect.get(target, key) ?? unavailable },


### PR DESCRIPTION
## Summary

- hydrate historical review blob sizes from the existing bounded recursive-tree REST metadata route
- cache one complete metadata map per distinct base/head revision
- preserve fail-closed handling when a tree is truncated or a diff blob is absent

## Why

The private-workspace admission deployed in #1488 made exact OpenClaw reviews depend on per-object GraphQL lookups. Under the current review burst, those workers repeatedly failed before model execution with `review_checkout_unavailable` / “remote blob size metadata is unavailable.” The durable queue retried the same exact heads without producing artifacts.

Every blob in a base-to-head diff must belong to either the exact base tree or exact head tree. ClawSweeper already has a bounded recursive-tree resolver that rejects truncated responses, invalid entries, and repositories over the tracked-file limit, so source hydration can use that complete metadata instead of amplifying GraphQL requests per object batch.

## Behavior proof

- Claim: exact review source admission can resolve both sides of a real OpenClaw PR diff without per-object GraphQL metadata.
- Surface: `githubReviewTreeBlobSizes` through the revised hydration resolver.
- Scenario: OpenClaw Wave 13 completion PR base `46af4a9582b34444d11cc98310838060e1aae5ca` and head `4cc522493abf6cbacafc272251d832d52a2ed2a3`.
- Environment: local Node 24 process using authenticated live `gh api` REST reads.
- Result: both recursive trees were complete and untruncated, each yielded 39,880 unique blob identities, and the changed file’s base/head blobs resolved to 39,361 and 38,117 bytes.
- Limits: this proves live metadata acquisition and exact revision binding, not hosted workflow deployment; CI and a post-merge exact review provide that final proof.

## Validation

- `pnpm run build:all`
- `node --test test/review-blob-hydration.test.ts test/review-command-workflow.test.ts` — 122 passed
- focused live API behavior proof above
- committed-head autoreview P3 — clean, 0.91 confidence
- `pnpm run check` — 5,941 passed, 32 skipped; one unrelated macOS-only failure because system Bash lacks `mapfile` in `apply-drift-refresh` E2E. Linux CI is the platform-complete authority.

## OpenClaw Bay

Not affected. This changes private review source admission only; no queue, status, telemetry, or Bay data contract changes.
