### PR TITLE
fix: unblock reviews of large repository trees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Compact large-repository review tree metadata before the bounded GitHub subprocess returns it, preserving checkout admission limits.
+
 - Carry the durable review lease through oversized PR close proposals so direct exact publication can close eligible PRs; queued fallback still keeps PRs open with `skipped_changed_since_review` after lease expiry, pending the follow-up to create the final metadata proposal under publication ownership and re-evaluation at the next event or head.
 
 - Accept the exact-event PR admission handoff for mixed-case target repositories such as fallback-profile repos, whose profile slug is lowercased; the strict repo comparison failed every review of such pull requests after the oversized-PR policy landed.

--- a/src/clawsweeper-context-hydration.ts
+++ b/src/clawsweeper-context-hydration.ts
@@ -1112,7 +1112,18 @@ export function createContextHydration(dependencies: CreateContextHydrationDepen
           remoteTreeSizes ??= githubReviewTreeBlobSizes({
             repository: targetRepo(),
             headSha: options.headSha,
-            request: (path) => ghJsonOnce(["api", path], timeoutMs),
+            // Full tree paths and URLs can exceed ghOnce's output cap. Keep all
+            // entries and malformed shapes for the existing metadata guards.
+            request: (path) =>
+              ghJsonOnce(
+                [
+                  "api",
+                  path,
+                  "--jq",
+                  '{truncated,tree:(.tree|if type=="array" then map(if type=="object" then {type,sha,size} else . end) else . end)}',
+                ],
+                timeoutMs,
+              ),
           });
           return new Map(
             objectIds.flatMap((objectId) => {

--- a/test/review-blob-hydration.test.ts
+++ b/test/review-blob-hydration.test.ts
@@ -27,6 +27,7 @@ import {
   materializePullRequestReviewTreeForTest,
   removePullRequestReviewTree,
   REVIEW_TREE_MAX_BYTES,
+  REVIEW_TREE_MAX_FILES,
   ReviewGitError,
 } from "../dist/clawsweeper-review-blobs.js";
 import { MAX_SCAN_BYTES } from "../dist/agent-input-scan.js";
@@ -801,9 +802,15 @@ test("manual live proof admits pinned promisor trees with the requested reposito
         const argv = args[1] ?? [];
         if (argv[0] === "api") {
           metadataCalls++;
-          assert.deepEqual(argv, ["api", `repos/${repo}/git/trees/${fixture.headSha}?recursive=1`]);
+          assert.deepEqual(argv, [
+            "api",
+            `repos/${repo}/git/trees/${fixture.headSha}?recursive=1`,
+            "--jq",
+            '{truncated,tree:(.tree|if type=="array" then map(if type=="object" then {type,sha,size} else . end) else . end)}',
+          ]);
           assert.notEqual(reviewPolicyHashForTest(), profileBefore);
           assert.ok(args[2]?.timeout && args[2].timeout <= 30_000);
+          assert.equal(args[2]?.maxBuffer, 8 * 1024 * 1024);
           if (scenario === "unavailable") throw new Error("fixture metadata unavailable");
           const response = {
             truncated: scenario === "truncated",
@@ -1676,15 +1683,30 @@ test("review tree blob sizes use one bounded recursive-tree request", () => {
       ["d".repeat(40), 34],
     ],
   );
-  assert.throws(
-    () =>
-      githubReviewTreeBlobSizes({
-        repository: "openclaw/clawsweeper",
-        headSha,
-        request: () => ({ truncated: true, tree: [] }),
-      }),
-    /incomplete bounded review tree metadata response/,
-  );
+  for (const [response, message] of [
+    [{ truncated: true, tree: [] }, /incomplete bounded review tree metadata response/],
+    [{ truncated: false, tree: null }, /incomplete bounded review tree metadata response/],
+    [{ truncated: false, tree: { entry: {} } }, /incomplete bounded review tree metadata response/],
+    [{ truncated: false, tree: [null] }, /invalid bounded review tree metadata entry/],
+    [
+      { truncated: false, tree: [{ type: "blob", sha: "c".repeat(40), size: -1 }] },
+      /invalid bounded review tree blob metadata/,
+    ],
+    [
+      { truncated: false, tree: Array(REVIEW_TREE_MAX_FILES + 1).fill({ type: "tree" }) },
+      /bounded review tree metadata response exceeded its entry limit/,
+    ],
+  ] as const) {
+    assert.throws(
+      () =>
+        githubReviewTreeBlobSizes({
+          repository: "openclaw/clawsweeper",
+          headSha,
+          request: () => response,
+        }),
+      message,
+    );
+  }
 });
 
 test("large pinned deltas hydrate historical blobs after head checkout and produce the full offline binary patch", (t) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where reviews of large repositories fail during checkout preparation even though the repository is within the existing workspace limits. This blocked [OpenClaw #143557](https://github.com/openclaw/openclaw/pull/143557) in [two](https://github.com/openclaw/clawsweeper/actions/runs/34423162142) [review runs](https://github.com/openclaw/clawsweeper/actions/runs/34424179691): the complete GitHub tree response exceeds the metadata subprocess's 8 MiB output limit.

## Why This Change Was Made

Project only the bounded materialization request to the fields its validator consumes: `truncated` and each entry's `type`, `sha`, and `size`. Preserve every entry, its order, and malformed shapes so existing rejection and byte-accounting rules still apply. The sibling request retains its ETag behavior; output, deadline, file-count, and checkout limits are unchanged.

## User Impact

Large-repository reviews can finish metadata acquisition within the existing limits. Later checkout and review gates still apply.

## OpenClaw Bay Impact

No Bay changes are needed. The request projection changes no public status fields, dashboard routes, queue events, or publication contracts.

## Documentation Impact

Reviewed `AGENTS.md`, `CONTRIBUTING.md`, and the documentation ownership index. Existing admission and workflow contracts remain accurate; added the fix to the current unreleased changelog.

## Evidence

- Focused caller/validator proof passes: seven leaf cases (eight TAP nodes including the parent). Existing malformed-entry, truncated-tree, count, and size guards remain covered.
- Static checks, all three builds, lint, and 13 changed-coverage cases passed. Independent Codex review found no actionable findings through P2.
- The full local check was interrupted after observed host disk exhaustion. An existing 4,097-event producer test had reported a failure without its buffered diagnostic; that failure remains unclassified. Exact-head CI must complete the full check before landing.

## Real Behavior Proof

**Claim and surface:** an actual `gh api` subprocess can read the complete pinned OpenClaw tree under the same 8 MiB/30-second bounds. This is a read-only GitHub request, exercised with Node 26.8.1 on macOS.

The executed driver read the projection from the changed materialization owner and invoked `spawnSync("gh", args, { encoding: "utf8", maxBuffer: 8388608, timeout: 30000, stdio: ["ignore", "pipe", "pipe"] })`.

Before, `args` contained `api` and `repos/openclaw/openclaw/git/trees/06f2c068434ef80c416b6de3966ac5a14d959536?recursive=1`. After, it appended `--jq` and the exact projection in this patch.

| Observation | Before | After |
| --- | --- | --- |
| Subprocess | `ENOBUFS`, `SIGTERM` | exit 0 |
| Complete response size | 10,690,338 bytes | 3,259,332 bytes |
| Metadata | Complete source response retained for comparison | All 42,241 ordered entry facts and 39,872 distinct blob-size mappings identical; `truncated: false` |

The retained result records bind the production source and output hashes. Seven additional local jq observations preserve malformed shapes and oversized entry counts for the unchanged validator.

**Limits:** the local process exposes `ENOBUFS`; the hosted failures wrapped their underlying exception, so their exact errno was not observed. This proves metadata acquisition and fidelity, not completion of a hosted review or unlimited future repository growth. No live apply, queue mutation, credentials change, or deployment was part of the proof.
