### PR TITLE
fix(review): project bounded tree metadata at source

### DIFF
--- a/src/clawsweeper-context-hydration.ts
+++ b/src/clawsweeper-context-hydration.ts
@@ -45,6 +45,9 @@ import { isGitHubNotFoundError } from "./github-retry.js";
 import { type RepositoryProfile } from "./repository-profiles.js";
 import { compareCodeUnits, stableJson } from "./stable-json.js";
 
+const REVIEW_TREE_METADATA_JQ =
+  '{truncated, tree: (.tree | if type == "array" then map(if type == "object" then {type, sha, size} else . end) else . end)}';
+
 interface CreateContextHydrationDependencies {
   asRecord: (value: unknown) => Record<string, unknown>;
   CLAWSWEEPER_BOT_AUTHORS: Set<string>;
@@ -984,7 +987,7 @@ export function createContextHydration(dependencies: CreateContextHydrationDepen
         const sizes = githubReviewTreeBlobSizes({
           repository: targetRepo(),
           headSha: revision,
-          request: (path) => ghJson(["api", path]),
+          request: (path) => ghJson(["api", path, "--jq", REVIEW_TREE_METADATA_JQ]),
         });
         remoteTreeSizes.set(revision, sizes);
         return sizes;
@@ -1114,15 +1117,7 @@ export function createContextHydration(dependencies: CreateContextHydrationDepen
             headSha: options.headSha,
             // Path and URL metadata can exceed the CLI capture limit before admission runs.
             request: (path) =>
-              ghJsonOnce(
-                [
-                  "api",
-                  path,
-                  "--jq",
-                  '{truncated, tree: (.tree | if type == "array" then map(if type == "object" then {type, sha, size} else . end) else . end)}',
-                ],
-                timeoutMs,
-              ),
+              ghJsonOnce(["api", path, "--jq", REVIEW_TREE_METADATA_JQ], timeoutMs),
           });
           return new Map(
             objectIds.flatMap((objectId) => {

--- a/test/review-blob-hydration.test.ts
+++ b/test/review-blob-hydration.test.ts
@@ -1523,6 +1523,10 @@ test("source preparation reports unavailable historical blobs before restricted 
         targetRepo: () => "fixture/repository",
         ghJson: (args: string[]) => {
           assert.equal(args[0], "api");
+          assert.deepEqual(args.slice(2), [
+            "--jq",
+            '{truncated, tree: (.tree | if type == "array" then map(if type == "object" then {type, sha, size} else . end) else . end)}',
+          ]);
           const revision = args[1]?.match(/\/git\/trees\/([0-9a-f]+)\?recursive=1$/)?.[1];
           assert.ok(revision);
           const tree = git(fixture.source, "ls-tree", "-r", "-l", revision)


### PR DESCRIPTION
## What this fixes

#1519 projected the Git Trees response used by final review-tree materialization, but exact-review source hydration has a separate recursive-tree call. Wave 13 still failed there before admission.

Apply #1519's validated projection to that remaining source-hydration call and share the projection constant between both paths. The projection preserves malformed entries for downstream rejection while removing unused path/URL fields from production-sized responses.

## Evidence

- `pnpm run build && node --test test/review-blob-hydration.test.ts` — 33 passed, including #1519's >8 MB capture regression and a new exact source-hydration argument assertion
- format, all builds, all lint, and changed-coverage stages — passed
- P3 exact-commit autoreview — clean, 0.99
- live OpenClaw tree: 10,692,481 bytes raw → 3,110,958 bytes projected; blob SHA/size inventory preserved

## Production historical-hydration proof

Ran the exact PR head `270b2471a67a9fcf8e978718546fbc745b9f1be6` locally on macOS against the real OpenClaw checkout and PR #143533:

```text
pnpm run review -- --local-only \
  --target-repo openclaw/openclaw \
  --item-number 143533 \
  --target-dir /Users/dallin/openclaw-wave13-completion \
  --output-retention summary \
  --result-format json \
  --codex-timeout-ms 120000
```

Observed completion:

- source/context hydration completed in 12,146 ms
- pinned base/merge-base `46af4a9582b34444d11cc98310838060e1aae5ca`
- pinned PR head `4cc522493abf6cbacafc272251d832d52a2ed2a3`
- fetched current-main comparison `1baeb74f01730d183e3500163f741ca235e2d6fc`
- review completed successfully in 1m 58s with `decision: keep_open`, `confidence: high`, and no findings
- retained summary artifact: `artifacts/local-review-143533/143533.md`
- checkout inspection verified; review status complete; terminal failure false

The run used the normal production source-preparation path and retained the existing admission limits: 200,000 files / 2 GiB projected and actual checkout usage, plus the 1 GiB filesystem reserve. No limit was raised or bypassed.
