### PR TITLE
fix: isolate GitHub etag cache from the exact-review queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Isolate the GitHub ETag cache in repository-sharded Durable Objects so cache reads and writes no longer compete with exact-review admission, claims, or webhooks.
+
 - Refresh durable review freshness after unchanged exact-head re-reviews while preserving idempotent publication retries, and record bounded activity-cursor diagnostics for drift-blocked publication.
 
 - Preserve bounded, recognized command-intake HTTP failure codes in review-request diagnostics without exposing raw responses or changing retry behavior.

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -133,9 +133,7 @@ import {
 } from "./exact-review-command-intake.ts";
 import { recentDurablePublicationEvents } from "./recent-durable-publication-events.ts";
 import { sanitizedServerError } from "./error-safety.ts";
-import { GithubEtagResponseStore } from "./github-etag-cache.ts";
 import { GithubWebhookReadModelStore } from "./github-webhook-read-model.ts";
-import { githubEtagCacheKeyFromValue } from "../src/github-etag-cache-contract.ts";
 import {
   ExactReviewArtifactReceiptStore,
   exactReviewArtifactReceiptTuple,
@@ -908,7 +906,6 @@ export class ExactReviewQueue {
   private githubEgressTelemetryStore;
   private commandIntakeStore;
   private artifactReceiptStore;
-  private githubEtagResponseStore;
   private githubWebhookReadModelStore;
   private readonly random: () => number;
   private readonly baselines = new WeakMap<ExactReviewQueueState, ExactReviewQueueBaseline>();
@@ -973,7 +970,6 @@ export class ExactReviewQueue {
       this.storage,
       env.STATE_SNAPSHOTS,
     );
-    this.githubEtagResponseStore = new GithubEtagResponseStore(this.storage);
     this.githubWebhookReadModelStore = new GithubWebhookReadModelStore(this.storage);
     // The public lifecycle reader remains side-effect free. Its bounded read
     // schema and public Bay repository coverage scope are established
@@ -4281,34 +4277,6 @@ export class ExactReviewQueue {
         console.warn("artifact_cache_prune_failed");
       });
       return json({ ok: true, hit: Boolean(receipt), receipt });
-    }
-
-    if (request.method === "POST" && url.pathname === "/github-etag-cache/lookup") {
-      const body = await request.json().catch(() => null);
-      if (!githubEtagCacheKeyFromValue(body)) {
-        return json({ error: "invalid_github_etag_cache_key" }, 400);
-      }
-      const entry = this.githubEtagResponseStore.lookup(body, Date.now());
-      return json({ ok: true, hit: Boolean(entry), entry });
-    }
-
-    if (request.method === "POST" && url.pathname === "/github-etag-cache/store") {
-      const body = await request.json().catch(() => null);
-      try {
-        const result = await this.githubEtagResponseStore.store200(body, Date.now());
-        if (!result.ok) return json({ error: result.error }, result.status);
-        return json(result, result.stored ? 201 : 200);
-      } catch {
-        console.warn("github_etag_cache_store_failed");
-        return json({ error: "github_etag_cache_unavailable" }, 503);
-      }
-    }
-
-    if (request.method === "POST" && url.pathname === "/github-etag-cache/confirm") {
-      const body = await request.json().catch(() => null);
-      const result = this.githubEtagResponseStore.confirm304(body, Date.now());
-      if (!result.ok) return json({ error: result.error }, result.status);
-      return json(result);
     }
 
     if (request.method === "POST" && url.pathname === "/github-read-model/ingest") {
@@ -10912,7 +10880,6 @@ export class ExactReviewQueue {
     this.lifecycleTelemetryStore.syncBayRepositoryScope(exactReviewPublicBayRepositories(this.env));
     this.githubEgressTelemetryStore.ensureSchemaSync();
     this.artifactReceiptStore.ensureSchemaSync();
-    this.githubEtagResponseStore.ensureSchemaSync();
     this.githubWebhookReadModelStore.ensureSchemaSync();
     let meta = this.readStorageMetaSync();
     let migratedLegacy = false;

--- a/dashboard/github-etag-cache.ts
+++ b/dashboard/github-etag-cache.ts
@@ -5,6 +5,20 @@ import {
 } from "../src/github-etag-cache-contract.ts";
 import { recordOrEmpty as objectValue } from "../src/value-coerce.ts";
 
+import {
+  EXACT_REVIEW_QUEUE_TRACE_HEADER,
+  exactReviewQueueEndpointTemplate,
+  exactReviewQueueTraceId,
+} from "./exact-review-queue-observability.ts";
+
+export const GITHUB_ETAG_CACHE_FALLBACK_SHARD = "fallback";
+
+export function githubEtagCacheShard(value: unknown): string {
+  const key = githubEtagCacheKeyFromValue(value);
+  const repository = key && /^\/repos\/([^/]+\/[^/]+)\//.exec(key.route)?.[1];
+  return repository?.toLowerCase() || GITHUB_ETAG_CACHE_FALLBACK_SHARD;
+}
+
 export const GITHUB_ETAG_CACHE_TABLE = "github_etag_response_cache_v1";
 export const GITHUB_ETAG_CACHE_MAX_ENTRIES = 2_048;
 export { GITHUB_ETAG_CACHE_MAX_BODY_BYTES };
@@ -331,4 +345,78 @@ async function sha256Bytes(value: Uint8Array<ArrayBuffer>): Promise<string> {
 
 function firstRow(rows: Iterable<SqlRow>): SqlRow | undefined {
   return Array.from(rows)[0];
+}
+
+// This namespace owns only disposable HTTP cache state, never queue state.
+export class GithubEtagCache {
+  private readonly store: GithubEtagResponseStore;
+
+  constructor(state: { storage: GithubEtagStorage }) {
+    this.store = new GithubEtagResponseStore(state.storage);
+    this.store.ensureSchemaSync();
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    try {
+      return await this.handleFetch(request);
+    } catch (error) {
+      console.error("github_etag_cache_handler_failed", {
+        phase: "fetch",
+        trace_id: exactReviewQueueTraceId(request.headers.get(EXACT_REVIEW_QUEUE_TRACE_HEADER)),
+        endpoint: exactReviewQueueEndpointTemplate(new URL(request.url).pathname),
+        failure_category: "handler_exception",
+      });
+      throw error;
+    }
+  }
+
+  private async handleFetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    if (request.method === "GET" && url.pathname === "/stats") {
+      return json({ ok: true, telemetry: this.store.telemetry(Date.now()) });
+    }
+
+    if (request.method === "POST" && url.pathname === "/github-etag-cache/lookup") {
+      const body = await request.json().catch(() => null);
+      if (!githubEtagCacheKeyFromValue(body)) {
+        return json({ error: "invalid_github_etag_cache_key" }, 400);
+      }
+      const entry = this.store.lookup(body, Date.now());
+      return json({ ok: true, hit: Boolean(entry), entry });
+    }
+
+    if (request.method === "POST" && url.pathname === "/github-etag-cache/store") {
+      const body = await request.json().catch(() => null);
+      try {
+        const result = await this.store.store200(body, Date.now());
+        if (result.ok === false) return json({ error: result.error }, result.status);
+        return json(result, result.stored ? 201 : 200);
+      } catch {
+        console.warn("github_etag_cache_store_failed");
+        return json({ error: "github_etag_cache_unavailable" }, 503);
+      }
+    }
+
+    if (request.method === "POST" && url.pathname === "/github-etag-cache/confirm") {
+      const body = await request.json().catch(() => null);
+      const result = this.store.confirm304(body, Date.now());
+      if (result.ok === false) return json({ error: result.error }, result.status);
+      return json(result);
+    }
+
+    return json({ error: "not_found" }, 404);
+  }
+}
+
+function json(value: unknown, status = 200): Response {
+  return new Response(JSON.stringify(value, null, 2), {
+    status,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      "cache-control": "no-store",
+      "access-control-allow-origin": "*",
+      "access-control-allow-methods": "GET,POST,OPTIONS",
+      "access-control-allow-headers": "authorization,content-type",
+    },
+  });
 }

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -1,3 +1,5 @@
+import { githubEtagCacheShard } from "./github-etag-cache.ts";
+export { GithubEtagCache } from "./github-etag-cache.ts";
 import {
   commandTextForClawSweeperFastAck,
   directReReviewAdditionalPrompt,
@@ -1276,17 +1278,17 @@ export default {
       url.pathname === "/internal/exact-review/github-etag-cache/lookup" &&
       request.method === "POST"
     )
-      return authenticatedExactReviewQueueRequest(request, env, "/github-etag-cache/lookup");
+      return authenticatedGithubEtagCacheRequest(request, env, "/github-etag-cache/lookup");
     if (
       url.pathname === "/internal/exact-review/github-etag-cache/store" &&
       request.method === "POST"
     )
-      return authenticatedExactReviewQueueRequest(request, env, "/github-etag-cache/store");
+      return authenticatedGithubEtagCacheRequest(request, env, "/github-etag-cache/store");
     if (
       url.pathname === "/internal/exact-review/github-etag-cache/confirm" &&
       request.method === "POST"
     )
-      return authenticatedExactReviewQueueRequest(request, env, "/github-etag-cache/confirm");
+      return authenticatedGithubEtagCacheRequest(request, env, "/github-etag-cache/confirm");
     const githubReadModelRoute =
       request.method === "POST"
         ? /^\/internal\/state\/github-read-model\/(item|comments|activity|workflows|placeholders|repair)$/.exec(
@@ -5255,7 +5257,12 @@ async function attachExactReviewSourceAuthorityAcknowledgement(
   }
 }
 
-async function exactReviewQueueFetch(queue: DurableObjectStub, path: string, request?: Request) {
+async function exactReviewQueueFetch(
+  queue: DurableObjectStub,
+  path: string,
+  request?: Request,
+  service: "exact_review_queue" | "github_etag_cache" = "exact_review_queue",
+) {
   const body = request ? await request.text() : undefined;
   const traceId = newExactReviewQueueTraceId();
   const endpoint = exactReviewQueueEndpointTemplate(path);
@@ -5283,7 +5290,7 @@ async function exactReviewQueueFetch(queue: DurableObjectStub, path: string, req
     const responseBody = await response.clone().text();
     try {
       JSON.parse(responseBody);
-      console.error("exact_review_queue_structured_server_response", {
+      console.error(`${service}_structured_server_response`, {
         trace_id: traceId,
         endpoint,
         phase: "request",
@@ -5293,7 +5300,7 @@ async function exactReviewQueueFetch(queue: DurableObjectStub, path: string, req
       });
       return { response, malformedServerResponse: false };
     } catch {
-      console.error("exact_review_queue_malformed_server_response", {
+      console.error(`${service}_malformed_server_response`, {
         trace_id: traceId,
         endpoint,
         phase: "request",
@@ -5308,7 +5315,7 @@ async function exactReviewQueueFetch(queue: DurableObjectStub, path: string, req
     const remote = failure.remote === true;
     const retryable = failure.retryable === true;
     const overloaded = failure.overloaded === true;
-    console.error("exact_review_queue_request_failed", {
+    console.error(`${service}_request_failed`, {
       trace_id: traceId,
       endpoint,
       phase: "request",
@@ -6677,6 +6684,41 @@ async function boundedCommandProofBody(request: Request): Promise<string | null>
     await reader.cancel().catch(() => undefined);
     reader.releaseLock();
   }
+}
+
+async function githubEtagCacheRequest(env, path: string, body: string) {
+  const namespace: DurableObjectNamespace | undefined = env.GITHUB_ETAG_CACHE;
+  if (!namespace) return json({ error: "github_etag_cache_not_configured" }, 503);
+  try {
+    const shard = githubEtagCacheShard(parseJsonObject(body));
+    const stub = namespace.get(namespace.idFromName(shard));
+    const { response, malformedServerResponse } = await exactReviewQueueFetch(
+      stub,
+      path,
+      new Request(`https://clawsweeper-etag-cache${path}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body,
+      }),
+      "github_etag_cache",
+    );
+    return malformedServerResponse
+      ? json({ error: "github_etag_cache_unavailable" }, response.status)
+      : response;
+  } catch {
+    return json({ error: "github_etag_cache_unavailable" }, 503);
+  }
+}
+
+async function authenticatedGithubEtagCacheRequest(request: Request, env, path: string) {
+  const secret = stringEnv(env.CLAWSWEEPER_WEBHOOK_SECRET);
+  if (!secret) return json({ error: "webhook_not_configured" }, 503);
+  const body = await request.text();
+  const signature = request.headers.get("x-clawsweeper-exact-review-signature") || "";
+  if (!(await verifyGithubWebhookSignature({ secret, signature, bodyText: body }))) {
+    return json({ error: "invalid_signature" }, 401);
+  }
+  return githubEtagCacheRequest(env, path, body);
 }
 
 async function authenticatedExactReviewQueueRequest(
@@ -11994,12 +12036,12 @@ async function githubJson(env, path) {
   });
   const requestBody = key ? githubEtagCacheRequestBody(key, "dashboard") : null;
   const etagBrokerEnabled = Boolean(
-    requestBody && exactReviewQueueStub(env) && stringEnv(env.CLAWSWEEPER_WEBHOOK_SECRET),
+    requestBody && env.GITHUB_ETAG_CACHE && stringEnv(env.CLAWSWEEPER_WEBHOOK_SECRET),
   );
   let cachedEntry: Record<string, unknown> | null = null;
   if (etagBrokerEnabled && requestBody) {
     try {
-      const lookup = await githubEtagQueuePost(env, "lookup", requestBody);
+      const lookup = await githubEtagCachePost(env, "lookup", requestBody);
       cachedEntry = lookup.hit === true ? objectValue(lookup.entry) : null;
     } catch {
       cachedEntry = null;
@@ -12008,7 +12050,7 @@ async function githubJson(env, path) {
   let response = await githubJsonResponse(env, path, token, String(cachedEntry?.etag || ""));
   if (response.status === 304 && etagBrokerEnabled && requestBody && cachedEntry) {
     try {
-      const confirmed = await githubEtagQueuePost(env, "confirm", {
+      const confirmed = await githubEtagCachePost(env, "confirm", {
         ...requestBody,
         etag: String(cachedEntry.etag || ""),
         body_digest: String(cachedEntry.bodyDigest || ""),
@@ -12034,7 +12076,7 @@ async function githubJson(env, path) {
   if (etagBrokerEnabled && requestBody) {
     const etag = response.headers.get("etag") || "";
     const bodyBytes = new TextEncoder().encode(body).byteLength;
-    await githubEtagQueuePost(env, "store", {
+    await githubEtagCachePost(env, "store", {
       ...requestBody,
       etag,
       ...(bodyBytes > GITHUB_ETAG_CACHE_MAX_BODY_BYTES ? { body_bytes: bodyBytes } : { body }),
@@ -12057,15 +12099,11 @@ function githubJsonResponse(env, path, token: string, ifNoneMatch: string) {
   });
 }
 
-async function githubEtagQueuePost(env, operation: "lookup" | "store" | "confirm", body) {
-  const response = await exactReviewQueueRequest(
+async function githubEtagCachePost(env, operation: "lookup" | "store" | "confirm", body) {
+  const response = await githubEtagCacheRequest(
     env,
     `/github-etag-cache/${operation}`,
-    new Request("https://clawsweeper-etag-cache", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify(body),
-    }),
+    JSON.stringify(body),
   );
   const result = objectValue(await response.json().catch(() => null));
   if (!response.ok) throw new Error(String(result.error || "GitHub ETag cache unavailable"));

--- a/dashboard/wrangler.toml
+++ b/dashboard/wrangler.toml
@@ -22,6 +22,10 @@ class_name = "StatusStore"
 name = "EXACT_REVIEW_QUEUE"
 class_name = "ExactReviewQueue"
 
+[[durable_objects.bindings]]
+name = "GITHUB_ETAG_CACHE"
+class_name = "GithubEtagCache"
+
 [[migrations]]
 tag = "v1"
 new_sqlite_classes = ["StatusStore"]
@@ -29,6 +33,10 @@ new_sqlite_classes = ["StatusStore"]
 [[migrations]]
 tag = "v2"
 new_sqlite_classes = ["ExactReviewQueue"]
+
+[[migrations]]
+tag = "v3"
+new_sqlite_classes = ["GithubEtagCache"]
 
 [[routes]]
 pattern = "clawsweeper.openclaw.ai"

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -387,7 +387,37 @@ command-status identifiers so the leased GitHub Actions executor can update the
 original acknowledgement through completion. GitHub Actions remains the
 executor and the existing review/apply safety model remains unchanged.
 
-The singleton Durable Object stores each delivery receipt and queue item in its
+The Worker's Durable Object bindings separate three storage owners:
+`STATUS_STORE` (`StatusStore`) holds dashboard state, `EXACT_REVIEW_QUEUE`
+(`ExactReviewQueue`) holds queue state, and `GITHUB_ETAG_CACHE` (`GithubEtagCache`)
+holds disposable GitHub response bodies and validators. The cache uses
+`idFromName("owner/repo")` from the store-validated, normalized `/repos/` route,
+with repository names lowercased. Requests without a valid repository key use
+the single `fallback` shard and retain the existing validation errors. Credential
+pool, media type, query, and page remain part of the cache key within each shard.
+The 2,048-entry cap and 30-day retention now apply per shard.
+
+The additive `v3` migration creates only `GithubEtagCache`; existing classes,
+queue storage, leases, fences, and alarms are unchanged. Runners keep the same
+HMAC-authenticated `/internal/exact-review/github-etag-cache/{lookup,store,confirm}`
+routes and response contract. Both these routes and dashboard health reads use
+the new binding directly, with no queue fallback. Deploy the binding and code
+together through Wrangler. The namespace starts empty; misses use the existing
+GitHub fetch/revalidation path. Old queue cache tables are deliberately left
+inert: they are not read, migrated, recreated, or pruned by the new code, avoiding
+extra work in the overloaded queue. A rollback may reuse them, subject to the
+existing validator/digest checks; no cached body is served without confirmation.
+
+Cache transport failures retain generated trace IDs and the existing
+`github_etag_cache_lookup`, `github_etag_cache_store`, and
+`github_etag_cache_confirm` endpoint labels, under `github_etag_cache_*` log
+events. Each shard's binding-only `GET /stats` returns its trailing 24-hour
+`telemetry` counters; no public cache-stats route is added. The public
+`/api/exact-review-queue` payload and Bay's observer contract are unchanged.
+After deployment, compare queue canceled invocations and bare 5xx rates against
+the pre-deploy window, and confirm etag requests are served by `GithubEtagCache`.
+
+The singleton queue Durable Object stores each delivery receipt and queue item in its
 own SQLite row. Receipt insertion and item coalescing commit in one transaction,
 so a crash cannot record a duplicate-suppression receipt without its queued
 work. Receipts retain the seven-day idempotency window and expire through the

--- a/scripts/e2e/github-etag-cache-split.mjs
+++ b/scripts/e2e/github-etag-cache-split.mjs
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { createHash, createHmac } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// Install the pinned Wrangler proof toolchain outside the repository, then pass its prefix.
+const require = createRequire(path.resolve(process.argv[2], "package.json"));
+const { Miniflare } = require("miniflare");
+const { build } = require("esbuild");
+const persist = mkdtempSync(path.join(tmpdir(), "etag-split-"));
+const secret = "synthetic-etag-split-hmac";
+const sourceFiles = [
+  "dashboard/worker.ts",
+  "dashboard/github-etag-cache.ts",
+  "dashboard/exact-review-queue.ts",
+  "dashboard/wrangler.toml",
+];
+const observations = [];
+let runtime;
+const bundle = await build({
+  entryPoints: ["dashboard/worker.ts"],
+  bundle: true,
+  write: false,
+  format: "esm",
+  platform: "browser",
+  target: "es2024",
+});
+const options = {
+  modules: true,
+  script: bundle.outputFiles[0].text,
+  compatibilityDate: "2026-05-11",
+  bindings: { CLAWSWEEPER_WEBHOOK_SECRET: secret },
+  // Deliberately omit EXACT_REVIEW_QUEUE: all etag requests must remain independent.
+  durableObjects: { GITHUB_ETAG_CACHE: { className: "GithubEtagCache", useSQLite: true } },
+  durableObjectsPersist: persist,
+  outboundService: () => {
+    throw new Error("Proof must not access an external service");
+  },
+};
+const key = { credential_pool: "target_app", route: "/repos/openclaw/openclaw/issues/7" };
+async function request(operation, body, signatureSecret = secret) {
+  const text = typeof body === "string" ? body : JSON.stringify(body);
+  const response = await runtime.dispatchFetch(
+    `https://proof/internal/exact-review/github-etag-cache/${operation}`,
+    {
+      method: "POST",
+      headers: {
+        "x-clawsweeper-exact-review-signature":
+          "sha256=" + createHmac("sha256", signatureSecret).update(text).digest("hex"),
+      },
+      body: text,
+    },
+  );
+  const value = await response.json();
+  observations.push({ operation, status: response.status, ...value });
+  return { status: response.status, value };
+}
+try {
+  runtime = new Miniflare(options);
+  assert.equal((await request("store", key, "wrong-synthetic-secret")).status, 401);
+  assert.deepEqual((await request("lookup", key)).value, { ok: true, hit: false, entry: null });
+  const stored = await request("store", { ...key, etag: '"v1"', body: '{"number":7}' });
+  assert.equal(stored.status, 201);
+  assert.equal(
+    stored.value.entry.bodyDigest,
+    createHash("sha256").update('{"number":7}').digest("hex"),
+  );
+  const entry = stored.value.entry;
+  assert.deepEqual((await request("lookup", key)).value.entry, entry);
+  const other = { ...key, route: "/repos/openclaw/clawsweeper/issues/7" };
+  assert.equal((await request("lookup", other)).value.hit, false);
+  const confirmation = { ...key, etag: entry.etag, body_digest: entry.bodyDigest };
+  assert.equal((await request("confirm", confirmation)).value.body, '{"number":7}');
+  for (const operation of ["lookup", "store", "confirm"]) {
+    assert.equal((await request(operation, "invalid-json")).status, 400);
+  }
+  assert.deepEqual(
+    (await request("confirm", { ...confirmation, body_digest: "a".repeat(64) })).value,
+    { ok: true, confirmed: false, reason: "entry_changed_or_expired" },
+  );
+  const namespace = await runtime.getDurableObjectNamespace("GITHUB_ETAG_CACHE");
+  async function telemetry(shard) {
+    return (
+      await (await namespace.get(namespace.idFromName(shard)).fetch("https://cache/stats")).json()
+    ).telemetry;
+  }
+  assert.deepEqual(await telemetry("openclaw/openclaw"), {
+    cache_miss: 1,
+    cache_hit: 1,
+    cache_200_stored: 1,
+    cache_304_served: 1,
+    cache_skip: 1,
+  });
+  assert.deepEqual(await telemetry("openclaw/clawsweeper"), { cache_miss: 1 });
+  assert.deepEqual(await telemetry("fallback"), {});
+  await runtime.dispose();
+  runtime = new Miniflare(options);
+  assert.equal((await request("lookup", key)).value.hit, true);
+  assert.equal((await request("confirm", confirmation)).value.body, '{"number":7}');
+  const head = execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+  console.log(
+    JSON.stringify(
+      {
+        head,
+        source_sha256: Object.fromEntries(
+          sourceFiles.map((file) => [
+            file,
+            createHash("sha256").update(readFileSync(file)).digest("hex"),
+          ]),
+        ),
+        runtime: "workerd / SQLite Durable Objects",
+        queue_binding: "absent",
+        shard_stats: "verified independent counters for two repositories and fallback",
+        restart_persistence: "verified",
+        external_requests: 0,
+        observations,
+        limits:
+          "Synthetic HMAC and bodies; no production deploy, GitHub requests, migration application, or load-reduction claim.",
+      },
+      null,
+      2,
+    ),
+  );
+} finally {
+  await runtime?.dispose();
+  rmSync(persist, { recursive: true, force: true });
+}

--- a/test/dashboard-worker-etag-cache.test.ts
+++ b/test/dashboard-worker-etag-cache.test.ts
@@ -1,0 +1,189 @@
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+import test from "node:test";
+import worker, { GithubEtagCache } from "../dashboard/worker.ts";
+import {
+  GITHUB_ETAG_CACHE_FALLBACK_SHARD,
+  githubEtagCacheShard,
+} from "../dashboard/github-etag-cache.ts";
+import {
+  EXACT_REVIEW_QUEUE_TRACE_HEADER,
+  exactReviewQueueTraceId,
+} from "../dashboard/exact-review-queue-observability.ts";
+import { MemoryDurableStorage } from "./dashboard-worker-harness.ts";
+
+const secret = "synthetic-etag-hmac";
+const key = { credential_pool: "target_app", route: "/repos/OpenClaw/OpenClaw/issues/7" };
+function signed(operation: string, body: unknown, signingSecret = secret): Request {
+  const text = typeof body === "string" ? body : JSON.stringify(body);
+  return new Request(`https://worker/internal/exact-review/github-etag-cache/${operation}`, {
+    method: "POST",
+    headers: {
+      "x-clawsweeper-exact-review-signature":
+        "sha256=" + createHmac("sha256", signingSecret).update(text).digest("hex"),
+      [EXACT_REVIEW_QUEUE_TRACE_HEADER]: "untrusted-client-value",
+    },
+    body: text,
+  });
+}
+
+function harness() {
+  const shards = new Map<string, GithubEtagCache>();
+  const calls: Array<{ shard: string; path: string; trace: string | null }> = [];
+  const env = {
+    CLAWSWEEPER_WEBHOOK_SECRET: secret,
+    EXACT_REVIEW_QUEUE: {
+      idFromName() {
+        throw new Error("etag traffic must not touch queue");
+      },
+    },
+    GITHUB_ETAG_CACHE: {
+      idFromName(name: string) {
+        return name;
+      },
+      get(shard: string) {
+        let cache = shards.get(shard);
+        if (!cache) {
+          cache = new GithubEtagCache({ storage: new MemoryDurableStorage() });
+          shards.set(shard, cache);
+        }
+        return {
+          fetch: (request: Request) => {
+            calls.push({
+              shard,
+              path: new URL(request.url).pathname,
+              trace: request.headers.get(EXACT_REVIEW_QUEUE_TRACE_HEADER),
+            });
+            return cache.fetch(request);
+          },
+        };
+      },
+    },
+  };
+  return { env, shards, calls };
+}
+
+test("cache shard comes from the validated canonical route with a fixed fallback", () => {
+  assert.equal(githubEtagCacheShard(key), "openclaw/openclaw");
+  assert.equal(
+    githubEtagCacheShard({
+      ...key,
+      route: "/api/v3/repos/openclaw/clawsweeper/actions/runs?page=2",
+      surface: "dashboard",
+    }),
+    "openclaw/clawsweeper",
+  );
+  for (const value of [null, {}, { ...key, route: "/user" }, { ...key, cache_key: "forged" }]) {
+    assert.equal(githubEtagCacheShard(value), GITHUB_ETAG_CACHE_FALLBACK_SHARD);
+  }
+});
+
+test("authenticated cache traffic bypasses the queue, isolates repos and preserves traces and stats", async () => {
+  const { env, shards, calls } = harness();
+  const other = { ...key, route: "/repos/openclaw/clawsweeper/issues/7" };
+  assert.equal((await worker.fetch(signed("store", key, "operator-placeholder"), env)).status, 401);
+  assert.equal(calls.length, 0);
+  assert.deepEqual(await (await worker.fetch(signed("lookup", key), env)).json(), {
+    ok: true,
+    hit: false,
+    entry: null,
+  });
+  const stored = await worker.fetch(
+    signed("store", { ...key, etag: '"v1"', body: '{"number":7}' }),
+    env,
+  );
+  assert.equal(stored.status, 201);
+  const { entry } = await stored.json();
+  assert.equal((await (await worker.fetch(signed("lookup", other), env)).json()).hit, false);
+  const hit = await (await worker.fetch(signed("lookup", key), env)).json();
+  assert.equal(hit.hit, true);
+  assert.deepEqual(hit.entry, entry);
+  const confirmed = await worker.fetch(
+    signed("confirm", { ...key, etag: entry.etag, body_digest: entry.bodyDigest }),
+    env,
+  );
+  assert.equal(confirmed.status, 200);
+  assert.equal((await confirmed.json()).body, '{"number":7}');
+  assert.deepEqual([...shards.keys()], ["openclaw/openclaw", "openclaw/clawsweeper"]);
+  assert.ok(calls.every((call) => exactReviewQueueTraceId(call.trace)));
+  assert.equal(new Set(calls.map((call) => call.trace)).size, calls.length);
+  assert.deepEqual(
+    await (await shards.get("openclaw/openclaw")!.fetch(new Request("https://cache/stats"))).json(),
+    {
+      ok: true,
+      telemetry: { cache_miss: 1, cache_hit: 1, cache_200_stored: 1, cache_304_served: 1 },
+    },
+  );
+});
+
+test("cache keeps validation/skip responses and never falls back to an absent or failed queue", async () => {
+  const { env, calls } = harness();
+  for (const operation of ["lookup", "store", "confirm"]) {
+    const response = await worker.fetch(signed(operation, "not-json"), env);
+    assert.equal(response.status, 400);
+    assert.deepEqual(await response.json(), {
+      error:
+        operation === "confirm"
+          ? "invalid_github_etag_confirmation"
+          : "invalid_github_etag_cache_key",
+    });
+  }
+  assert.ok(calls.every((call) => call.shard === GITHUB_ETAG_CACHE_FALLBACK_SHARD));
+  assert.deepEqual(await (await worker.fetch(signed("store", key), env)).json(), {
+    ok: true,
+    stored: false,
+    reason: "missing_or_invalid_etag",
+  });
+  assert.deepEqual(
+    await (
+      await worker.fetch(
+        signed("confirm", { ...key, etag: '"old"', body_digest: "a".repeat(64) }),
+        env,
+      )
+    ).json(),
+    { ok: true, confirmed: false, reason: "entry_changed_or_expired" },
+  );
+  const missing = await worker.fetch(signed("lookup", key), {
+    CLAWSWEEPER_WEBHOOK_SECRET: secret,
+    EXACT_REVIEW_QUEUE: env.EXACT_REVIEW_QUEUE,
+  });
+  assert.equal(missing.status, 503);
+  assert.deepEqual(await missing.json(), { error: "github_etag_cache_not_configured" });
+});
+
+test("cache transport keeps trace-labelled structured and malformed failures independent of queue", async () => {
+  const originalError = console.error;
+  const logs: Array<[string, Record<string, unknown>]> = [];
+  console.error = (message: string, detail: Record<string, unknown>) => {
+    logs.push([message, detail]);
+  };
+  try {
+    for (const scenario of ["structured", "bare", "overloaded"] as const) {
+      const { env } = harness();
+      const diagnostic = "private-upstream-detail";
+      env.GITHUB_ETAG_CACHE.get = () => ({
+        fetch: async () => {
+          if (scenario === "overloaded")
+            throw Object.assign(new Error(diagnostic), { overloaded: true });
+          return scenario === "structured"
+            ? Response.json(
+                { error: "github_etag_cache_unavailable" },
+                { status: 503, headers: { "retry-after": "5" } },
+              )
+            : new Response(diagnostic, { status: 500 });
+        },
+      });
+      const response = await worker.fetch(signed("lookup", key), env);
+      assert.equal(response.status, scenario === "bare" ? 500 : 503);
+      assert.deepEqual(await response.json(), { error: "github_etag_cache_unavailable" });
+      if (scenario === "structured") assert.equal(response.headers.get("retry-after"), "5");
+      const [message, detail] = logs.at(-1)!;
+      assert.ok(message.startsWith("github_etag_cache_"));
+      assert.equal(detail.endpoint, "github_etag_cache_lookup");
+      assert.ok(exactReviewQueueTraceId(detail.trace_id));
+      assert.equal(JSON.stringify(logs).includes(diagnostic), false);
+    }
+  } finally {
+    console.error = originalError;
+  }
+});

--- a/test/github-etag-read-broker.test.ts
+++ b/test/github-etag-read-broker.test.ts
@@ -9,7 +9,7 @@ import {
   GITHUB_ETAG_CACHE_TABLE,
   GithubEtagResponseStore,
 } from "../dashboard/github-etag-cache.ts";
-import worker, { ExactReviewQueue, githubJsonForTest } from "../dashboard/worker.ts";
+import worker, { GithubEtagCache, githubJsonForTest } from "../dashboard/worker.ts";
 import { createGitHubRuntime } from "../dist/clawsweeper-github-runtime.js";
 import {
   githubEtagCacheKey,
@@ -478,7 +478,7 @@ test("dashboard health client counts oversized bodies through size-only stores",
   for (const size of [200, 600]) {
     await t.test(`${size} KiB`, async () => {
       const storage = new MemoryDurableStorage();
-      const queue = new ExactReviewQueue({ storage }, {});
+      const queue = new GithubEtagCache({ storage });
       const paths: string[] = [];
       const stores: Record<string, unknown>[] = [];
       const originalQueueFetch = queue.fetch.bind(queue);
@@ -491,7 +491,7 @@ test("dashboard health client counts oversized bodies through size-only stores",
       const env = {
         GITHUB_TOKEN: "dashboard-token",
         CLAWSWEEPER_WEBHOOK_SECRET: webhookSecret,
-        EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+        GITHUB_ETAG_CACHE: new MemoryDurableNamespace(queue),
       };
       const originalFetch = globalThis.fetch;
       const body = jsonBodyBytes(size * 1_024, "é");
@@ -523,11 +523,11 @@ test("dashboard health client counts oversized bodies through size-only stores",
 
 test("publisher HMAC endpoints persist and confirm bodies while operator scope is rejected", async () => {
   const storage = new MemoryDurableStorage();
-  const queue = new ExactReviewQueue({ storage }, {});
+  const queue = new GithubEtagCache({ storage });
   const env = {
     CLAWSWEEPER_WEBHOOK_SECRET: webhookSecret,
     EXACT_REVIEW_OPERATOR_SECRET: operatorSecret,
-    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+    GITHUB_ETAG_CACHE: new MemoryDurableNamespace(queue),
   };
   const key = requiredKey("repository_actions", "/repos/openclaw/openclaw/issues/7");
   const request = githubEtagCacheRequestBody(key, "apply");
@@ -576,11 +576,11 @@ test("publisher HMAC endpoints persist and confirm bodies while operator scope i
 test("dashboard health reads send If-None-Match and replay only after durable confirmation", async () => {
   const originalFetch = globalThis.fetch;
   const storage = new MemoryDurableStorage();
-  const queue = new ExactReviewQueue({ storage }, {});
+  const queue = new GithubEtagCache({ storage });
   const env = {
     GITHUB_TOKEN: "dashboard-token",
     CLAWSWEEPER_WEBHOOK_SECRET: webhookSecret,
-    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+    GITHUB_ETAG_CACHE: new MemoryDurableNamespace(queue),
   };
   let resource = {
     etag: '"health-v1"',


### PR DESCRIPTION
## Problem

[Issue 1529](https://github.com/openclaw/clawsweeper/issues/1529) measured 361 canceled invocations and 80 HTTP 5xx responses in a 25-minute window, including overloaded-object exceptions. GitHub ETag lookup/confirm/store accounted for 7,284 requests (about 45% of the singleton queue object's load), competing with enqueue, claim, webhook and alarm work.

## Design

Add `GithubEtagCache` and the `GITHUB_ETAG_CACHE` binding. Derive `idFromName("owner/repo")` from the existing store-validated normalized `/repos/` route, lowercase the repository, and use one fixed `fallback` shard for unattributable/invalid keys. All currently valid keys carry a repository, so hash sharding is unnecessary. Credential pool, media type, query/page, digest confirmation, body bounds, retention and response semantics remain unchanged; the 2,048-entry cap now applies per shard.

Move the three handlers and their schema initialization out of `ExactReviewQueue`. Both the existing authenticated Worker routes and the dashboard's internal GitHub health client call the new binding directly. No runner or workflow changes. Preserve the existing trace header and endpoint labels; cache failure logs use a cache-specific prefix. Binding-only shard `GET /stats` exposes the existing 24-hour store counters. `/api/exact-review-queue` loses no fields: it never exposed these store counters.

## Rollout and skew

The additive `v3` migration creates only `GithubEtagCache`; existing v1/v2 migrations, namespaces, queue data, leases, fences, ordering, and alarms are unchanged. Deploy code plus the binding together using the existing Wrangler deployment. Runner URLs and HMAC authentication stay stable. New code never falls back to the queue for etag traffic, including the dashboard health client. The new namespace starts empty and uses the existing miss/revalidation behavior. Existing queue cache tables are left inert, with no copying, deletion, or additional alarm cleanup.

Maintainer decision and review disposition: Peter Steinberger selected this cache-isolation mitigation on 2026-09-10 and expressly approved changing the Worker's Durable Object layout for issue 1529 while preserving the queue contract. The work order requires stopping before merge, with production verification and issue closure owned by the coordinator. The review's P1 merge-risk item about unmeasured production relief/unapplied production migration is therefore retained as a post-deploy operational check, and rejected as an additional contributor pre-merge proof requirement. This does not claim observed production recovery or authorize this agent to merge or deploy. The existing exact-head runtime proof is unchanged and remains sufficient; no code changes were needed for this disposition.

Production deployment and migration application are not part of this PR's proof. After deployment, compare canceled invocations and bare 500/503 rates on the queue against the issue's window, check enqueue/claim/webhook health, and confirm etag operations are served by the new namespace. Leave the issue open until that verification.

## Proof

Contract: authenticated HTTP cache operations retain lookup/store/confirm behavior while being independent of the queue. Exercise synthetic repository keys and JSON bodies through the actual bundled Worker in workerd with SQLite Durable Objects, deliberately omitting `EXACT_REVIEW_QUEUE`. Observe 401 for wrong HMAC, cold miss, 201 store, lookup metadata without a body, digest-matched confirmation, distinct repository shards, fixed fallback with original 400 responses, independent stats, and persistence after runtime restart. No external network requests are allowed.

Reproduction: install the repository's pinned `wrangler@4.107.0` into a disposable tool prefix, then run `node scripts/e2e/github-etag-cache-split.mjs <tool-prefix>`. The script emits the tested head, source hashes, assertions, and response trace. Runtime: workerd / SQLite on AWS Crabbox, lease `cbx_fb1a91340ff1`, image `ami-0461d919be7deb53c`, Node 24. Proof is synthetic runtime behavior, not a production load test or a claim of observed production recovery.

Validation on the committed content passed: `pnpm install --frozen-lockfile`, `pnpm run build:node`, `pnpm run build:dashboard`, focused cache/broker/routing/telemetry/read-model node tests, `pnpm run check` (6,027 tests: 6,009 passed, 18 platform skips, zero failures/cancellations), `pnpm run lint`, `npx oxfmt --check` on all nine changed files, and `git diff --check`. Full validation used Node 24.18.1 on the lease above. Pre-commit and committed-branch Codex autoreviews both returned scoped-clean through P2, with no accepted/actionable findings.

The runtime proof and Wrangler packaging dry run passed on exact head `8b73bb337b7dfa23e5395d7a208fe2475d003712` (Crabbox run `run_6bdcc1933fd666553ada63280d2d23f3`). The dry run recognized all three bindings and exited without deployment. Compact proof excerpt:

```json
{"head":"8b73bb337b7dfa23e5395d7a208fe2475d003712","runtime":"workerd / SQLite Durable Objects","queue_binding":"absent","restart_persistence":"verified","external_requests":0}
```

The synthetic stored body `{"number":7}` had SHA-256 `1bd100ac70001bd61cbdc55406d9a0adc23c22bbde375761288fbe291965b1fa`; both confirmation and post-restart confirmation returned those exact bytes. Repository counters were independently verified: one miss/hit/store/304/skip on `openclaw/openclaw`, one miss on `openclaw/clawsweeper`, and no cache outcomes on the invalid-key fallback shard.

## Bay impact

None. This changes private cache storage and routing only. The public queue projection, lifecycle/status contracts, and Bay's observer-only API remain unchanged. No Bay code or UI change is needed.

Refs #1529
