### PR TITLE
fix(ci): retry the control-plane helper download on TLS and connection errors

### DIFF
--- a/.github/workflows/exact-review-reconcile-run.yml
+++ b/.github/workflows/exact-review-reconcile-run.yml
@@ -42,7 +42,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          curl -fsSL --retry 3 "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/scripts/control-plane-curl.sh" -o "$RUNNER_TEMP/control-plane-curl.sh"
+          curl -fsSL --retry 3 --retry-all-errors --retry-connrefused "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/scripts/control-plane-curl.sh" -o "$RUNNER_TEMP/control-plane-curl.sh"
           test -s "$RUNNER_TEMP/control-plane-curl.sh"
           source "$RUNNER_TEMP/control-plane-curl.sh"
           declare -F control_plane_curl > /dev/null

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -287,7 +287,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          curl -fsSL --retry 3 "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/scripts/control-plane-curl.sh" -o "$RUNNER_TEMP/control-plane-curl.sh"
+          curl -fsSL --retry 3 --retry-all-errors --retry-connrefused "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/scripts/control-plane-curl.sh" -o "$RUNNER_TEMP/control-plane-curl.sh"
           test -s "$RUNNER_TEMP/control-plane-curl.sh"
           source "$RUNNER_TEMP/control-plane-curl.sh"
           declare -F control_plane_curl > /dev/null
@@ -497,7 +497,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          curl -fsSL --retry 3 "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/scripts/control-plane-curl.sh" -o "$RUNNER_TEMP/control-plane-curl.sh"
+          curl -fsSL --retry 3 --retry-all-errors --retry-connrefused "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/scripts/control-plane-curl.sh" -o "$RUNNER_TEMP/control-plane-curl.sh"
           test -s "$RUNNER_TEMP/control-plane-curl.sh"
           source "$RUNNER_TEMP/control-plane-curl.sh"
           declare -F control_plane_curl > /dev/null
@@ -2624,7 +2624,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          curl -fsSL --retry 3 "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/scripts/control-plane-curl.sh" -o "$RUNNER_TEMP/control-plane-curl.sh"
+          curl -fsSL --retry 3 --retry-all-errors --retry-connrefused "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/scripts/control-plane-curl.sh" -o "$RUNNER_TEMP/control-plane-curl.sh"
           test -s "$RUNNER_TEMP/control-plane-curl.sh"
           source "$RUNNER_TEMP/control-plane-curl.sh"
           declare -F control_plane_curl > /dev/null
@@ -3866,7 +3866,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          curl -fsSL --retry 3 "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/scripts/control-plane-curl.sh" -o "$RUNNER_TEMP/control-plane-curl.sh"
+          curl -fsSL --retry 3 --retry-all-errors --retry-connrefused "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/scripts/control-plane-curl.sh" -o "$RUNNER_TEMP/control-plane-curl.sh"
           test -s "$RUNNER_TEMP/control-plane-curl.sh"
           source "$RUNNER_TEMP/control-plane-curl.sh"
           declare -F control_plane_curl > /dev/null
@@ -5957,7 +5957,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          curl -fsSL --retry 3 "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/scripts/control-plane-curl.sh" -o "$RUNNER_TEMP/control-plane-curl.sh"
+          curl -fsSL --retry 3 --retry-all-errors --retry-connrefused "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/scripts/control-plane-curl.sh" -o "$RUNNER_TEMP/control-plane-curl.sh"
           test -s "$RUNNER_TEMP/control-plane-curl.sh"
           source "$RUNNER_TEMP/control-plane-curl.sh"
           declare -F control_plane_curl > /dev/null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Retry the pinned control-plane helper download on TLS and connection errors so a single handshake failure no longer drops an exact-review event before enqueue.
 - Keep large repository reviews within the GitHub CLI response limit by projecting recursive-tree metadata before capture, preserving complete blob sizes and strict private-checkout admission.
 
 - Carry the durable review lease through oversized PR close proposals so direct exact publication can close eligible PRs; queued fallback still keeps PRs open with `skipped_changed_since_review` after lease expiry, pending the follow-up to create the final metadata proposal under publication ownership and re-evaluation at the next event or head.

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -7745,7 +7745,7 @@ test("all workflow control-plane curls use the shared helper after download or f
         if (step.name === "Fetch control-plane retry helper") {
           assert.match(
             run,
-            /curl -fsSL --retry 3 "https:\/\/raw\.githubusercontent\.com\/\$\{GITHUB_REPOSITORY\}\/\$\{GITHUB_SHA\}\/scripts\/control-plane-curl\.sh"/,
+            /curl -fsSL --retry 3 --retry-all-errors --retry-connrefused "https:\/\/raw\.githubusercontent\.com\/\$\{GITHUB_REPOSITORY\}\/\$\{GITHUB_SHA\}\/scripts\/control-plane-curl\.sh"/,
           );
           assert.match(run, /test -s "\$RUNNER_TEMP\/control-plane-curl\.sh"/);
           assert.match(run, /declare -F control_plane_curl/);


### PR DESCRIPTION
## Problem

The workflow steps that download the pinned `scripts/control-plane-curl.sh` from raw.githubusercontent.com before checkout use `curl -fsSL --retry 3`. curl's default retry policy does not cover TLS connect errors (exit 35), so one handshake failure fails the step and the exact-review event is dropped before it reaches the queue. Two `Review event item` runs failed this way on 2026-09-10 (for example run 34485446753, `Fetch control-plane retry helper`, exit code 35).

## Fix

Add `--retry-all-errors --retry-connrefused` to all six helper fetch sites (five in `sweep.yml`, one in `exact-review-reconcile-run.yml`), keeping the SHA-pinned URL and the `test -s` / `declare -F` bootstrap checks. The workflow audit test's expected command is updated to require the new flags.

## Proof

- `node --test test/sweep-workflow.test.ts test/repair/workflow-sparse-checkout.test.ts`: 171 passed, 0 failed.
- `oxfmt --check` clean on the changed files; autoreview scoped-clean through P2.

## Impact

Transient raw.githubusercontent.com TLS or connection failures now retry up to three times instead of dropping the event. No behavior change on success.

## Real behavior proof (real curl, local flaky server)

A local Node TCP server (`127.0.0.1`, ephemeral port) serves the actual `scripts/control-plane-curl.sh` but resets the first two connections. Real `curl 8.7.1` was run against it exactly as the workflow does, with `--retry-delay 1` added only to keep the run short.

```text
=== new flags: curl -fsSL --retry 3 --retry-all-errors --retry-connrefused
curl: (56) Recv failure: Connection reset by peer
curl: (56) Recv failure: Connection reset by peer
curl_rc=0
helper_bytes=1716
control_plane_curl defined after sourcing
server: attempt 1 -> resetting connection
server: attempt 2 -> resetting connection
server: attempt 3 -> serving helper (1716 bytes)

=== control: old flags (curl -fsSL --retry 3) against the same server
curl: (56) Recv failure: Connection reset by peer
curl_rc=56
server: attempt 1 -> resetting connection
```

With the new flags curl retried through both resets, downloaded the real helper, and `declare -F control_plane_curl` succeeded after sourcing it. With the previous flags the same failure ended the download on the first attempt, which is what dropped the events in production (there as a TLS connect error, exit 35, which curl's default retry policy also skips).
