### PR TITLE
fix: unblock large repository review checkouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Keep large repository reviews within the GitHub CLI response limit by projecting recursive-tree metadata before capture, preserving complete blob sizes and strict private-checkout admission.
+
 - Carry the durable review lease through oversized PR close proposals so direct exact publication can close eligible PRs; queued fallback still keeps PRs open with `skipped_changed_since_review` after lease expiry, pending the follow-up to create the final metadata proposal under publication ownership and re-evaluation at the next event or head.
 
 - Accept the exact-event PR admission handoff for mixed-case target repositories such as fallback-profile repos, whose profile slug is lowercased; the strict repo comparison failed every review of such pull requests after the oversized-PR policy landed.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ one-item reviews. Each review writes
 `records/<repo-slug>/items/<number>.md` with the decision, evidence, proposed
 maintainer-facing comment, runtime metadata, and GitHub snapshot hash.
 
+PR checkout preparation captures only the recursive tree's entry types, object
+IDs, sizes, and truncation flag from the GitHub CLI. This keeps path and URL
+metadata from exhausting the response buffer while preserving the existing
+checkout size limits and rejection of incomplete or malformed trees.
+
 Media proof preparation recognizes image/video filename extensions and GitHub
 attachment URLs, including legacy repository asset links. Attachments are fetched
 with GET and classified by the response content type; images are saved locally

