### PR TITLE
fix: refresh durable markers for unchanged re-reviews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Refresh durable review freshness after unchanged exact-head re-reviews while preserving idempotent publication retries, and record bounded activity-cursor diagnostics for drift-blocked publication.
+
 - Preserve bounded, recognized command-intake HTTP failure codes in review-request diagnostics without exposing raw responses or changing retry behavior.
 
 - Refresh markdown-it to 15.0.1 and Playwright to 1.63.0, retaining the repository's release-age policy and Node 24 runtime floor.

--- a/docs/pr-review-comments.md
+++ b/docs/pr-review-comments.md
@@ -31,6 +31,20 @@ Each synced comment includes the durable identity marker:
 ClawSweeper edits that comment in place instead of posting repeated comments.
 Report front matter stores the synced comment id, URL, hash, and sync time.
 
+A newly completed exact-head re-review refreshes the existing comment's
+`reviewed_at` and review-version marker even when its verdict and prose are
+unchanged. Reapplying that same completed review remains idempotent; item-update
+and lease-only metadata do not independently require a comment rewrite.
+
+ClawSweeper-owned placeholders, acknowledgements, lease comments, and edits to
+those comments are excluded from reviewed discussion/source activity. Human
+comments quoting the same markers remain source activity. The separate PR
+review-activity cursor covers PR reviews, inline comments, and review
+thread resolution, not ordinary issue comments. When that cursor changes, apply
+logs `reviewed_pr_activity_cursor_drift` with the expected and two observed
+version/count/digest cursors, distinguishing stable drift from a change between
+reads. It never logs review bodies and still refuses publication on drift.
+
 Explicit manual reports carry `publication_policy: record_comment_only`. Their
 publisher permits the selected durable comment and canonical report/plan/packet
 tuple, plus owned coordination. It suppresses automation action markers and

