### PR TITLE
fix(review): finalize oversized PRs with queue-owned activity evidence

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -3712,6 +3712,26 @@ jobs:
             echo "state_writer_json=$STATE_WRITER_JSON" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Mark active lease retry waiting
+        if: ${{ always() && steps.publication-context.outputs.claimed == 'true' && steps.publication-context.outputs.has_command_context == 'true' && steps.exact-review-publication-result.outputs.outcome == 'success' && steps.exact-review-publication-result.outputs.completion_kind == 'retryable_failure' && steps.exact-review-publication-result.outputs.reason_code == 'review_lease_active' }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
+          TARGET_REPO: ${{ steps.publication-context.outputs.target_repo }}
+          ITEM_NUMBER: ${{ steps.publication-context.outputs.item_number }}
+          COMMAND_STATUS_MARKER: ${{ fromJSON(steps.publication-context.outputs.decision).commandStatusMarker || '' }}
+          STATUS_COMMENT_ID: ${{ fromJSON(steps.publication-context.outputs.decision).statusCommentId || '' }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          pnpm run repair:update-command-status -- \
+            --repo "$TARGET_REPO" \
+            --item-number "$ITEM_NUMBER" \
+            --marker "$COMMAND_STATUS_MARKER" \
+            --status-comment-id "$STATUS_COMMENT_ID" \
+            --state "Waiting" \
+            --detail "Another same-revision review is active; this publication attempt is waiting for that lease to expire." \
+            --run-url "$RUN_URL"
+
       - name: Complete durable exact review publication
         id: complete-exact-review-publication
         if: ${{ steps.publication-context.outputs.claimed == 'true' && always() }}
@@ -3830,26 +3850,6 @@ jobs:
             exit 0
           fi
           exit 1
-
-      - name: Mark active lease retry waiting
-        if: ${{ always() && steps.publication-context.outputs.claimed == 'true' && steps.publication-context.outputs.has_command_context == 'true' && steps.exact-review-publication-result.outputs.outcome == 'success' && steps.exact-review-publication-result.outputs.completion_kind == 'retryable_failure' && steps.exact-review-publication-result.outputs.reason_code == 'review_lease_active' && steps.complete-exact-review-publication.outcome == 'success' }}
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
-          TARGET_REPO: ${{ steps.publication-context.outputs.target_repo }}
-          ITEM_NUMBER: ${{ steps.publication-context.outputs.item_number }}
-          COMMAND_STATUS_MARKER: ${{ fromJSON(steps.publication-context.outputs.decision).commandStatusMarker || '' }}
-          STATUS_COMMENT_ID: ${{ fromJSON(steps.publication-context.outputs.decision).statusCommentId || '' }}
-          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          pnpm run repair:update-command-status -- \
-            --repo "$TARGET_REPO" \
-            --item-number "$ITEM_NUMBER" \
-            --marker "$COMMAND_STATUS_MARKER" \
-            --status-comment-id "$STATUS_COMMENT_ID" \
-            --state "Waiting" \
-            --detail "Another same-revision review is active; durable publication will retry after its lease expires." \
-            --run-url "$RUN_URL"
 
       - name: Submit artifact-publication GitHub egress telemetry
         if: ${{ always() && steps.publication-context.outputs.claimed == 'true' && steps.publication-context.outputs.direct_lifecycle_recovery != 'true' && steps.artifact-github-egress-observer.outcome == 'success' }}

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -527,6 +527,7 @@ jobs:
               process.exit(1);
             }
             process.stdout.write(JSON.stringify({
+              oversized_activity_version: 1,
               lease_id: process.env.QUEUE_LEASE_ID,
               ...(hasTuple ? { item_key: itemKey, lease_revision: leaseRevision } : {}),
               run_id: process.env.GITHUB_RUN_ID,
@@ -571,6 +572,7 @@ jobs:
             elif RESPONSE="$response" node <<'NODE'
               const fs = require("node:fs");
               const response = JSON.parse(process.env.RESPONSE || "{}");
+              if (process.env.GITHUB_ENV) fs.appendFileSync(process.env.GITHUB_ENV, `CLAWSWEEPER_OVERSIZED_ACTIVITY_CONTEXT=${JSON.stringify(response.oversized_activity_version === 1 && response.oversized_activity ? {...response.oversized_activity,queueUrl:process.env.QUEUE_URL,failurePath:require("node:path").join(process.env.RUNNER_TEMP || process.cwd(),`clawsweeper-oversized-${response.oversized_activity.reference?.epoch}-${process.env.GITHUB_RUN_ID}-${process.env.GITHUB_RUN_ATTEMPT}.json`)} : null)}\n`);
               const dispatch = JSON.parse(process.env.DISPATCH_PAYLOAD || "{}");
               const requestedItemKey = String(process.env.ITEM_KEY || "").trim();
               const requestedLeaseRevision = Number(process.env.QUEUE_LEASE_REVISION);
@@ -2430,7 +2432,10 @@ jobs:
                 !["true", "false"].includes(reviewFailureRetryable))
             ) process.exit(1);
             if (requeueLatest && directLifecycleRequeue) process.exit(1);
+            const activityContext = JSON.parse(process.env.CLAWSWEEPER_OVERSIZED_ACTIVITY_CONTEXT || "null");
+            const activityFailure = activityContext ? {oversized_activity_failed: typeof activityContext.failurePath !== "string" || require("node:fs").existsSync(activityContext.failurePath)} : {};
             process.stdout.write(JSON.stringify({
+              ...activityFailure,
               lease_id: process.env.QUEUE_LEASE_ID,
               ...(protocolVersion === 2
                 ? {
@@ -2648,6 +2653,7 @@ jobs:
             if (!Number.isInteger(leaseRevision) || leaseRevision < 1) process.exit(1);
             if (!Number.isInteger(runAttempt) || runAttempt < 1) process.exit(1);
             process.stdout.write(JSON.stringify({
+              oversized_activity_version: 1,
               lease_id: process.env.QUEUE_LEASE_ID,
               item_key: process.env.ITEM_KEY,
               lease_revision: leaseRevision,
@@ -2693,6 +2699,7 @@ jobs:
             elif RESPONSE="$response" node <<'NODE'
               const fs = require("node:fs");
               const response = JSON.parse(process.env.RESPONSE || "{}");
+              if (process.env.GITHUB_ENV) fs.appendFileSync(process.env.GITHUB_ENV, `CLAWSWEEPER_OVERSIZED_ACTIVITY_CONTEXT=${JSON.stringify(response.oversized_activity_version === 1 && response.oversized_activity ? {...response.oversized_activity,queueUrl:process.env.QUEUE_URL,failurePath:require("node:path").join(process.env.RUNNER_TEMP || process.cwd(),`clawsweeper-oversized-${response.oversized_activity.reference?.epoch}-${process.env.GITHUB_RUN_ID}-${process.env.GITHUB_RUN_ATTEMPT}.json`)} : null)}\n`);
               const decision = response.decision;
               const publication = decision?.publication;
               const producerDecision = publication?.producerDecision;
@@ -3794,7 +3801,10 @@ jobs:
               const parsed = JSON.parse(process.env.STATE_WRITER_JSON || "");
               if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) stateWriter = parsed;
             } catch {}
+            const activityContext = JSON.parse(process.env.CLAWSWEEPER_OVERSIZED_ACTIVITY_CONTEXT || "null");
+            const activityFailure = activityContext ? {oversized_activity_failed: typeof activityContext.failurePath !== "string" || require("node:fs").existsSync(activityContext.failurePath)} : {};
             process.stdout.write(JSON.stringify({
+              ...activityFailure,
               lease_id: process.env.QUEUE_LEASE_ID,
               item_key: process.env.ITEM_KEY,
               lease_revision: leaseRevision,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Close eligible oversized PRs on direct and queued publication using queue-owned activity baselines, complete write receipts, and acknowledgement fences; upgraded consumers keep missing or stale evidence open while already-running legacy consumers retain their existing safeguards.
+
 - Keep large repository reviews within the GitHub CLI response limit by projecting recursive-tree metadata before capture, preserving complete blob sizes and strict private-checkout admission.
 
 - Carry the durable review lease through oversized PR close proposals so direct exact publication can close eligible PRs; queued fallback still keeps PRs open with `skipped_changed_since_review` after lease expiry, pending the follow-up to create the final metadata proposal under publication ownership and re-evaluation at the next event or head.

--- a/dashboard/exact-review-decision.ts
+++ b/dashboard/exact-review-decision.ts
@@ -1,3 +1,7 @@
+import {
+  parseOversizedActivityReference,
+  type OversizedActivityReference,
+} from "../src/oversized-activity-contract.ts";
 import { stableJson } from "../src/stable-json.ts";
 import {
   validProofAllowedScenarios,
@@ -39,6 +43,7 @@ const EXACT_REVIEW_ADDITIONAL_PROMPT_MAX_CHARS = 5000;
 const EXACT_REVIEW_INGRESS_FINGERPRINT_PATTERN = /^[0-9a-f]{64}$/;
 
 export type ExactReviewBaseDecision = {
+  oversizedActivityReference?: OversizedActivityReference;
   targetRepo: string;
   targetBranch: string;
   itemNumber: number;
@@ -328,6 +333,15 @@ export function exactReviewBaseDecisionFrom(value: unknown): ExactReviewBaseDeci
   }
   const decision = objectValue(value);
   const targetRepo = String(decision.targetRepo || "").trim();
+  const activityReference =
+    decision.oversizedActivityReference === undefined
+      ? undefined
+      : parseOversizedActivityReference(
+          decision.oversizedActivityReference,
+          String(decision.targetRepo),
+          Number(decision.itemNumber),
+        );
+  if (activityReference === null) return null;
   const targetBranch = String(decision.targetBranch || "").trim();
   const itemNumber = Number(decision.itemNumber);
   const itemKind = String(decision.itemKind || "");
@@ -487,6 +501,7 @@ export function exactReviewBaseDecisionFrom(value: unknown): ExactReviewBaseDeci
   ].filter(Boolean).length;
   if (commandMetadataCount !== 0 && commandMetadataCount !== 4) return null;
   return {
+    ...(activityReference ? { oversizedActivityReference: activityReference } : {}),
     targetRepo,
     targetBranch,
     itemNumber,
@@ -744,6 +759,13 @@ export function mergePendingExactReviewDecision(
   next: ExactReviewDecision,
 ): ExactReviewDecision {
   const merged = { ...current, ...next };
+  if (
+    !next.oversizedActivityReference &&
+    (["sourceHeadSha", "sourceUpdatedAt", "commandStatusMarker"] as const).some(
+      (key) => Object.hasOwn(next, key) && next[key] !== current[key],
+    )
+  )
+    delete merged.oversizedActivityReference;
   // Coalescing cannot widen an admitted manual revision. A separately claimed
   // successor may review normally; it cannot lend authority to these bytes.
   const retainedPolicy = decisionPublicationPolicy(current);
@@ -981,6 +1003,8 @@ export function exactReviewQueueIsBatchablePublication(
   return (
     exactReviewQueueIsPublication(item) &&
     !item.terminalFinalization &&
+    // The size lane holds a per-item claim/fence through queued apply.
+    !item.decision.oversizedActivityReference &&
     !item.decision.publication?.directLifecycle
   );
 }

--- a/dashboard/exact-review-queue-observability.ts
+++ b/dashboard/exact-review-queue-observability.ts
@@ -30,6 +30,8 @@ const EXACT_REVIEW_QUEUE_ENDPOINTS = new Map<string, string>([
   ["/github-read-model/repair", "github_read_model_repair"],
   ["/github-read-model/workflows", "github_read_model_workflows"],
   ["/heartbeat", "heartbeat"],
+  ["/oversized-activity", "oversized_activity"],
+  ["/pull-request-acknowledgement", "pull_request_acknowledgement"],
   ["/item-status", "item_status"],
   ["/lifecycle-audit/inventory", "lifecycle_audit_inventory"],
   ["/lifecycle-bay", "lifecycle_bay"],

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -2951,7 +2951,14 @@ export class ExactReviewQueue {
             decision.targetRepo,
             decision.itemNumber,
           )?.reference;
-          if (currentReference && currentReference.epoch !== activityReference.epoch) {
+          if (!currentReference) {
+            activityReference = store.unavailable(
+              decision.targetRepo,
+              decision.itemNumber,
+              this.oversizedScope(decision),
+              "claimed activity evidence is missing",
+            );
+          } else if (currentReference.epoch !== activityReference.epoch) {
             activityReference = currentReference;
             store.invalidate(activityReference, "claimed activity reference is stale");
           }

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -1,3 +1,18 @@
+import { OversizedActivityStore } from "./oversized-activity-store.ts";
+import {
+  oversizedActivityNeeded,
+  parseOversizedActivityReference,
+  parseOversizedActivityEvidence,
+  type OversizedActivityReference,
+  type OversizedActivityOwner,
+  type OversizedAcknowledgementReceipt,
+} from "../src/oversized-activity-contract.ts";
+import {
+  isOversizedCommentWrite,
+  ownedCommentWriteIntent,
+  ownedCommentWriteResult,
+  type OversizedCommentRequest,
+} from "../src/oversized-activity-write.ts";
 import { stableJson } from "../src/stable-json.ts";
 import {
   terminalReviewFailureReason,
@@ -126,7 +141,10 @@ import {
   unknownBaySnapshot,
 } from "./exact-review-lifecycle-telemetry.ts";
 import { GithubEgressTelemetryStore } from "./github-egress-telemetry.ts";
-import { resolvePullRequestAcknowledgement } from "./pull-request-acknowledgement.ts";
+import {
+  resolvePullRequestAcknowledgement,
+  settlePullRequestAcknowledgement,
+} from "./pull-request-acknowledgement.ts";
 import {
   ExactReviewCommandIntakeStore,
   type ExactReviewCommandIntakeRecord,
@@ -196,6 +214,7 @@ import {
   mergePendingExactReviewDecision,
   type ExactReviewBranchAuthorityReservation,
   type ExactReviewDecision,
+  type ExactReviewBaseDecision,
   type ExactReviewEditedSemanticInput,
   type ExactReviewIngress,
   type ExactReviewPublication,
@@ -1008,7 +1027,55 @@ export class ExactReviewQueue {
     const mutating = request.method !== "GET";
     if (mutating) this.invalidateReadCaches();
     try {
-      return await this.handleFetch(request, hostedTargetMetadataToken);
+      const route = new URL(request.url).pathname;
+      const completion =
+        route === "/complete" || route === "/heartbeat"
+          ? objectValue(
+              await request
+                .clone()
+                .json()
+                .catch(() => null),
+            )
+          : null;
+      let previous: ExactReviewQueueItem | undefined;
+      if (completion) {
+        await this.ready;
+        const state = this.readStateSync();
+        previous =
+          state.items[String(completion.item_key)] ??
+          exactReviewItemForLease(state, String(completion.lease_id));
+      }
+      const response = await this.handleFetch(request, hostedTargetMetadataToken);
+      const ref =
+        previous?.leaseDecision?.oversizedActivityReference ??
+        previous?.decision.oversizedActivityReference;
+      if (
+        response.ok &&
+        completion &&
+        previous &&
+        ref &&
+        previous.leaseId === completion.lease_id &&
+        previous.claimedRunId === String(completion.run_id) &&
+        previous.claimGeneration === Number(completion.claim_generation)
+      ) {
+        const store = new OversizedActivityStore(this.storage.kv);
+        const owner = {
+          itemKey: previous.key,
+          leaseId: previous.leaseId!,
+          runId: previous.claimedRunId!,
+          runAttempt: previous.claimedRunAttempt!,
+          claimGeneration: previous.claimGeneration!,
+        };
+        if (route === "/complete") {
+          if (typeof completion.oversized_activity_failed === "boolean")
+            store.seal(ref, owner, completion.oversized_activity_failed);
+          store.release(ref, owner);
+        } else {
+          const current = this.readStateSync().items[previous.key];
+          if (current?.leaseId === owner.leaseId) store.fence(ref, owner, current.leaseExpiresAt!);
+        }
+      }
+      return response;
     } catch (error) {
       rethrowQueueFailure(error, "fetch", request);
     } finally {
@@ -2590,6 +2657,108 @@ export class ExactReviewQueue {
       );
     }
 
+    // Binding-only: the authenticated webhook ingress delegates all PR acknowledgement effects here.
+    if (request.method === "POST" && url.pathname === "/pull-request-acknowledgement") {
+      const body = objectValue(await request.json().catch(() => null));
+      const decision = exactReviewDecisionFrom(body.decision);
+      const installationId = Number(body.installation_id);
+      if (
+        !decision ||
+        decision.itemKind !== "pull_request" ||
+        !Number.isSafeInteger(installationId) ||
+        installationId < 1
+      )
+        return json({ error: "invalid_acknowledgement" }, 400);
+      const admission = await this.hostedTargetAdmission(
+        decision.targetRepo,
+        hostedTargetMetadataToken,
+      );
+      if (admission.outcome === "terminal") return json({ commentId: null, outcome: "resolved" });
+      if (admission.outcome === "retryable") return hostedTargetProbeResponse(admission);
+      try {
+        const result = await this.withOversizedAcknowledgement(
+          decision,
+          exactReviewTargetReadToken(this.env, decision.targetRepo, installationId),
+          (journal) =>
+            exactReviewSourceAuthorityAcknowledgement(
+              this.env,
+              { decision, installationId },
+              journal,
+              body.settle === true,
+            ),
+        );
+        return json(result);
+      } catch {
+        if (body.settle !== true) return json({ deferred: true, commentId: null }, 202);
+        this.storage.kv.put(
+          `oversized-ack-cleanup:v1:${decision.targetRepo.toLowerCase()}#${decision.itemNumber}`,
+          { decision, installationId, nextAttemptAt: Date.now() + 30_000 },
+        );
+        await this.scheduleNext(this.readStateSync(), Date.now());
+        return json({ deferred: true, commentId: null }, 202);
+      }
+    }
+
+    if (request.method === "POST" && url.pathname === "/oversized-activity") {
+      const body = objectValue(await request.json().catch(() => null));
+      const ref = parseOversizedActivityReference(body.reference);
+      const owner = objectValue(body.owner) as unknown as OversizedActivityOwner;
+      const item = this.readStateSync().items[owner.itemKey];
+      const store = new OversizedActivityStore(this.storage.kv);
+      if (
+        !ref ||
+        !item ||
+        item.leaseId !== owner.leaseId ||
+        item.claimedRunId !== owner.runId ||
+        item.claimedRunAttempt !== owner.runAttempt ||
+        item.claimGeneration !== owner.claimGeneration ||
+        !store.owns(ref, owner) ||
+        item.decision.targetRepo.toLowerCase() !== ref.repo.toLowerCase() ||
+        item.decision.itemNumber !== ref.number
+      )
+        return json({
+          ok: true,
+          evidence: null,
+          authority_current: false,
+          reason: "missing or stale queue-owned evidence",
+        });
+      if (body.operation === "read") return json({ ok: true, evidence: store.evidence(ref) });
+      if (body.operation === "begin" && store.evidence(ref) === null)
+        return json({ ok: true, recorded: false, authority_current: true, evidence: null });
+      const receipt = body.receipt as OversizedAcknowledgementReceipt;
+      if (
+        !parseOversizedActivityEvidence({
+          reference: ref,
+          baseline: null,
+          invalid: null,
+          receipts: [receipt],
+        })
+      )
+        return json({ error: "invalid_oversized_write_receipt" }, 400);
+      const trusted = exactReviewCommandBotLogins(this.env);
+      trusted.add("clawsweeper");
+      if (
+        [receipt.before, receipt.after].some(
+          (image) => image && !trusted.has(image.author.toLowerCase()),
+        )
+      )
+        return json({ error: "invalid_oversized_write_actor" }, 400);
+      try {
+        if (
+          body.operation === "begin" &&
+          receipt.completedAt === null &&
+          receipt.after === null &&
+          receipt.pullAfter === null
+        )
+          store.begin(ref, receipt);
+        else if (body.operation === "complete" && receipt.completedAt) store.complete(ref, receipt);
+        else return json({ error: "invalid_oversized_write_operation" }, 400);
+      } catch {
+        return json({ error: "oversized_write_conflict" }, 409);
+      }
+      return json({ ok: true, recorded: true });
+    }
+
     if (request.method === "POST" && url.pathname === "/claim") {
       const body = objectValue(await request.json().catch(() => null));
       const leaseId = String(body.lease_id || "").trim();
@@ -2681,6 +2850,123 @@ export class ExactReviewQueue {
       }
       if (admission.outcome === "retryable") return hostedTargetProbeResponse(admission);
 
+      const wantsOversizedEvidence =
+        body.oversized_activity_version === 1 && item.decision.itemKind === "pull_request";
+      let activityReference: OversizedActivityReference | undefined;
+      let activityClaimToken: string | undefined;
+      if (wantsOversizedEvidence) {
+        const store = new OversizedActivityStore(this.storage.kv);
+        const activityControl = store.control(item.decision.targetRepo, item.decision.itemNumber);
+        if (
+          activityControl &&
+          (activityControl.busyUntil > now ||
+            (activityControl.fence &&
+              activityControl.fence.expiresAt > now &&
+              (activityControl.fence.owner.itemKey !== item.key ||
+                activityControl.fence.owner.leaseId !== leaseId)))
+        )
+          return json({ error: "oversized_acknowledgement_busy" }, 503);
+        const before = item;
+        const decision = item.leaseDecision ?? item.decision;
+        let metadataToken: Promise<string> | undefined;
+        const readMetadata = async (path: string) =>
+          githubTokenJson({
+            env: this.env,
+            token: await (metadataToken ??= exactReviewTargetReadToken(
+              this.env,
+              decision.targetRepo,
+            )),
+            path: `/${path}`,
+            method: "GET",
+            body: undefined,
+            errorLabel: "oversized queue metadata",
+          });
+        let needsActivity = Boolean(decision.oversizedActivityReference);
+        if (!needsActivity) {
+          try {
+            needsActivity = oversizedActivityNeeded(
+              await readMetadata(`repos/${decision.targetRepo}/pulls/${decision.itemNumber}`),
+              this.env.CLAWSWEEPER_MAX_PR_CHANGED_LINES,
+            );
+          } catch {
+            /* Missing evidence only prevents upgraded closing. */
+          }
+        }
+        // Every metadata await may expire, replace, or supersede this lease.
+        now = Date.now();
+        state = this.readStateSync();
+        item = state.items[before.key];
+        if (
+          !item ||
+          item.leaseId !== leaseId ||
+          item.leaseRevision !== before.leaseRevision ||
+          !isLiveExactReviewLease(
+            item,
+            now,
+            exactReviewPublicationDispatchLeaseMs(this.env),
+            exactReviewHeartbeatGraceMs(this.env),
+          )
+        )
+          return json({ error: "lease_not_active" }, 409);
+        if (item.claimedRunId && item.claimedRunId !== runId)
+          return json({ error: "lease_already_claimed" }, 409);
+        if (needsActivity) {
+          activityReference =
+            decision.oversizedActivityReference ??
+            (await store.prepare(
+              decision.targetRepo,
+              decision.itemNumber,
+              this.oversizedScope(decision),
+              async (path) =>
+                githubTokenJson({
+                  env: this.env,
+                  token: await (metadataToken ??= exactReviewTargetReadToken(
+                    this.env,
+                    decision.targetRepo,
+                  )),
+                  path: `/${path}`,
+                  method: "GET",
+                  body: undefined,
+                  errorLabel: "oversized queue baseline",
+                }),
+            ));
+          state = this.readStateSync();
+          item = state.items[before.key];
+          now = Date.now();
+          if (
+            !item ||
+            item.leaseId !== leaseId ||
+            item.leaseRevision !== before.leaseRevision ||
+            !isLiveExactReviewLease(
+              item,
+              now,
+              exactReviewPublicationDispatchLeaseMs(this.env),
+              exactReviewHeartbeatGraceMs(this.env),
+            )
+          )
+            return json({ error: "lease_not_active" }, 409);
+          if (item.claimedRunId && item.claimedRunId !== runId)
+            return json({ error: "lease_already_claimed" }, 409);
+          const currentReference = store.control(
+            decision.targetRepo,
+            decision.itemNumber,
+          )?.reference;
+          if (currentReference && currentReference.epoch !== activityReference.epoch) {
+            activityReference = currentReference;
+            store.invalidate(activityReference, "claimed activity reference is stale");
+          }
+          const held = store.control(decision.targetRepo, decision.itemNumber)?.fence;
+          if (!held || held.expiresAt <= Date.now())
+            activityClaimToken = store.lockAcknowledgement(activityReference);
+          item.decision = { ...item.decision, oversizedActivityReference: activityReference };
+          if (item.leaseDecision)
+            item.leaseDecision = {
+              ...item.leaseDecision,
+              oversizedActivityReference: activityReference,
+            };
+        }
+      }
+
       // Deploys can observe a pre-snapshot lease. Recover it only when no newer
       // enqueue has replaced the decision that was dispatched for this revision.
       if (!item.leaseDecision) {
@@ -2711,7 +2997,15 @@ export class ExactReviewQueue {
           await this.writeState(state);
           this.recordLifecycleClaim(item, now);
           await this.scheduleNext(state, now);
-          return json(exactReviewClaimResponse(item, claimProtocolVersion, claimGeneration));
+          return json(
+            this.oversizedClaimResponse(
+              item,
+              claimProtocolVersion,
+              claimGeneration,
+              activityReference,
+              activityClaimToken,
+            ),
+          );
         }
       } else if (item.claimedRunId && runAttempt === null) {
         if (
@@ -2730,7 +3024,15 @@ export class ExactReviewQueue {
           await this.writeState(state);
         }
         this.recordLifecycleClaim(item, now);
-        return json(exactReviewClaimResponse(item, claimProtocolVersion, claimGeneration));
+        return json(
+          this.oversizedClaimResponse(
+            item,
+            claimProtocolVersion,
+            claimGeneration,
+            activityReference,
+            activityClaimToken,
+          ),
+        );
       }
 
       item.state = "leased";
@@ -2745,7 +3047,15 @@ export class ExactReviewQueue {
       await this.writeState(state);
       this.recordLifecycleClaim(item, now);
       await this.scheduleNext(state, now);
-      return json(exactReviewClaimResponse(item, claimProtocolVersion, item.claimGeneration));
+      return json(
+        this.oversizedClaimResponse(
+          item,
+          claimProtocolVersion,
+          item.claimGeneration,
+          activityReference,
+          activityClaimToken,
+        ),
+      );
     }
 
     if (request.method === "POST" && url.pathname === "/heartbeat") {
@@ -5159,6 +5469,7 @@ export class ExactReviewQueue {
     await this.processBranchAuthorityReservations(startedAt, hostedTargetMetadataToken);
     await this.processSourceAuthorityReservations(startedAt, hostedTargetMetadataToken);
     await this.processCommandIntakes(startedAt, hostedTargetMetadataToken);
+    await this.processDeferredOversizedAcknowledgements(hostedTargetMetadataToken);
     const batchItemKeys = new Set<string>(this.batchStore.activeLeaseSnapshot(startedAt).itemKeys);
     let terminalized: ExactReviewLifecycleProjection[] = [];
     let snapshot = this.storage.transactionSync(() => {
@@ -13351,6 +13662,163 @@ export class ExactReviewQueue {
     this.storage.kv.delete(EXACT_REVIEW_QUEUE_STATE_KEY);
   }
 
+  private async deferredAcknowledgements() {
+    return Array.from(
+      (await this.storage.list({ prefix: "oversized-ack-cleanup:v1:" })).entries(),
+    ) as Array<
+      [string, { decision: ExactReviewDecision; installationId: number; nextAttemptAt: number }]
+    >;
+  }
+  private async processDeferredOversizedAcknowledgements(metadataToken: HostedTargetMetadataToken) {
+    for (const [key, entry] of (await this.deferredAcknowledgements())
+      .filter(([, entry]) => entry.nextAttemptAt <= Date.now())
+      .slice(0, 8)) {
+      try {
+        const admission = await this.hostedTargetAdmission(
+          entry.decision.targetRepo,
+          metadataToken,
+        );
+        if (admission.outcome === "terminal") {
+          this.storage.kv.delete(key);
+          continue;
+        }
+        if (admission.outcome === "retryable")
+          throw new Error("target acknowledgement admission deferred");
+        await this.withOversizedAcknowledgement(
+          entry.decision,
+          exactReviewTargetReadToken(this.env, entry.decision.targetRepo, entry.installationId),
+          (journal) => exactReviewSourceAuthorityAcknowledgement(this.env, entry, journal, true),
+        );
+        this.storage.kv.delete(key);
+      } catch {
+        this.storage.kv.put(key, { ...entry, nextAttemptAt: Date.now() + 30_000 });
+      }
+    }
+  }
+
+  private oversizedScope(decision: ExactReviewBaseDecision) {
+    return {
+      head: decision.sourceHeadSha ?? null,
+      command: decision.commandStatusMarker ?? null,
+      source: decision.sourceUpdatedAt ?? null,
+    };
+  }
+  private oversizedClaimResponse(
+    item: ExactReviewQueueItem,
+    protocol: 1 | 2,
+    generation: number,
+    ref?: OversizedActivityReference,
+    claimToken?: string,
+  ) {
+    const response = exactReviewClaimResponse(item, protocol, generation);
+    if (!ref) return response;
+    const store = new OversizedActivityStore(this.storage.kv);
+    const owner: OversizedActivityOwner = {
+      itemKey: item.key,
+      leaseId: item.leaseId!,
+      claimGeneration: generation,
+      runId: item.claimedRunId!,
+      runAttempt: item.claimedRunAttempt!,
+    };
+    if (claimToken) store.unlockAcknowledgement(ref, claimToken);
+    const fenced = store.fence(ref, owner, item.leaseExpiresAt!);
+    if (!fenced) {
+      store.invalidate(ref, "publication fence could not be established");
+      throw new Error("oversized publication fence is not available");
+    }
+    return {
+      ...response,
+      oversized_activity_version: 1,
+      oversized_activity: fenced ? { reference: ref, owner } : null,
+    };
+  }
+  private async withOversizedAcknowledgement<T>(
+    decision: ExactReviewBaseDecision,
+    token: Promise<string>,
+    operation: (
+      journal?: (
+        request: OversizedCommentRequest,
+        write: () => Promise<unknown>,
+      ) => Promise<unknown>,
+      metadataOnly?: boolean,
+    ) => Promise<T>,
+  ): Promise<T> {
+    if (decision.itemKind !== "pull_request") return operation();
+    const store = new OversizedActivityStore(this.storage.kv);
+    if (store.blocked(decision.targetRepo, decision.itemNumber))
+      throw new Error("oversized acknowledgement is fenced");
+    const read = async (path: string) =>
+      githubTokenJson({
+        env: this.env,
+        token: await token,
+        path: path.startsWith("/") ? path : `/${path}`,
+        method: "GET",
+        body: undefined,
+        errorLabel: "oversized acknowledgement metadata",
+      });
+    let needsActivity = false;
+    try {
+      needsActivity = oversizedActivityNeeded(
+        await read(`repos/${decision.targetRepo}/pulls/${decision.itemNumber}`),
+        this.env.CLAWSWEEPER_MAX_PR_CHANGED_LINES,
+      );
+    } catch {
+      /* Keep the acknowledgement path; no evidence is granted. */
+    }
+    // Metadata awaits can admit another claimant. Both the success and fallback
+    // paths acquire current acknowledgement ownership before any effects.
+    if (store.blocked(decision.targetRepo, decision.itemNumber))
+      throw new Error("oversized acknowledgement is fenced");
+    const ref = needsActivity
+      ? await store.prepare(
+          decision.targetRepo,
+          decision.itemNumber,
+          this.oversizedScope(decision),
+          read,
+        )
+      : store.unavailable(
+          decision.targetRepo,
+          decision.itemNumber,
+          this.oversizedScope(decision),
+          "size evidence unavailable or outside metadata-only admission",
+        );
+    const acknowledgementToken = store.lockAcknowledgement(ref);
+    try {
+      return await operation(async (request, write) => {
+        store.assertAcknowledgement(ref, acknowledgementToken);
+        if (!isOversizedCommentWrite(request, ref)) return write();
+        let intent: OversizedAcknowledgementReceipt;
+        try {
+          const before = request.method === "POST" ? null : await read(request.path);
+          intent = ownedCommentWriteIntent(request, before);
+          store.begin(ref, intent);
+        } catch (error) {
+          store.invalidate(
+            ref,
+            `acknowledgement intent unavailable: ${error instanceof Error ? error.message : String(error)}`,
+          );
+          store.assertAcknowledgement(ref, acknowledgementToken);
+          return write();
+        }
+        store.assertAcknowledgement(ref, acknowledgementToken);
+        const result = await write();
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 1100));
+          const pull = await read(`repos/${ref.repo}/pulls/${ref.number}`);
+          store.complete(ref, ownedCommentWriteResult(intent, result, pull));
+        } catch (error) {
+          store.invalidate(
+            ref,
+            `acknowledgement receipt unavailable: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+        return result;
+      }, needsActivity);
+    } finally {
+      store.unlockAcknowledgement(ref, acknowledgementToken);
+    }
+  }
+
   private async processCommandIntakes(
     now: number,
     hostedTargetMetadataToken: HostedTargetMetadataToken,
@@ -13509,20 +13977,33 @@ export class ExactReviewQueue {
           }
           const decision = current.verifiedDecision;
           if (!decision) throw new Error("command effects decision is missing");
-          await Promise.all([
-            convergeCommandAcknowledgement({
-              env: this.env,
-              token: token(),
-              decision,
-              sourceCommentId: current.intake.sourceCommentId,
-            }),
-            addCommandReaction({
-              env: this.env,
-              token: token(),
-              repo: decision.targetRepo,
-              commentId: current.intake.sourceCommentId,
-            }),
-          ]);
+          await this.withOversizedAcknowledgement(
+            decision,
+            token(),
+            async (journal, metadataOnly) => {
+              await Promise.all([
+                convergeCommandAcknowledgement({
+                  env: this.env,
+                  token: token(),
+                  decision,
+                  sourceCommentId: current.intake.sourceCommentId,
+                  journal,
+                }),
+                // Metadata-only size proposals already skip review reactions in the workflow.
+                // Do not create unjournaled reaction activity after their queue baseline.
+                ...(metadataOnly
+                  ? []
+                  : [
+                      addCommandReaction({
+                        env: this.env,
+                        token: token(),
+                        repo: decision.targetRepo,
+                        commentId: current.intake.sourceCommentId,
+                      }),
+                    ]),
+              ]);
+            },
+          );
           this.commandIntakeStore.finish(
             current.intake.commandVersionId,
             "completed",
@@ -13733,9 +14214,14 @@ export class ExactReviewQueue {
       }
       try {
         if (current.reviewAcknowledgementPending) {
-          const acknowledgement = await exactReviewSourceAuthorityAcknowledgement(
-            this.env,
-            current,
+          const acknowledgement = await this.withOversizedAcknowledgement(
+            current.decision,
+            exactReviewTargetReadToken(
+              this.env,
+              current.decision.targetRepo,
+              current.installationId,
+            ),
+            (journal) => exactReviewSourceAuthorityAcknowledgement(this.env, current, journal),
           );
           if (acknowledgement.outcome === "lookup_limit") {
             console.warn("exact-review source authority acknowledgement lookup limit reached");
@@ -14188,7 +14674,15 @@ export class ExactReviewQueue {
           this.freshPublicationItemKeysSync(state, now, heads),
           this.supersededPublicationItemKeysSync(state, heads),
         );
-    const sourceAuthorityNext = await this.nextSourceAuthorityVerificationAt();
+    const sourceAuthorityWake = await this.nextSourceAuthorityVerificationAt();
+    const acknowledgementWake = (await this.deferredAcknowledgements()).reduce(
+      (next, entry) => Math.min(next, entry[1].nextAttemptAt),
+      Infinity,
+    );
+    const combinedAuthorityWake = Math.min(sourceAuthorityWake ?? Infinity, acknowledgementWake);
+    const sourceAuthorityNext = Number.isFinite(combinedAuthorityWake)
+      ? combinedAuthorityWake
+      : null;
     const commandIntakeNext = this.commandIntakeStore.nextAttemptAt();
     const credentialCircuitNext = exactReviewGithubCircuitNextWakeAt(state, now);
     const bayTelemetryRecoveryPending = this.bayTelemetryRecoveryPendingSync();
@@ -16999,7 +17493,9 @@ async function exactReviewSourceAuthorityLiveHead(
 
 async function exactReviewSourceAuthorityAcknowledgement(
   env,
-  reservation: ExactReviewSourceAuthorityReservation,
+  reservation: Pick<ExactReviewSourceAuthorityReservation, "decision" | "installationId">,
+  journal?: (request: OversizedCommentRequest, write: () => Promise<unknown>) => Promise<unknown>,
+  settle = false,
 ) {
   const credentials = githubAppCredentials(env);
   if (!credentials) throw new Error("github app is not configured");
@@ -17012,20 +17508,35 @@ async function exactReviewSourceAuthorityAcknowledgement(
     repositories: [repoName(reservation.decision.targetRepo)],
     permissions: { issues: "write", pull_requests: "write" },
   });
-  return resolvePullRequestAcknowledgement({
-    githubJson: (request) =>
-      githubTokenJson({
-        env,
-        token,
-        path: request.path,
-        method: request.method,
-        body: request.body,
-        errorLabel: request.errorLabel,
-      }),
+  const options = {
+    githubJson: (request: {
+      path: string;
+      method?: string;
+      body?: unknown;
+      errorLabel: string;
+    }) => {
+      const write = () =>
+        githubTokenJson({
+          env,
+          token,
+          path: request.path,
+          method: request.method,
+          body: request.body,
+          errorLabel: request.errorLabel,
+        });
+      return journal && request.method !== "GET"
+        ? journal({ ...request, method: request.method ?? "GET" }, write)
+        : write();
+    },
     targetRepo: reservation.decision.targetRepo,
     itemNumber: reservation.decision.itemNumber,
     sourceAction: reservation.decision.sourceAction,
-  });
+  };
+  if (settle) {
+    await settlePullRequestAcknowledgement(options);
+    return { outcome: "resolved" as const, commentId: null };
+  }
+  return resolvePullRequestAcknowledgement(options);
 }
 
 function sourceAuthorityAcknowledgementIdentity(
@@ -17063,8 +17574,13 @@ export async function convergeCommandAcknowledgement(options: {
   token: Promise<string>;
   decision: DirectReReviewDecision;
   sourceCommentId: number;
+  journal?: (request: OversizedCommentRequest, write: () => Promise<unknown>) => Promise<unknown>;
 }) {
   const token = await options.token;
+  const request = (args) =>
+    options.journal && args.method !== "GET"
+      ? options.journal(args, () => githubTokenJson(args))
+      : githubTokenJson(args);
   const ackMarker = clawSweeperCommandAckMarker(options.sourceCommentId);
   const statusMarker = options.decision.commandStatusMarker;
   const trustedBotLogins = exactReviewCommandBotLogins(options.env);
@@ -17077,7 +17593,7 @@ export async function convergeCommandAcknowledgement(options: {
   const list = async () => {
     const matching: Record<string, unknown>[] = [];
     for (let page = 1; page <= 5; page += 1) {
-      const comments = await githubTokenJson({
+      const comments = await request({
         env: options.env,
         token,
         path: `/repos/${options.decision.targetRepo}/issues/${options.decision.itemNumber}/comments?per_page=100&page=${page}`,
@@ -17104,7 +17620,7 @@ export async function convergeCommandAcknowledgement(options: {
     !comments.some((comment) => Number(comment.id) === suppliedStatusCommentId)
   ) {
     const supplied = objectValue(
-      await githubTokenJson({
+      await request({
         env: options.env,
         token,
         path: `/repos/${options.decision.targetRepo}/issues/comments/${suppliedStatusCommentId}`,
@@ -17135,7 +17651,7 @@ export async function convergeCommandAcknowledgement(options: {
     const bareId = Number(bare?.id) || null;
     const body = renderClawSweeperQueuedAcknowledgement(options.sourceCommentId, statusMarker);
     exact = objectValue(
-      await githubTokenJson({
+      await request({
         env: options.env,
         token,
         path: bareId
@@ -17155,7 +17671,7 @@ export async function convergeCommandAcknowledgement(options: {
   for (const duplicate of convergence.prunable.slice(0, 20)) {
     const id = Number(duplicate.id);
     if (!Number.isSafeInteger(id) || id <= 0) continue;
-    await githubTokenJson({
+    await request({
       env: options.env,
       token,
       path: `/repos/${options.decision.targetRepo}/issues/comments/${id}`,

--- a/dashboard/oversized-activity-store.ts
+++ b/dashboard/oversized-activity-store.ts
@@ -1,0 +1,291 @@
+import { randomUUID } from "node:crypto";
+import { stableJson } from "../src/stable-json.ts";
+import {
+  activityHash,
+  captureOversizedActivity,
+  OVERSIZED_ACTIVITY_FENCE_MS,
+  parseOversizedActivityEvidence,
+  type OversizedActivityReference,
+  type OversizedActivityBaseline,
+  type OversizedActivityEvidence,
+  type OversizedAcknowledgementReceipt,
+  type OversizedActivityOwner,
+} from "../src/oversized-activity-contract.ts";
+
+type Kv = { get<T = unknown>(key: string): T | undefined; put(key: string, value: unknown): void };
+type Meta = {
+  reference: OversizedActivityReference;
+  scope: string;
+  receiptCount: number;
+  invalid: string | null;
+  pending: string | null;
+  consumers?: Record<string, "active" | "complete" | "failed">;
+};
+type Control = {
+  reference: OversizedActivityReference;
+  scope: string;
+  busyUntil: number;
+  busyOwner?: string;
+  fence?: { owner: OversizedActivityOwner; expiresAt: number };
+};
+const prefix = "oversized-activity:v1:";
+const controlKey = (repo: string, number: number) =>
+  `${prefix}item:${repo.toLowerCase()}#${number}`;
+const epochKey = (ref: OversizedActivityReference) => `${prefix}epoch:${ref.epoch}`;
+
+/** Additive, separate keys: no rewrite or migration of existing queue items. */
+export class OversizedActivityStore {
+  private readonly kv: Kv;
+  constructor(kv: Kv) {
+    this.kv = kv;
+  }
+  control(repo: string, number: number): Control | undefined {
+    return this.kv.get(controlKey(repo, number));
+  }
+  private meta(ref: OversizedActivityReference): Meta | undefined {
+    const meta = this.kv.get<Meta>(epochKey(ref));
+    return meta && stableJson(meta.reference) === stableJson(ref) ? meta : undefined;
+  }
+  reference(repo: string, number: number, scope: unknown): OversizedActivityReference | undefined {
+    const c = this.control(repo, number);
+    return c?.scope === activityHash(scope) ? c.reference : undefined;
+  }
+  blocked(repo: string, number: number, now = Date.now()): boolean {
+    const c = this.control(repo, number);
+    return Boolean(c && (c.busyUntil > now || (c.fence && c.fence.expiresAt > now)));
+  }
+  async prepare(
+    repo: string,
+    number: number,
+    scope: unknown,
+    read: (path: string) => Promise<unknown>,
+  ): Promise<OversizedActivityReference> {
+    const old = this.control(repo, number);
+    const scopeHash = activityHash(scope);
+    if (old?.scope === scopeHash) return old.reference;
+    if (this.blocked(repo, number)) throw new Error("oversized acknowledgement is fenced");
+    const reference: OversizedActivityReference = { version: 1, repo, number, epoch: randomUUID() };
+    const meta: Meta = {
+      reference,
+      scope: scopeHash,
+      receiptCount: 0,
+      invalid: "activity baseline capture incomplete",
+      pending: null,
+    };
+    const captureToken = randomUUID();
+    const control: Control = {
+      reference,
+      scope: scopeHash,
+      busyUntil: Date.now() + 60_000,
+      busyOwner: captureToken,
+    };
+    this.kv.put(epochKey(reference), meta);
+    this.kv.put(controlKey(repo, number), control);
+    try {
+      // The source command/event must be outside GitHub's coarse timestamp margin.
+      await new Promise((resolve) => setTimeout(resolve, 2100));
+      const capture = captureOversizedActivity(repo, number, new Date().toISOString(), true);
+      let next = capture.next();
+      while (next.done !== true) next = capture.next(await read(next.value));
+      const current = this.control(repo, number);
+      if (
+        current?.reference.epoch !== reference.epoch ||
+        current.busyOwner !== captureToken ||
+        current.busyUntil <= Date.now()
+      )
+        throw new Error("activity capture ownership expired or changed");
+      const b = next.value;
+      // Keep each KV value below the platform limit even at the 300-entry bound.
+      this.kv.put(`${epochKey(reference)}:source`, b.source);
+      this.kv.put(`${epochKey(reference)}:comments`, b.comments);
+      b.streams.forEach((s, i) => this.kv.put(`${epochKey(reference)}:stream:${i}`, s));
+      meta.invalid = null;
+      this.kv.put(epochKey(reference), meta);
+    } catch (error) {
+      this.invalidate(
+        reference,
+        `queue activity baseline unavailable: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    } finally {
+      const current = this.control(repo, number);
+      if (current?.reference.epoch === reference.epoch && current.busyOwner === captureToken) {
+        current.busyUntil = 0;
+        delete current.busyOwner;
+        this.kv.put(controlKey(repo, number), current);
+      }
+    }
+    return reference;
+  }
+  unavailable(
+    repo: string,
+    number: number,
+    scope: unknown,
+    reason: string,
+  ): OversizedActivityReference {
+    if (this.blocked(repo, number)) throw new Error("oversized acknowledgement is fenced");
+    const existing = this.control(repo, number);
+    if (existing) {
+      this.invalidate(existing.reference, reason);
+      return existing.reference;
+    }
+    const reference: OversizedActivityReference = { version: 1, repo, number, epoch: randomUUID() };
+    const scopeHash = activityHash(scope);
+    this.kv.put(epochKey(reference), {
+      reference,
+      scope: scopeHash,
+      receiptCount: 0,
+      invalid: reason,
+      pending: null,
+    });
+    this.kv.put(controlKey(repo, number), { reference, scope: scopeHash, busyUntil: 0 });
+    return reference;
+  }
+  lockAcknowledgement(ref: OversizedActivityReference): string {
+    if (this.blocked(ref.repo, ref.number)) throw new Error("oversized acknowledgement is fenced");
+    const c = this.control(ref.repo, ref.number);
+    if (!c || c.reference.epoch !== ref.epoch)
+      throw new Error("oversized acknowledgement reference is stale");
+    c.busyUntil = Date.now() + 60_000;
+    c.busyOwner = randomUUID();
+    this.kv.put(controlKey(ref.repo, ref.number), c);
+    return c.busyOwner;
+  }
+  assertAcknowledgement(ref: OversizedActivityReference, token: string): void {
+    const c = this.control(ref.repo, ref.number);
+    if (
+      !c ||
+      c.reference.epoch !== ref.epoch ||
+      c.busyOwner !== token ||
+      (c.fence && c.fence.expiresAt > Date.now())
+    )
+      throw new Error("oversized acknowledgement is fenced");
+    c.busyUntil = Date.now() + 60_000;
+    this.kv.put(controlKey(ref.repo, ref.number), c);
+  }
+  unlockAcknowledgement(ref: OversizedActivityReference, token: string): void {
+    const c = this.control(ref.repo, ref.number);
+    if (c?.reference.epoch !== ref.epoch || c.busyOwner !== token) return;
+    c.busyUntil = 0;
+    delete c.busyOwner;
+    this.kv.put(controlKey(ref.repo, ref.number), c);
+  }
+  fence(
+    ref: OversizedActivityReference,
+    owner: OversizedActivityOwner,
+    expiresAt: number,
+  ): boolean {
+    const c = this.control(ref.repo, ref.number);
+    const meta = this.meta(ref);
+    if (!c || c.reference.epoch !== ref.epoch || c.busyUntil > Date.now()) return false;
+    if (
+      meta?.pending &&
+      !meta.invalid &&
+      (!c.fence || stableJson(c.fence.owner) !== stableJson(owner))
+    ) {
+      this.invalidate(ref, "an owned write was still unresolved at publication handoff");
+    }
+    if (
+      c.fence &&
+      c.fence.expiresAt > Date.now() &&
+      stableJson(c.fence.owner) !== stableJson(owner) &&
+      !(
+        c.fence.owner.itemKey === owner.itemKey &&
+        c.fence.owner.leaseId === owner.leaseId &&
+        owner.claimGeneration > c.fence.owner.claimGeneration
+      )
+    )
+      return false;
+    if (meta) {
+      const key = activityHash(owner);
+      const consumers = meta.consumers ?? {};
+      if (Object.entries(consumers).some(([other, state]) => other !== key && state !== "complete"))
+        meta.invalid = "previous publication owner did not seal its writes";
+      if (Object.keys(consumers).length >= 500 && !consumers[key])
+        meta.invalid = "publication owner history exceeds the validation bound";
+      else consumers[key] = "active";
+      meta.consumers = consumers;
+      this.kv.put(epochKey(ref), meta);
+    }
+    c.fence = { owner, expiresAt: Math.min(expiresAt, Date.now() + OVERSIZED_ACTIVITY_FENCE_MS) };
+    this.kv.put(controlKey(ref.repo, ref.number), c);
+    return true;
+  }
+  owns(ref: OversizedActivityReference, owner: OversizedActivityOwner): boolean {
+    const c = this.control(ref.repo, ref.number);
+    return Boolean(
+      c?.reference.epoch === ref.epoch &&
+      c.fence &&
+      c.fence.expiresAt > Date.now() &&
+      stableJson(c.fence.owner) === stableJson(owner),
+    );
+  }
+  seal(ref: OversizedActivityReference, owner: OversizedActivityOwner, failed: boolean): void {
+    const meta = this.meta(ref);
+    if (!meta) return;
+    const key = activityHash(owner);
+    if (meta.consumers?.[key])
+      meta.consumers[key] = failed || meta.consumers[key] === "failed" ? "failed" : "complete";
+    if (failed) meta.invalid = "publisher could not persist all owned-write receipts";
+    this.kv.put(epochKey(ref), meta);
+  }
+  release(ref: OversizedActivityReference, owner: OversizedActivityOwner): void {
+    const c = this.control(ref.repo, ref.number);
+    if (!c?.fence || stableJson(c.fence.owner) !== stableJson(owner)) return;
+    delete c.fence;
+    this.kv.put(controlKey(ref.repo, ref.number), c);
+  }
+  invalidate(ref: OversizedActivityReference, reason: string): void {
+    const meta = this.meta(ref);
+    if (!meta) return;
+    meta.invalid = reason;
+    this.kv.put(epochKey(ref), meta);
+  }
+  begin(ref: OversizedActivityReference, receipt: OversizedAcknowledgementReceipt): void {
+    const meta = this.meta(ref);
+    if (!meta) throw new Error("activity evidence is missing");
+    if (meta.pending) meta.invalid = "an earlier owned write has no complete receipt";
+    meta.receiptCount++;
+    meta.pending = receipt.id;
+    if (meta.receiptCount > 500) meta.invalid = "owned-write history exceeds the validation bound";
+    this.kv.put(`${epochKey(ref)}:receipt:${meta.receiptCount}`, receipt);
+    this.kv.put(`${epochKey(ref)}:intent:${receipt.id}`, meta.receiptCount);
+    this.kv.put(epochKey(ref), meta);
+  }
+  complete(ref: OversizedActivityReference, receipt: OversizedAcknowledgementReceipt): void {
+    const meta = this.meta(ref);
+    const index = this.kv.get<number>(`${epochKey(ref)}:intent:${receipt.id}`);
+    if (!meta || !index) throw new Error("activity write intent is missing");
+    const original = this.kv.get<OversizedAcknowledgementReceipt>(
+      `${epochKey(ref)}:receipt:${index}`,
+    );
+    if (
+      !original ||
+      stableJson({ ...receipt, after: null, completedAt: null, pullAfter: null }) !==
+        stableJson(original)
+    )
+      throw new Error("activity write intent changed");
+    this.kv.put(`${epochKey(ref)}:receipt:${index}`, receipt);
+    if (meta.pending === receipt.id) meta.pending = null;
+    this.kv.put(epochKey(ref), meta);
+  }
+  evidence(ref: OversizedActivityReference): OversizedActivityEvidence | null {
+    const meta = this.meta(ref);
+    if (!meta) return null;
+    if (meta.invalid)
+      return { reference: ref, baseline: null, receipts: [], invalid: meta.invalid };
+    const key = epochKey(ref);
+    const baseline: OversizedActivityBaseline = {
+      source: this.kv.get(`${key}:source`)!,
+      comments: this.kv.get(`${key}:comments`)!,
+      streams: [0, 1, 2, 3].map((i) => this.kv.get(`${key}:stream:${i}`)!),
+    };
+    return parseOversizedActivityEvidence({
+      reference: ref,
+      baseline,
+      receipts: Array.from({ length: meta.receiptCount }, (_, i) =>
+        this.kv.get(`${key}:receipt:${i + 1}`),
+      ),
+      invalid: meta.pending ? "owned write has no complete receipt" : null,
+    });
+  }
+}

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -14,10 +14,6 @@ import { isExactReviewCloseGuardLabel } from "../src/repair/exact-review-guard-l
 import { sha256Hex } from "./exact-review-direct-publication.ts";
 import { exactReviewSourceRevisionMaterial } from "./exact-review-source-revision.ts";
 import {
-  resolvePullRequestAcknowledgement,
-  settlePullRequestAcknowledgement,
-} from "./pull-request-acknowledgement.ts";
-import {
   GITHUB_ETAG_CACHE_MAX_BODY_BYTES,
   githubEtagCacheKey,
   githubEtagCacheRequestBody,
@@ -1151,6 +1147,8 @@ export default {
       return authenticatedExactReviewQueueRequest(request, env, "/state-writer/heartbeat");
     if (url.pathname === "/internal/state-writer/release" && request.method === "POST")
       return authenticatedExactReviewQueueRequest(request, env, "/state-writer/release");
+    if (url.pathname === "/internal/exact-review/oversized-activity" && request.method === "POST")
+      return exactReviewQueueRequest(env, "/oversized-activity", request);
     if (url.pathname === "/internal/exact-review/claim" && request.method === "POST")
       return exactReviewQueueRequest(env, "/claim", request);
     // Heartbeat authenticates by full lease tuple, matching /claim and /complete: the
@@ -7196,65 +7194,36 @@ async function enqueueExactReview({
 }
 
 async function acknowledgePullRequestReceipt({ env, ctx, decision }) {
-  if (decision.itemKind !== "pull_request") return null;
-  const credentials = githubAppCredentials(env);
-  if (!credentials || !Number.isInteger(decision.installationId) || decision.installationId <= 0) {
-    return null;
-  }
-  const appJwt = await signGithubAppJwt(credentials.issuer, credentials.privateKey);
-  const token = await createGithubAppTokenFor({
-    env,
-    appJwt,
-    installationId: decision.installationId,
-    label: decision.targetRepo,
-    repositories: [repoName(decision.targetRepo)],
-    permissions: { issues: "write", pull_requests: "write" },
-  });
-  const createsReceipt = ["opened", "ready_for_review"].includes(decision.sourceAction);
-  const acknowledgement = await resolvePullRequestAcknowledgement({
-    githubJson: (request) =>
-      githubTokenJson({
-        env,
-        token,
-        path: request.path,
-        method: request.method,
-        body: request.body,
-        errorLabel: request.errorLabel,
+  if (decision.itemKind !== "pull_request" || !githubAppCredentials(env)) return null;
+  if (!Number.isInteger(decision.installationId) || decision.installationId <= 0) return null;
+  const queue = exactReviewQueueStub(env);
+  if (!queue) throw new Error("acknowledgement queue is unavailable");
+  const resolve = async (settle: boolean) => {
+    const { response } = await exactReviewQueueFetch(
+      queue,
+      "/pull-request-acknowledgement",
+      new Request("https://clawsweeper-exact-review-queue/pull-request-acknowledgement", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ decision, installation_id: decision.installationId, settle }),
       }),
-    targetRepo: decision.targetRepo,
-    itemNumber: decision.itemNumber,
-    sourceAction: decision.sourceAction,
-  });
-  if (acknowledgement.outcome === "lookup_limit") {
-    console.warn("ClawSweeper pull request acknowledgement lookup limit reached");
-    return null;
-  }
-  if (createsReceipt) {
+    );
+    if (!response.ok) throw new Error("queue acknowledgement deferred");
+    return objectValue(await response.json());
+  };
+  const acknowledgement = await resolve(false);
+  if (acknowledgement.deferred === true) throw new Error("queue acknowledgement deferred");
+  if (["opened", "ready_for_review"].includes(decision.sourceAction)) {
     const cleanup = async () => {
       for (const delayMs of fastAckSettleDelaysMs(env.CLAWSWEEPER_FAST_ACK_SETTLE_DELAYS_MS)) {
         await sleep(delayMs);
-        await settlePullRequestAcknowledgement({
-          githubJson: (request) =>
-            githubTokenJson({
-              env,
-              token,
-              path: request.path,
-              method: request.method,
-              body: request.body,
-              errorLabel: request.errorLabel,
-            }),
-          targetRepo: decision.targetRepo,
-          itemNumber: decision.itemNumber,
-          sourceAction: decision.sourceAction,
-        });
+        await resolve(true);
       }
     };
-    const promise = cleanup().catch(() => {
-      console.error("ClawSweeper fast ack cleanup failed");
-    });
+    const promise = cleanup().catch(() => console.error("ClawSweeper fast ack cleanup deferred"));
     if (ctx?.waitUntil) ctx.waitUntil(promise);
   }
-  return acknowledgement.commentId;
+  return Number(acknowledgement.commentId) || null;
 }
 
 async function createFastAckComment({

--- a/dashboard/wrangler.toml
+++ b/dashboard/wrangler.toml
@@ -2,6 +2,7 @@ name = "clawsweeper-status"
 main = "worker.ts"
 account_id = "91b59577e757131d68d55a471fe32aca"
 compatibility_date = "2026-05-11"
+compatibility_flags = ["nodejs_compat"]
 workers_dev = true
 
 [triggers]

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -381,11 +381,31 @@ Do not move these into the dashboard:
 The dashboard Worker owns durable exact-review admission only: it deduplicates
 webhook deliveries, coalesces each repository/item pair, and leases at most
 32 Actions executors, with up to 24 active leases per target repository. It does
-not decide review outcomes or perform target repository mutations. For
+not decide review outcomes or close target items. It owns bounded acknowledgement
+comment effects; GitHub Actions owns review publication and apply. For
 command-triggered reviews, the queue retains the bounded review prompt and
 command-status identifiers so the leased GitHub Actions executor can update the
 original acknowledgement through completion. GitHub Actions remains the
 executor and the existing review/apply safety model remains unchanged.
+
+For oversized PRs, the Durable Object additionally owns the pre-acknowledgement
+activity baseline, append-only write history, and acknowledgement fence described
+in [the size policy](oversized-pr-close-policy.md#queue-owned-evidence-and-publication).
+Version-1 evidence references pass through the validated decision allowlist.
+The internal `POST /internal/exact-review/oversized-activity` endpoint binds reads
+and write receipts to the current item/lease/run/attempt/claim generation; it is
+not a public observer or browser API. Source PR acknowledgements and delayed
+cleanup are delegated through the private queue binding, so they share the same
+journal and fence. Baseline streams and individual receipts use separate KV keys;
+existing SQL queue items and rollback state are not migrated or discarded.
+The Worker enables `nodejs_compat` for the shared SHA-256 and UUID implementation.
+
+Upgraded consumers keep oversized proposals open when evidence is absent,
+malformed, stale, or incomplete while preserving ordinary publication/completion.
+The explicitly accepted September 9, 2026 legacy exception lets already-running
+pre-capability consumers finish with their existing safeguards. They are not
+retroactively fenced or invalidated. The existing observer projection and Bay
+lifecycle contract are unchanged; neither surface gains action controls.
 
 The singleton Durable Object stores each delivery receipt and queue item in its
 own SQLite row. Receipt insertion and item coalescing commit in one transaction,

--- a/docs/oversized-pr-close-policy.md
+++ b/docs/oversized-pr-close-policy.md
@@ -91,6 +91,10 @@ publication attempts. Oversized references use the existing single-item queued
 publisher to preserve this per-item fence; ordinary review publication batching
 is unchanged.
 
+A queued publication that encounters another active review writes and receipts its
+Waiting status before completing the publishing lease. Completion seals that
+status effect and releases ownership; a released owner still cannot mutate it.
+
 ## Rollout and legacy exception
 
 The maintainer explicitly accepted a bounded legacy exception on September 9,

--- a/docs/oversized-pr-close-policy.md
+++ b/docs/oversized-pr-close-policy.md
@@ -56,8 +56,8 @@ The Durable Object stores the baseline in separate bounded keys and journals eac
 owned acknowledgement POST, PATCH, and DELETE, including duplicate cleanup. Each
 write has a persisted intent before its request and a receipt with the comment ID,
 kind, before/after body and identity fingerprints, comment timestamps, and the
-resulting PR timestamp/count when observed. An uncertain response or incomplete
-receipt prevents closing. Receipt history is retained independently of queue-item
+resulting PR timestamp/count from the post-write observation. An uncertain
+response, malformed post-write snapshot, or incomplete receipt prevents closing. Receipt history is retained independently of queue-item
 completion; no existing queue-storage migration is required.
 
 The decision allowlist carries a validated, item-bound version-1 reference to that

--- a/docs/oversized-pr-close-policy.md
+++ b/docs/oversized-pr-close-policy.md
@@ -42,13 +42,72 @@ create the durable proposal through that writer; existing reviews update the
 canonical comment. Both carry the reserved lease identity. Ordinary admitted PRs reuse the payload during hydration.
 Each head or label change is evaluated again. This policy never reopens a PR.
 
-Known gap: when direct publication is not accepted and the proposal falls back
-to the durable queue, the queued lease-expiry write advances PR activity after
-the report's observation. The unchanged source-freshness guard keeps the PR
-open with `skipped_changed_since_review`; it can be re-evaluated at the next
-event or head. Deferred publication is not fixed by carrying the lease tuple.
-The follow-up is to create the final metadata proposal under publication
-ownership, after the publisher acquires its current lease and fence.
+## Queue-owned evidence and publication
+
+Before acknowledgement effects on an oversized PR, the queue captures PR metadata
+and the four bounded activity streams: issue comments, timeline, inline comments,
+and submitted reviews. Each stream retains the existing three-page, 300-entry
+refusal boundary. Missing pages, repeated identities, undatable activity, changing
+counts/metadata, and activity inside the observation-second margin invalidate the
+evidence. Settled acknowledgements already present are part of the baseline.
+Capture adds metadata reads only; it never fetches PR files, commits, or blobs.
+
+The Durable Object stores the baseline in separate bounded keys and journals each
+owned acknowledgement POST, PATCH, and DELETE, including duplicate cleanup. Each
+write has a persisted intent before its request and a receipt with the comment ID,
+kind, before/after body and identity fingerprints, comment timestamps, and the
+resulting PR timestamp/count when observed. An uncertain response or incomplete
+receipt prevents closing. Receipt history is retained independently of queue-item
+completion; no existing queue-storage migration is required.
+
+The decision allowlist carries a validated, item-bound version-1 reference to that
+journal. Capability-aware claims establish an explicit per-item acknowledgement
+fence. The fence lasts through publication/apply completion or lease release and
+has a deadline bounded by the execution lease and 30 minutes. Heartbeats can renew
+a current owner's deadline; a crashed owner cannot block acknowledgements forever.
+Queue convergence defers while fenced. As in the existing metadata-only workflow,
+queue intake omits the review eyes reaction for oversized proposals; ordinary
+reviews retain it. The Worker's fast PR acknowledgement and
+its delayed cleanup also use this owner; deferred cleanup is retained for retry.
+
+The upgraded workflow/CLI records reservation, command/review status, durable
+comment, mutation-lease, and queued-expiry writes in the same journal. The original
+artifact carries the reference, so queued publication can fetch receipts added
+after artifact creation without replacing the baseline. Publication owns the
+current claim before finalization. It waits a bounded interval for its recorded
+writes to appear in PR metadata, replays exact preimages and write responses,
+compares all non-owned activity against the original baseline, and repeats the
+size/head/exemption and existing canonical-comment checks before closing. A
+same-second human review edit remains a fingerprint change even when an owned
+write has the same PR timestamp. Missing, malformed, stale, ambiguous, or
+incomplete evidence keeps the PR open; ordinary comment delivery and completion
+continue subject to their existing authority and canonical-comment guards.
+
+If the journal is unavailable, the consumer writes a durable local failure marker
+before continuing ordinary comment effects. That marker prevents its close and is
+sealed into the queue at completion. A successor also refuses if a prior owner
+never sealed its writes, so a crash cannot lose the failure evidence between
+publication attempts. Oversized references use the existing single-item queued
+publisher to preserve this per-item fence; ordinary review publication batching
+is unchanged.
+
+## Rollout and legacy exception
+
+The maintainer explicitly accepted a bounded legacy exception on September 9,
+2026: already-running pre-capability workflow/apply consumers started from the
+previous main head before deployment finish under their existing safeguards.
+They may close eligible oversized PRs under that existing guard profile. This is
+an explicit transition exception, not retroactive evidence enforcement. Do not
+invalidate or reopen their work, pause the sweep, or drain those runs.
+
+Every upgraded consumer requires valid queue-owned evidence to close. Against an
+older Worker, the new workflow receives no evidence capability and retains the
+proposal with a normal kept-open result. The new Worker preserves old claim,
+heartbeat, publication, and completion contracts. New workflows advertise the
+capability when claiming; their close path cannot silently fall back to legacy
+freshness behavior. The coordinator must verify the serving deployment SHA and
+the end of the pre-capability cohort after deployment. Bay continues to observe
+the existing proposal/close lifecycle and gains no mutation controls.
 
 `CLAWSWEEPER_OVERSIZED_PR_CLOSE_ENABLED` gates apply; it defaults off in a
 standalone CLI and defaults to `true` in the sweep workflow. The normal
@@ -59,24 +118,12 @@ with `decision: close` and its additions, deletions, changedFiles, threshold,
 and head evidence. The report also records a metadata source fingerprint and
 comment counts. No scanner or model provenance is asserted.
 
-Apply requires complete recorded metadata and repeats the live PR size,
-head, open-state, lock, and exemption checks immediately before closing.
-Changed metadata or unreadable live state blocks the close. The source record also carries the observation time taken before the PR metadata
-read; initial activity at that second or within the one-second clock margin is
-ambiguous and keeps the proposal open. Missing handoff observation times fall
-back conservatively to the PR update timestamp. Submitted reviews expose no
-edit timestamp, so a PR update timestamp in that observation window also blocks
-initial receipt creation when reviews exist. Before comment
-publication, apply captures bounded issue-comment, timeline, inline-comment,
-and review metadata, with a maximum of three 100-entry pages per stream.
-Incomplete reads keep the proposal open. The receipt excludes only the exact
-owned review-comment ID and verifies that comment against its write response;
-all other activity remains fingerprinted. The baseline is persisted before
-publication, and the exact owned write identity is persisted before any
-post-publication read, including when subsequent validation fails. Forced checks before closing catch
-body edits and same-second human comments after publication, and persisted
-receipts preserve that protection across retries. PR files, commits, blobs,
-scanner work, and model review are not hydrated by this guard.
+Apply requires complete recorded size/head metadata and repeats the live PR
+open-state, lock, size, head, and exemption checks immediately before closing.
+The queue baseline includes review bodies because submitted reviews do not expose
+an edit timestamp. Only individually receipted comment writes can change the
+expected comment images; all other stream entries stay fingerprinted. The queue
+fence and evidence are checked again after the final bounded activity capture.
 
 Changed metadata or unreadable live state blocks the close. The public notice
 uses proposal wording until GitHub confirms the close, so an aborted close never
@@ -102,9 +149,11 @@ The public comment is:
 
 `node scripts/proof-oversized-pr-close.mjs` exercises metadata admission and
 dry-run retention, with a 49,999-line control.
-`node scripts/proof-oversized-pr-close-effects.mjs` drives the built CLI through
-a loopback HTTP GitHub adapter and inspects service state plus items/closed
-records for first/existing durable review reservation and closing, protected-label refusal, and late exemption, body,
-and human-comment changes. This uses synthetic data and transport; it does not
-close a live GitHub PR. The workflow test also executes a HTTP-409 finalization
-branch and verifies that supersession prevents publication.
+`node scripts/proof-oversized-pr-close-effects.mjs` runs the built CLI through a
+loopback GitHub service and the queue receipt store/acknowledgement writer. It
+covers first/existing durable comments on direct/queued publication, one-second
+POST/PATCH/DELETE metadata propagation, same-second review edits, human comments,
+labels/heads, and missing/malformed/stale evidence. Metadata reads are counted
+separately and file/blob hydration, scanner, and model work remain zero. Dashboard
+tests exercise claim/evidence/receipt/completion routes and old-consumer protocol
+compatibility. These use synthetic data and do not close a live GitHub PR.

--- a/scripts/proof-oversized-pr-close-effects.mjs
+++ b/scripts/proof-oversized-pr-close-effects.mjs
@@ -3,347 +3,447 @@ import { spawn } from "node:child_process";
 import { createServer } from "node:http";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
+import { OversizedActivityStore } from "../dashboard/oversized-activity-store.ts";
+import { convergeCommandAcknowledgement } from "../dashboard/exact-review-queue.ts";
+import {
+  ownedCommentWriteIntent,
+  ownedCommentWriteResult,
+} from "../src/oversized-activity-write.ts";
 
 const root = resolve(process.argv[2] || ".artifacts/oversized-effects-proof");
 mkdirSync(root, { recursive: true });
 const adapter = join(root, "github-http-adapter.mjs");
 writeFileSync(
   adapter,
-  `import { readFileSync } from 'node:fs';
-let args = process.argv.slice(2);
-if (args[0] === '--repo') args = args.slice(2);
-let method = 'GET', path, body;
-if (args[0] === 'api') {
-  path = '/' + args[1];
-  const mi = args.indexOf('--method'); if (mi >= 0) method = args[mi + 1];
-  const bi = args.indexOf('--input'); if (bi >= 0) body = readFileSync(args[bi + 1], 'utf8');
-  const fi = args.indexOf('-f'); if (fi >= 0 && args[fi + 1].startsWith('body=')) body = JSON.stringify({body: args[fi + 1].slice(5)});
-} else if (args[0] === 'pr' && args[1] === 'close') {
-  method = 'PATCH'; path = '/repos/openclaw/openclaw/pulls/' + args[2]; body = JSON.stringify({state:'closed'});
-} else throw new Error('Unexpected command at isolated GitHub transport');
-if (!path.startsWith('/repos/openclaw/openclaw/')) throw new Error('Unexpected repository');
-const base = new URL(process.env.PROOF_HTTP_URL);
-if (base.hostname !== '127.0.0.1' || base.protocol !== 'http:') throw new Error('Loopback transport required');
-const response = await fetch(new URL(path, base), {method, body, headers:{'content-type':'application/json'}});
-const text = await response.text();
-if (!response.ok) { console.error(text); process.exit(1); }
-process.stdout.write(args.includes("--slurp") ? JSON.stringify([JSON.parse(text)]) : text);
+  `import {readFileSync} from 'node:fs';
+let args=process.argv.slice(2); if(args[0]==='--repo')args=args.slice(2);
+let method='GET',path,body;
+if(args[0]==='api') {
+ path='/'+args[1]; const m=args.findIndex(x=>x==='--method'||x==='-X'); if(m>=0)method=args[m+1];
+ const i=args.indexOf('--input'); if(i>=0)body=readFileSync(args[i+1],'utf8');
+ const f=args.indexOf('-f'); if(f>=0&&args[f+1].startsWith('body='))body=JSON.stringify({body:args[f+1].slice(5)});
+} else if(args[0]==='pr'&&args[1]==='close'){method='PATCH';path='/repos/openclaw/openclaw/pulls/'+args[2];body=JSON.stringify({state:'closed'});}else throw new Error('unexpected GitHub command');
+if(!path.startsWith('/repos/openclaw/openclaw/'))throw new Error('unexpected target');
+const base=new URL(process.env.PROOF_HTTP_URL); if(base.hostname!=='127.0.0.1'||base.protocol!=='http:')throw new Error('loopback required');
+const r=await fetch(new URL(path,base),{method,body,headers:{'content-type':'application/json'}});const t=await r.text();if(!r.ok){console.error(t);process.exit(1);}process.stdout.write(args.includes('--slurp')?JSON.stringify([JSON.parse(t)]):t);
 `,
 );
-const initial = {
-  number: 141913,
-  title: "Synthetic final-effect proof",
-  body: "Synthetic PR body",
-  html_url: "https://github.com/openclaw/openclaw/pull/141913",
-  state: "open",
-  locked: false,
-  draft: true,
-  author_association: "OWNER",
-  user: { login: "synthetic-owner" },
-  additions: 45791,
-  deletions: 120895,
-  changed_files: 2747,
-  comments: 0,
-  review_comments: 0,
-  labels: [],
-  assignees: [],
-  milestone: null,
-  requested_reviewers: [],
-  requested_teams: [],
-  created_at: "2026-01-01T00:00:00Z",
-  updated_at: "2026-09-08T00:00:00Z",
-  head: { sha: "b".repeat(40), repo: { full_name: "synthetic-owner/openclaw" } },
-  base: { ref: "main", sha: "a".repeat(40) },
-};
-const summaries = [];
-for (const scenario of [
-  "eligible",
-  "reserved-first-review",
-  "reserved-existing-review",
-  "reserved-queued-review",
-  "protected",
-  "ambiguous-initial-comment",
-  "stable-old-comment",
-  "late-exemption",
-  "late-body",
+const number = 141913,
+  repo = "openclaw/openclaw",
+  head = "b".repeat(40);
+const marker = "<!-- clawsweeper-command-status:synthetic-proof -->";
+const oldTime = new Date(Date.now() - 86_400_000).toISOString().replace(/\.\d{3}Z$/, "Z");
+const scenarios = [
+  "first-direct",
+  "existing-direct",
+  "first-queued",
+  "existing-queued",
+  "review-unchanged",
+  "same-second-review-edit",
   "late-human-comment",
-  "late-review-edit-retry",
-]) {
-  const reserveLease = scenario.startsWith("reserved-");
-  const quietObservation =
-    scenario === "stable-old-comment" || scenario === "late-review-edit-retry";
+  "late-review-edit",
+  "late-label",
+  "late-head",
+  "propagation-race",
+  "evidence-absent",
+  "evidence-malformed",
+  "evidence-stale",
+  "journal-begin-unavailable",
+  "journal-complete-unavailable",
+  "journal-malformed-response",
+];
+const selected = process.env.PROOF_SCENARIOS?.split(",") || scenarios;
+const summaries = [];
+for (const scenario of selected) {
   const directory = join(root, scenario);
   mkdirSync(directory, { recursive: true });
-  const pull = structuredClone(initial);
-  if (scenario === "protected") pull.labels = ["security"];
+  const pull = {
+    number,
+    title: "Synthetic oversized PR",
+    body: "Synthetic body",
+    html_url: `https://github.com/${repo}/pull/${number}`,
+    state: "open",
+    locked: false,
+    draft: true,
+    author_association: "OWNER",
+    user: { login: "synthetic-owner" },
+    additions: 45791,
+    deletions: 120895,
+    changed_files: 2747,
+    comments: 0,
+    review_comments: 0,
+    labels: [],
+    assignees: [],
+    milestone: null,
+    requested_reviewers: [],
+    requested_teams: [],
+    created_at: oldTime,
+    updated_at: oldTime,
+    head: { sha: head, repo: { full_name: "synthetic-owner/openclaw" } },
+    base: { ref: "main", sha: "a".repeat(40) },
+  };
   const comments = [],
     timeline = [],
-    requests = [];
-  const reviews = [];
-  if (scenario === "reserved-existing-review") {
-    const prior = {
-      id: 999,
-      body: `Prior durable review\n\n<!-- clawsweeper-review-version item=141913 reviewed_at=2026-09-07T00:00:00Z sha=${initial.head.sha} source_revision=${"a".repeat(64)} lease_owner=previous lease_comment_id=999 v=1 -->\n<!-- clawsweeper-review item=141913 -->`,
-      user: { login: "clawsweeper[bot]", type: "Bot" },
-      created_at: "2026-09-07T00:00:00Z",
-      updated_at: "2026-09-07T00:00:00Z",
-    };
-    comments.push(prior);
-    timeline.push({ ...prior, event: "commented" });
-    pull.comments = 1;
+    reviews = [],
+    requests = [],
+    projections = [];
+  let nextId = 1000,
+    ref,
+    owner,
+    context,
+    mutationCount = 0,
+    interventionDone = false,
+    applying = false;
+  const memory = new Map();
+  const store = new OversizedActivityStore({
+    get: (key) => structuredClone(memory.get(key)),
+    put: (key, value) => memory.set(key, structuredClone(value)),
+  });
+  const comment = (id, body, author = "clawsweeper[bot]") => ({
+    id,
+    body,
+    user: { login: author, type: author.includes("bot") ? "Bot" : "User" },
+    author_association: "NONE",
+    html_url: `${pull.html_url}#issuecomment-${id}`,
+    issue_url: `https://api.github.com/repos/${repo}/issues/${number}`,
+    created_at: oldTime,
+    updated_at: oldTime,
+  });
+  if (scenario.startsWith("existing")) {
+    const c = comment(
+      999,
+      `Previous review\n<!-- clawsweeper-review-version item=${number} reviewed_at=${oldTime} sha=${head} source_revision=${"a".repeat(64)} lease_owner=old lease_comment_id=999 v=1 -->\n<!-- clawsweeper-review item=${number} -->`,
+    );
+    comments.push(c);
+    timeline.push({ ...c, event: "commented" });
   }
-  if (scenario === "late-review-edit-retry") {
-    const review = {
-      id: 700,
-      body: "Original submitted review",
-      submitted_at: "2026-01-01T00:00:00Z",
-      state: "COMMENTED",
-      user: { login: "synthetic-human" },
-    };
-    reviews.push(review);
-    timeline.push({ ...review, event: "reviewed" });
-  }
-  if (scenario === "ambiguous-initial-comment" || scenario === "stable-old-comment") {
-    const human = {
-      id: 1001,
-      body: "Human comment edited in the observation second",
-      user: { login: "synthetic-human", type: "User" },
-      created_at: "2026-01-01T00:00:00Z",
-      updated_at: initial.updated_at,
-    };
-    comments.push(human);
-    timeline.push({ ...human, event: "commented" });
-    pull.comments = 1;
-  }
+  comments.push(comment(800, "@clawsweeper re-review", "synthetic-human"));
+  timeline.push({ ...comments.at(-1), event: "commented" });
+  pull.comments = comments.length;
+  const review = {
+    id: 700,
+    body: "Original review body",
+    submitted_at: oldTime,
+    state: "COMMENTED",
+    user: { login: "synthetic-reviewer" },
+  };
+  reviews.push(review);
+  timeline.push({ ...review, event: "reviewed" });
   const server = createServer(async (request, response) => {
     try {
-      const url = new URL(request.url, "http://127.0.0.1");
       const chunks = [];
-      for await (const chunk of request) chunks.push(chunk);
-      const text = Buffer.concat(chunks).toString();
-      const input = text ? JSON.parse(text) : {};
-      requests.push({ method: request.method, path: url.pathname });
+      for await (const c of request) chunks.push(c);
+      const raw = Buffer.concat(chunks).toString();
+      const input = raw ? JSON.parse(raw) : {};
+      const url = new URL(request.url, "http://127.0.0.1");
+      const path = url.pathname;
+      requests.push({ method: request.method, path });
       const send = (value, status = 200) => {
         response.writeHead(status, { "content-type": "application/json" });
         response.end(JSON.stringify(value));
       };
-      const path = url.pathname;
+      if (path === "/internal/exact-review/heartbeat") return send({ ok: true });
+      if (path === "/internal/exact-review/oversized-activity") {
+        if (
+          applying &&
+          ((scenario === "journal-begin-unavailable" && input.operation === "begin") ||
+            (scenario === "journal-complete-unavailable" && input.operation === "complete"))
+        )
+          return send({ error: "synthetic evidence outage" }, 503);
+        if (applying && scenario === "journal-malformed-response" && input.operation === "begin") {
+          response.writeHead(200);
+          response.end("not-json");
+          return;
+        }
+
+        if (!ref || input.reference?.epoch !== ref.epoch || !store.owns(ref, input.owner))
+          return send({ ok: true, evidence: null });
+        if (input.operation === "read") return send({ ok: true, evidence: store.evidence(ref) });
+        if (input.operation === "begin") store.begin(ref, input.receipt);
+        else if (input.operation === "complete") store.complete(ref, input.receipt);
+        else return send({ error: "invalid operation" }, 400);
+        return send({ ok: true, recorded: true });
+      }
       if (request.method === "GET") {
         if (/\/issues\/comments\/\d+$/.test(path)) {
-          const comment = comments.find((entry) => entry.id === Number(path.split("/").at(-1)));
-          return comment ? send(comment) : send({ error: "comment missing" }, 404);
+          const c = comments.find((c) => c.id === Number(path.split("/").at(-1)));
+          return c ? send(c) : send({ error: "missing comment" }, 404);
         }
-        if (path.endsWith("/pulls/141913")) return send(pull);
-        if (path.endsWith("/issues/141913"))
+        if (path.endsWith(`/pulls/${number}`)) return send(pull);
+        if (path.endsWith(`/issues/${number}`))
           return send({
             ...pull,
-            pull_request: { url: "https://api.github.com/repos/openclaw/openclaw/pulls/141913" },
+            pull_request: { url: `https://api.github.com/repos/${repo}/pulls/${number}` },
           });
         const page = Number(url.searchParams.get("page") || 1),
           start = (page - 1) * 100;
-        if (path.endsWith("/issues/141913/comments"))
+        if (path.endsWith(`/issues/${number}/comments`))
           return send(comments.slice(start, start + 100));
         if (path.endsWith("/timeline")) return send(timeline.slice(start, start + 100));
         if (path.endsWith("/reviews")) return send(reviews.slice(start, start + 100));
-        if (path.endsWith("/pulls/141913/comments")) return send([]);
+        if (path.endsWith(`/pulls/${number}/comments`)) return send([]);
         return send({ error: "unimplemented read" }, 404);
       }
-      if (request.method === "POST" && path.endsWith("/issues/141913/comments")) {
-        const comment = {
-          id: Math.max(999, ...comments.map((entry) => entry.id)) + 1,
-          body: input.body,
-          user: { login: "clawsweeper[bot]", type: "Bot" },
-          html_url:
-            pull.html_url +
-            "#issuecomment-" +
-            (Math.max(999, ...comments.map((entry) => entry.id)) + 1),
-          created_at: quietObservation ? "2026-09-08T00:00:04Z" : "2026-09-08T00:00:01Z",
-          updated_at: quietObservation ? "2026-09-08T00:00:04Z" : "2026-09-08T00:00:01Z",
-        };
-        comments.push(comment);
-        timeline.push({ ...comment, event: "commented" });
-        pull.comments++;
-        pull.updated_at = comment.updated_at;
-        if (scenario === "late-review-edit-retry") {
-          reviews[0].body = "Review edited after proposal publication";
-          timeline.find((event) => event.id === 700).body = reviews[0].body;
-        }
-        if (scenario === "late-exemption") pull.labels.push("size: accepted-large");
-        if (scenario === "late-body")
-          pull.body = "Human edited the body after proposal publication";
-        if (scenario === "late-human-comment") {
-          const human = {
-            ...comment,
-            id: 1001,
-            body: "Same-second human follow-up",
-            user: { login: "synthetic-human", type: "User" },
-          };
-          comments.push(human);
-          timeline.push({ ...human, event: "commented" });
-          pull.comments++;
-        }
-        return send(comment, 201);
-      }
-      if (request.method === "PATCH" && /\/issues\/comments\/\d+$/.test(path)) {
-        const owned = comments.find((comment) => comment.id === Number(path.split("/").at(-1)));
-        owned.body = input.body;
-        owned.updated_at = quietObservation ? "2026-09-08T00:00:06Z" : "2026-09-08T00:00:03Z";
+      mutationCount++;
+      const timestamp = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+      let result;
+      if (request.method === "POST" && path.endsWith(`/issues/${number}/comments`)) {
+        result = { ...comment(nextId++, input.body), created_at: timestamp, updated_at: timestamp };
+        comments.push(result);
+        timeline.push({ ...result, event: "commented" });
+      } else if (request.method === "PATCH" && /\/issues\/comments\/\d+$/.test(path)) {
+        result = comments.find((c) => c.id === Number(path.split("/").at(-1)));
+        assert.ok(result);
+        result.body = input.body;
+        result.updated_at = timestamp;
         Object.assign(
-          timeline.find((event) => event.id === owned.id),
-          owned,
+          timeline.find((e) => e.id === result.id),
+          result,
         );
-        pull.updated_at = owned.updated_at;
-        return send(owned);
-      }
-      if (request.method === "DELETE" && path.endsWith("/issues/comments/1000")) {
-        comments.splice(
-          comments.findIndex((comment) => comment.id === 1000),
-          1,
-        );
-        timeline.splice(
-          timeline.findIndex((event) => event.id === 1000),
-          1,
-        );
-        pull.comments--;
-        return send({});
-      }
-      if (
+      } else if (request.method === "DELETE" && /\/issues\/comments\/\d+$/.test(path)) {
+        const id = Number(path.split("/").at(-1));
+        const index = comments.findIndex((c) => c.id === id);
+        if (index < 0) return send({ error: "missing comment" }, 404);
+        comments.splice(index, 1);
+        const ti = timeline.findIndex((c) => c.id === id);
+        if (ti >= 0) timeline.splice(ti, 1);
+        result = {};
+      } else if (
         request.method === "PATCH" &&
-        path.endsWith("/pulls/141913") &&
+        path.endsWith(`/pulls/${number}`) &&
         input.state === "closed"
       ) {
         pull.state = "closed";
-        pull.updated_at = quietObservation ? "2026-09-08T00:00:05Z" : "2026-09-08T00:00:02Z";
-        return send(pull);
+        result = pull;
+      } else return send({ error: "unexpected mutation" }, 400);
+      // Intervene after the owned status PATCH, in exactly its GitHub timestamp second.
+      if (
+        !interventionDone &&
+        request.method === "PATCH" &&
+        String(input.body || "").includes(marker)
+      ) {
+        interventionDone = true;
+        if (scenario === "same-second-review-edit" || scenario === "late-review-edit") {
+          review.body = "Human edited after baseline";
+          timeline.find((e) => e.id === 700).body = review.body;
+        }
+        if (scenario === "late-human-comment") {
+          const h = {
+            ...comment(nextId++, "Human follow-up", "synthetic-human"),
+            created_at: timestamp,
+            updated_at: timestamp,
+          };
+          comments.push(h);
+          timeline.push({ ...h, event: "commented" });
+        }
+        if (scenario === "late-label") pull.labels.push("size: accepted-large");
+        if (scenario === "late-head") pull.head.sha = "c".repeat(40);
       }
-      return send({ error: "unexpected mutation" }, 400);
+      const projectedCount = comments.length;
+      projections.push({
+        method: request.method,
+        path,
+        updatedAt: timestamp,
+        comments: projectedCount,
+        propagationMs: 1000,
+      });
+      setTimeout(() => {
+        pull.updated_at = timestamp;
+        pull.comments = projectedCount;
+      }, 1000);
+      return send(result, request.method === "POST" ? 201 : 200);
     } catch (error) {
       response.writeHead(500);
       response.end(String(error));
     }
   });
   await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const origin = `http://127.0.0.1:${server.address().port}`;
   const env = {
     PATH: process.env.PATH,
     HOME: directory,
     GH_BIN: process.execPath,
     GH_BIN_ARGS: JSON.stringify([adapter]),
-    GH_TOKEN: "synthetic-loopback-token",
+    GH_TOKEN: "synthetic-loopback",
     GITHUB_TOKEN: "",
-    PROOF_HTTP_URL: `http://127.0.0.1:${server.address().port}`,
+    PROOF_HTTP_URL: origin,
     CLAWSWEEPER_OVERSIZED_PR_CLOSE_ENABLED: "true",
     CLAWSWEEPER_MAX_PR_CHANGED_LINES: "50000",
+    CLAWSWEEPER_ACTION_LEDGER_DISABLED: "1",
   };
-  const run = async (name, args) => {
-    const child = spawn(process.execPath, ["dist/clawsweeper.js", ...args], {
+  const read = async (path) => {
+    const r = await fetch(`${origin}/${path.replace(/^\//, "")}`);
+    assert.equal(r.status, 200);
+    return r.json();
+  };
+  const run = async (name, args, cli = "dist/clawsweeper.js") => {
+    const child = spawn(process.execPath, [cli, ...args], {
       env,
       stdio: ["ignore", "pipe", "pipe"],
     });
-    let output = "",
-      stdout = "";
-    child.stdout.on("data", (chunk) => {
-      output += chunk;
-      stdout += chunk;
+    let stdout = "",
+      output = "";
+    child.stdout.on("data", (c) => {
+      stdout += c;
+      output += c;
     });
-    child.stderr.on("data", (chunk) => (output += chunk));
-    const code = await new Promise((resolve, reject) => {
+    child.stderr.on("data", (c) => (output += c));
+    const exit = await new Promise((resolve, reject) => {
       child.on("error", reject);
       child.on("close", resolve);
     });
     writeFileSync(
-      join(directory, name + ".log"),
+      join(directory, `${name}.log`),
       output
         .replaceAll(root, "<proof>")
         .replaceAll(process.cwd(), "<checkout>")
         .replaceAll(process.execPath, "<node>"),
     );
-    assert.equal(code, 0, output);
+    assert.equal(exit, 0, output);
     return stdout;
   };
   try {
+    ref = await store.prepare(repo, number, { head, command: marker }, read);
+    assert.equal(store.evidence(ref)?.invalid, null);
+    const baselineReadCount = requests.length;
+    const journal = async (request, write) => {
+      const before = request.method === "POST" ? null : await read(request.path);
+      const intent = ownedCommentWriteIntent(request, before);
+      store.begin(ref, intent);
+      const result = await write();
+      await new Promise((r) => setTimeout(r, 1100));
+      store.complete(
+        ref,
+        ownedCommentWriteResult(intent, result, await read(`repos/${repo}/pulls/${number}`)),
+      );
+      return result;
+    };
+    const acknowledgementToken = store.lockAcknowledgement(ref);
+    const ackId = await convergeCommandAcknowledgement({
+      env: { GITHUB_API_URL: origin },
+      token: Promise.resolve("synthetic"),
+      decision: { targetRepo: repo, itemNumber: number, commandStatusMarker: marker },
+      sourceCommentId: 800,
+      journal,
+    });
+    store.unlockAcknowledgement(ref, acknowledgementToken);
+    owner = {
+      itemKey: `${repo}#${number}`,
+      leaseId: "synthetic-review",
+      claimGeneration: 1,
+      runId: "123456789",
+      runAttempt: 1,
+    };
+    assert.equal(store.fence(ref, owner, Date.now() + 600_000), true);
+    context = {
+      reference: ref,
+      owner,
+      queueUrl: origin,
+      failurePath: join(directory, `evidence-failure-${ref.epoch}.json`),
+    };
+    env.CLAWSWEEPER_OVERSIZED_ACTIVITY_CONTEXT = JSON.stringify(context);
+    // A late duplicate-convergence attempt must defer without touching GitHub.
+    assert.equal(store.blocked(repo, number), true);
+    const reservation = JSON.parse(
+      await run("reserve", [
+        "reserve-review-lease",
+        "--target-repo",
+        repo,
+        "--item-number",
+        String(number),
+        "--review-timeout-ms",
+        "60000",
+      ]),
+    );
+    assert.equal(reservation.status, "posted");
     const admission = join(directory, "admission.json"),
       items = join(directory, "items"),
       closed = join(directory, "closed");
-    writeFileSync(
-      admission,
-      JSON.stringify(
-        {
-          repo: "openclaw/openclaw",
-          pull,
-          observedAt: quietObservation ? "2026-09-08T00:00:03Z" : initial.updated_at,
-        },
-        null,
-        2,
-      ),
-    );
-    let reservation;
-    if (reserveLease) {
-      reservation = JSON.parse(
-        await run("reserve", [
-          "reserve-review-lease",
-          "--target-repo",
-          "openclaw/openclaw",
-          "--item-number",
-          "141913",
-          "--review-timeout-ms",
-          "60000",
-        ]),
-      );
-      assert.equal(reservation.status, "posted");
-      assert.equal(reservation.commentId, 1000);
-      assert.equal(reservation.headSha, initial.head.sha);
-      // Match the workflow metadata refresh after its reservation/status writes.
-      writeFileSync(
-        admission,
-        JSON.stringify({ repo: "openclaw/openclaw", pull, observedAt: "2026-09-08T00:00:10Z" }),
-      );
-    }
-    const beforeReviewRequests = requests.length;
+    writeFileSync(admission, JSON.stringify({ repo, pull, observedAt: new Date().toISOString() }));
+    const beforeReview = requests.length;
     await run("review", [
       "review",
       "--target-repo",
-      "openclaw/openclaw",
+      repo,
       "--item-number",
-      "141913",
+      String(number),
       "--pr-admission-file",
       admission,
       "--artifact-dir",
       items,
       "--skip-start-comment",
-      ...(reservation
-        ? [
-            "--review-lease-owner",
-            reservation.owner,
-            "--review-lease-comment-id",
-            String(reservation.commentId),
-          ]
-        : []),
+      "--review-lease-owner",
+      reservation.owner,
+      "--review-lease-comment-id",
+      String(reservation.commentId),
     ]);
-    const reviewRequests = requests.length - beforeReviewRequests;
-    assert.equal(reviewRequests, 0, "metadata admission must not fetch transport context");
-    if (reservation) {
-      const report = readFileSync(join(items, "141913.md"), "utf8");
-      assert.ok(report.includes(`review_lease_owner: ${reservation.owner}`));
-      assert.match(report, /^review_lease_comment_id: 1000$/m);
-    }
-    if (scenario === "reserved-queued-review") {
+    const reviewRequests = requests.length - beforeReview;
+    assert.equal(reviewRequests, 0);
+    await run(
+      "status",
+      [
+        "--repo",
+        repo,
+        "--item-number",
+        String(number),
+        "--marker",
+        marker,
+        "--status-comment-id",
+        String(ackId),
+        "--state",
+        "Complete",
+        "--detail",
+        "Synthetic review finished",
+        "--run-url",
+        "https://github.com/openclaw/clawsweeper/actions/runs/123456789",
+      ],
+      "dist/repair/update-command-status.js",
+    );
+    if (scenario.endsWith("queued")) {
       await run("expire", [
         "expire-review-lease",
         "--repo",
-        "openclaw/openclaw",
+        repo,
         "--item-number",
-        "141913",
+        String(number),
         "--comment-id",
         String(reservation.commentId),
       ]);
-      const expiredBody = comments.find((entry) => entry.id === reservation.commentId).body;
-      assert.match(expiredBody, /clawsweeper-review-lease item=141913/);
-      assert.ok(Date.parse(expiredBody.match(/lease_expires_at=([^ ]+)/)[1]) <= Date.now());
+      store.seal(ref, owner, existsSync(context.failurePath));
+      store.release(ref, owner);
+      owner = {
+        ...owner,
+        itemKey: `${repo}#${number}@publish:123456789:1`,
+        leaseId: "synthetic-publisher",
+        claimGeneration: 2,
+      };
+      assert.equal(store.fence(ref, owner, Date.now() + 600_000), true);
+      context = {
+        ...context,
+        owner,
+        failurePath: join(directory, `publisher-evidence-failure-${ref.epoch}.json`),
+      };
+      env.CLAWSWEEPER_OVERSIZED_ACTIVITY_CONTEXT = JSON.stringify(context);
     }
-    const applyArgs = [
+    if (scenario.startsWith("evidence-")) {
+      const file = join(items, `${number}.md`);
+      let markdown = readFileSync(file, "utf8");
+      if (scenario === "evidence-absent")
+        markdown = markdown.replace(/^oversized_activity_reference:.*\n/m, "");
+      if (scenario === "evidence-malformed")
+        markdown = markdown.replace(
+          /^oversized_activity_reference:.*$/m,
+          "oversized_activity_reference: {broken",
+        );
+      if (scenario === "evidence-stale")
+        markdown = markdown.replace(ref.epoch, "00000000-0000-0000-0000-000000000000");
+      writeFileSync(file, markdown);
+    }
+    applying = true;
+    await run("apply", [
       "apply-decisions",
       "--target-repo",
-      "openclaw/openclaw",
+      repo,
       "--items-dir",
       items,
       "--closed-dir",
@@ -353,97 +453,69 @@ for (const scenario of [
       "--report-path",
       join(directory, "apply.json"),
       "--item-number",
-      "141913",
+      String(number),
       "--apply-kind",
       "all",
       "--min-age-minutes",
       "0",
       "--close-delay-ms",
       "0",
+      "--exact-event-publication",
+      "--event-apply-proof",
       "--skip-dashboard",
-    ];
-    await run("apply", applyArgs);
-    let retry;
-    if (scenario === "late-review-edit-retry") {
-      const original = JSON.parse(readFileSync(join(directory, "apply.json"), "utf8"));
-      assert.ok(original.some((entry) => /activity changed/.test(entry.reason)));
-      assert.match(readFileSync(join(items, "141913.md"), "utf8"), /oversized_activity_receipt:/);
-      await run("retry", applyArgs);
-      retry = JSON.parse(readFileSync(join(directory, "apply.json"), "utf8"));
+    ]);
+    const apply = JSON.parse(readFileSync(join(directory, "apply.json"), "utf8"));
+    const shouldClose = [
+      "first-direct",
+      "existing-direct",
+      "first-queued",
+      "existing-queued",
+      "review-unchanged",
+      "propagation-race",
+    ].includes(scenario);
+    assert.equal(pull.state, shouldClose ? "closed" : "open", JSON.stringify(apply));
+    assert.equal(existsSync(join(closed, `${number}.md`)), shouldClose);
+    if (
+      shouldClose ||
+      scenario.startsWith("evidence-") ||
+      scenario.startsWith("journal-") ||
+      ["same-second-review-edit", "late-human-comment", "late-review-edit"].includes(scenario)
+    )
       assert.ok(
-        retry.some((entry) => /persisted PR activity receipt/.test(entry.reason)),
-        JSON.stringify(retry),
+        apply.some((r) => r.action === "review_comment_synced"),
+        JSON.stringify(apply),
       );
-    }
-    const isClosed =
-      (reserveLease && scenario !== "reserved-queued-review") ||
-      scenario === "eligible" ||
-      scenario === "stable-old-comment";
-    assert.equal(
-      pull.state,
-      isClosed ? "closed" : "open",
-      readFileSync(join(directory, "apply.json"), "utf8"),
-    );
-    assert.equal(existsSync(join(closed, "141913.md")), isClosed);
-    assert.equal(existsSync(join(items, "141913.md")), !isClosed);
     const closeWrites = requests.filter(
-      (entry) => entry.method === "PATCH" && entry.path.endsWith("/pulls/141913"),
+      (r) => r.method === "PATCH" && r.path.endsWith(`/pulls/${number}`),
     ).length;
-    assert.equal(closeWrites, isClosed ? 1 : 0);
-    const owned = comments.filter(
-      (entry) =>
-        entry.user.login === "clawsweeper[bot]" &&
-        !entry.body.includes("<!-- clawsweeper-review-status"),
-    );
-    assert.equal(
-      owned.length,
-      scenario === "protected" ||
-        scenario === "ambiguous-initial-comment" ||
-        scenario === "reserved-queued-review"
-        ? 0
-        : 1,
-    );
-    if (owned.length)
-      assert.match(
-        owned[0].body,
-        isClosed
-          ? /ClawSweeper closed this pull request/
-          : /ClawSweeper proposes closing this pull request/,
-      );
-    assert.ok(requests.every((entry) => !/\/(files|commits|blobs)(\/|$)/.test(entry.path)));
-    if (scenario === "reserved-queued-review") {
-      const result = JSON.parse(readFileSync(join(directory, "apply.json"), "utf8"));
-      assert.ok(
-        result.some(
-          (entry) =>
-            entry.action === "skipped_changed_since_review" &&
-            entry.reason === "updated_at changed",
-        ),
-        JSON.stringify(result),
-      );
-    }
+    assert.equal(closeWrites, shouldClose ? 1 : 0);
+    assert.ok(requests.every((r) => !/\/(files|commits|blobs)(\/|$)/.test(r.path)));
+    store.seal(ref, owner, existsSync(context.failurePath));
+    store.release(ref, owner);
+    assert.equal(store.blocked(repo, number), false);
     const summary = {
       scenario,
-      ...(reservation
-        ? {
-            reservation: "posted",
-            leaseCommentId: reservation.commentId,
-            reviewRequests,
-            durableCommentId: owned[0]?.id,
-          }
-        : {}),
       state: pull.state,
       closeWrites,
-      ownedComments: owned.length,
-      location: isClosed ? "closed" : "items",
-      apply: JSON.parse(readFileSync(join(directory, "apply.json"), "utf8")),
-      ...(retry ? { retry } : {}),
+      reviewRequests,
+      baselineMetadataReads: baselineReadCount,
+      metadataReads: requests.filter((r) => r.method === "GET").length,
+      receiptCount: [...memory.keys()].filter((key) => key.includes(":receipt:")).length,
+      githubMutations: mutationCount,
+      fencedLateAcknowledgement: true,
+      completed: true,
+      apply,
     };
     summaries.push(summary);
     writeFileSync(
-      join(directory, "server-state.json"),
-      JSON.stringify({ pull, comments, timeline, reviews, requests }, null, 2),
+      join(directory, "trace.json"),
+      JSON.stringify(
+        { summary, requests, projections, evidence: store.evidence(ref), pull, comments, reviews },
+        null,
+        2,
+      ),
     );
+    console.log(JSON.stringify(summary));
   } finally {
     server.closeAllConnections();
     await new Promise((resolve) => server.close(resolve));
@@ -451,18 +523,5 @@ for (const scenario of [
 }
 writeFileSync(join(root, "results.json"), JSON.stringify(summaries, null, 2));
 console.log(
-  JSON.stringify(
-    {
-      environment: {
-        node: process.version,
-        platform: process.platform,
-        transport: "isolated loopback HTTP through the built CLI GitHub command adapter",
-      },
-      results: summaries,
-      limits:
-        "Synthetic GitHub service and data; no live GitHub close or production dispatch. Filesystem records and HTTP service state are observed final effects.",
-    },
-    null,
-    2,
-  ),
+  "PASS: built CLI, queue receipt store, acknowledgement writer, delayed GitHub projection; synthetic loopback only; hydration=0 scanner=0 model=0",
 );

--- a/scripts/proof-oversized-pr-close-effects.mjs
+++ b/scripts/proof-oversized-pr-close-effects.mjs
@@ -1,3 +1,4 @@
+import { parse as parseYaml } from "yaml";
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { createServer } from "node:http";
@@ -52,6 +53,7 @@ const scenarios = [
   "journal-complete-unavailable",
   "journal-malformed-response",
   "journal-post-write-metadata-malformed",
+  "retry-status-before-completion",
 ];
 const selected = process.env.PROOF_SCENARIOS?.split(",") || scenarios;
 const summaries = [];
@@ -146,6 +148,14 @@ for (const scenario of selected) {
         response.end(JSON.stringify(value));
       };
       if (path === "/internal/exact-review/heartbeat") return send({ ok: true });
+      if (path === "/internal/exact-review/complete") {
+        assert.equal(input.item_key, owner.itemKey);
+        assert.equal(input.lease_id, owner.leaseId);
+        assert.equal(input.claim_generation, owner.claimGeneration);
+        store.seal(ref, owner, input.oversized_activity_failed === true);
+        store.release(ref, owner);
+        return send({ ok: true, requeued: true });
+      }
       if (path === "/internal/exact-review/oversized-activity") {
         if (
           applying &&
@@ -160,7 +170,7 @@ for (const scenario of selected) {
         }
 
         if (!ref || input.reference?.epoch !== ref.epoch || !store.owns(ref, input.owner))
-          return send({ ok: true, evidence: null });
+          return send({ ok: true, evidence: null, authority_current: false });
         if (input.operation === "read") return send({ ok: true, evidence: store.evidence(ref) });
         if (input.operation === "begin") store.begin(ref, input.receipt);
         else if (input.operation === "complete") store.complete(ref, input.receipt);
@@ -411,7 +421,7 @@ for (const scenario of selected) {
       ],
       "dist/repair/update-command-status.js",
     );
-    if (scenario.endsWith("queued")) {
+    if (scenario.endsWith("queued") || scenario === "retry-status-before-completion") {
       await run("expire", [
         "expire-review-lease",
         "--repo",
@@ -436,6 +446,93 @@ for (const scenario of selected) {
         failurePath: join(directory, `publisher-evidence-failure-${ref.epoch}.json`),
       };
       env.CLAWSWEEPER_OVERSIZED_ACTIVITY_CONTEXT = JSON.stringify(context);
+    }
+    if (scenario === "retry-status-before-completion") {
+      const workflow = parseYaml(readFileSync(".github/workflows/sweep.yml", "utf8"));
+      const steps = Object.values(workflow.jobs).find((job) =>
+        job.steps?.some((step) => step.id === "complete-exact-review-publication"),
+      ).steps;
+      const waiting = steps.find((step) => step.name === "Mark active lease retry waiting");
+      const completion = steps.find((step) => step.id === "complete-exact-review-publication");
+      assert.ok(steps.indexOf(waiting) < steps.indexOf(completion));
+      assert.doesNotMatch(waiting.if, /complete-exact-review-publication/);
+      const runShell = async (name, script, extra) => {
+        const child = spawn("bash", ["-euo", "pipefail", "-c", script], {
+          env: { ...env, ...extra },
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+        let output = "";
+        child.stdout.on("data", (c) => (output += c));
+        child.stderr.on("data", (c) => (output += c));
+        const code = await new Promise((resolve, reject) => {
+          child.on("error", reject);
+          child.on("close", resolve);
+        });
+        writeFileSync(
+          join(directory, `${name}.log`),
+          output
+            .replaceAll(root, "<proof>")
+            .replaceAll(process.cwd(), "<checkout>")
+            .replaceAll(process.execPath, "<node>"),
+        );
+        return { code, output };
+      };
+      const statusEnv = {
+        TARGET_REPO: repo,
+        ITEM_NUMBER: String(number),
+        COMMAND_STATUS_MARKER: marker,
+        STATUS_COMMENT_ID: String(ackId),
+        RUN_URL: "https://github.com/openclaw/clawsweeper/actions/runs/123456789",
+      };
+      const waited = await runShell("waiting-step", waiting.run, statusEnv);
+      assert.equal(waited.code, 0, waited.output);
+      assert.match(comments.find((c) => c.id === ackId).body, /waiting/i);
+      const waitingReceipt = store.evidence(ref).receipts.at(-1);
+      assert.equal(waitingReceipt.kind, "PATCH");
+      assert.equal(waitingReceipt.after.id, ackId);
+      assert.ok(waitingReceipt.completedAt);
+      const completed = await runShell("completion-step", completion.run, {
+        SOURCE_CHECKOUT_OUTCOME: "success",
+        QUEUE_URL: origin,
+        QUEUE_LEASE_ID: owner.leaseId,
+        ITEM_KEY: owner.itemKey,
+        LEASE_REVISION: "1",
+        CLAIM_GENERATION: String(owner.claimGeneration),
+        GITHUB_RUN_ID: owner.runId,
+        RUN_ATTEMPT: String(owner.runAttempt),
+        OUTCOME: "success",
+        COMPLETION_KIND: "retryable_failure",
+        REASON_CODE: "review_lease_active",
+      });
+      assert.equal(completed.code, 0, completed.output);
+      assert.equal(store.blocked(repo, number), false);
+      const beforeLate = mutationCount;
+      const late = await runShell(
+        "released-owner",
+        waiting.run.replace('--state "Waiting"', '--state "Complete"'),
+        statusEnv,
+      );
+      assert.notEqual(late.code, 0);
+      assert.match(late.output, /ownership is no longer current/);
+      assert.equal(mutationCount, beforeLate);
+      const summary = {
+        scenario,
+        state: pull.state,
+        closeWrites: 0,
+        waitingWritten: true,
+        waitingReceipted: true,
+        completionRequeued: true,
+        releasedOwnerRejected: true,
+        reviewRequests,
+        completed: true,
+      };
+      summaries.push(summary);
+      writeFileSync(
+        join(directory, "trace.json"),
+        JSON.stringify({ summary, requests, projections, evidence: store.evidence(ref) }, null, 2),
+      );
+      console.log(JSON.stringify(summary));
+      continue;
     }
     if (scenario.startsWith("evidence-")) {
       const file = join(items, `${number}.md`);

--- a/scripts/proof-oversized-pr-close-effects.mjs
+++ b/scripts/proof-oversized-pr-close-effects.mjs
@@ -51,6 +51,7 @@ const scenarios = [
   "journal-begin-unavailable",
   "journal-complete-unavailable",
   "journal-malformed-response",
+  "journal-post-write-metadata-malformed",
 ];
 const selected = process.env.PROOF_SCENARIOS?.split(",") || scenarios;
 const summaries = [];
@@ -93,7 +94,9 @@ for (const scenario of selected) {
     context,
     mutationCount = 0,
     interventionDone = false,
-    applying = false;
+    applying = false,
+    postWrite = false,
+    malformedMetadataReads = 0;
   const memory = new Map();
   const store = new OversizedActivityStore({
     get: (key) => structuredClone(memory.get(key)),
@@ -169,7 +172,15 @@ for (const scenario of selected) {
           const c = comments.find((c) => c.id === Number(path.split("/").at(-1)));
           return c ? send(c) : send({ error: "missing comment" }, 404);
         }
-        if (path.endsWith(`/pulls/${number}`)) return send(pull);
+        if (path.endsWith(`/pulls/${number}`)) {
+          if (
+            scenario === "journal-post-write-metadata-malformed" &&
+            postWrite &&
+            malformedMetadataReads++ < 9
+          )
+            return send({});
+          return send(pull);
+        }
         if (path.endsWith(`/issues/${number}`))
           return send({
             ...pull,
@@ -185,6 +196,7 @@ for (const scenario of selected) {
         return send({ error: "unimplemented read" }, 404);
       }
       mutationCount++;
+      if (applying) postWrite = true;
       const timestamp = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
       let result;
       if (request.method === "POST" && path.endsWith(`/issues/${number}/comments`)) {

--- a/src/clawsweeper-apply-decision-workflow.ts
+++ b/src/clawsweeper-apply-decision-workflow.ts
@@ -1,7 +1,4 @@
-import {
-  createOversizedPrFreshnessGuard,
-  parseOversizedPrSourceSnapshot,
-} from "./clawsweeper-oversized-pr-freshness.js";
+import { createQueueOwnedOversizedFreshnessGuard } from "./oversized-activity-runtime.js";
 import { REVIEW_SECTIONS } from "./clawsweeper-policy.js";
 import {
   oversizedPrCloseEnabled,
@@ -755,11 +752,11 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
         isPairBlockedCloseReport(markdown);
       const oversizedMetadataDecision = closeReason === "oversized_pull_request" &&
         parseOversizedPullRequestEvidence(frontMatterValue(markdown, "oversized_pull_request")) !== null;
-      let oversizedActivityGuard: ReturnType<typeof createOversizedPrFreshnessGuard> | undefined;
+      let oversizedActivityGuard: ReturnType<typeof createQueueOwnedOversizedFreshnessGuard> | undefined;
       const persistOversizedActivityReceipt = (): void => {
         const receipt = oversizedActivityGuard?.receipt();
         if (!receipt || dryRun || frontMatterValue(markdown, "action_taken") === "closed" || !existsSync(path)) return;
-        markdown = replaceFrontMatterValue(markdown, "oversized_activity_receipt", JSON.stringify(receipt));
+        markdown = replaceFrontMatterValue(markdown, "oversized_activity_reference", JSON.stringify(receipt));
         writeReportMarkdown(path, markdown);
       };
       const verifiedLocalCheckout = hasVerifiedLocalCheckoutAccess(markdown);
@@ -1122,7 +1119,7 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
             ) === "equal")
         );
       };
-      const currentReviewActivityBlock = oversizedMetadataDecision ? () => oversizedActivityGuard?.check(liveReadGeneration.id) ?? null : createApplyReviewActivityGuard(dependencies, {
+      const currentReviewActivityBlock = oversizedMetadataDecision ? () => null : createApplyReviewActivityGuard(dependencies, {
         expectedCursor: expectedReviewActivityCursor,
         itemKind: item.kind,
         number,
@@ -1823,6 +1820,7 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
         state === "open" &&
         (isCloseProposal || guardedReviewAction) &&
         !stalePrReviewHead &&
+        !oversizedMetadataDecision &&
         !reviewedSourceFresh()
       ) {
         if (markReviewedSourceDrift()) break;
@@ -1855,15 +1853,9 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
       }
       let markedReviewComment = markedReviewCommentForApply(reviewComment);
       if (oversizedMetadataDecision && state === "open") {
-        oversizedActivityGuard = createOversizedPrFreshnessGuard({
-          repo, number, source: parseOversizedPrSourceSnapshot(frontMatterValue(markdown, "oversized_pr_source")),
-          priorReceipt: frontMatterValue(markdown, "oversized_activity_receipt"),
-          ...(existingReviewComment && commentBodyMatches(existingReviewComment, markedReviewComment) ? { ownedComment: existingReviewComment } : {}),
-          ghJson,
-        });
-        const block = oversizedActivityGuard.check(liveReadGeneration.id, true);
-        if (block) { if (markApplySkipped("kept_open", block)) break; continue; }
-        persistOversizedActivityReceipt();
+        let reference: unknown;
+        try { reference = JSON.parse(frontMatterValue(markdown,"oversized_activity_reference") || "null"); } catch { reference = null; }
+        oversizedActivityGuard = createQueueOwnedOversizedFreshnessGuard({repo,number,reference,ghJson});
       }
       const { postProofCoveringPrFreshnessBlock, postProofFreshnessBlock } =
         createApplyProofFreshnessGuards({

--- a/src/clawsweeper-github-runtime.ts
+++ b/src/clawsweeper-github-runtime.ts
@@ -1,3 +1,4 @@
+import { observeOversizedCommentWrite } from "./oversized-activity-runtime.js";
 import { spawnSync } from "node:child_process";
 import { createHmac } from "node:crypto";
 import { appendFileSync, closeSync, openSync } from "node:fs";
@@ -379,10 +380,12 @@ export function createGitHubRuntime(dependencies: CreateGitHubRuntimeDependencie
       });
     }
     try {
-      const result = run("gh", resolvedArgs, {
-        timeoutMs,
-        ...(preparedEnv ? { env: preparedEnv } : {}),
-      });
+      const result = observeOversizedCommentWrite(resolvedArgs, (requestArgs) =>
+        run("gh", requestArgs, {
+          timeoutMs,
+          ...(preparedEnv ? { env: preparedEnv } : {}),
+        }),
+      );
       recordGitHubRequest(resolvedArgs, scope, "success");
       return result;
     } catch (error) {

--- a/src/clawsweeper-oversized-pr-freshness.ts
+++ b/src/clawsweeper-oversized-pr-freshness.ts
@@ -1,69 +1,27 @@
 import { createHash } from "node:crypto";
-import { labelNames } from "./clawsweeper-item-policy.js";
 import { compareCodeUnits, stableJson } from "./stable-json.js";
-import { recordOrEmpty, stringOrEmpty } from "./value-coerce.js";
+import { recordOrEmpty } from "./value-coerce.js";
 
-export interface OversizedPrSourceSnapshot {
-  fingerprint: string;
-  updatedAt: string;
-  observedAt: string;
-  comments: number;
-  reviewComments: number;
-}
-
+export {
+  oversizedPrSourceSnapshot,
+  parseOversizedPrSourceSnapshot,
+  type OversizedPrSourceSnapshot,
+} from "./oversized-pr-snapshot.js";
+import {
+  oversizedPrSourceSnapshot,
+  type OversizedPrSourceSnapshot,
+} from "./oversized-pr-snapshot.js";
 export interface OversizedPrActivityReceipt {
   sourceFingerprint: string;
   activityFingerprint: string;
   ownedCommentId: number | null;
   ownedCommentFingerprint: string | null;
 }
-
 const hash = (value: unknown) => createHash("sha256").update(stableJson(value)).digest("hex");
 const count = (value: unknown): value is number =>
   typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
 const timestamp = (value: unknown): value is string =>
   typeof value === "string" && Number.isFinite(Date.parse(value));
-const digest = (value: unknown): value is string =>
-  typeof value === "string" && /^[a-f0-9]{64}$/.test(value);
-
-export function oversizedPrSourceSnapshot(
-  pull: Record<string, unknown>,
-  observedAt?: string,
-): OversizedPrSourceSnapshot | null {
-  if (
-    !timestamp(pull.updated_at) ||
-    !count(pull.comments) ||
-    !count(pull.review_comments) ||
-    typeof pull.title !== "string" ||
-    !(typeof pull.body === "string" || pull.body === null) ||
-    !Array.isArray(pull.labels)
-  )
-    return null;
-  return {
-    fingerprint: hash({
-      head: recordOrEmpty(pull.head).sha,
-      additions: pull.additions,
-      deletions: pull.deletions,
-      changedFiles: pull.changed_files,
-      state: pull.state,
-      locked: pull.locked === true,
-      title: pull.title,
-      body: pull.body ?? "",
-      labels: labelNames(pull.labels).sort(),
-      draft: pull.draft === true,
-      baseRef: stringOrEmpty(recordOrEmpty(pull.base).ref),
-      assignees: pull.assignees ?? [],
-      milestone: pull.milestone ?? null,
-      requestedReviewers: pull.requested_reviewers ?? [],
-      requestedTeams: pull.requested_teams ?? [],
-    }),
-    updatedAt: pull.updated_at,
-    observedAt: timestamp(observedAt) ? observedAt : pull.updated_at,
-    comments: pull.comments,
-    reviewComments: pull.review_comments,
-  };
-}
-
 function jsonRecord(value: unknown): Record<string, unknown> {
   if (typeof value === "string") {
     try {
@@ -73,23 +31,6 @@ function jsonRecord(value: unknown): Record<string, unknown> {
     }
   }
   return recordOrEmpty(value);
-}
-
-export function parseOversizedPrSourceSnapshot(value: unknown): OversizedPrSourceSnapshot | null {
-  const source = jsonRecord(value);
-  return digest(source.fingerprint) &&
-    timestamp(source.updatedAt) &&
-    timestamp(source.observedAt) &&
-    count(source.comments) &&
-    count(source.reviewComments)
-    ? {
-        fingerprint: source.fingerprint,
-        updatedAt: source.updatedAt,
-        observedAt: source.observedAt,
-        comments: source.comments,
-        reviewComments: source.reviewComments,
-      }
-    : null;
 }
 
 function commentIdentity(value: Record<string, unknown>): unknown {

--- a/src/clawsweeper-report-document.ts
+++ b/src/clawsweeper-report-document.ts
@@ -669,6 +669,7 @@ review_comment_id: unknown
 review_comment_url: unknown
 decision: ${options.decision.decision}
 close_reason: ${options.decision.closeReason}
+${options.decision.oversizedActivityReference ? `oversized_activity_reference: ${JSON.stringify(options.decision.oversizedActivityReference)}\n` : ""}
 ${options.decision.oversizedPullRequestSource ? `oversized_pr_source: ${JSON.stringify(options.decision.oversizedPullRequestSource)}\n` : ""}
 ${options.decision.oversizedPullRequest ? `oversized_pull_request: ${JSON.stringify(options.decision.oversizedPullRequest)}\n` : ""}
 confidence: ${options.decision.confidence}

--- a/src/clawsweeper-review-command-workflow.ts
+++ b/src/clawsweeper-review-command-workflow.ts
@@ -1,3 +1,4 @@
+import { oversizedActivityContextFromEnv } from "./oversized-activity-runtime.js";
 import { existsSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
 import { oversizedPrSourceSnapshot } from "./clawsweeper-oversized-pr-freshness.js";
 import {
@@ -595,6 +596,8 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
             item.updatedAt = stringOrUndefined(pullRequestPayload.updated_at) ?? item.updatedAt;
             const context = oversizedPullRequestContext(pullRequestPayload);
             const decision = oversizedPullRequestDecision(admission.decision, oversizedPrSourceSnapshot(pullRequestPayload, pullObservedAt));
+            const activityReference = oversizedActivityContextFromEnv()?.reference;
+            if (activityReference && activityReference.repo.toLowerCase() === item.repo.toLowerCase() && activityReference.number === item.number) decision.oversizedActivityReference = activityReference;
             const runtime = { model: "none", reasoningEffort: "none", contextElapsedMs: 0, codexElapsedMs: 0 };
             const action = reviewActionForDecision({ item, decision, git, runtime });
             const reportPath = join(artifactDir, reportFileName(item.repo, item.number));

--- a/src/clawsweeper-types.ts
+++ b/src/clawsweeper-types.ts
@@ -563,6 +563,7 @@ export interface ReviewCommentRenderOptions {
 }
 
 export interface Decision {
+  oversizedActivityReference?: import("./oversized-activity-contract.js").OversizedActivityReference;
   oversizedPullRequestSource?: import("./clawsweeper-oversized-pr-freshness.js").OversizedPrSourceSnapshot;
   /** Runner-owned GitHub metadata; never populated from model output. */
   oversizedPullRequest?: import("./clawsweeper-oversized-pr-policy.js").OversizedPullRequestEvidence;

--- a/src/codex-env.ts
+++ b/src/codex-env.ts
@@ -73,6 +73,12 @@ export function codexEnv(options: CodexEnvOptions = {}): NodeJS.ProcessEnv {
   delete env.GH_TOKEN;
   delete env.GITHUB_TOKEN;
   delete env.REPO_TOKEN;
+  // Queue ownership and write receipts belong to the publisher, never to reviewed code.
+  delete env.CLAWSWEEPER_OVERSIZED_ACTIVITY_CONTEXT;
+  delete env.CLAWSWEEPER_WEBHOOK_SECRET;
+  delete env.GITHUB_ENV;
+  delete env.GITHUB_EVENT_PATH;
+  for (const key of Object.keys(env)) if (key.startsWith("EXACT_REVIEW_")) delete env[key];
   delete env.COMMIT_SWEEPER_TARGET_GH_TOKEN;
   delete env.CLAWSWEEPER_PROOF_INSPECTION_TOKEN;
   delete env.CLAWSWEEPER_APP_ID;

--- a/src/oversized-activity-contract.ts
+++ b/src/oversized-activity-contract.ts
@@ -1,0 +1,403 @@
+import {
+  ACCEPTED_LARGE_LABEL,
+  PR_AUTO_CLOSE_EXEMPT_LABEL_NAMES,
+} from "./repair/exact-review-guard-labels.ts";
+import { createHash } from "node:crypto";
+import { stableJson } from "./stable-json.ts";
+import { recordOrEmpty } from "./value-coerce.ts";
+import {
+  oversizedPrSourceSnapshot,
+  parseOversizedPrSourceSnapshot,
+  type OversizedPrSourceSnapshot,
+} from "./oversized-pr-snapshot.ts";
+
+export const OVERSIZED_ACTIVITY_VERSION = 1;
+export const OVERSIZED_ACTIVITY_FENCE_MS = 30 * 60_000;
+export const activityHash = (value: unknown): string =>
+  createHash("sha256").update(stableJson(value)).digest("hex");
+const timestamp = (value: unknown): value is string =>
+  typeof value === "string" && Number.isFinite(Date.parse(value));
+const positive = (value: unknown): value is number =>
+  Number.isSafeInteger(value) && Number(value) > 0;
+const digest = (value: unknown): value is string =>
+  typeof value === "string" && /^[a-f0-9]{64}$/.test(value);
+
+export interface OversizedActivityReference {
+  version: 1;
+  repo: string;
+  number: number;
+  epoch: string;
+}
+export interface OversizedCommentImage {
+  id: number;
+  bodyFingerprint: string;
+  fingerprint: string;
+  createdAt: string;
+  updatedAt: string;
+  author: string;
+}
+export interface OversizedActivityEntry {
+  identity: string;
+  fingerprint: string;
+  commentId: number | null;
+}
+export interface OversizedActivityBaseline {
+  source: OversizedPrSourceSnapshot;
+  comments: OversizedCommentImage[];
+  streams: OversizedActivityEntry[][];
+}
+export interface OversizedAcknowledgementReceipt {
+  id: string;
+  kind: "POST" | "PATCH" | "DELETE";
+  before: OversizedCommentImage | null;
+  after: OversizedCommentImage | null;
+  requestedBodyFingerprint: string | null;
+  startedAt: string;
+  completedAt: string | null;
+  pullAfter: OversizedPrSourceSnapshot | null;
+}
+export interface OversizedActivityEvidence {
+  reference: OversizedActivityReference;
+  baseline: OversizedActivityBaseline | null;
+  receipts: OversizedAcknowledgementReceipt[];
+  invalid: string | null;
+}
+export interface OversizedActivityOwner {
+  itemKey: string;
+  leaseId: string;
+  claimGeneration: number;
+  runId: string;
+  runAttempt: number;
+}
+export interface OversizedActivityContext {
+  reference: OversizedActivityReference;
+  owner: OversizedActivityOwner;
+  queueUrl: string;
+  failurePath?: string;
+}
+
+export function parseOversizedActivityReference(
+  value: unknown,
+  repo?: string,
+  number?: number,
+): OversizedActivityReference | null {
+  const v = recordOrEmpty(value);
+  return v.version === 1 &&
+    typeof v.repo === "string" &&
+    /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(v.repo) &&
+    positive(v.number) &&
+    typeof v.epoch === "string" &&
+    /^[a-f0-9-]{36}$/.test(v.epoch) &&
+    (!repo || v.repo.toLowerCase() === repo.toLowerCase()) &&
+    (!number || v.number === number)
+    ? { version: 1, repo: v.repo, number: v.number, epoch: v.epoch }
+    : null;
+}
+
+export function oversizedCommentImage(value: unknown): OversizedCommentImage {
+  const v = recordOrEmpty(value);
+  const author = recordOrEmpty(v.user).login;
+  if (
+    !positive(v.id) ||
+    typeof v.body !== "string" ||
+    !timestamp(v.created_at) ||
+    !timestamp(v.updated_at) ||
+    typeof author !== "string" ||
+    !author
+  )
+    throw new Error("incomplete comment write image");
+  const identity = {
+    id: v.id,
+    body: v.body,
+    createdAt: v.created_at,
+    updatedAt: v.updated_at,
+    author,
+    association: v.author_association ?? "",
+  };
+  return {
+    id: v.id,
+    bodyFingerprint: activityHash(v.body),
+    fingerprint: activityHash(identity),
+    createdAt: v.created_at,
+    updatedAt: v.updated_at,
+    author,
+  };
+}
+
+function validImage(v: unknown): v is OversizedCommentImage {
+  const r = recordOrEmpty(v);
+  return (
+    positive(r.id) &&
+    digest(r.bodyFingerprint) &&
+    digest(r.fingerprint) &&
+    timestamp(r.createdAt) &&
+    timestamp(r.updatedAt) &&
+    typeof r.author === "string" &&
+    r.author.length > 0
+  );
+}
+
+/** Shared by the Worker and synchronous CLI: exactly the same bounded reads and checks. */
+export function* captureOversizedActivity(
+  repo: string,
+  number: number,
+  observedAt: string,
+  initial = false,
+): Generator<string, OversizedActivityBaseline, unknown> {
+  const root = `repos/${repo}`;
+  const source = oversizedPrSourceSnapshot(
+    recordOrEmpty(yield `${root}/pulls/${number}`),
+    observedAt,
+  );
+  if (!source) throw new Error("live PR metadata snapshot is incomplete");
+  const streams: Record<string, unknown>[][] = [];
+  for (const endpoint of [
+    `issues/${number}/comments`,
+    `issues/${number}/timeline`,
+    `pulls/${number}/comments`,
+    `pulls/${number}/reviews`,
+  ]) {
+    const entries: Record<string, unknown>[] = [];
+    const identities = new Set<string>();
+    for (let page = 1; page <= 3; page++) {
+      const batch = yield `${root}/${endpoint}?per_page=100&page=${page}`;
+      if (!Array.isArray(batch)) throw new Error("activity response is incomplete or invalid");
+      for (const raw of batch) {
+        const entry = recordOrEmpty(raw);
+        const identity = activityIdentity(entry, endpoint.endsWith("/timeline"));
+        if (!identity || identities.has(identity))
+          throw new Error("activity identity is missing or repeated");
+        identities.add(identity);
+        entries.push(entry);
+      }
+      if (batch.length < 100) break;
+      if (page === 3) throw new Error("activity exceeds the bounded 300-entry window");
+    }
+    streams.push(entries);
+  }
+  const [comments = [], timeline = [], inline = [], reviews = []] = streams;
+  if (
+    [...comments, ...inline].some(
+      (e) => typeof e.body !== "string" || !timestamp(e.created_at) || !timestamp(e.updated_at),
+    ) ||
+    reviews.some((e) => !timestamp(e.submitted_at)) ||
+    timeline.some(
+      (e) =>
+        e.event !== "committed" && ![e.created_at, e.updated_at, e.submitted_at].some(timestamp),
+    )
+  )
+    throw new Error("activity timestamps are incomplete");
+  if (source.comments !== comments.length || source.reviewComments !== inline.length)
+    throw new Error("live PR activity counts changed during capture");
+  const confirmed = oversizedPrSourceSnapshot(
+    recordOrEmpty(yield `${root}/pulls/${number}`),
+    observedAt,
+  );
+  if (!confirmed || stableJson(confirmed) !== stableJson(source))
+    throw new Error("PR metadata changed during activity capture");
+  if (initial) {
+    const cutoff = Math.floor(Date.parse(observedAt) / 1000) * 1000 - 1000;
+    if (reviews.length && Date.parse(source.updatedAt) >= cutoff)
+      throw new Error("ambiguous PR timestamp cannot exclude review-summary edits");
+    if (
+      streams.some((stream) =>
+        stream.some((e) =>
+          [e.created_at, e.updated_at, e.submitted_at].some(
+            (t) => timestamp(t) && Date.parse(t) >= cutoff,
+          ),
+        ),
+      )
+    )
+      throw new Error("ambiguous or new PR activity at the admission observation boundary");
+  }
+  return {
+    source,
+    comments: comments.map(oversizedCommentImage),
+    streams: streams.map((stream, index) =>
+      stream
+        .map((e) => ({
+          identity: activityIdentity(e, index === 1)!,
+          fingerprint: index === 0 ? oversizedCommentImage(e).fingerprint : activityHash(e),
+          commentId: index === 0 || (index === 1 && e.event === "commented") ? Number(e.id) : null,
+        }))
+        .sort((a, b) => (a.identity < b.identity ? -1 : a.identity > b.identity ? 1 : 0)),
+    ),
+  };
+}
+
+function activityIdentity(entry: Record<string, unknown>, timeline: boolean): string | null {
+  if (Number.isSafeInteger(entry.id) && Number(entry.id) >= 0)
+    return stableJson({ event: entry.event ?? "", id: entry.id });
+  if (!timeline || typeof entry.event !== "string") return null;
+  if (typeof entry.sha === "string" || typeof entry.node_id === "string")
+    return stableJson({ event: entry.event, sha: entry.sha ?? null, node: entry.node_id ?? null });
+  if (entry.event !== "cross-referenced" || !timestamp(entry.created_at)) return null;
+  const source = recordOrEmpty(entry.source),
+    issue = recordOrEmpty(source.issue),
+    actor = recordOrEmpty(entry.actor);
+  const id = typeof issue.id === "number" ? issue.id : (issue.node_id ?? issue.html_url);
+  return source.type === "issue" && id != null
+    ? stableJson({
+        event: entry.event,
+        createdAt: entry.created_at,
+        actor: actor.id ?? actor.login ?? null,
+        source: id,
+      })
+    : null;
+}
+
+export function parseOversizedActivityEvidence(value: unknown): OversizedActivityEvidence | null {
+  const v = recordOrEmpty(value),
+    b = recordOrEmpty(v.baseline);
+  const ref = parseOversizedActivityReference(v.reference);
+  if (!ref || !(v.invalid === null || typeof v.invalid === "string") || !Array.isArray(v.receipts))
+    return null;
+  if (
+    v.baseline !== null &&
+    (!parseOversizedPrSourceSnapshot(b.source) ||
+      !Array.isArray(b.comments) ||
+      b.comments.length >= 300 ||
+      !b.comments.every(validImage) ||
+      new Set(b.comments.map((c) => c.id)).size !== b.comments.length ||
+      recordOrEmpty(b.source).comments !== b.comments.length ||
+      !Array.isArray(b.streams) ||
+      b.streams.length !== 4 ||
+      !b.streams.every(
+        (s) =>
+          Array.isArray(s) &&
+          s.length < 300 &&
+          new Set(s.map((e) => recordOrEmpty(e).identity)).size === s.length &&
+          s.every((entry) => {
+            const e = recordOrEmpty(entry);
+            return (
+              typeof e.identity === "string" &&
+              e.identity.length <= 4096 &&
+              digest(e.fingerprint) &&
+              (e.commentId === null || positive(e.commentId))
+            );
+          }),
+      ))
+  )
+    return null;
+  if (
+    !v.receipts.every((raw) => {
+      const r = recordOrEmpty(raw);
+      return (
+        typeof r.id === "string" &&
+        /^[a-f0-9-]{36}$/.test(r.id) &&
+        ["POST", "PATCH", "DELETE"].includes(String(r.kind)) &&
+        (r.before === null || validImage(r.before)) &&
+        (r.after === null || validImage(r.after)) &&
+        (r.requestedBodyFingerprint === null || digest(r.requestedBodyFingerprint)) &&
+        timestamp(r.startedAt) &&
+        (r.completedAt === null || timestamp(r.completedAt)) &&
+        (r.pullAfter === null || parseOversizedPrSourceSnapshot(r.pullAfter))
+      );
+    })
+  )
+    return null;
+  return v as unknown as OversizedActivityEvidence;
+}
+
+export function oversizedActivityBlock(
+  evidence: OversizedActivityEvidence | null,
+  current: OversizedActivityBaseline,
+): string | null {
+  if (!evidence?.baseline || evidence.invalid)
+    return evidence?.invalid || "missing queue-owned activity evidence";
+  const base = evidence.baseline;
+  if (
+    base.source.fingerprint !== current.source.fingerprint ||
+    base.source.reviewComments !== current.source.reviewComments
+  )
+    return "oversized PR metadata changed since queue admission";
+  const expected = new Map(base.comments.map((c) => [c.id, c]));
+  const owned = new Set<number>();
+  let updatedAt = base.source.updatedAt;
+  const seen = new Set<string>();
+  for (const r of evidence.receipts) {
+    if (!r.completedAt || seen.has(r.id)) return "incomplete or ambiguous owned-write receipt";
+    seen.add(r.id);
+    if (
+      r.kind === "POST"
+        ? r.before !== null || !r.after || expected.has(r.after.id)
+        : !r.before || expected.get(r.before.id)?.fingerprint !== r.before.fingerprint
+    )
+      return "owned-write preimage does not match queue baseline";
+    if (r.kind === "DELETE") {
+      if (r.after !== null || !r.before || !r.pullAfter) return "incomplete deletion receipt";
+      expected.delete(r.before.id);
+      owned.add(r.before.id);
+    } else {
+      if (
+        !r.after ||
+        r.after.bodyFingerprint !== r.requestedBodyFingerprint ||
+        (r.before && r.before.id !== r.after.id)
+      )
+        return "invalid owned-write response";
+      expected.set(r.after.id, r.after);
+      owned.add(r.after.id);
+      if (Date.parse(r.after.updatedAt) > Date.parse(updatedAt)) updatedAt = r.after.updatedAt;
+    }
+    if (r.pullAfter) {
+      if (
+        r.pullAfter.fingerprint !== base.source.fingerprint ||
+        r.pullAfter.reviewComments !== base.source.reviewComments ||
+        r.pullAfter.comments !== expected.size
+      )
+        return "non-owned metadata or comment count changed during owned write";
+      if (Date.parse(r.pullAfter.updatedAt) > Date.parse(updatedAt))
+        updatedAt = r.pullAfter.updatedAt;
+    }
+  }
+  if (
+    current.comments.length !== expected.size ||
+    current.comments.some((c) => expected.get(c.id)?.fingerprint !== c.fingerprint)
+  )
+    return "non-owned PR comment changed or an owned write is unreceipted";
+  const nonOwned = (b: OversizedActivityBaseline) =>
+    b.streams.map((stream) =>
+      stream.filter((e) => e.commentId === null || !owned.has(e.commentId)),
+    );
+  if (stableJson(nonOwned(base)) !== stableJson(nonOwned(current)))
+    return "non-owned PR activity changed since queue admission";
+  if (current.source.updatedAt !== updatedAt)
+    return "PR updated_at changed beyond receipted writes";
+  return null;
+}
+
+/** Routing hint only; the existing policy still owns threshold, head and exemption checks. */
+export function oversizedActivityNeeded(value: unknown, thresholdValue: unknown): boolean {
+  const p = recordOrEmpty(value);
+  const exemptions = new Set<string>([ACCEPTED_LARGE_LABEL, ...PR_AUTO_CLOSE_EXEMPT_LABEL_NAMES]);
+  if (
+    Array.isArray(p.labels) &&
+    p.labels.some((label) => {
+      const name = typeof label === "string" ? label : recordOrEmpty(label).name;
+      return typeof name === "string" && exemptions.has(name.trim().toLowerCase());
+    })
+  )
+    return false;
+  if (
+    p.state !== "open" ||
+    p.locked === true ||
+    !Number.isSafeInteger(p.changed_files) ||
+    Number(p.changed_files) < 0 ||
+    typeof recordOrEmpty(p.head).sha !== "string" ||
+    !/^[a-f0-9]{40}$/i.test(String(recordOrEmpty(p.head).sha))
+  )
+    return false;
+  const raw = typeof thresholdValue === "string" ? thresholdValue.trim() : "";
+  const parsed = /^\d+$/.test(raw) ? Number(raw) : NaN;
+  const threshold = Number.isSafeInteger(parsed) && parsed > 0 ? parsed : 50_000;
+  return (
+    typeof p.additions === "number" &&
+    typeof p.deletions === "number" &&
+    Number.isSafeInteger(p.additions) &&
+    p.additions >= 0 &&
+    Number.isSafeInteger(p.deletions) &&
+    p.deletions >= 0 &&
+    Number.isSafeInteger(p.additions + p.deletions) &&
+    p.additions + p.deletions > threshold
+  );
+}

--- a/src/oversized-activity-contract.ts
+++ b/src/oversized-activity-contract.ts
@@ -290,7 +290,7 @@ export function parseOversizedActivityEvidence(value: unknown): OversizedActivit
         (r.after === null || validImage(r.after)) &&
         (r.requestedBodyFingerprint === null || digest(r.requestedBodyFingerprint)) &&
         timestamp(r.startedAt) &&
-        (r.completedAt === null || timestamp(r.completedAt)) &&
+        (r.completedAt === null || (timestamp(r.completedAt) && r.pullAfter !== null)) &&
         (r.pullAfter === null || parseOversizedPrSourceSnapshot(r.pullAfter))
       );
     })
@@ -316,7 +316,8 @@ export function oversizedActivityBlock(
   let updatedAt = base.source.updatedAt;
   const seen = new Set<string>();
   for (const r of evidence.receipts) {
-    if (!r.completedAt || seen.has(r.id)) return "incomplete or ambiguous owned-write receipt";
+    if (!r.completedAt || !r.pullAfter || seen.has(r.id))
+      return "incomplete or ambiguous owned-write receipt";
     seen.add(r.id);
     if (
       r.kind === "POST"

--- a/src/oversized-activity-runtime.ts
+++ b/src/oversized-activity-runtime.ts
@@ -1,0 +1,299 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { recordOrEmpty, stringOrEmpty } from "./value-coerce.js";
+import {
+  captureOversizedActivity,
+  oversizedActivityBlock,
+  parseOversizedActivityEvidence,
+  parseOversizedActivityReference,
+  type OversizedActivityContext,
+  type OversizedActivityReference,
+} from "./oversized-activity-contract.js";
+import {
+  isOversizedCommentWrite,
+  ownedCommentWriteIntent,
+  ownedCommentWriteResult,
+} from "./oversized-activity-write.js";
+
+const wait = (ms: number) => Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+export function oversizedActivityContextFromEnv(): OversizedActivityContext | null {
+  try {
+    const value = JSON.parse(process.env.CLAWSWEEPER_OVERSIZED_ACTIVITY_CONTEXT || "null");
+    const v = recordOrEmpty(value),
+      o = recordOrEmpty(v.owner);
+    const reference = parseOversizedActivityReference(v.reference);
+    const url = new URL(String(v.queueUrl));
+    if (
+      !reference ||
+      !(url.protocol === "https:" || (url.protocol === "http:" && url.hostname === "127.0.0.1")) ||
+      typeof o.itemKey !== "string" ||
+      typeof o.leaseId !== "string" ||
+      typeof o.runId !== "string" ||
+      !/^[1-9]\d{0,29}$/.test(o.runId) ||
+      !Number.isSafeInteger(o.runAttempt) ||
+      Number(o.runAttempt) < 1 ||
+      !Number.isSafeInteger(o.claimGeneration) ||
+      Number(o.claimGeneration) < 1 ||
+      (v.failurePath !== undefined && (typeof v.failurePath !== "string" || !v.failurePath))
+    )
+      return null;
+    return { ...v, reference } as unknown as OversizedActivityContext;
+  } catch {
+    return null;
+  }
+}
+class OversizedPublicationOwnershipError extends Error {}
+function failurePath(context: OversizedActivityContext): string {
+  return (
+    context.failurePath ||
+    join(
+      process.env.RUNNER_TEMP || process.cwd(),
+      ".artifacts",
+      `oversized-activity-${context.reference.epoch}-${context.owner.runId}-${context.owner.runAttempt}-${context.owner.claimGeneration}.json`,
+    )
+  );
+}
+export function oversizedActivityFailed(context = oversizedActivityContextFromEnv()): boolean {
+  return Boolean(context && existsSync(failurePath(context)));
+}
+function recordEvidenceFailure(context: OversizedActivityContext, ownershipLost = false): void {
+  const path = failurePath(context);
+  mkdirSync(dirname(path), { recursive: true });
+  if (existsSync(path)) {
+    try {
+      ownershipLost ||= JSON.parse(readFileSync(path, "utf8")).ownershipLost === true;
+    } catch {
+      /* Presence already disables closing. */
+    }
+  }
+  writeFileSync(path, JSON.stringify({ version: 1, ownershipLost }), "utf8");
+  console.warn("[oversized] queue write evidence unavailable; closing disabled for this publisher");
+}
+function requireRemainingOwnership(context: OversizedActivityContext): void {
+  if (!oversizedActivityFailed(context)) return;
+  try {
+    if (JSON.parse(readFileSync(failurePath(context), "utf8")).ownershipLost === true)
+      throw new OversizedPublicationOwnershipError(
+        "queue publication ownership is no longer current",
+      );
+  } catch (error) {
+    if (error instanceof OversizedPublicationOwnershipError) throw error;
+    // An unreadable marker still disables closing; existing comment guards remain in force.
+  }
+}
+
+function activityRequest(
+  context: OversizedActivityContext,
+  operation: string,
+  receipt?: unknown,
+): Record<string, unknown> {
+  const response = spawnSync(
+    "curl",
+    [
+      "--silent",
+      "--show-error",
+      "--connect-timeout",
+      "5",
+      "--max-time",
+      "20",
+      "--request",
+      "POST",
+      "--header",
+      "content-type: application/json",
+      "--data-binary",
+      "@-",
+      "--write-out",
+      "\n%{http_code}",
+      `${context.queueUrl.replace(/\/$/, "")}/internal/exact-review/oversized-activity`,
+    ],
+    {
+      input: JSON.stringify({
+        reference: context.reference,
+        owner: context.owner,
+        operation,
+        ...(receipt ? { receipt } : {}),
+      }),
+      encoding: "utf8",
+      maxBuffer: 4 * 1024 * 1024,
+    },
+  );
+  if (response.status !== 0) throw new Error("queue activity evidence transport unavailable");
+  const split = response.stdout.lastIndexOf("\n");
+  const status = Number(response.stdout.slice(split + 1));
+  if (status === 404 && operation === "read") return { evidence: null };
+  if (status !== 200) throw new Error(`queue activity evidence request refused (${status})`);
+  return recordOrEmpty(JSON.parse(response.stdout.slice(0, split)));
+}
+
+/** Opt-in transport journal. Every successful request has a durable pre-write intent. */
+export function observeOversizedCommentWrite(
+  args: string[],
+  invoke: (args: string[]) => string,
+  input?: string,
+  requestEvidence: typeof activityRequest = activityRequest,
+): string {
+  const context = oversizedActivityContextFromEnv();
+  const offset = args[0] === "--repo" ? 2 : 0;
+  if (!context || args[offset] !== "api") return invoke(args);
+  const methodIndex = args.findIndex((v) => v === "--method" || v === "-X");
+  const bodyIndex = args.findIndex((v) => v === "--input");
+  const fields = args.flatMap((v, i) =>
+    ["-f", "--raw-field", "-F", "--field"].includes(v) ? [args[i + 1] ?? ""] : [],
+  );
+  const method =
+    methodIndex >= 0
+      ? String(args[methodIndex + 1]).toUpperCase()
+      : bodyIndex >= 0 || fields.length
+        ? "POST"
+        : "GET";
+  const path = String(args[offset + 1] || "");
+  let body: unknown;
+  if (bodyIndex >= 0)
+    body = JSON.parse(
+      args[bodyIndex + 1] === "-" ? input || "null" : readFileSync(args[bodyIndex + 1]!, "utf8"),
+    );
+  else
+    body = Object.fromEntries(
+      fields.map((f) => [f.slice(0, f.indexOf("=")), f.slice(f.indexOf("=") + 1)]),
+    );
+  const request = { path, method, body };
+  if (!isOversizedCommentWrite(request, context.reference)) return invoke(args);
+  const read = (path: string) => JSON.parse(invoke(["api", path.replace(/^\//, "")]) || "null");
+  requireRemainingOwnership(context);
+  if (oversizedActivityFailed(context)) return invoke(args);
+  let intent: ReturnType<typeof ownedCommentWriteIntent>;
+  let beforePull: Record<string, unknown>;
+  const pullPath = `repos/${context.reference.repo}/pulls/${context.reference.number}`;
+  try {
+    const before = method === "POST" ? null : read(path);
+    intent = ownedCommentWriteIntent(request, before);
+    beforePull = recordOrEmpty(read(pullPath));
+    const begun = requestEvidence(context, "begin", intent);
+    if (begun.authority_current === false)
+      throw new OversizedPublicationOwnershipError(
+        "queue publication ownership is no longer current",
+      );
+    if (begun.recorded !== true) throw new Error("queue write intent was not persisted");
+  } catch (error) {
+    recordEvidenceFailure(context, error instanceof OversizedPublicationOwnershipError);
+    if (error instanceof OversizedPublicationOwnershipError) throw error;
+    return invoke(args);
+  }
+  let result: string;
+  try {
+    result = invoke(args);
+  } catch (error) {
+    recordEvidenceFailure(context);
+    throw error;
+  }
+  try {
+    const parsed = method === "DELETE" ? null : JSON.parse(result || "null");
+    const expectedTime = Date.parse(stringOrEmpty(recordOrEmpty(parsed).updated_at));
+    const expectedCount =
+      Number(beforePull.comments) + (method === "POST" ? 1 : method === "DELETE" ? -1 : 0);
+    if (method === "DELETE") wait(1100);
+    let pull: Record<string, unknown> = {};
+    for (let attempt = 0; attempt < 9; attempt++) {
+      pull = recordOrEmpty(read(pullPath));
+      if (
+        Number(pull.comments) === expectedCount &&
+        (!Number.isFinite(expectedTime) || Date.parse(String(pull.updated_at)) >= expectedTime)
+      )
+        break;
+      wait(250);
+    }
+    const completed = requestEvidence(
+      context,
+      "complete",
+      ownedCommentWriteResult(intent, parsed, pull),
+    );
+    if (completed.authority_current === false)
+      throw new OversizedPublicationOwnershipError(
+        "queue publication ownership is no longer current",
+      );
+    if (completed.recorded !== true) throw new Error("owned write receipt was not persisted");
+  } catch (error) {
+    recordEvidenceFailure(context, error instanceof OversizedPublicationOwnershipError);
+    if (error instanceof OversizedPublicationOwnershipError) throw error;
+  }
+  return result;
+}
+
+export function createQueueOwnedOversizedFreshnessGuard(options: {
+  repo: string;
+  number: number;
+  reference: unknown;
+  ghJson: <T>(args: string[]) => T;
+}) {
+  let closed = false;
+  const ref = parseOversizedActivityReference(options.reference, options.repo, options.number);
+  const context = oversizedActivityContextFromEnv();
+  const matches = Boolean(
+    ref &&
+    context &&
+    ref.epoch === context.reference.epoch &&
+    ref.repo.toLowerCase() === context.reference.repo.toLowerCase() &&
+    ref.number === context.reference.number,
+  );
+  const check = (_generation?: number, _force?: boolean): string | null => {
+    if (closed) return null;
+    if (oversizedActivityFailed(context))
+      return "queue-owned write evidence was unavailable in this publisher";
+    if (!matches || !context) return "missing, malformed, or stale queue-owned activity evidence";
+    try {
+      const evidence = parseOversizedActivityEvidence(activityRequest(context, "read").evidence);
+      if (
+        !evidence ||
+        evidence.reference.epoch !== ref!.epoch ||
+        !evidence.baseline ||
+        evidence.invalid
+      )
+        return evidence?.invalid || "missing or invalid queue-owned activity evidence";
+      const latest = Math.max(
+        Date.parse(evidence.baseline.source.updatedAt),
+        ...evidence.receipts.map((r) =>
+          Date.parse(
+            r.after?.updatedAt || r.pullAfter?.updatedAt || evidence.baseline!.source.updatedAt,
+          ),
+        ),
+      );
+      for (let attempt = 0; attempt < 9; attempt++) {
+        const pull = recordOrEmpty(
+          options.ghJson(["api", `repos/${options.repo}/pulls/${options.number}`]),
+        );
+        if (Date.parse(String(pull.updated_at)) >= latest) break;
+        if (attempt === 8) return "owned writes did not settle before finalization deadline";
+        wait(250);
+      }
+      const capture = captureOversizedActivity(
+        options.repo,
+        options.number,
+        new Date().toISOString(),
+      );
+      let next = capture.next();
+      while (next.done !== true) next = capture.next(options.ghJson(["api", next.value]));
+      const block = oversizedActivityBlock(evidence, next.value);
+      if (block) return block;
+      // The fence must still belong to this publisher after the metadata reads.
+      const finalEvidence = parseOversizedActivityEvidence(
+        activityRequest(context, "read").evidence,
+      );
+      return finalEvidence && JSON.stringify(finalEvidence) === JSON.stringify(evidence)
+        ? null
+        : "queue evidence or publication ownership changed during finalization";
+    } catch (error) {
+      return `oversized PR queue revalidation failed: ${error instanceof Error ? error.message : String(error)}`;
+    }
+  };
+  return {
+    check,
+    markClosed() {
+      closed = true;
+    },
+    recordOwnComment(_comment: Record<string, unknown>) {},
+    receipt(): OversizedActivityReference | null {
+      return ref;
+    },
+  };
+}

--- a/src/oversized-activity-write.ts
+++ b/src/oversized-activity-write.ts
@@ -1,0 +1,73 @@
+import { randomUUID } from "node:crypto";
+import { recordOrEmpty } from "./value-coerce.ts";
+import {
+  activityHash,
+  oversizedCommentImage,
+  type OversizedActivityReference,
+  type OversizedAcknowledgementReceipt,
+} from "./oversized-activity-contract.ts";
+import { oversizedPrSourceSnapshot } from "./oversized-pr-snapshot.ts";
+
+export interface OversizedCommentRequest {
+  path: string;
+  method: string;
+  body?: unknown;
+}
+export function isOversizedCommentWrite(
+  request: OversizedCommentRequest,
+  ref: OversizedActivityReference,
+): boolean {
+  const root = `repos/${ref.repo}/issues/`.toLowerCase();
+  const path = request.path.replace(/^\//, "").toLowerCase();
+  return (
+    ["POST", "PATCH", "DELETE"].includes(request.method) &&
+    (path === `${root}${ref.number}/comments` ||
+      new RegExp(`^${root.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}comments/[1-9]\\d*$`).test(path))
+  );
+}
+export function ownedCommentWriteIntent(
+  request: OversizedCommentRequest,
+  before: unknown,
+): OversizedAcknowledgementReceipt {
+  const image = request.method === "POST" ? null : oversizedCommentImage(before);
+  const body = recordOrEmpty(request.body).body;
+  const previousBody = recordOrEmpty(before).body;
+  if (
+    (image &&
+      (!/^(?:clawsweeper(?:\[bot\])?|openclaw-clawsweeper\[bot\])$/i.test(image.author) ||
+        typeof previousBody !== "string" ||
+        !previousBody.includes("<!-- clawsweeper-"))) ||
+    (request.method !== "DELETE" &&
+      (typeof body !== "string" || !body.includes("<!-- clawsweeper-")))
+  )
+    throw new Error("comment write is outside the owned acknowledgement/review contract");
+  return {
+    id: randomUUID(),
+    kind: request.method as OversizedAcknowledgementReceipt["kind"],
+    before: image,
+    after: null,
+    requestedBodyFingerprint: request.method === "DELETE" ? null : activityHash(body),
+    startedAt: new Date().toISOString(),
+    completedAt: null,
+    pullAfter: null,
+  };
+}
+export function ownedCommentWriteResult(
+  intent: OversizedAcknowledgementReceipt,
+  result: unknown,
+  pull: unknown,
+): OversizedAcknowledgementReceipt {
+  const after = intent.kind === "DELETE" ? null : oversizedCommentImage(result);
+  if (
+    after &&
+    (after.bodyFingerprint !== intent.requestedBodyFingerprint ||
+      (intent.before && after.id !== intent.before.id))
+  )
+    throw new Error("comment write response does not match its intent");
+  return {
+    ...intent,
+    after,
+    completedAt: new Date().toISOString(),
+    pullAfter: oversizedPrSourceSnapshot(recordOrEmpty(pull)),
+  };
+}

--- a/src/oversized-activity-write.ts
+++ b/src/oversized-activity-write.ts
@@ -64,10 +64,7 @@ export function ownedCommentWriteResult(
       (intent.before && after.id !== intent.before.id))
   )
     throw new Error("comment write response does not match its intent");
-  return {
-    ...intent,
-    after,
-    completedAt: new Date().toISOString(),
-    pullAfter: oversizedPrSourceSnapshot(recordOrEmpty(pull)),
-  };
+  const pullAfter = oversizedPrSourceSnapshot(recordOrEmpty(pull));
+  if (!pullAfter) throw new Error("post-write PR metadata snapshot is incomplete");
+  return { ...intent, after, completedAt: new Date().toISOString(), pullAfter };
 }

--- a/src/oversized-pr-snapshot.ts
+++ b/src/oversized-pr-snapshot.ts
@@ -1,0 +1,89 @@
+import { createHash } from "node:crypto";
+import { stableJson } from "./stable-json.ts";
+import { recordOrEmpty, stringOrEmpty } from "./value-coerce.ts";
+const labelNames = (labels: unknown[]) =>
+  labels
+    .map((label) => (typeof label === "string" ? label : recordOrEmpty(label).name))
+    .filter((name): name is string => typeof name === "string" && Boolean(name));
+
+export interface OversizedPrSourceSnapshot {
+  fingerprint: string;
+  updatedAt: string;
+  observedAt: string;
+  comments: number;
+  reviewComments: number;
+}
+
+const hash = (value: unknown) => createHash("sha256").update(stableJson(value)).digest("hex");
+const count = (value: unknown): value is number =>
+  typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+const timestamp = (value: unknown): value is string =>
+  typeof value === "string" && Number.isFinite(Date.parse(value));
+const digest = (value: unknown): value is string =>
+  typeof value === "string" && /^[a-f0-9]{64}$/.test(value);
+
+export function oversizedPrSourceSnapshot(
+  pull: Record<string, unknown>,
+  observedAt?: string,
+): OversizedPrSourceSnapshot | null {
+  if (
+    !timestamp(pull.updated_at) ||
+    !count(pull.comments) ||
+    !count(pull.review_comments) ||
+    typeof pull.title !== "string" ||
+    !(typeof pull.body === "string" || pull.body === null) ||
+    !Array.isArray(pull.labels)
+  )
+    return null;
+  return {
+    fingerprint: hash({
+      head: recordOrEmpty(pull.head).sha,
+      additions: pull.additions,
+      deletions: pull.deletions,
+      changedFiles: pull.changed_files,
+      state: pull.state,
+      locked: pull.locked === true,
+      title: pull.title,
+      body: pull.body ?? "",
+      labels: labelNames(pull.labels).sort(),
+      draft: pull.draft === true,
+      baseRef: stringOrEmpty(recordOrEmpty(pull.base).ref),
+      assignees: pull.assignees ?? [],
+      milestone: pull.milestone ?? null,
+      requestedReviewers: pull.requested_reviewers ?? [],
+      requestedTeams: pull.requested_teams ?? [],
+    }),
+    updatedAt: pull.updated_at,
+    observedAt: timestamp(observedAt) ? observedAt : pull.updated_at,
+    comments: pull.comments,
+    reviewComments: pull.review_comments,
+  };
+}
+
+function jsonRecord(value: unknown): Record<string, unknown> {
+  if (typeof value === "string") {
+    try {
+      value = JSON.parse(value);
+    } catch {
+      return {};
+    }
+  }
+  return recordOrEmpty(value);
+}
+
+export function parseOversizedPrSourceSnapshot(value: unknown): OversizedPrSourceSnapshot | null {
+  const source = jsonRecord(value);
+  return digest(source.fingerprint) &&
+    timestamp(source.updatedAt) &&
+    timestamp(source.observedAt) &&
+    count(source.comments) &&
+    count(source.reviewComments)
+    ? {
+        fingerprint: source.fingerprint,
+        updatedAt: source.updatedAt,
+        observedAt: source.observedAt,
+        comments: source.comments,
+        reviewComments: source.reviewComments,
+      }
+    : null;
+}

--- a/src/repair/github-cli.ts
+++ b/src/repair/github-cli.ts
@@ -1,3 +1,7 @@
+import {
+  observeOversizedCommentWrite,
+  oversizedActivityContextFromEnv,
+} from "../oversized-activity-runtime.js";
 import type { JsonValue } from "./json-types.js";
 import { execFile, execFileSync, spawnSync } from "node:child_process";
 import { promisify } from "node:util";
@@ -161,6 +165,13 @@ export function ghPagedLimitWithRetry<T = JsonValue>(
 }
 
 export function ghText(ghArgs: string[], options: GhRunOptions = {}): string {
+  return observeOversizedCommentWrite(
+    ghArgs,
+    (args) => ghTextUnobserved(args, options),
+    options.input,
+  );
+}
+function ghTextUnobserved(ghArgs: string[], options: GhRunOptions = {}): string {
   const env = ghCommandEnv(ghArgs, options);
   const command = ghCommand(ghArgs, env);
   const text = execFileSync(command.command, command.args, {
@@ -253,7 +264,8 @@ export async function ghTextWithRetryAsync(
 }
 
 export async function ghTextAsync(ghArgs: string[], options: GhRunOptions = {}): Promise<string> {
-  if (options.input !== undefined) return ghText(ghArgs, options);
+  if (options.input !== undefined || oversizedActivityContextFromEnv())
+    return ghText(ghArgs, options);
   const env = ghCommandEnv(ghArgs, options);
   const command = ghCommand(ghArgs, env);
   const { stdout } = await execFileAsync(command.command, command.args, {

--- a/src/repair/process-env.ts
+++ b/src/repair/process-env.ts
@@ -39,6 +39,12 @@ export function codexSubprocessEnv(): NodeJS.ProcessEnv {
   delete env.GH_TOKEN;
   delete env.GITHUB_TOKEN;
   delete env.REPO_TOKEN;
+  // Queue ownership and write receipts belong to the publisher, never to reviewed code.
+  delete env.CLAWSWEEPER_OVERSIZED_ACTIVITY_CONTEXT;
+  delete env.CLAWSWEEPER_WEBHOOK_SECRET;
+  delete env.GITHUB_ENV;
+  delete env.GITHUB_EVENT_PATH;
+  for (const key of Object.keys(env)) if (key.startsWith("EXACT_REVIEW_")) delete env[key];
   delete env.CLAWSWEEPER_CRABFLEET_AGENT_TOKEN;
   delete env.CLAWSWEEPER_CRABFLEET_SERVICE_TOKEN;
   delete env.CLAWSWEEPER_CRABFLEET_RUNNER_PTY_URL;

--- a/test/codex-process.test.ts
+++ b/test/codex-process.test.ts
@@ -1089,7 +1089,10 @@ const server = http.createServer((request, response) => {
   });
 });
 server.listen(0, "127.0.0.1", () => {
-  fs.writeFileSync(process.env.WORK_STATE_PORT_PATH, String(server.address().port));
+  // Publish readiness only after the port file is complete.
+  const temporaryPath = process.env.WORK_STATE_PORT_PATH + ".tmp";
+  fs.writeFileSync(temporaryPath, String(server.address().port));
+  fs.renameSync(temporaryPath, process.env.WORK_STATE_PORT_PATH);
 });
 `,
     );

--- a/test/dashboard-oversized-activity.test.ts
+++ b/test/dashboard-oversized-activity.test.ts
@@ -386,3 +386,24 @@ for (const fails of [false, true]) {
     }
   });
 }
+
+test("an unavailable queue evidence reference keeps claim and completion usable", async () => {
+  const h = await setup(true);
+  h.storage.kv.delete(`oversized-activity:v1:item:${repo}#${number}`);
+  const response = await h.post("claim", { ...h.tuple, oversized_activity_version: 1 });
+  assert.equal(response.status, 200);
+  const claim: any = await response.json();
+  assert.equal(claim.claimed, true);
+  assert.ok(claim.oversized_activity);
+  const read: any = await (
+    await h.post("oversized-activity", { ...claim.oversized_activity, operation: "read" })
+  ).json();
+  assert.equal(read.evidence.baseline, null);
+  assert.match(read.evidence.invalid, /evidence is missing/);
+  const complete = await h.post("complete", {
+    ...h.tuple,
+    outcome: "success",
+    oversized_activity_failed: false,
+  });
+  assert.equal(complete.status, 200);
+});

--- a/test/dashboard-oversized-activity.test.ts
+++ b/test/dashboard-oversized-activity.test.ts
@@ -1,0 +1,388 @@
+import {
+  assert,
+  test,
+  ExactReviewQueue,
+  MemoryDurableStorage,
+  MemoryDurableNamespace,
+  worker,
+  leasedExactReviewQueueItem,
+} from "./dashboard-worker-harness.ts";
+import { OversizedActivityStore } from "../dashboard/oversized-activity-store.ts";
+import {
+  ownedCommentWriteIntent,
+  ownedCommentWriteResult,
+} from "../src/oversized-activity-write.ts";
+
+const repo = "openclaw/openclaw",
+  number = 42;
+const pull = {
+  number,
+  title: "Synthetic",
+  body: "Body",
+  updated_at: "2026-01-01T00:00:00Z",
+  comments: 0,
+  review_comments: 0,
+  labels: [],
+  state: "open",
+  head: { sha: "b".repeat(40) },
+  additions: 50001,
+  deletions: 0,
+  changed_files: 1,
+};
+async function setup(upgraded: boolean) {
+  const storage = new MemoryDurableStorage();
+  const store = new OversizedActivityStore(storage.kv);
+  const ref = upgraded
+    ? await store.prepare(repo, number, { head: "b" }, async (path) =>
+        path.endsWith("/pulls/42") ? pull : [],
+      )
+    : undefined;
+  const item: any = leasedExactReviewQueueItem(number, "123");
+  item.decision = {
+    ...item.decision,
+    itemKind: "pull_request",
+    sourceEvent: "pull_request",
+    ...(ref ? { oversizedActivityReference: ref } : {}),
+  };
+  item.leaseDecision = { ...item.decision };
+  await storage.put("exact-review-queue", { deliveries: {}, items: { [item.key]: item } });
+  const queue = new ExactReviewQueue({ storage }, { hostedTargetPredicate: () => true });
+  const env = { EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue) };
+  const tuple = {
+    item_key: item.key,
+    lease_id: item.leaseId,
+    lease_revision: 1,
+    claim_generation: 1,
+    run_id: "123",
+    run_attempt: 1,
+  };
+  const post = (path: string, body: unknown) =>
+    worker.fetch(
+      new Request(`https://clawsweeper.openclaw.ai/internal/exact-review/${path}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+      env,
+    );
+  return { storage, store, ref, item, tuple, post };
+}
+
+test("upgraded Worker claim round-trips evidence, validates write receipts and releases the acknowledgement fence", async () => {
+  const h = await setup(true);
+  const response = await h.post("claim", { ...h.tuple, oversized_activity_version: 1 });
+  assert.equal(response.status, 200);
+  const claim: any = await response.json();
+  assert.equal(claim.oversized_activity_version, 1);
+  assert.deepEqual(claim.decision.oversizedActivityReference, h.ref);
+  const context = claim.oversized_activity;
+  assert.ok(context);
+  assert.equal(h.store.blocked(repo, number), true);
+  const get: any = await (
+    await h.post("oversized-activity", { ...context, operation: "read" })
+  ).json();
+  assert.ok(get.evidence.baseline);
+  assert.equal(get.evidence.receipts.length, 0);
+  const malformed = await h.post("oversized-activity", {
+    ...context,
+    operation: "begin",
+    receipt: { id: 1 },
+  });
+  assert.equal(malformed.status, 400);
+  const body = "<!-- clawsweeper-command-ack:8 -->";
+  const intent = ownedCommentWriteIntent(
+    { method: "POST", path: `repos/${repo}/issues/42/comments`, body: { body } },
+    null,
+  );
+  assert.equal(
+    (await h.post("oversized-activity", { ...context, operation: "begin", receipt: intent }))
+      .status,
+    200,
+  );
+  const incomplete: any = await (
+    await h.post("oversized-activity", { ...context, operation: "read" })
+  ).json();
+  assert.match(incomplete.evidence.invalid, /no complete receipt/);
+  const timestamp = new Date().toISOString();
+  const comment = {
+    id: 9,
+    body,
+    user: { login: "clawsweeper[bot]" },
+    created_at: timestamp,
+    updated_at: timestamp,
+  };
+  const receipt = ownedCommentWriteResult(intent, comment, {
+    ...pull,
+    comments: 1,
+    updated_at: timestamp,
+  });
+  assert.equal(
+    (await h.post("oversized-activity", { ...context, operation: "complete", receipt })).status,
+    200,
+  );
+  assert.equal(new OversizedActivityStore(h.storage.kv).evidence(h.ref!)?.receipts.length, 1);
+  const wrong: any = await (
+    await h.post("oversized-activity", {
+      ...context,
+      owner: { ...context.owner, runId: "999" },
+      operation: "read",
+    })
+  ).json();
+  assert.equal(wrong.evidence, null);
+  const done = await h.post("complete", {
+    ...h.tuple,
+    outcome: "success",
+    oversized_activity_failed: false,
+  });
+  assert.equal(done.status, 200, await done.text());
+  assert.equal(h.store.blocked(repo, number), false);
+});
+
+test("old-head claim and completion retain their existing Worker protocol without evidence negotiation", async () => {
+  const h = await setup(false);
+  const response = await h.post("claim", h.tuple);
+  assert.equal(response.status, 200);
+  const claim: any = await response.json();
+  assert.equal(claim.claimed, true);
+  assert.equal(claim.oversized_activity_version, undefined);
+  assert.equal(claim.oversized_activity, undefined);
+  assert.equal(claim.decision.oversizedActivityReference, undefined);
+  assert.equal(h.store.control(repo, number), undefined);
+  const heartbeat = await h.post("heartbeat", { ...h.tuple, phase: "finalizing" });
+  assert.equal(heartbeat.status, 200);
+  const done = await h.post("complete", { ...h.tuple, outcome: "success" });
+  assert.equal(done.status, 200, await done.text());
+  assert.equal(h.store.control(repo, number), undefined);
+});
+
+test("queue owner captures the baseline and durable intent before acknowledgement effects, then fences late convergence", async () => {
+  const { createServer } = await import("node:http");
+  const storage = new MemoryDurableStorage();
+  const live = { ...pull, head: { ...pull.head }, labels: [] };
+  const events: string[] = [];
+  const server = createServer((request, response) => {
+    const path = new URL(request.url!, "http://127.0.0.1").pathname;
+    events.push(path);
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify(path.endsWith("/pulls/42") ? live : []));
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  try {
+    const address = server.address() as { port: number };
+    const queue = new ExactReviewQueue(
+      { storage },
+      { GITHUB_API_URL: `http://127.0.0.1:${address.port}` },
+    );
+    const decision = {
+      targetRepo: repo,
+      targetBranch: "main",
+      itemNumber: number,
+      itemKind: "pull_request",
+      sourceEvent: "pull_request",
+      sourceAction: "opened",
+      supersedesInProgress: false,
+    };
+    const store = new OversizedActivityStore(storage.kv);
+    await (queue as any).withOversizedAcknowledgement(
+      decision,
+      Promise.resolve("synthetic"),
+      async (journal: any) => {
+        assert.equal(typeof journal, "function");
+        const ref = store.control(repo, number)!.reference;
+        assert.ok(store.evidence(ref)?.baseline);
+        assert.equal(store.evidence(ref)?.baseline?.source.comments, 0);
+        const body = "<!-- clawsweeper-pr-ack item=42 -->";
+        await journal(
+          { path: `/repos/${repo}/issues/42/comments`, method: "POST", body: { body } },
+          async () => {
+            assert.match(store.evidence(ref)?.invalid || "", /no complete receipt/);
+            assert.equal(events.length, 7);
+            events.push("WRITE");
+            live.comments = 1;
+            live.updated_at = new Date().toISOString();
+            return {
+              id: 9,
+              body,
+              created_at: live.updated_at,
+              updated_at: live.updated_at,
+              user: { login: "clawsweeper[bot]" },
+            };
+          },
+        );
+      },
+    );
+    const ref = store.control(repo, number)!.reference;
+    assert.equal(store.evidence(ref)?.receipts.length, 1);
+    const owner = {
+      itemKey: `${repo}#42`,
+      leaseId: "synthetic",
+      claimGeneration: 1,
+      runId: "123",
+      runAttempt: 1,
+    };
+    assert.equal(store.fence(ref, owner, Date.now() + 60000), true);
+    await assert.rejects(
+      () =>
+        (queue as any).withOversizedAcknowledgement(
+          decision,
+          Promise.resolve("synthetic"),
+          async () => {
+            events.push("late duplicate POST/DELETE");
+          },
+        ),
+      /fenced/,
+    );
+    assert.equal(events.includes("late duplicate POST/DELETE"), false);
+  } finally {
+    server.closeAllConnections();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+});
+
+test("a failed size lookup cannot bypass a fence acquired during that lookup", async () => {
+  const { createServer } = await import("node:http");
+  const storage = new MemoryDurableStorage();
+  const store = new OversizedActivityStore(storage.kv);
+  const ref = await store.prepare(repo, number, {}, async (path) =>
+    path.endsWith("/pulls/42") ? pull : [],
+  );
+  let reached!: () => void;
+  const started = new Promise<void>((resolve) => {
+    reached = resolve;
+  });
+  let finish!: () => void;
+  const server = createServer((_request, response) => {
+    finish = () => {
+      response.writeHead(400);
+      response.end("synthetic missing metadata");
+    };
+    reached();
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  try {
+    const address = server.address() as { port: number };
+    const queue = new ExactReviewQueue(
+      { storage },
+      { GITHUB_API_URL: `http://127.0.0.1:${address.port}` },
+    );
+    let writes = 0;
+    const pending = (queue as any).withOversizedAcknowledgement(
+      { targetRepo: repo, itemNumber: number, itemKind: "pull_request" },
+      Promise.resolve("synthetic"),
+      async () => {
+        writes++;
+      },
+    );
+    await started;
+    assert.equal(
+      store.fence(
+        ref,
+        {
+          itemKey: `${repo}#42`,
+          leaseId: "claim",
+          claimGeneration: 1,
+          runId: "123",
+          runAttempt: 1,
+        },
+        Date.now() + 60000,
+      ),
+      true,
+    );
+    finish();
+    await assert.rejects(pending, /fenced/);
+    assert.equal(writes, 0);
+  } finally {
+    server.closeAllConnections();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+});
+
+test("oversized evidence selects the per-item publication owner even when batching is enabled", async () => {
+  const { exactReviewQueueIsBatchablePublication } =
+    await import("../dashboard/exact-review-decision.ts");
+  const decision: any = {
+    targetRepo: repo,
+    targetBranch: "main",
+    itemNumber: number,
+    itemKind: "pull_request",
+    sourceEvent: "pull_request",
+    sourceAction: "exact_review_artifact_publish",
+    supersedesInProgress: false,
+  };
+  assert.equal(exactReviewQueueIsBatchablePublication({ decision }), true);
+  decision.oversizedActivityReference = {
+    version: 1,
+    repo,
+    number,
+    epoch: "10000000-0000-0000-0000-000000000000",
+  };
+  assert.equal(exactReviewQueueIsBatchablePublication({ decision }), false);
+});
+
+for (const fails of [false, true]) {
+  test(`claim revalidates an expired lease after ${fails ? "failed" : "ordinary-size"} metadata probe`, async () => {
+    const { createServer } = await import("node:http");
+    const { generateKeyPairSync } = await import("node:crypto");
+    const { privateKey } = generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+      privateKeyEncoding: { type: "pkcs8", format: "pem" },
+      publicKeyEncoding: { type: "spki", format: "pem" },
+    });
+    const storage = new MemoryDurableStorage();
+    const item: any = leasedExactReviewQueueItem(number, "123");
+    item.decision = { ...item.decision, itemKind: "pull_request", sourceEvent: "pull_request" };
+    item.leaseDecision = { ...item.decision };
+    await storage.put("exact-review-queue", { deliveries: {}, items: { [item.key]: item } });
+    let probes = 0;
+    const server = createServer(async (request, response) => {
+      const path = new URL(request.url!, "http://127.0.0.1").pathname;
+      let data: unknown = { id: 123 };
+      if (path.endsWith("/access_tokens")) data = { token: "synthetic" };
+      if (path.endsWith("/pulls/42")) {
+        probes++;
+        const state: any = await storage.get("exact-review-queue");
+        state.items[item.key].leaseExpiresAt = Date.now() - 1;
+        await storage.put("exact-review-queue", state);
+        data = fails ? { error: "synthetic metadata failure" } : { ...pull, additions: 1 };
+      }
+      response.writeHead(fails && path.endsWith("/pulls/42") ? 400 : 200, {
+        "content-type": "application/json",
+      });
+      response.end(JSON.stringify(data));
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    try {
+      const address = server.address() as { port: number };
+      const queue = new ExactReviewQueue(
+        { storage },
+        {
+          hostedPublicTargetProbe: async () => "public",
+          CLAWSWEEPER_APP_CLIENT_ID: "Iv23test",
+          CLAWSWEEPER_APP_PRIVATE_KEY: privateKey,
+          GITHUB_API_URL: `http://127.0.0.1:${address.port}`,
+        },
+      );
+      const response = await queue.fetch(
+        new Request("https://queue.invalid/claim", {
+          method: "POST",
+          body: JSON.stringify({
+            item_key: item.key,
+            lease_id: item.leaseId,
+            lease_revision: 1,
+            run_id: "123",
+            run_attempt: 1,
+            oversized_activity_version: 1,
+          }),
+        }),
+      );
+      assert.equal(probes, 1);
+      assert.equal(response.status, 409);
+      assert.equal((await response.json()).error, "lease_not_active");
+      const after: any = await storage.get("exact-review-queue");
+      assert.ok(after.items[item.key].leaseExpiresAt < Date.now());
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+}

--- a/test/dashboard-worker-queue-runtime.test.ts
+++ b/test/dashboard-worker-queue-runtime.test.ts
@@ -1121,7 +1121,7 @@ test("source authority acknowledgement errors remain deferred without enqueue", 
     assert.equal(reservation.attempts, EXACT_REVIEW_SOURCE_AUTHORITY_RETRY_LIMIT);
     assert.ok(reservation.nextAttemptAt > 0);
     assert.equal(reservation.reviewAcknowledgementPending, true);
-    assert.equal(pullReads, 0);
+    assert.equal(pullReads, 1); // Size probe only; no head-authority verification.
     const state = (await harness.storage.get("exact-review-queue")) as {
       items: Record<string, unknown>;
     };
@@ -1295,7 +1295,7 @@ test("source authority acknowledgement recovery preserves concurrent receipt and
           98_084,
         );
         assert.equal(harness.storage.rawHas(reservationKey), false);
-        assert.equal(pullReads, 1);
+        assert.equal(pullReads, 2); // Size probe plus authoritative head read.
       } else {
         assert.equal(state.items[`openclaw/fs-safe#${itemNumber}`], undefined);
         const reservation = harness.storage.rawGet(reservationKey) as {
@@ -1304,7 +1304,7 @@ test("source authority acknowledgement recovery preserves concurrent receipt and
         };
         assert.equal(reservation.decision.sourceHeadSha, "e".repeat(40));
         assert.equal(reservation.reviewAcknowledgementPending, true);
-        assert.equal(pullReads, 0);
+        assert.equal(pullReads, 1); // The size probe does not bind source authority.
         harness.storage.rawPut(reservationKey, { ...reservation, nextAttemptAt: 0 });
         await harness.queue.alarm();
         const afterStaleHead = (await harness.storage.get("exact-review-queue")) as {
@@ -1312,7 +1312,7 @@ test("source authority acknowledgement recovery preserves concurrent receipt and
         };
         assert.equal(afterStaleHead.items[`openclaw/fs-safe#${itemNumber}`], undefined);
         assert.equal(harness.storage.rawHas(reservationKey), false);
-        assert.equal(pullReads, 1);
+        assert.equal(pullReads, 3);
         assert.equal(sqlCount(harness.storage, "exact_review_queue_deliveries"), 1);
       }
     });

--- a/test/dashboard-worker-webhook-ingress.test.ts
+++ b/test/dashboard-worker-webhook-ingress.test.ts
@@ -2516,7 +2516,9 @@ test("hosted pull request receipt fast acks precede verification and stay idempo
       assert.ok(
         JSON.stringify(tokenRequest.permissions) ===
           JSON.stringify({ issues: "write", pull_requests: "write" }) ||
-          JSON.stringify(tokenRequest.permissions) === JSON.stringify({ pull_requests: "read" }),
+          JSON.stringify(tokenRequest.permissions) === JSON.stringify({ pull_requests: "read" }) ||
+          JSON.stringify(tokenRequest.permissions) ===
+            JSON.stringify({ issues: "read", pull_requests: "read" }),
       );
       return jsonResponse({ token: "target-token" });
     }
@@ -2887,10 +2889,11 @@ test("hosted pull request receipt fast acks precede verification and stay idempo
     await Promise.all(waitUntilPromises);
     assert.ok(acknowledgementLookupUsesSince.includes(false));
     assert.ok(acknowledgementLookupUsesSince.includes(true));
-    assert.deepEqual(errorLogs, [
-      ["ClawSweeper pull request fast ack failed"],
-      ["ClawSweeper pull request fast ack failed"],
-    ]);
+    // A duplicate ingress may also defer while queue-owned cleanup is active.
+    // Keep the error surface fixed without asserting timer-dependent log counts.
+    assert.ok(errorLogs.length >= 2);
+    for (const entry of errorLogs)
+      assert.deepEqual(entry, ["ClawSweeper pull request fast ack failed"]);
     assert.doesNotMatch(JSON.stringify(errorLogs), new RegExp(logMarker));
   } finally {
     globalThis.fetch = originalFetch;
@@ -2908,7 +2911,11 @@ test("hosted pull request receipts dedupe across opened and ready_for_review", a
   const storage = new MemoryDurableStorage();
   const queue = new ExactReviewQueue(
     { storage },
-    { hostedPublicTargetProbe: publicHostedTargetProbe },
+    {
+      hostedPublicTargetProbe: publicHostedTargetProbe,
+      CLAWSWEEPER_APP_CLIENT_ID: "Iv23test",
+      CLAWSWEEPER_APP_PRIVATE_KEY: privateKey,
+    },
   );
   type AckComment = {
     id: number;

--- a/test/oversized-activity-contract.test.ts
+++ b/test/oversized-activity-contract.test.ts
@@ -1,0 +1,426 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  activityHash,
+  captureOversizedActivity,
+  oversizedActivityBlock,
+  oversizedActivityNeeded,
+  parseOversizedActivityEvidence,
+} from "../src/oversized-activity-contract.ts";
+import {
+  ownedCommentWriteIntent,
+  ownedCommentWriteResult,
+} from "../src/oversized-activity-write.ts";
+import { OversizedActivityStore } from "../dashboard/oversized-activity-store.ts";
+import { exactReviewBaseDecisionFrom } from "../dashboard/exact-review-decision.ts";
+
+const repo = "openclaw/openclaw",
+  number = 42;
+const reference = {
+  version: 1 as const,
+  repo,
+  number,
+  epoch: "10000000-0000-0000-0000-000000000000",
+};
+const old = "2026-01-01T00:00:00Z",
+  now = "2026-01-01T00:00:10Z",
+  writeTime = "2026-01-01T00:00:12Z";
+function fixture() {
+  const pull = {
+    number,
+    title: "Synthetic",
+    body: "PR body",
+    updated_at: old,
+    comments: 1,
+    review_comments: 0,
+    labels: [],
+    state: "open",
+    additions: 50001,
+    deletions: 0,
+    changed_files: 1,
+    head: { sha: "b".repeat(40) },
+    base: { ref: "main" },
+  };
+  const comment = {
+    id: 9,
+    body: "<!-- clawsweeper-command-ack:8 -->",
+    created_at: old,
+    updated_at: old,
+    user: { login: "clawsweeper[bot]" },
+  };
+  const review = { id: 7, body: "Review A", submitted_at: old, state: "COMMENTED" };
+  const streams = [
+    [comment],
+    [
+      { ...comment, event: "commented" },
+      { ...review, event: "reviewed" },
+    ],
+    [],
+    [review],
+  ];
+  const paths: string[] = [];
+  const read = (path: string): unknown => {
+    paths.push(path);
+    if (path.endsWith("/pulls/42")) return structuredClone(pull);
+    const index = path.includes("/issues/42/comments")
+      ? 0
+      : path.includes("/timeline")
+        ? 1
+        : path.includes("/pulls/42/comments")
+          ? 2
+          : 3;
+    return structuredClone(streams[index]);
+  };
+  const capture = (initial = false) => {
+    const g = captureOversizedActivity(repo, number, now, initial);
+    let n = g.next();
+    while (n.done !== true) n = g.next(read(n.value));
+    return n.value;
+  };
+  return { pull, comment, review, streams, paths, read, capture };
+}
+
+test("queue baseline retains submitted review bodies; same-second human edit refuses", () => {
+  const f = fixture(),
+    baseline = f.capture(true);
+  const request = {
+    method: "PATCH",
+    path: `repos/${repo}/issues/comments/9`,
+    body: { body: "<!-- clawsweeper-command-ack:8 --> Complete" },
+  };
+  const before = structuredClone(f.comment),
+    intent = ownedCommentWriteIntent(request, before);
+  f.comment.body = request.body.body;
+  f.comment.updated_at = writeTime;
+  f.pull.updated_at = writeTime;
+  Object.assign(f.streams[1]![0]!, f.comment);
+  const receipt = ownedCommentWriteResult(intent, f.comment, f.pull);
+  const evidence = { reference, baseline, receipts: [receipt], invalid: null };
+  assert.equal(oversizedActivityBlock(evidence, f.capture()), null);
+  f.review.body = "Review B";
+  Object.assign(f.streams[1]![1]!, f.review);
+  assert.match(oversizedActivityBlock(evidence, f.capture())!, /non-owned PR activity/);
+});
+
+test("duplicate acknowledgement POST then DELETE in the PATCH second has complete receipts", () => {
+  const f = fixture(),
+    baseline = f.capture(true),
+    receipts = [];
+  const duplicate = { ...f.comment, id: 10, created_at: writeTime, updated_at: writeTime };
+  const post = ownedCommentWriteIntent(
+    { method: "POST", path: "unused", body: { body: duplicate.body } },
+    null,
+  );
+  f.pull.comments = 2;
+  f.pull.updated_at = writeTime;
+  receipts.push(ownedCommentWriteResult(post, duplicate, f.pull));
+  const patch = ownedCommentWriteIntent(
+    { method: "PATCH", path: "unused", body: { body: f.comment.body + " Complete" } },
+    f.comment,
+  );
+  f.comment.body += " Complete";
+  f.comment.updated_at = writeTime;
+  Object.assign(f.streams[1]![0]!, f.comment);
+  receipts.push(ownedCommentWriteResult(patch, f.comment, f.pull));
+  const deletion = ownedCommentWriteIntent({ method: "DELETE", path: "unused" }, duplicate);
+  f.pull.comments = 1;
+  receipts.push(ownedCommentWriteResult(deletion, null, f.pull));
+  assert.equal(
+    oversizedActivityBlock({ reference, baseline, receipts, invalid: null }, f.capture()),
+    null,
+  );
+  assert.match(
+    oversizedActivityBlock(
+      { reference, baseline, receipts: receipts.slice(0, 2), invalid: null },
+      f.capture(),
+    )!,
+    /comment/,
+  );
+  f.review.body = "Human edit in same second";
+  Object.assign(f.streams[1]![1]!, f.review);
+  assert.match(
+    oversizedActivityBlock({ reference, baseline, receipts, invalid: null }, f.capture())!,
+    /non-owned PR activity/,
+  );
+});
+
+test("baseline capture keeps bounded pagination, completeness, and admission ambiguity guards", () => {
+  for (const mutation of ["missing", "undatable", "ambiguous", "duplicate", "overlarge"]) {
+    const f = fixture();
+    if (mutation === "missing") f.pull.comments = 2;
+    if (mutation === "undatable") f.comment.updated_at = "";
+    if (mutation === "ambiguous") f.comment.updated_at = now;
+    if (mutation === "duplicate") {
+      f.streams[0]!.push({ ...f.comment });
+      f.pull.comments = 2;
+    }
+    if (mutation === "overlarge") {
+      f.streams[0] = Array.from({ length: 100 }, (_, id) => ({ ...f.comment, id: id + 100 }));
+      f.pull.comments = 300;
+    }
+    assert.throws(() => f.capture(true), undefined, mutation);
+  }
+  const f = fixture();
+  f.capture(true);
+  assert.equal(f.paths.length, 6);
+  assert.ok(f.paths.every((p) => !/\/(files|commits|blobs)(\/|$)/.test(p)));
+});
+
+test("evidence and decision allowlist reject malformed or wrong-target references explicitly", () => {
+  const f = fixture(),
+    evidence = { reference, baseline: f.capture(true), receipts: [], invalid: null };
+  assert.ok(parseOversizedActivityEvidence(evidence));
+  for (const value of [
+    null,
+    {},
+    { ...evidence, baseline: { ...evidence.baseline, streams: [[null], [], [], []] } },
+    { ...evidence, receipts: [null] },
+    {
+      ...evidence,
+      baseline: {
+        ...evidence.baseline,
+        comments: [evidence.baseline.comments[0], evidence.baseline.comments[0]],
+      },
+    },
+  ])
+    assert.equal(parseOversizedActivityEvidence(value), null);
+  const decision = {
+    targetRepo: repo,
+    targetBranch: "main",
+    itemNumber: number,
+    itemKind: "pull_request",
+    sourceEvent: "pull_request",
+    sourceAction: "opened",
+    supersedesInProgress: false,
+    oversizedActivityReference: reference,
+  };
+  assert.deepEqual(exactReviewBaseDecisionFrom(decision)?.oversizedActivityReference, reference);
+  for (const ref of [
+    { ...reference, number: 43 },
+    { ...reference, repo: "elsewhere/repo" },
+    { ...reference, epoch: "broken" },
+    null,
+  ])
+    assert.equal(
+      exactReviewBaseDecisionFrom({ ...decision, oversizedActivityReference: ref }),
+      null,
+    );
+  assert.equal(
+    oversizedActivityNeeded({ ...fixture().pull, additions: 50000, deletions: 0 }, undefined),
+    false,
+  );
+  assert.equal(
+    oversizedActivityNeeded({ ...fixture().pull, additions: 50001, deletions: 0 }, undefined),
+    true,
+  );
+  assert.equal(
+    oversizedActivityNeeded({ ...fixture().pull, additions: 2, deletions: 0 }, "1"),
+    true,
+  );
+  assert.equal(activityHash("a").length, 64);
+});
+
+test("durable receipts survive reconstruction and fence prevents convergence until release or expiry", async () => {
+  const memory = new Map<string, unknown>();
+  const kv = {
+    get: <T>(key: string) => structuredClone(memory.get(key)) as T | undefined,
+    put: (key: string, value: unknown) => {
+      memory.set(key, structuredClone(value));
+    },
+  };
+  const f = fixture();
+  const store = new OversizedActivityStore(kv);
+  const ref = await store.prepare(repo, number, { head: "b" }, async (path) => f.read(path));
+  assert.ok(store.evidence(ref)?.baseline);
+  const intent = ownedCommentWriteIntent(
+    { method: "PATCH", path: "unused", body: { body: f.comment.body } },
+    f.comment,
+  );
+  store.begin(ref, intent);
+  assert.match(store.evidence(ref)?.invalid || "", /no complete receipt/);
+  store.complete(ref, ownedCommentWriteResult(intent, f.comment, f.pull));
+  assert.equal(new OversizedActivityStore(kv).evidence(ref)?.receipts.length, 1);
+  const owner = {
+    itemKey: `${repo}#${number}`,
+    leaseId: "lease",
+    claimGeneration: 1,
+    runId: "123",
+    runAttempt: 1,
+  };
+  assert.equal(store.fence(ref, owner, Date.now() + 60000), true);
+  assert.throws(() => store.lockAcknowledgement(ref), /fenced/);
+  store.release(ref, { ...owner, runId: "999" });
+  assert.equal(store.blocked(repo, number), true);
+  store.release(ref, owner);
+  assert.equal(store.blocked(repo, number), false);
+  assert.equal(store.fence(ref, owner, Date.now() - 1), true);
+  assert.equal(store.blocked(repo, number), false);
+  assert.ok([...memory.values()].every((v) => Buffer.byteLength(JSON.stringify(v)) < 128 * 1024));
+});
+
+test("late baseline capture cannot overwrite a successor fence or its pending receipts", async () => {
+  const memory = new Map<string, unknown>();
+  const kv = {
+    get: <T>(key: string) => structuredClone(memory.get(key)) as T | undefined,
+    put: (key: string, value: unknown) => {
+      memory.set(key, structuredClone(value));
+    },
+  };
+  const store = new OversizedActivityStore(kv),
+    f = fixture();
+  let first = true;
+  const owner = {
+    itemKey: `${repo}#${number}`,
+    leaseId: "successor",
+    claimGeneration: 2,
+    runId: "124",
+    runAttempt: 1,
+  };
+  const ref = await store.prepare(repo, number, { head: "b" }, async (path) => {
+    if (first) {
+      first = false;
+      const key = `oversized-activity:v1:item:${repo}#${number}`;
+      const control: any = kv.get(key);
+      kv.put(key, { ...control, busyUntil: Date.now() - 1 });
+      const token = store.lockAcknowledgement(control.reference);
+      store.unlockAcknowledgement(control.reference, token);
+      assert.equal(store.fence(control.reference, owner, Date.now() + 60000), true);
+      const intent = ownedCommentWriteIntent(
+        { method: "PATCH", path: "unused", body: { body: f.comment.body } },
+        f.comment,
+      );
+      store.begin(control.reference, intent);
+    }
+    return f.read(path);
+  });
+  assert.equal(store.owns(ref, owner), true);
+  assert.match(store.evidence(ref)?.invalid || "", /capture ownership/);
+  const meta: any = kv.get(`oversized-activity:v1:epoch:${ref.epoch}`);
+  assert.equal(meta.receiptCount, 1);
+  assert.ok(meta.pending);
+});
+
+test("unsealed or failed publishers cannot authorize a successor close", async () => {
+  for (const seal of [undefined, false, true]) {
+    const memory = new Map<string, unknown>();
+    const kv = {
+      get: <T>(key: string) => structuredClone(memory.get(key)) as T | undefined,
+      put: (key: string, value: unknown) => {
+        memory.set(key, structuredClone(value));
+      },
+    };
+    const store = new OversizedActivityStore(kv),
+      f = fixture();
+    const ref = await store.prepare(repo, number, {}, async (path) => f.read(path));
+    const owner = {
+      itemKey: `${repo}#${number}`,
+      leaseId: "producer",
+      claimGeneration: 1,
+      runId: "123",
+      runAttempt: 1,
+    };
+    assert.equal(store.fence(ref, owner, Date.now() + 60000), true);
+    if (seal !== undefined) store.seal(ref, owner, seal);
+    store.release(ref, owner);
+    assert.equal(
+      store.fence(
+        ref,
+        {
+          ...owner,
+          itemKey: `${repo}#${number}@publish:123:1`,
+          leaseId: "publisher",
+          runId: "124",
+        },
+        Date.now() + 60000,
+      ),
+      true,
+    );
+    if (seal === false) assert.equal(store.evidence(ref)?.invalid, null);
+    else assert.ok(store.evidence(ref)?.invalid);
+  }
+});
+
+test("reviewer subprocesses cannot inherit publisher receipt capabilities", async () => {
+  const { codexEnv } = await import("../dist/codex-env.js");
+  const { codexSubprocessEnv } = await import("../dist/repair/process-env.js");
+  const keys = [
+    "CLAWSWEEPER_OVERSIZED_ACTIVITY_CONTEXT",
+    "CLAWSWEEPER_WEBHOOK_SECRET",
+    "EXACT_REVIEW_LEASE_ID",
+    "EXACT_REVIEW_DECISION",
+    "GITHUB_ENV",
+    "GITHUB_EVENT_PATH",
+  ];
+  const prior = new Map(keys.map((key) => [key, process.env[key]]));
+  try {
+    for (const key of keys) process.env[key] = "synthetic-publisher-capability";
+    for (const env of [codexEnv({ ghToken: "synthetic-read-only" }), codexSubprocessEnv()])
+      for (const key of keys) assert.equal(env[key], undefined, key);
+    assert.equal(codexEnv({ ghToken: "synthetic-read-only" }).GH_TOKEN, "synthetic-read-only");
+  } finally {
+    for (const [key, value] of prior) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+});
+
+test("publisher losing ownership during pre-write metadata cannot mutate the comment", async () => {
+  const { observeOversizedCommentWrite } = await import("../dist/oversized-activity-runtime.js");
+  const { mkdtempSync, rmSync } = await import("node:fs");
+  const { join } = await import("node:path");
+  const { tmpdir } = await import("node:os");
+  const directory = mkdtempSync(join(tmpdir(), "oversized-owner-"));
+  const prior = process.env.CLAWSWEEPER_OVERSIZED_ACTIVITY_CONTEXT;
+  let current = true,
+    writes = 0;
+  const owner = {
+    itemKey: `${repo}#42`,
+    leaseId: "synthetic",
+    claimGeneration: 1,
+    runId: "123",
+    runAttempt: 1,
+  };
+  process.env.CLAWSWEEPER_OVERSIZED_ACTIVITY_CONTEXT = JSON.stringify({
+    reference,
+    owner,
+    queueUrl: "http://127.0.0.1",
+    failurePath: join(directory, "failed.json"),
+  });
+  const f = fixture();
+  try {
+    assert.throws(
+      () =>
+        observeOversizedCommentWrite(
+          [
+            "api",
+            `repos/${repo}/issues/comments/9`,
+            "--method",
+            "PATCH",
+            "-f",
+            `body=${f.comment.body} Updated`,
+          ],
+          (args) => {
+            if (args[1]!.endsWith("/pulls/42")) {
+              current = false;
+              return JSON.stringify(f.pull);
+            }
+            if (!args.includes("--method")) return JSON.stringify(f.comment);
+            writes++;
+            return JSON.stringify(f.comment);
+          },
+          undefined,
+          () =>
+            current
+              ? { ok: true, recorded: true }
+              : { ok: true, recorded: false, authority_current: false },
+        ),
+      /ownership is no longer current/,
+    );
+    assert.equal(writes, 0);
+  } finally {
+    if (prior === undefined) delete process.env.CLAWSWEEPER_OVERSIZED_ACTIVITY_CONTEXT;
+    else process.env.CLAWSWEEPER_OVERSIZED_ACTIVITY_CONTEXT = prior;
+    rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/test/oversized-activity-contract.test.ts
+++ b/test/oversized-activity-contract.test.ts
@@ -424,3 +424,33 @@ test("publisher losing ownership during pre-write metadata cannot mutate the com
     rmSync(directory, { recursive: true, force: true });
   }
 });
+
+test("completed write receipts reject malformed post-write PR metadata", () => {
+  const f = fixture();
+  const intent = ownedCommentWriteIntent(
+    { method: "POST", path: "unused", body: { body: f.comment.body } },
+    null,
+  );
+  for (const value of [null, {}, { ...f.pull, comments: undefined }])
+    assert.throws(
+      () => ownedCommentWriteResult(intent, f.comment, value),
+      /post-write PR metadata/,
+    );
+  const completed = { ...ownedCommentWriteResult(intent, f.comment, f.pull), pullAfter: null };
+  assert.equal(
+    parseOversizedActivityEvidence({
+      reference,
+      baseline: f.capture(),
+      receipts: [completed],
+      invalid: null,
+    }),
+    null,
+  );
+  assert.match(
+    oversizedActivityBlock(
+      { reference, baseline: f.capture(), receipts: [completed], invalid: null },
+      f.capture(),
+    )!,
+    /incomplete/,
+  );
+});

--- a/test/oversized-pr-close.test.ts
+++ b/test/oversized-pr-close.test.ts
@@ -255,8 +255,7 @@ for (const scenario of [
                 ...(scenario === "exact-close" ? ["--exact-event-publication"] : []),
               ],
             });
-          if (scenario === "close-error") assert.throws(apply);
-          else apply();
+          apply();
         });
         const result = existsSync(workspace.reportPath)
           ? JSON.parse(readFileSync(workspace.reportPath, "utf8"))
@@ -277,60 +276,36 @@ for (const scenario of [
           );
         }
         const mutations = existsSync(calls) ? readFileSync(calls, "utf8") : "";
+        assert.ok(existsSync(report), JSON.stringify(result));
+        assert.equal(existsSync(join(workspace.closedDir, `${pull.number}.md`)), false);
+        assert.doesNotMatch(mutations, /pr close/);
         if (
-          scenario === "close" ||
-          scenario === "exact-close" ||
-          scenario === "notice-error" ||
-          scenario === "durable-reserved-lease"
+          [
+            "close",
+            "exact-close",
+            "durable-reserved-lease",
+            "notice-error",
+            "close-error",
+          ].includes(scenario)
         ) {
           assert.ok(
-            existsSync(join(workspace.closedDir, `${pull.number}.md`)),
-            JSON.stringify(result) + mutations,
+            result.some(
+              (entry: any) =>
+                entry.action === "kept_open" && /queue-owned activity evidence/.test(entry.reason),
+            ),
+            JSON.stringify(result),
           );
-          assert.equal(existsSync(report), false);
-          const currentComment = JSON.parse(
+          assert.ok(
+            result.some((entry: any) => entry.action === "review_comment_synced"),
+            JSON.stringify(result),
+          );
+          const commentState = JSON.parse(
             readFileSync(join(workspace.root, `comment-state-${pull.number}.json`), "utf8"),
           );
-          assert.match(
-            currentComment.body,
-            scenario === "notice-error"
-              ? /ClawSweeper proposes closing this pull request/
-              : /ClawSweeper closed this pull request/,
-          );
-          assert.doesNotMatch(currentComment.body, /did not apply/);
-          assert.equal(
-            mutations.split("\n").filter((line) => line.includes("pr close")).length,
-            1,
-            mutations,
-          );
-          assert.equal(
-            mutations
-              .split("\n")
-              .filter((line) => line.includes("comments") && line.includes("POST")).length,
-            scenario === "durable-reserved-lease" ? 0 : 1,
-            mutations,
-          );
-        } else {
-          assert.ok(existsSync(report), JSON.stringify(result));
-          assert.equal(existsSync(join(workspace.closedDir, `${pull.number}.md`)), false);
-          if (scenario.startsWith("late-") || scenario === "close-error") {
-            assert.match(readFileSync(report, "utf8"), /oversized_activity_receipt: /);
-            assert.equal(
-              mutations
-                .split("\n")
-                .filter((line) => line.includes("comments") && line.includes("POST")).length,
-              1,
-              mutations,
-            );
-            if (scenario !== "close-error") assert.doesNotMatch(mutations, /pr close/);
-            const currentComment = JSON.parse(
-              readFileSync(join(workspace.root, `comment-state-${pull.number}.json`), "utf8"),
-            );
-            assert.match(currentComment.body, /ClawSweeper proposes closing this pull request/);
-            assert.doesNotMatch(currentComment.body, /ClawSweeper closed this pull request/);
-          } else assert.equal(mutations, "");
-          assert.match(readFileSync(report, "utf8"), /decision: close/);
+          assert.match(commentState.body, /ClawSweeper proposes closing/);
+          assert.doesNotMatch(commentState.body, /ClawSweeper closed/);
         }
+        assert.match(readFileSync(report, "utf8"), /decision: close/);
       } finally {
         if (previousGate === undefined) delete process.env.CLAWSWEEPER_OVERSIZED_PR_CLOSE_ENABLED;
         else process.env.CLAWSWEEPER_OVERSIZED_PR_CLOSE_ENABLED = previousGate;

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -2138,12 +2138,9 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
   );
   assert.match(publishComplete.run ?? "", /direct_lifecycle_requeue/);
   assert.ok(publisher.steps.indexOf(publishResult) < publisher.steps.indexOf(publishComplete));
-  assert.ok(publisher.steps.indexOf(publishComplete) < publisher.steps.indexOf(activeLeaseWaiting));
+  assert.ok(publisher.steps.indexOf(activeLeaseWaiting) < publisher.steps.indexOf(publishComplete));
   assert.match(activeLeaseWaiting.if ?? "", /reason_code == 'review_lease_active'/);
-  assert.match(
-    activeLeaseWaiting.if ?? "",
-    /complete-exact-review-publication\.outcome == 'success'/,
-  );
+  assert.doesNotMatch(activeLeaseWaiting.if ?? "", /complete-exact-review-publication/);
   assert.match(activeLeaseWaiting.run ?? "", /--state "Waiting"/);
 
   const publisherSource = readText("src/repair/publish-event-result.ts");


### PR DESCRIPTION
## Problem

Oversized PR proposals were correct but ClawSweeper's own comment writes could prevent closing. [Run 34387138905](https://github.com/openclaw/clawsweeper/actions/runs/34387138905) kept a PR open after a command-status update advanced `updated_at`. [Run 34402255248](https://github.com/openclaw/clawsweeper/actions/runs/34402255248) synced the durable comment, then refused because metadata changed during activity capture. Queued lease expiry caused the same class of drift.

## Root cause

Acknowledgements can precede workflow admission, and their complete write history was not retained. Refreshing the baseline at publication would hide intervening human activity: submitted reviews have no edit timestamp, so a human body edit can share an owned write's timestamp. Publication needs the original activity evidence and receipts for its own effects.

## Design

The queue captures PR metadata and bounded issue-comment, timeline, inline-comment, and submitted-review streams before oversized acknowledgement effects. The existing three-page/300-entry refusal boundary, timestamp margin, identity checks, and complete-count checks remain. Baseline pieces and individual receipts use additive KV keys; existing queue items and rollback state are not migrated or discarded.

Each owned POST/PATCH/DELETE has a persisted intent and a complete receipt with comment identity, before/after fingerprints, timestamps, and post-write PR metadata. The Worker's fast PR acknowledgement and duplicate cleanup now use the same queue owner. Validated item-bound references pass through the decision allowlist and report handoff; queued publication retrieves the complete journal, including writes made after artifact creation.

Capability-aware claims fence acknowledgement convergence until completion/release, with a deadline bounded by the execution lease and 30 minutes. Capture and acknowledgement ownership are checked across awaits. Oversized references use the existing single-item queued publisher; ordinary publication batching is unchanged. Reviewer subprocesses do not inherit publisher capabilities.

Apply records reservation, status, durable-comment, mutation-lease, and expiry writes. It settles recorded writes, compares non-owned activity with the original baseline, and rechecks size, head, exemptions, canonical-comment ownership, and the current fence before closing. Missing/malformed/stale evidence keeps the PR open. Journal availability failures preserve ordinary comment delivery, record a local no-close marker, and seal that failure at queue completion. A successor refuses an unsealed predecessor's evidence.

The threshold, exemptions, fallback-profile apply policy, and zero file/blob hydration, scanner, and model work for oversized items remain unchanged. No PR is reopened.

## Deploy-skew safety

A new workflow/CLI against an old Worker receives no evidence capability and refuses the close while continuing ordinary publication/completion. The upgraded Worker retains the old claim, heartbeat, publication, and completion protocol. Shared hashing uses the Worker's `nodejs_compat` setting, validated with Wrangler and native workerd.

## Rollout and legacy exception

The maintainer explicitly accepted a bounded legacy exception on September 9, 2026. Already-running pre-capability workflow/apply consumers started from the previous main head before deployment finish under their existing safeguards, including any closes those safeguards permit. They are not retroactively fenced, invalidated, or reopened. The live sweep is not paused or drained.

Every upgraded consumer requires valid queue evidence to close; there is no upgraded fallback to the old close guard. The coordinator must verify the serving deployment SHA and the natural completion of the pre-capability cohort after deployment. This PR stops before merge and has not deployed the production Worker.

## Proof

Environment: local macOS, Node 24.20.0/26.8.1, repository-pinned pnpm 11.10.0. The effects proof executes the built CLI, actual acknowledgement helper and queue receipt store through isolated loopback GitHub HTTP, with POST/PATCH/DELETE timestamp/count effects and one-second metadata propagation. It observes HTTP effects and items/closed records. No live GitHub close, production dispatch, scanner, or model execution was performed. No remote Crabbox lease or container image was used.

| Case | Observed result |
| --- | --- |
| (a) First/existing durable comments, direct and queued | All four close; one close write each. Direct cases retain six comment-write receipts; queued cases retain nine, including expiry and replacement-lease effects. |
| (b) Untouched review vs same-second human edit | Untouched closes; the edited review stays open with `non-owned PR activity changed since queue admission`. |
| (c) Human comment/review edit/label/head after baseline | All remain open with zero close writes. Existing policy/canonical guards retain their refusal behavior. |
| (d) Delayed propagation | Closes with one-second projection lag; the trace exercises repeated post-write metadata polling before receipt completion. |
| (e1) Upgraded absent/malformed/stale or unavailable evidence | Keeps open and syncs the proposal. Begin/complete RPC failures, malformed RPC responses, and malformed post-write metadata also preserve comment delivery while preventing closing. |
| (e2) Old-head consumer against upgraded Worker | Archived `1d41377123e9d796222f3d8014059202ab00ce21` CLI completes first/existing review and allowed close; the new Worker accepts canonical publication and completes without requeue. |
| (e3) Explicit transition boundary | Documented above and in the active policy/dashboard docs as the maintainer-approved legacy exception. |

The baseline uses six metadata reads in the controlled fixture; review generation makes zero GitHub calls. The effects proof asserts no file/commit/blob reads. Unit regressions cover the duplicate acknowledgement POST/DELETE counterexample, human edits, malformed ingestion, retained receipts, claim/capture expiry races, missing backing evidence, and convergence fencing.

Native workerd proof additionally exercises actual Worker HTTP, Durable Object binding, SQLite, SHA-256 baseline creation, pending intents, completed receipts, owner sealing, and release. Outbound requests are disabled in that fixture. It is local runtime proof, not a production deployment.

Validation commands:

```text
pnpm install --frozen-lockfile
pnpm run build:node
pnpm run build:dashboard
pnpm run check:dashboard-strict
pnpm run check
pnpm run lint
npx oxfmt --check <changed files>
git diff --check
node scripts/proof-oversized-pr-close.mjs
node scripts/proof-oversized-pr-close-effects.mjs
wrangler deploy --dry-run --config dashboard/wrangler.toml
```

Current head: `d63674e7906389530fe7c8e8f78ec6d03fc0a0d4`.

Builds, strict dashboard checking, lint, changed-file formatting, whitespace validation, focused regressions, both proof scripts, Wrangler dry-run, and native workerd proof passed. Codex pre-commit autoreview is scoped-clean through P2 with no accepted/actionable findings.

The final local Node 24 full run executed 6,009 passing tests, 32 skips, and zero failed tests. Its process still exited nonzero because Node's coverage aggregator encountered an empty subprocess coverage file. This is an explicit local validation limitation, not a green full-gate claim. The [hosted full CI check](https://github.com/openclaw/clawsweeper/actions/runs/34442778134), [automerge integration](https://github.com/openclaw/clawsweeper/actions/runs/34442778139), and [CodeQL](https://github.com/openclaw/clawsweeper/actions/runs/34442778143) passed on `91152971314eb5562d1fe547af3e30d7458aecb6`. Exact-head CI for the retry-status follow-up must also pass before handoff.

An unrelated fixture readiness race exposed by the full run was fixed by atomically publishing the fake work-state server's port file. The test's timeout behavior is unchanged.

## Current review disposition

Addressed the [ClawSweeper retry-status finding](https://github.com/openclaw/clawsweeper/pull/1525#issuecomment-5613891626) in [the follow-up commit](https://github.com/openclaw/clawsweeper/commit/d63674e7906389530fe7c8e8f78ec6d03fc0a0d4). The Waiting update now runs before completion, and the completion-success dependency was removed from that step. Its wording describes the current wait without promising an already-confirmed requeue.

The workflow suite passed 157 tests. The new `retry-status-before-completion` scenario executes the actual Waiting and completion Bash bodies through the built status CLI and synthetic HTTP services:

```json
{"waitingWritten":true,"waitingReceipted":true,"completionRequeued":true,"releasedOwnerRejected":true,"closeWrites":0}
```

The released-owner attempt makes no additional mutation. Lint, formatting, whitespace validation, and fresh Codex autoreview passed; autoreview is scoped-clean through P2. The optional rank-up requests for corrected ordering and refreshed proof are satisfied. Production deployment identity and natural completion of the legacy cohort remain coordinator checks after merge under the explicit legacy exception.

## Bay impact

No Bay-specific change is required. Evidence, receipts, and acknowledgement ownership stay behind the private queue binding; the existing proposal/closed record and lifecycle projections remain. Bay gains no action controls or browser-side GitHub calls.

Closes #1517 (https://github.com/openclaw/clawsweeper/issues/1517).