--- a/src/clawsweeper-context-hydration.ts
+++ b/src/clawsweeper-context-hydration.ts
@@ -1097,7 +1097,17 @@ export function createContextHydration(dependencies: CreateContextHydrationDepen
           remoteTreeSizes ??= githubReviewTreeBlobSizes({
             repository: targetRepo(),
             headSha: options.headSha,
-            request: (path) => ghJsonOnce(["api", path], timeoutMs),
+            // Path and URL metadata can exceed the CLI capture limit before admission runs.
+            request: (path) =>
+              ghJsonOnce(
+                [
+                  "api",
+                  path,
+                  "--jq",
+                  '{truncated, tree: (.tree | if type == "array" then map(if type == "object" then {type, sha, size} else . end) else . end)}',
+                ],
+                timeoutMs,
+              ),
           });
           return new Map(
             objectIds.flatMap((objectId) => {

--- a/test/review-blob-hydration.test.ts
+++ b/test/review-blob-hydration.test.ts
@@ -31,12 +31,14 @@ import {
 } from "../dist/clawsweeper-review-blobs.js";
 import { MAX_SCAN_BYTES } from "../dist/agent-input-scan.js";
 import { createContextHydration } from "../dist/clawsweeper-context-hydration.js";
+import { createGitHubRuntime } from "../dist/clawsweeper-github-runtime.js";
 import { asRecord } from "../dist/clawsweeper-item-policy.js";
 import { createReviewRuntime } from "../dist/clawsweeper-review-runtime.js";
 import { main, reviewPolicyHashForTest } from "../dist/clawsweeper-runtime.js";
 import { runText } from "../dist/command.js";
 import { readReviewGit, reviewMergeBase } from "../dist/pr-review-evidence.js";
 import { ReviewSourcePreparationError } from "../dist/review-source-preparation.js";
+import { withMockGh } from "./helpers.ts";
 
 function git(cwd: string, ...args: string[]): string {
   return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
@@ -801,7 +803,10 @@ test("manual live proof admits pinned promisor trees with the requested reposito
         const argv = args[1] ?? [];
         if (argv[0] === "api") {
           metadataCalls++;
-          assert.deepEqual(argv, ["api", `repos/${repo}/git/trees/${fixture.headSha}?recursive=1`]);
+          assert.deepEqual(argv.slice(0, 2), [
+            "api",
+            `repos/${repo}/git/trees/${fixture.headSha}?recursive=1`,
+          ]);
           assert.notEqual(reviewPolicyHashForTest(), profileBefore);
           assert.ok(args[2]?.timeout && args[2].timeout <= 30_000);
           if (scenario === "unavailable") throw new Error("fixture metadata unavailable");
@@ -815,7 +820,14 @@ test("manual live proof admits pinned promisor trees with the requested reposito
                   : entry,
               ),
           };
-          return { status: 0, stdout: JSON.stringify(response), stderr: "" };
+          const filter = argv.indexOf("--jq");
+          return filter < 0
+            ? { status: 0, stdout: JSON.stringify(response), stderr: "" }
+            : nativeSpawn("jq", ["-c", argv[filter + 1]!], {
+                ...args[2],
+                input: JSON.stringify(response),
+                stdio: ["pipe", "pipe", "pipe"],
+              });
         }
         if (args[0] === process.execPath && argv[1] === "live-proof") {
           childLaunches++;
@@ -1644,6 +1656,109 @@ test("review blob sizes use one bounded GraphQL metadata request", () => {
     () => githubReviewBlobSizes({ repository: "../unsafe", objectIds, request: () => ({}) }),
     /invalid bounded review blob metadata request/,
   );
+});
+
+test("review checkout preserves large tree metadata within the GitHub CLI capture limit", () => {
+  const fixture = partialCloneFixture();
+  const reviewTree = join(fixture.root, "review-tree");
+  const metadataPath = join(fixture.root, "tree.json");
+  const tree = git(fixture.source, "ls-tree", "-rl", fixture.headSha)
+    .split("\n")
+    .map((line) => {
+      const match = /^(\d+) (\w+) ([0-9a-f]+)\s+(\d+|-)\t(.+)$/.exec(line);
+      assert.ok(match);
+      return {
+        mode: match[1],
+        type: match[2],
+        sha: match[3],
+        size: match[4] === "-" ? null : Number(match[4]),
+        path: match[5],
+        url: `https://api.github.com/repos/fixture/repository/git/blobs/${match[3]}`,
+      };
+    });
+  for (let index = 0; index < 33_000; index += 1) {
+    const sha = index.toString(16).padStart(40, "0");
+    tree.push({
+      mode: "100644",
+      type: "blob",
+      sha,
+      size: index + 1,
+      path: `synthetic/packages/${index}/${"segment/".repeat(20)}entry.ts`,
+      url: `https://api.github.com/repos/fixture/repository/git/blobs/${sha}`,
+    });
+  }
+  const metadata = { truncated: false, tree };
+  const raw = JSON.stringify(metadata);
+  assert.ok(Buffer.byteLength(raw) > 8 * 1024 * 1024);
+  writeFileSync(metadataPath, raw);
+  const unavailable = () => {
+    throw new Error("Unexpected dependency in tree metadata fixture");
+  };
+  let captured: typeof metadata | undefined;
+  const runtime = createGitHubRuntime({
+    ROOT: fixture.root,
+    run: unavailable,
+    targetRepo: () => "fixture/repository",
+  });
+  const context = createContextHydration(
+    new Proxy(
+      {
+        asRecord,
+        targetRepo: () => "fixture/repository",
+        ghJsonOnce: (args: string[], timeoutMs: number) => {
+          const output = runtime.ghOnce(args, timeoutMs);
+          assert.ok(Buffer.byteLength(output) < 8 * 1024 * 1024);
+          captured = JSON.parse(output);
+          return captured;
+        },
+      },
+      { get: (target, key) => Reflect.get(target, key) ?? unavailable },
+    ) as Parameters<typeof createContextHydration>[0],
+  );
+  const materialize = () =>
+    context.materializePullRequestReviewTree({
+      targetDir: fixture.target,
+      worktreeDir: reviewTree,
+      itemNumber: 982,
+      headSha: fixture.headSha,
+    });
+  try {
+    withMockGh(
+      fixture.root,
+      `const { spawnSync } = require("node:child_process");
+const args = process.argv.slice(2);
+const filter = args.indexOf("--jq");
+if (filter < 0) {
+  process.stdout.write(require("node:fs").readFileSync(${JSON.stringify(metadataPath)}));
+} else {
+  const result = spawnSync("jq", ["-c", args[filter + 1], ${JSON.stringify(metadataPath)}], { stdio: "inherit" });
+  process.exitCode = result.status ?? 1;
+}
+`,
+      () => {
+        for (const invalid of [
+          { ...metadata, truncated: true },
+          { truncated: false, tree: { entry: tree[0] } },
+          { truncated: false, tree: [null, ...tree] },
+        ]) {
+          writeFileSync(metadataPath, JSON.stringify(invalid));
+          assert.throws(materialize, { diagnosticReason: "review_checkout_unavailable" });
+          assert.equal(existsSync(reviewTree), false);
+        }
+        writeFileSync(metadataPath, raw);
+        assert.equal(materialize(), true);
+      },
+    );
+    assert.deepEqual(captured, {
+      truncated: false,
+      tree: tree.map(({ type, sha, size }) => ({ type, sha, size })),
+    });
+    assert.equal(git(reviewTree, "rev-parse", "HEAD"), fixture.headSha);
+    assert.equal(readFileSync(join(reviewTree, "added.txt"), "utf8"), "new implementation\n");
+  } finally {
+    removePullRequestReviewTree({ targetDir: fixture.target, worktreeDir: reviewTree });
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
 });
 
 test("review tree blob sizes use one bounded recursive-tree request", () => {


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/143547

## What Problem This Solves

Fixes valid large-repository reviews failing before model execution with “remote blob size metadata is unavailable.” The complete tree response for the linked OpenClaw PR is 10.7 MB, exceeding the existing 8 MiB GitHub CLI output capture. The resulting `ENOBUFS` is reported as a checkout metadata failure.

## Why This Change Was Made

Project the recursive-tree response inside `gh --jq` before capturing it. Keep the truncation flag and every entry's type, SHA, and size, which are the facts the existing checkout admission consumes. Preserve malformed container and entry shapes so the validator still rejects them. The CLI capture, private-workspace, file-count, deadline, and disk limits are unchanged.

## User Impact

Reviews can prepare valid large repositories without unused paths and URLs filling the metadata response buffer. Incomplete, truncated, malformed, or oversized source remains rejected.

## OpenClaw Bay Impact

Bay is unaffected. This changes internal source-preparation transport only; lifecycle, review publication, status, telemetry, and observer data contracts stay the same.

## Documentation Impact

The active README review overview now describes the metadata projection and unchanged admission guarantees. The existing Unreleased changelog records the fix. No workflow or operator configuration changes are required: new sweep runs build the checked-out source with `build:all`.

## Evidence

- The synthetic large-response regression fails on the original source with the observed checkout error, then passes with the fix. It exercises the actual `ghOnce` capture limit, real jq evaluation, and real partial-clone Git materialization, preserving every required metadata fact.
- Truncated responses, object-shaped tree containers, and null entries remain rejected. Existing manual-proof fixtures retain endpoint and request-count assertions while evaluating the actual filter.
- Focused final suite: 7 passing cases. Full `pnpm run check` passed: 5,943 tests passed, 32 platform skips, and no failures, plus 13 passing changed-coverage tests.
- Fresh managed P2 reviews of the local candidate and committed branch `e0f926b1543aeb5d8aef0f5b53e2a0b9a1ba54cd` are both clean, with no actionable findings.

## Real Behavior Proof

On Node 24.20.0/macOS, the built `createContextHydration(...).materializePullRequestReviewTree(...)` path ran against the actual public OpenClaw head `70842b03a5aa392ede6a0a14e7e1b758a499a5d3`, using the real GitHub CLI/API and Git transport. The standalone command was `node live-proof.mjs` after `pnpm run build`; the harness called the production owner and runtime directly and compared the captured response to the complete pinned GitHub tree.

The fixture had complete history and an explicitly chosen warm-base cache containing only blobs from `b30ff87b771b694e67ab7ba4c860386ac18db708`. This follows the hosted sequence of preparing a base checkout before private PR materialization; the seed is pinned rather than an assertion about current-main cache contents. Twelve changed-head objects were genuinely missing. The trace was:

```json
{
  "sourceSha256": "bb11b8544fc2138aaada0adf083e1038952b6d11edebadb1212d185d1c9253ec",
  "missingBlobsBefore": 12,
  "metadataRequests": 1,
  "metadataBytes": 3258092,
  "metadataEntries": 42225,
  "allTypeShaSizeAndTruncatedFactsPreserved": true,
  "materializedHead": "70842b03a5aa392ede6a0a14e7e1b758a499a5d3",
  "cleanWorkingTree": true,
  "trackedFiles": 40292,
  "durationMs": 15581
}
```

The original full response was 10,686,262 bytes, `truncated=false`, with valid metadata for all 40,292 blobs. Its captured replay fails with `ENOBUFS` at the unchanged 8 MiB limit. The fixed real request captured 3,258,092 bytes and completed the exact-head checkout. No model, target code, Gateway, or publication operation ran during this proof. Earlier shallow-history and wholly cold bare-cache fixtures hit unchanged setup/fetch deadlines; those failures were retained, and this is not a claim of cold-cache checkout success. The real tree payload is not committed.