--- a/scripts/e2e/exact-review-freshness.mjs
+++ b/scripts/e2e/exact-review-freshness.mjs
@@ -1,0 +1,465 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { execFileSync, spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { createServer } from "node:http";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { stripTypeScriptTypes } from "node:module";
+import { parseArgs } from "node:util";
+import {
+  itemSourceRevisionSha256ForTest,
+  renderReviewCommentFromReport,
+  renderReviewStartStatusComment,
+} from "../../dist/clawsweeper.js";
+import { createReviewedPrActivityCursorV2 } from "../../dist/review-activity-cursor.js";
+
+const source = resolve(import.meta.dirname, "../..");
+const { values } = parseArgs({
+  options: {
+    gh: { type: "string" },
+    output: { type: "string" },
+    "baseline-ref": { type: "string" },
+  },
+});
+assert.ok(values.gh?.startsWith("/"), "--gh must select the absolute stock GitHub CLI path");
+assert.ok(values.output, "--output must select a new evidence directory");
+const output = resolve(values.output);
+assert.ok(!existsSync(output), "refusing to overwrite proof evidence");
+mkdirSync(output, { recursive: true });
+const socketRoot = realpathSync(mkdtempSync(join(tmpdir(), "review-proof-")));
+const root = join(output, "runtime");
+mkdirSync(root);
+for (const name of ["dist", "config", "schema", "prompts", "package.json"])
+  cpSync(join(source, name), join(root, name), { recursive: true });
+symlinkSync(join(source, "node_modules"), join(root, "node_modules"), "dir");
+if (values["baseline-ref"]) {
+  // Recompile only this repair's owner from the specified Git revision in the disposable runtime.
+  const prior = execFileSync(
+    "git",
+    ["show", `${values["baseline-ref"]}:src/clawsweeper-review-comment-state.ts`],
+    { cwd: source, encoding: "utf8" },
+  );
+  writeFileSync(
+    join(root, "dist/clawsweeper-review-comment-state.js"),
+    stripTypeScriptTypes(prior, { mode: "transform" }),
+  );
+}
+const hash = (value) => createHash("sha256").update(value).digest("hex");
+const repo = "openclaw/openclaw";
+const number = 321;
+const head = "a".repeat(40);
+const durableId = 9321;
+const leaseId = 700321;
+const leaseOwner = "exact-review-freshness-proof";
+const minute = Math.floor((Date.now() - 120_000) / 60_000) * 60_000;
+const reviewedAt = new Date(minute + 45_000).toISOString();
+const itemUpdatedAt = new Date(minute - 120_000).toISOString();
+const churnAt = new Date(minute + 50_000).toISOString();
+const humanReview = {
+  id: 7001,
+  user: { login: "fixture-reviewer" },
+  state: "COMMENTED",
+  body: "Earlier synthetic review.",
+  submitted_at: "2026-09-04T00:00:00Z",
+  commit_id: head,
+};
+const cursor = createReviewedPrActivityCursorV2({
+  reviews: [humanReview],
+  inlineComments: [],
+  reviewThreads: [],
+});
+const issue = {
+  number,
+  title: "Synthetic exact review freshness",
+  body: "A synthetic unchanged patch.",
+  html_url: `https://github.com/${repo}/pull/${number}`,
+  created_at: "2026-09-01T00:00:00Z",
+  updated_at: itemUpdatedAt,
+  state: "open",
+  locked: false,
+  author_association: "CONTRIBUTOR",
+  user: { login: "fixture-author" },
+  labels: ["rating: 🧂 unranked krab", "status: 📣 needs proof"],
+  pull_request: { url: `https://api.github.com/repos/${repo}/pulls/${number}` },
+};
+const revision = itemSourceRevisionSha256ForTest(issue, []);
+let kind = "pull_request";
+const baseReport = (time, lease) => `---
+repository: ${repo}
+number: ${number}
+type: ${kind}
+title: ${issue.title}
+url: ${issue.html_url}
+author: fixture-author
+author_association: CONTRIBUTOR
+reviewed_at: ${time}
+item_updated_at: ${itemUpdatedAt}
+item_snapshot_hash: synthetic-proof-snapshot
+item_source_revision: ${revision}
+review_timeline_revision: ${hash("[]")}
+review_activity_cursor: ${cursor}
+${kind === "pull_request" ? `pull_head_sha: ${head}\n` : ""}review_lease_owner: ${leaseOwner}
+review_lease_comment_id: ${lease}
+review_status: complete
+local_checkout_access: verified
+local_checkout_access_source: runner_preflight_v1
+decision: keep_open
+action_taken: kept_open
+close_reason: none
+confidence: high
+work_candidate: none
+work_status: none
+labels: ${JSON.stringify(issue.labels)}
+---
+
+## Summary
+
+Synthetic unchanged review.
+`;
+const render = (report) =>
+  `${renderReviewCommentFromReport(report, "none").trimEnd()}\n\n<!-- clawsweeper-review item=${number} -->`;
+let comments = [];
+let phase;
+const trace = [];
+const results = [];
+let nextCommentId = leaseId + 100;
+const comment = (id, body, updatedAt) => ({
+  id,
+  html_url: `${issue.html_url}#issuecomment-${id}`,
+  user: { login: "clawsweeper[bot]" },
+  created_at: updatedAt,
+  updated_at: updatedAt,
+  body,
+});
+const server = createServer(async (request, response) => {
+  let event;
+  try {
+    const chunks = [];
+    for await (const chunk of request) chunks.push(chunk);
+    const raw = Buffer.concat(chunks).toString();
+    const body = raw ? JSON.parse(raw) : undefined;
+    const url = new URL(request.url, "http://proof.invalid");
+    const path = url.pathname.replace(/^\/api\/v3/, "").replace(/^\/api\/graphql$/, "/graphql");
+    event = { phase, method: request.method, path, ...(body ? { body } : {}) };
+    trace.push(event);
+    const send = (value, code = 200) => {
+      response.writeHead(code, { "content-type": "application/json" });
+      response.end(code === 204 ? "" : JSON.stringify(value));
+    };
+    if (path === "/graphql") {
+      if (body.query.includes("closedByPullRequestsReferences"))
+        return send({
+          data: {
+            repository: {
+              hasIssuesEnabled: true,
+              issue: { number, closedByPullRequestsReferences: { nodes: [] } },
+            },
+          },
+        });
+      const connection = (nodes) => ({
+        totalCount: nodes.length,
+        pageInfo: { hasNextPage: false },
+        nodes,
+      });
+      assert.match(body.query, /ReviewedPrActivityCursorV2/);
+      return send({
+        data: {
+          repository: {
+            [`pr_${number}`]: {
+              reviews: connection([
+                {
+                  fullDatabaseId: String(humanReview.id),
+                  author: humanReview.user,
+                  state: humanReview.state,
+                  body: humanReview.body,
+                  submittedAt: humanReview.submitted_at,
+                  commit: { oid: head },
+                },
+              ]),
+              reviewThreads: connection([]),
+            },
+          },
+        },
+      });
+    }
+    const prefix = `/repos/${repo}`;
+    if (path === "/search/issues") return send({ items: [] });
+    if (path === `${prefix}/issues/${number}/comments`) {
+      if (request.method === "GET") return send(comments);
+      assert.equal(request.method, "POST");
+      const created = comment(++nextCommentId, body.body, new Date().toISOString());
+      comments.push(created);
+      issue.updated_at = created.updated_at;
+      return send(created, 201);
+    }
+    const commentId = /^\/repos\/openclaw\/openclaw\/issues\/comments\/(\d+)$/.exec(path)?.[1];
+    if (commentId) {
+      const selected = comments.find((entry) => entry.id === Number(commentId));
+      assert.ok(selected, "comment target must exist");
+      if (request.method === "GET") return send(selected);
+      if (request.method === "DELETE") {
+        assert.notEqual(selected.id, durableId, "durable review cannot be deleted");
+        comments = comments.filter((entry) => entry !== selected);
+        return send(null, 204);
+      }
+      assert.equal(request.method, "PATCH");
+      selected.body = body.body;
+      selected.updated_at = new Date().toISOString();
+      issue.updated_at = selected.updated_at;
+      return send(selected);
+    }
+    assert.equal(request.method, "GET", "only comment mutations are allowed");
+    if (path === `${prefix}/issues/${number}`) return send({ ...issue, comments: comments.length });
+    if (path === `${prefix}/pulls/${number}`)
+      return send({
+        ...issue,
+        comments: comments.length,
+        changed_files: 0,
+        commits: 0,
+        review_comments: 0,
+        draft: false,
+        merged: false,
+        head: { sha: head, ref: "fixture", repo: { full_name: repo } },
+        base: { sha: "b".repeat(40), ref: "main", repo: { full_name: repo } },
+      });
+    if (path === `${prefix}/issues/${number}/timeline`)
+      return send(
+        comments.map((entry) => ({
+          id: entry.id,
+          event: "commented",
+          actor: entry.user,
+          created_at: entry.created_at,
+        })),
+      );
+    if (path === `${prefix}/pulls/${number}/reviews`) return send([humanReview]);
+    if (
+      ["files", "commits", "comments"].some((kind) => path === `${prefix}/pulls/${number}/${kind}`)
+    )
+      return send([]);
+    if (path === `${prefix}/commits/${head}/check-runs`)
+      return send({ total_count: 0, check_runs: [] });
+    if (path === `${prefix}/commits/${head}/status`) return send({ total_count: 0, statuses: [] });
+    throw new Error(`unsupported proof request ${request.method} ${path}`);
+  } catch (error) {
+    if (event) event.error = error.message;
+    response.writeHead(500, { "content-type": "application/json" });
+    response.end(JSON.stringify({ message: error.message }));
+  }
+});
+const env = {
+  PATH: `${dirname(process.execPath)}:/usr/bin:/bin`,
+  HOME: root,
+  GH_CONFIG_DIR: join(root, "gh-config"),
+  GH_HOST: "proof.invalid",
+  GH_ENTERPRISE_TOKEN: "synthetic-proof-token",
+  GH_PROMPT_DISABLED: "1",
+  GH_NO_UPDATE_NOTIFIER: "1",
+  GH_NO_EXTENSION_UPDATE_NOTIFIER: "1",
+  GH_BIN: values.gh,
+  CLAWSWEEPER_ACTION_LEDGER_DISABLED: "1",
+  CLAWSWEEPER_GH_RETRY_ATTEMPTS: "1",
+  TMPDIR: root,
+};
+async function command(file, args) {
+  const child = spawn(file, args, { cwd: root, env, stdio: ["ignore", "pipe", "pipe"] });
+  let stdout = "",
+    stderr = "";
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk;
+  });
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+  const timeout = setTimeout(() => child.kill("SIGKILL"), 60_000);
+  try {
+    const code = await new Promise((done, reject) => {
+      child.once("error", reject);
+      child.once("close", done);
+    });
+    assert.equal(code, 0, `${stdout}\n${stderr}`);
+    return { code, stdout, stderr };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+try {
+  const socket = join(socketRoot, "gh.sock");
+  await new Promise((ready) => server.listen(socket, ready));
+  await command(values.gh, ["config", "set", "http_unix_socket", socket]);
+  for (const [name, itemKind, oldReviewedAt] of [
+    ["same-minute-issue", "issue", new Date(minute + 5_000).toISOString()],
+    ["same-minute-pr", "pull_request", new Date(minute + 5_000).toISOString()],
+    ["expired-pr", "pull_request", new Date(minute - 24 * 60 * 60 * 1000).toISOString()],
+  ]) {
+    kind = itemKind;
+    issue.pull_request =
+      kind === "pull_request"
+        ? { url: `https://api.github.com/repos/${repo}/pulls/${number}` }
+        : null;
+    issue.html_url = `https://github.com/${repo}/${kind === "pull_request" ? "pull" : "issues"}/${number}`;
+    issue.labels =
+      kind === "pull_request"
+        ? ["rating: 🧂 unranked krab", "status: 📣 needs proof"]
+        : ["issue-rating: 🧂 unranked krab"];
+    const scenario = join(root, name);
+    const items = join(scenario, "items");
+    mkdirSync(items, { recursive: true });
+    const oldBody = render(baseReport(oldReviewedAt, leaseId - 1));
+    comments = [
+      comment(durableId, oldBody, oldReviewedAt),
+      comment(
+        leaseId,
+        renderReviewStartStatusComment({
+          number,
+          kind,
+          title: issue.title,
+          headSha: kind === "pull_request" ? head : revision,
+          startedAt: new Date(minute).toISOString(),
+          leaseExpiresAt: new Date(Date.now() + 30 * 60_000).toISOString(),
+          leaseOwner,
+        }),
+        churnAt,
+      ),
+      comment(
+        leaseId + 1,
+        `Waiting for review.\n<!-- clawsweeper-command-status:${number}:re_review:fixture -->`,
+        churnAt,
+      ),
+    ];
+    issue.updated_at = churnAt;
+    comments[0].updated_at = churnAt;
+    const report = baseReport(reviewedAt, leaseId).replace(
+      /^---\n/,
+      `---\nreview_comment_id: ${durableId}\nreview_comment_url: ${issue.html_url}#issuecomment-${durableId}\nreview_comment_sha256: ${hash(oldBody)}\nreview_comment_synced_at: ${oldReviewedAt}\n`,
+    );
+    writeFileSync(join(items, `${number}.md`), report);
+    const args = [
+      join(root, "dist/clawsweeper.js"),
+      "apply-decisions",
+      "--target-repo",
+      repo,
+      "--skip-dashboard",
+      "--item-number",
+      String(number),
+      "--items-dir",
+      items,
+      "--closed-dir",
+      join(scenario, "closed"),
+      "--plans-dir",
+      join(scenario, "plans"),
+      "--report-path",
+      join(scenario, "apply-report.json"),
+      "--sync-comments-only",
+      "--comment-sync-min-age-days",
+      "0",
+      "--limit",
+      "0",
+      "--close-delay-ms",
+      "0",
+    ];
+    phase = `${name}:publish`;
+    const applied = await command(process.execPath, args);
+    writeFileSync(join(output, `${name}-publish.log`), `${applied.stdout}\n${applied.stderr}`);
+    const publishResult = JSON.parse(readFileSync(join(scenario, "apply-report.json"), "utf8"));
+    writeFileSync(
+      join(output, `${name}-published-report.md`),
+      readFileSync(join(items, `${number}.md`)),
+    );
+    assert.equal(publishResult[0]?.action, "review_comment_synced");
+    const published = comments.find((entry) => entry.id === durableId);
+    writeFileSync(
+      join(output, `${name}-publication.json`),
+      `${JSON.stringify(
+        {
+          reviewStateBaselineRef: values["baseline-ref"] ?? null,
+          publishResult,
+          durableId,
+          expectedReviewedAt: reviewedAt,
+          actualVersionMarker: published.body.match(/<!-- clawsweeper-review-version[^>]*-->/)?.[0],
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    assert.match(
+      published.body,
+      new RegExp(
+        `clawsweeper-review-version item=${number} reviewed_at=${reviewedAt.replaceAll(".", "\\.")} sha=${kind === "pull_request" ? head : "na"}`,
+      ),
+    );
+    const patches = () =>
+      trace.filter(
+        (entry) => entry.method === "PATCH" && entry.path.endsWith(`/comments/${durableId}`),
+      );
+    assert.equal(patches().filter((entry) => entry.phase === phase).length, 1);
+    const bodyAfterPublication = published.body;
+    const ack = comments.find((entry) => entry.id === leaseId + 1);
+    ack.body = `Review completed.\n<!-- clawsweeper-command-status:${number}:re_review:fixture -->`;
+    ack.updated_at = new Date().toISOString();
+    issue.updated_at = ack.updated_at;
+    phase = `${name}:retry`;
+    const retried = await command(process.execPath, args);
+    writeFileSync(join(output, `${name}-retry.log`), `${retried.stdout}\n${retried.stderr}`);
+    assert.equal(
+      patches().filter((entry) => entry.phase === phase).length,
+      0,
+      "same report must not rewrite the durable review",
+    );
+    assert.equal(comments.find((entry) => entry.id === durableId).body, bodyAfterPublication);
+    const retryResult = JSON.parse(readFileSync(join(scenario, "apply-report.json"), "utf8"));
+    assert.deepEqual(
+      retryResult,
+      [],
+      "same completed report remains outside the publication queue",
+    );
+    assert.equal(itemSourceRevisionSha256ForTest(issue, comments), revision);
+    results.push({
+      name,
+      kind,
+      oldReviewedAt,
+      reviewedAt,
+      head: kind === "pull_request" ? head : null,
+      durableId,
+      durablePatches: 1,
+      retryPatches: 0,
+      publishResult,
+      retryResult,
+    });
+  }
+  assert.ok(
+    trace.every((entry) => !entry.error),
+    "all loopback requests must be understood",
+  );
+  const summary = {
+    provider: "local-controlled-subprocess",
+    node: process.version,
+    head: execFileSync("git", ["rev-parse", "HEAD"], { cwd: source, encoding: "utf8" }).trim(),
+    scriptSha256: hash(readFileSync(new URL(import.meta.url))),
+    reviewStateBuildSha256: hash(
+      readFileSync(join(root, "dist/clawsweeper-review-comment-state.js")),
+    ),
+    reviewStateBaselineRef: values["baseline-ref"] ?? null,
+    results,
+    limits:
+      "Built apply-decisions CLI and stock gh CLI against synthetic local HTTP over a Unix socket. No hosted GitHub, cloud queue, new Codex review, merge, or deployment exercised. No container or cloud lease.",
+  };
+  writeFileSync(join(output, "summary.json"), `${JSON.stringify(summary, null, 2)}\n`);
+  console.log(JSON.stringify(summary, null, 2));
+} finally {
+  writeFileSync(join(output, "http-trace.json"), `${JSON.stringify(trace, null, 2)}\n`);
+  await new Promise((done) => server.close(done));
+  rmSync(socketRoot, { recursive: true, force: true });
+  rmSync(root, { recursive: true, force: true });
+}

--- a/src/clawsweeper-apply-review-activity.ts
+++ b/src/clawsweeper-apply-review-activity.ts
@@ -24,21 +24,38 @@ export function createApplyReviewActivityGuard(
     if (!isReviewedPrActivityCursor(expectedCursor)) {
       return "stored pull request review activity cursor is missing or invalid; fresh review required";
     }
-    try {
-      const currentCursor = readStableReviewedPrActivityCursor(() =>
-        fetchReviewedPrActivityCursor(number),
+    const observedCursors: Array<string | null> = [];
+    const recordDrift = (reason: "changed" | "unstable") => {
+      const diagnosticCursor = (cursor: string | null) =>
+        cursor && cursor.length <= 80 && isReviewedPrActivityCursor(cursor) ? cursor : null;
+      console.error(
+        JSON.stringify({
+          event: "reviewed_pr_activity_cursor_drift",
+          number,
+          reason,
+          expected_cursor: diagnosticCursor(expectedCursor),
+          observed_cursors: observedCursors.map(diagnosticCursor),
+        }),
       );
+      return "pull request review activity changed since review";
+    };
+    try {
+      const currentCursor = readStableReviewedPrActivityCursor(() => {
+        const cursor = fetchReviewedPrActivityCursor(number);
+        observedCursors.push(cursor);
+        return cursor;
+      });
       if (!currentCursor) return "pull request review activity exceeds the bounded reviewed cursor";
       const comparison = compareReviewedPrActivityCursors(expectedCursor, currentCursor);
       if (comparison === "rebaseline") {
         return "stored pull request review activity cursor version requires a fresh review";
       }
-      if (comparison === "changed") return "pull request review activity changed since review";
+      if (comparison === "changed") return recordDrift("changed");
       return null;
     } catch (error) {
       if (error instanceof GitHubRuntimeBudgetError) throw error;
       if (error instanceof ReviewedPrActivityChangedDuringReadError) {
-        return "pull request review activity changed since review";
+        return recordDrift("unstable");
       }
       const detail = trimMiddle(
         (error instanceof Error ? error.message : String(error)).replace(/\s+/g, " "),

--- a/src/clawsweeper-review-comment-state.ts
+++ b/src/clawsweeper-review-comment-state.ts
@@ -24,10 +24,10 @@ import { neutralizeReviewControlMarkers } from "./review-history.js";
 import type { ReviewCommentWorkflowDependencies } from "./clawsweeper-review-comment-dependencies.js";
 
 export function normalizeNoopReviewMarkerMetadata(body: string): string {
+  // A completed re-review must publish its freshness even when the verdict is unchanged.
   return body.replace(
     /<!--\s+clawsweeper-(?:review-version|verdict:[^\s>]+|action:[^\s>]+|security:[^\s>]+)\b[^>]*-->/g,
-    (marker) =>
-      marker.replace(/\s(?:reviewed_at|updated_at|lease_owner|lease_comment_id)=[^\s>]+/g, ""),
+    (marker) => marker.replace(/\s(?:updated_at|lease_owner|lease_comment_id)=[^\s>]+/g, ""),
   );
 }
 import type { createReviewCommentIdentity } from "./clawsweeper-review-comment-identity.js";

--- a/test/review-activity-cursor.test.ts
+++ b/test/review-activity-cursor.test.ts
@@ -237,6 +237,52 @@ test("v1 to v2 migration explicitly re-baselines instead of reporting activity c
   );
 });
 
+test("apply cursor drift distinguishes a changed snapshot from an unstable read without logging content", (t) => {
+  const expectedCursor = v2Cursor();
+  const changedCursor = v2Cursor({ reviewState: "DISMISSED" });
+  const messages: string[] = [];
+  t.mock.method(console, "error", (message: string) => messages.push(message));
+  for (const scenario of [
+    { reads: [expectedCursor, expectedCursor], reason: null },
+    { reads: [changedCursor, changedCursor], reason: "changed" },
+    { reads: [expectedCursor, changedCursor], reason: "unstable" },
+    { reads: [expectedCursor, "untrusted response content"], reason: "unstable" },
+  ]) {
+    let reads = 0;
+    messages.length = 0;
+    const guard = createApplyReviewActivityGuard(
+      {
+        fetchReviewedPrActivityCursor: () => scenario.reads[reads++] ?? null,
+        GitHubRuntimeBudgetError: class extends Error {
+          readonly reason = "test";
+        },
+      },
+      { expectedCursor: expectedCursor ?? undefined, itemKind: "pull_request", number: 42 },
+    );
+    assert.equal(
+      guard(),
+      scenario.reason ? "pull request review activity changed since review" : null,
+    );
+    assert.equal(reads, 2);
+    assert.deepEqual(
+      messages.map((message) => JSON.parse(message)),
+      scenario.reason
+        ? [
+            {
+              event: "reviewed_pr_activity_cursor_drift",
+              number: 42,
+              reason: scenario.reason,
+              expected_cursor: expectedCursor,
+              observed_cursors: scenario.reads.map((cursor) =>
+                isReviewedPrActivityCursor(cursor) ? cursor : null,
+              ),
+            },
+          ]
+        : [],
+    );
+  }
+});
+
 test("v2 query aliases a bounded PR batch and decoder fails closed", () => {
   const query = reviewedPrActivityCursorV2Query(
     "openclaw",

--- a/test/review-comment-noise.test.ts
+++ b/test/review-comment-noise.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { filterReviewComments } from "../dist/clawsweeper-review-comments.js";
+import {
+  itemSourceRevisionSha256ForTest,
+  renderReviewStartStatusComment,
+} from "../dist/clawsweeper.js";
 
 const context = {
   isClawSweeperComment(value: unknown): boolean {
@@ -13,17 +17,41 @@ const context = {
 };
 
 test("automatic receipt and review-progress comments do not enter review context", () => {
+  const issue = { title: "Review publication", body: "Same source", labels: [] };
+  const sourceRevision = itemSourceRevisionSha256ForTest(issue, []);
   for (const login of ["clawsweeper", "clawsweeper[bot]", "openclaw-clawsweeper[bot]"]) {
     for (const body of [
       "<!-- clawsweeper-pr-ack:opened item=42 -->\nClawSweeper picked this up.",
       "<!-- clawsweeper-review-progress:start -->\nReview in progress.",
       "<!-- clawsweeper-review-progress:start -->\nBlocked; no review verdict was produced.",
       "Review completed.\n<!-- clawsweeper-review-progress:end -->",
+      "Queued.\n<!-- clawsweeper-command-status:42:re_review:fixture -->",
+      "Acknowledged.\n<!-- clawsweeper-command-ack:42:fixture -->",
+      renderReviewStartStatusComment({
+        number: 42,
+        kind: "pull_request",
+        title: issue.title,
+        headSha: "a".repeat(40),
+        startedAt: "2026-09-09T19:53:58Z",
+        leaseOwner: "fixture-review",
+      }),
     ]) {
-      assert.deepEqual(filterReviewComments([{ user: { login }, body }], 42, context), {
+      const comment = { id: 123, user: { login }, body, updated_at: "2026-09-09T19:53:58Z" };
+      assert.deepEqual(filterReviewComments([comment], 42, context), {
         included: [],
         filtered: 1,
       });
+      assert.equal(itemSourceRevisionSha256ForTest(issue, [comment]), sourceRevision);
+      assert.equal(
+        itemSourceRevisionSha256ForTest(issue, [
+          {
+            ...comment,
+            body: `${body}\nUpdated status.`,
+            updated_at: "2026-09-09T19:57:00Z",
+          },
+        ]),
+        sourceRevision,
+      );
     }
   }
 });
@@ -39,6 +67,10 @@ test("human discussion quoting automatic status markers remains in review contex
     included: [human],
     filtered: 0,
   });
+  assert.notEqual(
+    itemSourceRevisionSha256ForTest({}, [human]),
+    itemSourceRevisionSha256ForTest({}, []),
+  );
 });
 
 test("substantive unmarked bot discussion is not removed with automatic status noise", () => {

--- a/test/review-comment-noop.test.ts
+++ b/test/review-comment-noop.test.ts
@@ -5,15 +5,23 @@ import { normalizeNoopReviewMarkerMetadata } from "../dist/clawsweeper-review-co
 const marker = () =>
   `<!-- clawsweeper-review-version item=41 reviewed_at=2026-08-09T21:12:00Z sha=na source_revision=${"a".repeat(64)} lease_owner=run-1 lease_comment_id=101 v=1 -->`;
 
-test("no-op public identity ignores only review clock and lease metadata", () => {
+test("no-op public identity ignores only item update and lease metadata", () => {
   const prior = marker();
   const refreshed = prior
-    .replace("21:12:00", "21:32:00")
+    .replace(" v=1", " updated_at=2026-08-09T21:32:00Z v=1")
     .replace("run-1", "run-2")
     .replace("101", "102");
   assert.equal(
     normalizeNoopReviewMarkerMetadata(prior),
     normalizeNoopReviewMarkerMetadata(refreshed),
+  );
+});
+
+test("a completed re-review retains its freshness in the public identity", () => {
+  const prior = marker();
+  assert.notEqual(
+    normalizeNoopReviewMarkerMetadata(prior),
+    normalizeNoopReviewMarkerMetadata(prior.replace("21:12:00", "21:32:00")),
   );
 });
 

--- a/test/review-comment-publication.test.ts
+++ b/test/review-comment-publication.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
+import { shouldSyncReviewComment } from "../dist/clawsweeper.js";
 import { createReviewCommentLeases } from "../dist/clawsweeper-review-comment-leases.js";
 import {
   createReviewCommentPublication,
@@ -167,6 +168,70 @@ function reviewCommentPublication(options: {
     ...options.state,
   } as never);
 }
+
+test("an unchanged exact-head re-review refreshes its durable comment once", () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-review-refresh-"));
+  try {
+    const reviewedAt = "2026-09-09T20:00:00Z";
+    let existing = durableReviewComment({
+      id: 20,
+      reviewedAt: "2026-09-08T17:51:38Z",
+      updatedAt: "2026-09-08T17:52:00Z",
+    });
+    const refreshed = durableReviewComment({
+      id: 20,
+      reviewedAt,
+      updatedAt: "2026-09-08T17:52:00Z",
+      leaseCommentId: 21,
+    });
+    const comments = () => [existing];
+    const state = reviewCommentState(comments);
+    const writes: string[][] = [];
+    const publication = reviewCommentPublication({
+      root,
+      comments,
+      state,
+      mutate: ({ args }) => {
+        writes.push(args);
+        const body = JSON.parse(readFileSync(args[args.indexOf("--input") + 1]!, "utf8")).body;
+        existing = { ...existing, body, updated_at: "2026-09-09T20:01:00Z" };
+        return JSON.stringify(existing);
+      },
+    });
+    const shouldSync = (body: string) =>
+      shouldSyncReviewComment({
+        syncCommentsOnly: false,
+        isCloseProposal: false,
+        commentSyncMinAgeDays: 7,
+        reviewCommentSyncedAt: String(existing.updated_at),
+        reviewedAt,
+        hasExistingReviewComment: true,
+        needsReviewCommentBodySync: !state.commentBodyMatches(existing, body),
+        needsReviewCommentHashSync: !state.reviewCommentHashMatches(
+          existing,
+          body,
+          sha256(String(existing.body)),
+          sha256(body),
+        ),
+        needsReviewCommentReferenceSync: false,
+      });
+
+    assert.equal(shouldSync(String(refreshed.body)), true);
+    const published = publication.upsertReviewComment(itemNumber, String(refreshed.body));
+    assert.equal(writes.length, 1);
+    assert.equal(writes[0]![1], "repos/openclaw/openclaw/issues/comments/20");
+    assert.equal(writes[0]![writes[0]!.indexOf("--method") + 1], "PATCH");
+    assert.equal(state.durableReviewVersion(published, itemNumber)?.reviewedAt, reviewedAt);
+    assert.equal(state.durableReviewVersion(published, itemNumber)?.headSha, headSha);
+    assert.equal(shouldSync(String(refreshed.body)), false);
+    assert.equal(
+      shouldSync(String(refreshed.body).replace("lease_comment_id=21", "lease_comment_id=22")),
+      false,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
 
 test("review version timestamps round-trip through the durable parser", () => {
   const fields: Record<string, string> = {


### PR DESCRIPTION
## What Problem This Solves

Fixes completed re-reviews being treated as unchanged when only the durable marker's `reviewed_at` advances. A same-minute issue re-review can report `review_comment_synced` while retaining the previous review timestamp. The publication equality contract also applies to exact-head PR review markers.

Related investigation: https://github.com/openclaw/openclaw/pull/133693. Its three September 9 `skipped_changed_since_review` results are **not causally explained by this timestamp bug**. The activity cursor excludes ordinary issue comments already, and a later run published on the same ClawSweeper revision before the PR merged. The failed runs did not retain their compared cursor values.

## Why This Change Was Made

Keep `reviewed_at` in durable-comment equality while continuing to ignore item-update and lease-only metadata. A newly completed review updates the existing comment; retrying that same report remains idempotent. Add bounded cursor diagnostics distinguishing stable snapshot drift from a change between the guard's two reads. Publication refusal, leases, and requeue behavior are unchanged.

## User Impact

Completed review freshness is retained even when the visible text is unchanged. Operators can distinguish two causes of activity-cursor refusal without logging review bodies. This does not change OpenClaw's wrapper gate or claim to have reproduced the historical PR livelock.

## OpenClaw Bay Impact

No Bay code or observer API change is needed. Publication outcomes retain their existing shape; the additional diagnostics are runner logs only. The runtime proof verifies existing comment-sync outcomes and idempotent retries.

## Documentation Impact

Updated active implementation documentation in `docs/pr-review-comments.md` with freshness, bot-comment filtering, and cursor-diagnostic contracts. Reviewed the repository contributor workflow and documented release context in `CHANGELOG.md`.

## Evidence

- Focused publication, cursor, noise, and live-state suite: 64 tests passed.
- Full local `pnpm run check` passed static checks, all builds, and lint; coverage reached an unrelated `state shard imports accept a complete 4097-event producer run` failure on a host with under 400 MiB free. Hosted CI will provide the full clean-runner gate; the local failure is being investigated without changing its assertion.
- Fresh independent Codex autoreview: no actionable P0–P2 findings.
- The new equality/publication regressions fail on the original owner and pass with the repair. Existing review, inline-comment, and thread-resolution drift protections remain covered.
- Parent-relative history confirms the timestamp normalization originated in https://github.com/openclaw/clawsweeper/pull/1088. This establishes the freshness regression's provenance, not the cause of the September 9 cursor mismatch.

## Real Behavior Proof

**Claim and surface:** The built `apply-decisions` CLI updates an existing durable comment when a completed review's marker advances, ignores its own comment activity, and does not rewrite the durable comment on retry.

**Environment:** macOS, Node 24.20.0, stock GitHub CLI 2.100.0 speaking HTTP over an isolated Unix socket. All GitHub data and credentials are synthetic. The harness refuses unrelated mutation endpoints and removes its copied runtime afterward.

**Reproduce:** After `pnpm run build:node`, run `node scripts/e2e/exact-review-freshness.mjs --gh /absolute/path/to/stock/gh --output /new/evidence/directory`. To reproduce the failing owner in the same disposable runtime, add `--baseline-ref 1d41377123e9d796222f3d8014059202ab00ce21` with another new output directory; this intentionally fails the same-minute issue assertion.

**Observed:** The baseline returns `review_comment_synced` / `recorded existing durable comment metadata`, but its issue marker remains at `03:21:05.000Z` instead of the completed `03:21:45.000Z`. The candidate passes three scenarios: same-minute issue, same-minute exact-head PR, and a PR with a 24-hour-old review. Each PATCHes existing comment ID 9321 exactly once; each retry performs zero durable PATCHes and preserves the body. PR fixtures include an old human review plus bot lease/acknowledgement activity and an acknowledgement edit before retry.

**Artifacts:** The command writes `summary.json`, per-scenario publication observations and publish/retry logs, plus `http-trace.json`. Candidate proof script SHA-256: `676b2d3d837e29be7c54a3ee9324de8ca595edd1dee56022cc78aba5d492595f`; built freshness-owner SHA-256: `f6aa7b062657105b0202cd9a4fe4a2417f43fd7a4638ec129335b03406eb2456`.

**Limits:** This exercises the actual CLI and stock GitHub transport against local synthetic HTTP. It does not exercise hosted GitHub, Cloudflare queue ownership, a new model review, merge, or deployment. The two PR cases cover existing successful behavior; they do not reproduce the historical activity-cursor mismatch. Post-landing monitoring will look for recurrence using the new diagnostics.
