### PR TITLE
fix(review): bound Git tree metadata before capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Keep large review-tree metadata within the existing subprocess capture limit by omitting unused fields while preserving complete blob sizes and checkout admission checks.
+
 - Carry the durable review lease through oversized PR close proposals so direct exact publication can close eligible PRs; queued fallback still keeps PRs open with `skipped_changed_since_review` after lease expiry, pending the follow-up to create the final metadata proposal under publication ownership and re-evaluation at the next event or head.
 
 - Accept the exact-event PR admission handoff for mixed-case target repositories such as fallback-profile repos, whose profile slug is lowercased; the strict repo comparison failed every review of such pull requests after the oversized-PR policy landed.

--- a/src/clawsweeper-context-hydration.ts
+++ b/src/clawsweeper-context-hydration.ts
@@ -1097,7 +1097,17 @@ export function createContextHydration(dependencies: CreateContextHydrationDepen
           remoteTreeSizes ??= githubReviewTreeBlobSizes({
             repository: targetRepo(),
             headSha: options.headSha,
-            request: (path) => ghJsonOnce(["api", path], timeoutMs),
+            request: (path) =>
+              ghJsonOnce(
+                [
+                  "api",
+                  path,
+                  "--jq",
+                  // Preserve entries and malformed values while omitting unused checkout metadata.
+                  '{truncated, tree: (.tree | if type == "array" then map(if type == "object" then {type, sha, size} else . end) else . end)}',
+                ],
+                timeoutMs,
+              ),
           });
           return new Map(
             objectIds.flatMap((objectId) => {

--- a/test/review-blob-hydration.test.ts
+++ b/test/review-blob-hydration.test.ts
@@ -27,6 +27,7 @@ import {
   materializePullRequestReviewTreeForTest,
   removePullRequestReviewTree,
   REVIEW_TREE_MAX_BYTES,
+  REVIEW_TREE_MAX_FILES,
   ReviewGitError,
 } from "../dist/clawsweeper-review-blobs.js";
 import { MAX_SCAN_BYTES } from "../dist/agent-input-scan.js";
@@ -801,7 +802,12 @@ test("manual live proof admits pinned promisor trees with the requested reposito
         const argv = args[1] ?? [];
         if (argv[0] === "api") {
           metadataCalls++;
-          assert.deepEqual(argv, ["api", `repos/${repo}/git/trees/${fixture.headSha}?recursive=1`]);
+          assert.deepEqual(argv, [
+            "api",
+            `repos/${repo}/git/trees/${fixture.headSha}?recursive=1`,
+            "--jq",
+            '{truncated, tree: (.tree | if type == "array" then map(if type == "object" then {type, sha, size} else . end) else . end)}',
+          ]);
           assert.notEqual(reviewPolicyHashForTest(), profileBefore);
           assert.ok(args[2]?.timeout && args[2].timeout <= 30_000);
           if (scenario === "unavailable") throw new Error("fixture metadata unavailable");
@@ -1646,7 +1652,7 @@ test("review blob sizes use one bounded GraphQL metadata request", () => {
   );
 });
 
-test("review tree blob sizes use one bounded recursive-tree request", () => {
+test("review tree blob sizes use one bounded recursive-tree request", async (t) => {
   const headSha = "a".repeat(40);
   let requests = 0;
   const result = githubReviewTreeBlobSizes({
@@ -1683,6 +1689,46 @@ test("review tree blob sizes use one bounded recursive-tree request", () => {
       }),
     /incomplete bounded review tree metadata response/,
   );
+  const blob = { type: "blob", sha: "c".repeat(40), size: 12 };
+  for (const [name, tree, message] of [
+    ["missing tree", undefined, /incomplete bounded review tree metadata response/],
+    ["object tree", { entry: blob }, /incomplete bounded review tree metadata response/],
+    ["null entry", [null], /invalid bounded review tree metadata entry/],
+    ["primitive entry", [42], /invalid bounded review tree metadata entry/],
+    [
+      "invalid object ID",
+      [{ ...blob, sha: "invalid" }],
+      /invalid bounded review tree blob metadata/,
+    ],
+    [
+      "missing size",
+      [{ type: "blob", sha: blob.sha }],
+      /invalid bounded review tree blob metadata/,
+    ],
+    ["negative size", [{ ...blob, size: -1 }], /invalid bounded review tree blob metadata/],
+    [
+      "unsafe size",
+      [{ ...blob, size: Number.MAX_SAFE_INTEGER + 1 }],
+      /invalid bounded review tree blob metadata/,
+    ],
+    [
+      "excess entries",
+      Array.from({ length: REVIEW_TREE_MAX_FILES + 1 }, () => ({ type: "tree" })),
+      /bounded review tree metadata response exceeded its entry limit/,
+    ],
+  ] as const) {
+    await t.test(name, () => {
+      assert.throws(
+        () =>
+          githubReviewTreeBlobSizes({
+            repository: "openclaw/clawsweeper",
+            headSha,
+            request: () => ({ truncated: false, tree }),
+          }),
+        message,
+      );
+    });
+  }
 });
 
 test("large pinned deltas hydrate historical blobs after head checkout and produce the full offline binary patch", (t) => {


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/143530

## What Problem This Solves

Resolves a problem where reviews of large repository trees stopped during checkout preparation even though the tree fit the private workspace budget. The affected OpenClaw review failed before reaching the model because its complete GitHub tree response exceeded the metadata subprocess capture limit.

## Why This Change Was Made

Project only the fields consumed by blob-size validation before capturing `gh` stdout. Preserve every entry, entry count, and malformed container or entry value so the existing validators retain their behavior.

The 8 MiB capture limit, 30-second deadline, 200,000-entry limit, 2 GiB checkout budget, disk reserve, source scanner, and credential routing remain unchanged.

## User Impact

Large valid tree metadata can reach normal checkout admission without increasing limits or retrying incomplete responses. Other GitHub reads keep their existing behavior.

## OpenClaw Bay Impact

Bay is unaffected: no queue, status, report, or public observer contract changes.

## Documentation Impact

Reviewed the README checkout-admission section and `docs/commit-sweeper.md`; their limits and safety contract remain accurate. Added an Unreleased changelog entry for the fix.

## Evidence

- `pnpm run build:all` passed; 42 focused hydration/JSON tests passed.
- `pnpm run check` passed: 5,951 tests passed, 32 platform-specific skips, zero failures. The first run used an external-drive temporary directory whose writable ancestor correctly failed three scanner-cache tests. An additional local fixture clone failure did not reproduce. An unchanged 27-test replay and the full rerun passed using macOS private temporary storage.
- Independent Codex reviews before commit and on the committed branch found no actionable P0–P2 issues.

## Real Behavior Proof

**Claim and surface:** the actual compiled `ghJsonOnce` capture and `githubReviewTreeBlobSizes` validator accept the projected metadata while preserving complete size accounting.

**Scenario and environment:** Node 24.20.0 and pnpm 11.10.0 on macOS, using authenticated read-only GitHub requests for immutable OpenClaw head `fc10c0d01576e4cb6bdbc117a36e735316465f4c`. The managed probe invoked `ghJsonOnce(["api", endpoint], 30_000)` and the same helper with the emitted `--jq` projection. Immutable local Git objects independently supplied the complete comparison map.

**Observed trace:** the original request failed with `ENOBUFS`; the projected result succeeded in 1.56 seconds. All 13 actual-`gh` loopback controls preserved malformed, truncated, count, size, and overflow behavior. All 379 built artifacts remained unchanged during the probe.

```json
{
  "capture_limit_bytes": 8388608,
  "projected_json_bytes": 3257322,
  "tree_entries": 42215,
  "blob_entries": 40282,
  "unique_blob_sizes": 39848,
  "blob_bytes": 541399666,
  "projected_checkout_bytes": 1082799332,
  "complete_map_sha256": "d2f28112efdbbc40d481456fff98597d00511f5e5183a53e7b634537fcb2109d"
}
```

**Limits:** this proves metadata transport and validation, not a complete hosted model review. The JSON byte count is the helper's trimmed stdout; the subprocess capture limit is unchanged. No workflows, mutation gates, model settings, or authentication configuration were changed.
