### PR TITLE
fix(queue): preserve pending alarm deadlines under request traffic

### DIFF
--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -943,6 +943,14 @@ export class ExactReviewQueue {
   private alarmSampleLoggedAt = -1;
   private scheduledAlarmDecision: AlarmScheduleDecision | null = null;
   private alarmScheduleLoggedAt = 0;
+  private alarmInFlightAt: number | null = null;
+  private alarmInFlightPhase:
+    | "startup"
+    | "branch_authority"
+    | "source_authority"
+    | "command_intake"
+    | "dispatch"
+    | null = null;
   private recentDurablePublicationEventsCache = new Map<
     string,
     { expiresAt: number; value: NonNullable<ReturnType<typeof recentDurablePublicationEvents>> }
@@ -5093,10 +5101,14 @@ export class ExactReviewQueue {
   }
 
   async alarm() {
+    this.alarmInFlightAt = Date.now();
+    this.alarmInFlightPhase = "startup";
     this.invalidateReadCaches();
     try {
       await this.handleAlarm();
     } finally {
+      this.alarmInFlightAt = null;
+      this.alarmInFlightPhase = null;
       this.invalidateReadCaches();
     }
   }
@@ -5129,9 +5141,13 @@ export class ExactReviewQueue {
     await this.storage.deleteAlarm();
     this.scheduledAlarmDecision = null;
     this.reconcileBayTelemetryInternalSync(startedAt);
+    this.alarmInFlightPhase = "branch_authority";
     await this.processBranchAuthorityReservations(startedAt, hostedTargetMetadataToken);
+    this.alarmInFlightPhase = "source_authority";
     await this.processSourceAuthorityReservations(startedAt, hostedTargetMetadataToken);
+    this.alarmInFlightPhase = "command_intake";
     await this.processCommandIntakes(startedAt, hostedTargetMetadataToken);
+    this.alarmInFlightPhase = "dispatch";
     const batchItemKeys = new Set<string>(this.batchStore.activeLeaseSnapshot(startedAt).itemKeys);
     let terminalized: ExactReviewLifecycleProjection[] = [];
     let snapshot = this.storage.transactionSync(() => {
@@ -14215,6 +14231,8 @@ export class ExactReviewQueue {
       console.info("exact_review_queue_alarm_schedule_status", {
         observed_at: this.alarmScheduleLoggedAt,
         stored_alarm_at: scheduled,
+        alarm_in_flight_at: this.alarmInFlightAt,
+        alarm_in_flight_phase: this.alarmInFlightPhase,
         selected_alarm_at: next,
         wake_reason: selected[0],
         decision_age_ms: this.scheduledAlarmDecision

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -942,6 +942,7 @@ export class ExactReviewQueue {
   private alarmSampleCount = 0;
   private alarmSampleLoggedAt = -1;
   private scheduledAlarmDecision: AlarmScheduleDecision | null = null;
+  private alarmScheduleLoggedAt = 0;
   private recentDurablePublicationEventsCache = new Map<
     string,
     { expiresAt: number; value: NonNullable<ReturnType<typeof recentDurablePublicationEvents>> }
@@ -14183,6 +14184,20 @@ export class ExactReviewQueue {
     }
     const next = selected[1]!;
     const scheduled = await this.storage.getAlarm();
+    // Bounded numeric-only diagnostics distinguish a missing alarm from a
+    // repeatedly replaced overdue alarm without exposing queue contents.
+    if (Date.now() - this.alarmScheduleLoggedAt >= 60_000) {
+      this.alarmScheduleLoggedAt = Date.now();
+      console.warn("exact_review_queue_alarm_schedule_status", {
+        observed_at: this.alarmScheduleLoggedAt,
+        stored_alarm_at: scheduled,
+        selected_alarm_at: next,
+        wake_reason: selected[0],
+        decision_age_ms: this.scheduledAlarmDecision
+          ? Math.max(0, this.alarmScheduleLoggedAt - this.scheduledAlarmDecision[2])
+          : null,
+      });
+    }
     if (
       preserveQueueWake &&
       (scheduled === null || scheduled <= now || scheduled > preservedWakeAt)

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -949,7 +949,7 @@ export class ExactReviewQueue {
   >();
 
   constructor(state, env, random: () => number = Math.random) {
-    console.warn("exact_review_queue_initialization", {
+    console.info("exact_review_queue_initialization", {
       phase: "constructor",
       observed_at: Date.now(),
     });
@@ -10873,7 +10873,7 @@ export class ExactReviewQueue {
   }
 
   private async initializeStorage() {
-    console.warn("exact_review_queue_initialization", {
+    console.info("exact_review_queue_initialization", {
       phase: "storage_begin",
       observed_at: Date.now(),
     });
@@ -10890,7 +10890,7 @@ export class ExactReviewQueue {
     this.githubEgressTelemetryStore.ensureSchemaSync();
     this.artifactReceiptStore.ensureSchemaSync();
     this.githubWebhookReadModelStore.ensureSchemaSync();
-    console.warn("exact_review_queue_initialization", {
+    console.info("exact_review_queue_initialization", {
       phase: "schema_ready",
       observed_at: Date.now(),
     });
@@ -10971,7 +10971,7 @@ export class ExactReviewQueue {
     this.storage.transactionSync(() => {
       this.backfillPublicationHeadsSync(this.readStateSync(), Date.now());
     });
-    console.warn("exact_review_queue_initialization", {
+    console.info("exact_review_queue_initialization", {
       phase: "storage_ready",
       observed_at: Date.now(),
     });
@@ -14079,6 +14079,9 @@ export class ExactReviewQueue {
   ) {
     const scheduled = await this.storage.getAlarm();
     const now = Date.now();
+    // Retained auxiliary work can be overdue. Use a fresh deadline so repeated
+    // requests do not keep replacing a pending alarm with an expired timestamp.
+    next = Math.max(now + 1_000, next);
     if (scheduled === null || scheduled <= now || next < scheduled) {
       await this.storage.setAlarm(next);
       const backoff = (this.bayTelemetryNoProgressDeadline ?? 0) > now;
@@ -14198,13 +14201,16 @@ export class ExactReviewQueue {
       this.scheduledAlarmDecision = null;
       return;
     }
-    const next = selected[1]!;
+    // Auxiliary wake sources do not share the queue read model's deadline floor.
+    // Normalize after the asynchronous reads, including recovery after a long gap.
     const scheduled = await this.storage.getAlarm();
+    const schedulingNow = Date.now();
+    const next = Math.max(schedulingNow + 1_000, selected[1]!);
     // Bounded numeric-only diagnostics distinguish a missing alarm from a
     // repeatedly replaced overdue alarm without exposing queue contents.
     if (Date.now() - this.alarmScheduleLoggedAt >= 60_000) {
       this.alarmScheduleLoggedAt = Date.now();
-      console.warn("exact_review_queue_alarm_schedule_status", {
+      console.info("exact_review_queue_alarm_schedule_status", {
         observed_at: this.alarmScheduleLoggedAt,
         stored_alarm_at: scheduled,
         selected_alarm_at: next,
@@ -14216,19 +14222,19 @@ export class ExactReviewQueue {
     }
     if (
       preserveQueueWake &&
-      (scheduled === null || scheduled <= now || scheduled > preservedWakeAt)
+      (scheduled === null || scheduled <= schedulingNow || scheduled > preservedWakeAt)
     ) {
       // An alarm was consumed/replaced while we awaited another authority.
       // Re-read durable state instead of reusing the earlier request snapshot.
       await this.scheduleNextFromState(this.readSchedulingStateSync(), Date.now(), true);
       return;
     }
-    if (scheduled === null || scheduled <= now || next < scheduled) {
+    if (scheduled === null || scheduled <= schedulingNow || next < scheduled) {
       await this.storage.setAlarm(next);
       this.scheduledAlarmDecision = [
         selected[0],
         next,
-        now,
+        schedulingNow,
         bayTelemetryRecoveryPending,
         (this.bayTelemetryNoProgressDeadline ?? 0) > now,
       ];

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -949,6 +949,10 @@ export class ExactReviewQueue {
   >();
 
   constructor(state, env, random: () => number = Math.random) {
+    console.warn("exact_review_queue_initialization", {
+      phase: "constructor",
+      observed_at: Date.now(),
+    });
     this.state = state;
     this.storage = state.storage;
     this.env = env;
@@ -10869,6 +10873,10 @@ export class ExactReviewQueue {
   }
 
   private async initializeStorage() {
+    console.warn("exact_review_queue_initialization", {
+      phase: "storage_begin",
+      observed_at: Date.now(),
+    });
     this.ensureStorageSchemaSync();
     this.commandIntakeStore.ensureSchemaSync();
     this.commandProofStore.ensureSchemaSync();
@@ -10882,6 +10890,10 @@ export class ExactReviewQueue {
     this.githubEgressTelemetryStore.ensureSchemaSync();
     this.artifactReceiptStore.ensureSchemaSync();
     this.githubWebhookReadModelStore.ensureSchemaSync();
+    console.warn("exact_review_queue_initialization", {
+      phase: "schema_ready",
+      observed_at: Date.now(),
+    });
     let meta = this.readStorageMetaSync();
     let migratedLegacy = false;
     const legacy = this.storage.kv.get(EXACT_REVIEW_QUEUE_STATE_KEY) as
@@ -10958,6 +10970,10 @@ export class ExactReviewQueue {
     }
     this.storage.transactionSync(() => {
       this.backfillPublicationHeadsSync(this.readStateSync(), Date.now());
+    });
+    console.warn("exact_review_queue_initialization", {
+      phase: "storage_ready",
+      observed_at: Date.now(),
     });
   }
 

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -944,6 +944,7 @@ export class ExactReviewQueue {
   private scheduledAlarmDecision: AlarmScheduleDecision | null = null;
   private alarmScheduleLoggedAt = 0;
   private alarmInFlightAt: number | null = null;
+  private overdueAlarmRecoveryAttempted = false;
   private alarmInFlightPhase:
     | "startup"
     | "branch_authority"
@@ -5101,6 +5102,7 @@ export class ExactReviewQueue {
   }
 
   async alarm() {
+    this.overdueAlarmRecoveryAttempted = false;
     this.alarmInFlightAt = Date.now();
     this.alarmInFlightPhase = "startup";
     this.invalidateReadCaches();
@@ -14249,8 +14251,26 @@ export class ExactReviewQueue {
       await this.scheduleNextFromState(this.readSchedulingStateSync(), Date.now(), true);
       return;
     }
-    if (scheduled === null || next < scheduled) {
+    // A delivery can remain stranded after repeated historical replacements.
+    // Retry it once per object generation, only well beyond normal delivery and
+    // retry delays and while no handler is running. Ordinary due alarms remain
+    // untouched. Fence before awaiting storage so concurrent requests cannot
+    // turn this recovery into another sliding deadline.
+    const recoverStrandedAlarm =
+      scheduled !== null &&
+      scheduled < schedulingNow - 5 * 60_000 &&
+      this.alarmInFlightAt === null &&
+      !this.overdueAlarmRecoveryAttempted;
+    if (scheduled === null || next < scheduled || recoverStrandedAlarm) {
+      if (recoverStrandedAlarm) this.overdueAlarmRecoveryAttempted = true;
       await this.storage.setAlarm(next);
+      if (recoverStrandedAlarm) {
+        console.info("exact_review_queue_stranded_alarm_rearmed", {
+          observed_at: schedulingNow,
+          previous_alarm_at: scheduled,
+          new_alarm_at: next,
+        });
+      }
       this.scheduledAlarmDecision = [
         selected[0],
         next,

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -14081,8 +14081,10 @@ export class ExactReviewQueue {
     const now = Date.now();
     // Retained auxiliary work can be overdue. Use a fresh deadline so repeated
     // requests do not keep replacing a pending alarm with an expired timestamp.
+    // A due stored alarm is still pending delivery. Do not postpone it; the
+    // alarm handler clears it before arranging the next wake.
     next = Math.max(now + 1_000, next);
-    if (scheduled === null || scheduled <= now || next < scheduled) {
+    if (scheduled === null || next < scheduled) {
       await this.storage.setAlarm(next);
       const backoff = (this.bayTelemetryNoProgressDeadline ?? 0) > now;
       this.scheduledAlarmDecision = [reason, next, now, null, backoff];
@@ -14229,7 +14231,7 @@ export class ExactReviewQueue {
       await this.scheduleNextFromState(this.readSchedulingStateSync(), Date.now(), true);
       return;
     }
-    if (scheduled === null || scheduled <= schedulingNow || next < scheduled) {
+    if (scheduled === null || next < scheduled) {
       await this.storage.setAlarm(next);
       this.scheduledAlarmDecision = [
         selected[0],

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -942,27 +942,15 @@ export class ExactReviewQueue {
   private alarmSampleCount = 0;
   private alarmSampleLoggedAt = -1;
   private scheduledAlarmDecision: AlarmScheduleDecision | null = null;
-  private alarmScheduleLoggedAt = 0;
   private alarmInFlightAt: number | null = null;
   private alarmTask: Promise<void> | null = null;
   private overdueAlarmRecoveryAttempted = false;
-  private alarmInFlightPhase:
-    | "startup"
-    | "branch_authority"
-    | "source_authority"
-    | "command_intake"
-    | "dispatch"
-    | null = null;
   private recentDurablePublicationEventsCache = new Map<
     string,
     { expiresAt: number; value: NonNullable<ReturnType<typeof recentDurablePublicationEvents>> }
   >();
 
   constructor(state, env, random: () => number = Math.random) {
-    console.info("exact_review_queue_initialization", {
-      phase: "constructor",
-      observed_at: Date.now(),
-    });
     this.state = state;
     this.storage = state.storage;
     this.env = env;
@@ -5108,12 +5096,10 @@ export class ExactReviewQueue {
     if (this.alarmTask) return this.alarmTask;
     this.overdueAlarmRecoveryAttempted = false;
     this.alarmInFlightAt = Date.now();
-    this.alarmInFlightPhase = "startup";
     this.invalidateReadCaches();
     this.alarmTask = this.handleAlarm().finally(() => {
       this.alarmTask = null;
       this.alarmInFlightAt = null;
-      this.alarmInFlightPhase = null;
       this.invalidateReadCaches();
     });
     return this.alarmTask;
@@ -5147,13 +5133,9 @@ export class ExactReviewQueue {
     await this.storage.deleteAlarm();
     this.scheduledAlarmDecision = null;
     this.reconcileBayTelemetryInternalSync(startedAt);
-    this.alarmInFlightPhase = "branch_authority";
     await this.processBranchAuthorityReservations(startedAt, hostedTargetMetadataToken);
-    this.alarmInFlightPhase = "source_authority";
     await this.processSourceAuthorityReservations(startedAt, hostedTargetMetadataToken);
-    this.alarmInFlightPhase = "command_intake";
     await this.processCommandIntakes(startedAt, hostedTargetMetadataToken);
-    this.alarmInFlightPhase = "dispatch";
     const batchItemKeys = new Set<string>(this.batchStore.activeLeaseSnapshot(startedAt).itemKeys);
     let terminalized: ExactReviewLifecycleProjection[] = [];
     let snapshot = this.storage.transactionSync(() => {
@@ -10895,10 +10877,6 @@ export class ExactReviewQueue {
   }
 
   private async initializeStorage() {
-    console.info("exact_review_queue_initialization", {
-      phase: "storage_begin",
-      observed_at: Date.now(),
-    });
     this.ensureStorageSchemaSync();
     this.commandIntakeStore.ensureSchemaSync();
     this.commandProofStore.ensureSchemaSync();
@@ -10912,10 +10890,6 @@ export class ExactReviewQueue {
     this.githubEgressTelemetryStore.ensureSchemaSync();
     this.artifactReceiptStore.ensureSchemaSync();
     this.githubWebhookReadModelStore.ensureSchemaSync();
-    console.info("exact_review_queue_initialization", {
-      phase: "schema_ready",
-      observed_at: Date.now(),
-    });
     let meta = this.readStorageMetaSync();
     let migratedLegacy = false;
     const legacy = this.storage.kv.get(EXACT_REVIEW_QUEUE_STATE_KEY) as
@@ -10992,10 +10966,6 @@ export class ExactReviewQueue {
     }
     this.storage.transactionSync(() => {
       this.backfillPublicationHeadsSync(this.readStateSync(), Date.now());
-    });
-    console.info("exact_review_queue_initialization", {
-      phase: "storage_ready",
-      observed_at: Date.now(),
     });
   }
 
@@ -14230,22 +14200,6 @@ export class ExactReviewQueue {
     const scheduled = await this.storage.getAlarm();
     const schedulingNow = Date.now();
     const next = Math.max(schedulingNow + 1_000, selected[1]!);
-    // Bounded numeric-only diagnostics distinguish a missing alarm from a
-    // repeatedly replaced overdue alarm without exposing queue contents.
-    if (Date.now() - this.alarmScheduleLoggedAt >= 60_000) {
-      this.alarmScheduleLoggedAt = Date.now();
-      console.info("exact_review_queue_alarm_schedule_status", {
-        observed_at: this.alarmScheduleLoggedAt,
-        stored_alarm_at: scheduled,
-        alarm_in_flight_at: this.alarmInFlightAt,
-        alarm_in_flight_phase: this.alarmInFlightPhase,
-        selected_alarm_at: next,
-        wake_reason: selected[0],
-        decision_age_ms: this.scheduledAlarmDecision
-          ? Math.max(0, this.alarmScheduleLoggedAt - this.scheduledAlarmDecision[2])
-          : null,
-      });
-    }
     if (
       preserveQueueWake &&
       (scheduled === null || scheduled <= schedulingNow || scheduled > preservedWakeAt)
@@ -14269,7 +14223,7 @@ export class ExactReviewQueue {
       if (recoverStrandedAlarm) this.overdueAlarmRecoveryAttempted = true;
       await this.storage.setAlarm(next);
       if (recoverStrandedAlarm) {
-        console.info("exact_review_queue_stranded_alarm_rearmed", {
+        console.warn("exact_review_queue_stranded_alarm_rearmed", {
           observed_at: schedulingNow,
           previous_alarm_at: scheduled,
           new_alarm_at: next,

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -944,6 +944,7 @@ export class ExactReviewQueue {
   private scheduledAlarmDecision: AlarmScheduleDecision | null = null;
   private alarmScheduleLoggedAt = 0;
   private alarmInFlightAt: number | null = null;
+  private alarmTask: Promise<void> | null = null;
   private overdueAlarmRecoveryAttempted = false;
   private alarmInFlightPhase:
     | "startup"
@@ -5101,18 +5102,21 @@ export class ExactReviewQueue {
     }
   }
 
-  async alarm() {
+  alarm(): Promise<void> {
+    // Native delivery can race a request-driven recovery. Both must join the
+    // same operation, including its failure, rather than dispatching twice.
+    if (this.alarmTask) return this.alarmTask;
     this.overdueAlarmRecoveryAttempted = false;
     this.alarmInFlightAt = Date.now();
     this.alarmInFlightPhase = "startup";
     this.invalidateReadCaches();
-    try {
-      await this.handleAlarm();
-    } finally {
+    this.alarmTask = this.handleAlarm().finally(() => {
+      this.alarmTask = null;
       this.alarmInFlightAt = null;
       this.alarmInFlightPhase = null;
       this.invalidateReadCaches();
-    }
+    });
+    return this.alarmTask;
   }
 
   private async handleAlarm() {
@@ -14278,6 +14282,22 @@ export class ExactReviewQueue {
         bayTelemetryRecoveryPending,
         (this.bayTelemetryNoProgressDeadline ?? 0) > now,
       ];
+      if (recoverStrandedAlarm && typeof this.state.waitUntil === "function") {
+        // Alarm delivery may itself be unavailable. Use the same processor and
+        // its admission checks, without holding the incoming request open.
+        // waitUntil expresses background ownership, not a retry guarantee.
+        this.state.waitUntil(
+          this.alarm().catch(async () => {
+            console.error("exact_review_queue_recovery_processor_failed");
+            const pending = await this.storage.getAlarm();
+            const failedAt = Date.now();
+            const retryAt = failedAt + 60_000;
+            if (pending === null || pending <= failedAt || retryAt < pending) {
+              await this.storage.setAlarm(retryAt);
+            }
+          }),
+        );
+      }
     }
   }
 }

--- a/scripts/e2e/exact-review-alarm-deadlines.mjs
+++ b/scripts/e2e/exact-review-alarm-deadlines.mjs
@@ -1,0 +1,111 @@
+import { createRequire } from "node:module";
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import assert from "node:assert/strict";
+import { resolve } from "node:path";
+const require = createRequire(resolve(process.argv[2], "package.json"));
+const { build } = require("esbuild");
+const { Miniflare } = require("miniflare");
+const root = process.cwd();
+const filename = root + "/dashboard/exact-review-queue.ts";
+const base = execFileSync(
+  "git",
+  ["show", (process.argv[3] || "d55f1be") + ":dashboard/exact-review-queue.ts"],
+  { encoding: "utf8", maxBuffer: 8e6 },
+);
+const entry = `import {ExactReviewQueue} from '${filename}';
+export class Q extends ExactReviewQueue {
+ constructor(ctx,env){super(ctx,env);this.ctx=ctx;}
+ async fetch(request){
+  await super.fetch(new Request('https://q/stats'));
+  this.commandIntakeStore.nextAttemptAt=()=>Date.now()-7200000;
+  const before=Date.now()+500; await this.storage.setAlarm(before);
+  this.invalidateReadCaches();
+  await super.fetch(new Request('https://q/stats'));
+  const after=await this.storage.getAlarm();
+  // Exercise the adjacent fast path independently on the same real storage.
+  const fastBefore=Date.now()+500;await this.storage.setAlarm(fastBefore);
+  await this.scheduleSourceAuthorityVerification(Date.now()-7200000);
+  const fastAfter=await this.storage.getAlarm();
+  await this.storage.deleteAlarm();
+  const missingStartedAt=Date.now();
+  await this.scheduleSourceAuthorityVerification(Date.now()-7200000);
+  const missingAfter=await this.storage.getAlarm();
+  await this.storage.deleteAlarm();
+  // Hold the input gate while a real pending alarm becomes due. Request
+  // scheduling must not move it later simply because delivery is delayed.
+  const due = await this.ctx.blockConcurrencyWhile(async()=>{
+   const dueBefore=Date.now()+20; await this.storage.setAlarm(dueBefore);
+   await new Promise(resolve=>setTimeout(resolve,80));
+   const dueObservedAt=Date.now();
+   await this.scheduleSourceAuthorityVerification(Date.now()-7200000);
+   const dueAfter=await this.storage.getAlarm();
+   await this.storage.deleteAlarm();
+   return {dueBefore,dueObservedAt,dueAfter};
+  });
+  return Response.json({before,after,fastBefore,fastAfter,missingStartedAt,missingAfter,...due});
+ }
+ async alarm(){} // Terminal local sink: no GitHub or production effects.
+}
+export default{fetch(r,e){return e.Q.get(e.Q.idFromName('proof')).fetch(r);}};`;
+const observations = {
+  runtime: "real workerd / SQLite Durable Object",
+  base_sha: execFileSync("git", ["rev-parse", process.argv[3] || "d55f1be"], {
+    encoding: "utf8",
+  }).trim(),
+  limits:
+    "Scheduling and storage paths are real; fixture seeds auxiliary due work and uses a no-op alarm sink. No external calls or claim of production dispatch.",
+};
+for (const variant of ["base", "head"]) {
+  const contents = variant === "base" ? base : readFileSync(filename, "utf8");
+  const bundle = await build({
+    stdin: { contents: entry, sourcefile: "proof.ts", loader: "ts", resolveDir: root },
+    bundle: true,
+    write: false,
+    format: "esm",
+    platform: "browser",
+    target: "es2024",
+    plugins: [
+      {
+        name: "source",
+        setup(b) {
+          b.onLoad({ filter: /\/dashboard\/exact-review-queue\.ts$/ }, () => ({
+            contents,
+            loader: "ts",
+            resolveDir: root + "/dashboard",
+          }));
+        },
+      },
+    ],
+  });
+  const mf = new Miniflare({
+    modules: true,
+    script: bundle.outputFiles[0].text,
+    compatibilityDate: "2026-05-11",
+    durableObjects: { Q: { className: "Q", useSQLite: true } },
+    outboundService: () => {
+      throw Error("External request forbidden");
+    },
+  });
+  try {
+    const result = await (await mf.dispatchFetch("https://proof/check")).json();
+    observations[variant] = result;
+    if (variant === "base") {
+      assert.ok(result.after < result.before);
+      assert.ok(result.fastAfter < result.fastBefore);
+      assert.ok(result.missingAfter < result.missingStartedAt + 1000);
+      assert.ok(result.dueObservedAt > result.dueBefore);
+      assert.ok(result.dueAfter > result.dueBefore);
+    } else {
+      assert.equal(result.after, result.before);
+      assert.equal(result.fastAfter, result.fastBefore);
+      assert.ok(result.missingAfter >= result.missingStartedAt + 1000);
+      assert.ok(result.dueObservedAt > result.dueBefore);
+      assert.equal(result.dueAfter, result.dueBefore);
+    }
+  } finally {
+    await mf.dispose();
+  }
+}
+if (process.argv[4]) writeFileSync(process.argv[4], JSON.stringify(observations, null, 2));
+console.log(JSON.stringify(observations, null, 2));

--- a/scripts/e2e/exact-review-alarm-deadlines.mjs
+++ b/scripts/e2e/exact-review-alarm-deadlines.mjs
@@ -43,7 +43,23 @@ export class Q extends ExactReviewQueue {
    await this.storage.deleteAlarm();
    return {dueBefore,dueObservedAt,dueAfter};
   });
-  return Response.json({before,after,fastBefore,fastAfter,missingStartedAt,missingAfter,...due});
+  // Advance only the application's clock to exercise the five-minute recovery
+  // threshold quickly. Alarm storage and scheduling still use real workerd.
+  const recovery = await this.ctx.blockConcurrencyWhile(async()=>{
+   const realNow=Date.now;
+   try {
+    const stranded=Date.now()+500;await this.storage.setAlarm(stranded);
+    let observed=stranded+6*60_000;Date.now=()=>observed;
+    await this.scheduleNext({items:{},deliveries:{}},observed);
+    const first=await this.storage.getAlarm();
+    observed+=6*60_000;
+    await this.scheduleNext({items:{},deliveries:{}},observed);
+    const second=await this.storage.getAlarm();
+    await this.storage.deleteAlarm();
+    return {stranded,first,second};
+   } finally {Date.now=realNow;}
+  });
+  return Response.json({before,after,fastBefore,fastAfter,missingStartedAt,missingAfter,...due,...recovery});
  }
  async alarm(){} // Terminal local sink: no GitHub or production effects.
 }
@@ -54,7 +70,7 @@ const observations = {
     encoding: "utf8",
   }).trim(),
   limits:
-    "Scheduling and storage paths are real; fixture seeds auxiliary due work and uses a no-op alarm sink. No external calls or claim of production dispatch.",
+    "Scheduling and storage paths are real; fixture seeds auxiliary due work and uses a no-op alarm sink. Stranded recovery advances only the application clock; native alarm storage remains real. No external calls or claim of production dispatch.",
 };
 for (const variant of ["base", "head"]) {
   const contents = variant === "base" ? base : readFileSync(filename, "utf8");
@@ -102,6 +118,8 @@ for (const variant of ["base", "head"]) {
       assert.ok(result.missingAfter >= result.missingStartedAt + 1000);
       assert.ok(result.dueObservedAt > result.dueBefore);
       assert.equal(result.dueAfter, result.dueBefore);
+      assert.ok(result.first > result.stranded);
+      assert.equal(result.second, result.first);
     }
   } finally {
     await mf.dispose();

--- a/scripts/e2e/exact-review-alarm-recovery.mjs
+++ b/scripts/e2e/exact-review-alarm-recovery.mjs
@@ -1,0 +1,106 @@
+import { createRequire } from "node:module";
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import assert from "node:assert/strict";
+const require = createRequire(resolve(process.argv[2], "package.json"));
+const { build } = require("esbuild");
+const { Miniflare } = require("miniflare");
+const root = process.cwd();
+const filename = root + "/dashboard/exact-review-queue.ts";
+const baseRef = process.argv[3] || "e522ad2";
+const entry = `import {ExactReviewQueue} from '${filename}';
+export class Q extends ExactReviewQueue {
+ constructor(ctx,env){super(ctx,env);this.ctx=ctx;this.executions=0;}
+ async handleAlarm(){
+  this.executions++;
+  await new Promise(resolve=>setTimeout(resolve,150));
+  if(this.fail){await this.storage.deleteAlarm();throw Error('synthetic processor failure');}
+ }
+ async fetch(request){
+  const url=new URL(request.url);
+  if(url.pathname==='/start'){
+   await super.fetch(new Request('https://q/stats'));
+   this.fail=url.searchParams.has('fail');
+   this.commandIntakeStore.nextAttemptAt=()=>Date.now()-7200000;
+   const realNow=Date.now;
+   const stored=realNow()+100;await this.storage.setAlarm(stored);
+   try {
+    Date.now=()=>stored+6*60_000;
+    await this.scheduleNext({items:{},deliveries:{}},Date.now());
+    // Exercise the public native-entry method while request recovery runs.
+    // This is a method-level race, not a claim of native platform delivery.
+    if(this.executions){this.ctx.waitUntil(this.alarm().catch(()=>{}));}
+   }finally{Date.now=realNow;}
+   return Response.json({executions:this.executions,inFlight:this.alarmInFlightAt!==null});
+  }
+  return Response.json({executions:this.executions,inFlight:this.alarmInFlightAt!==null,alarm:await this.storage.getAlarm(),now:Date.now()});
+ }
+}
+export default{fetch(r,e){return e.Q.get(e.Q.idFromName(new URL(r.url).searchParams.has('fail')?'failure':'success')).fetch(r);}};`;
+const observations = {
+  runtime: "real workerd / SQLite Durable Object",
+  base_sha: execFileSync("git", ["rev-parse", baseRef], { encoding: "utf8" }).trim(),
+  limits:
+    "Real alarm wrapper, scheduler, storage, request/background lifecycle. Application clock advances six minutes; handleAlarm is a controlled delayed success/failure sink with no external effects. Native-entry race is a method call, not platform alarm delivery.",
+};
+for (const variant of ["base", "head"]) {
+  const contents =
+    variant === "base"
+      ? execFileSync("git", ["show", baseRef + ":dashboard/exact-review-queue.ts"], {
+          encoding: "utf8",
+          maxBuffer: 8e6,
+        })
+      : readFileSync(filename, "utf8");
+  const bundle = await build({
+    stdin: { contents: entry, sourcefile: "proof.ts", loader: "ts", resolveDir: root },
+    bundle: true,
+    write: false,
+    format: "esm",
+    platform: "browser",
+    target: "es2024",
+    plugins: [
+      {
+        name: "source",
+        setup(b) {
+          b.onLoad({ filter: /\/dashboard\/exact-review-queue\.ts$/ }, () => ({
+            contents,
+            loader: "ts",
+            resolveDir: root + "/dashboard",
+          }));
+        },
+      },
+    ],
+  });
+  const mf = new Miniflare({
+    modules: true,
+    script: bundle.outputFiles[0].text,
+    compatibilityDate: "2026-05-11",
+    durableObjects: { Q: { className: "Q", useSQLite: true } },
+    outboundService: () => {
+      throw Error("External request forbidden");
+    },
+  });
+  try {
+    observations[variant] = {};
+    for (const scenario of ["success", "failure"]) {
+      const query = scenario === "failure" ? "?fail" : "";
+      const start = await (await mf.dispatchFetch("https://proof/start" + query)).json();
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      const settled = await (await mf.dispatchFetch("https://proof/state" + query)).json();
+      observations[variant][scenario] = { start, settled };
+      if (variant === "base") assert.equal(start.executions, 0);
+      else {
+        assert.equal(start.executions, 1);
+        assert.equal(start.inFlight, true);
+        assert.equal(settled.executions, 1);
+        assert.equal(settled.inFlight, false);
+        if (scenario === "failure") assert.ok(settled.alarm > settled.now);
+      }
+    }
+  } finally {
+    await mf.dispose();
+  }
+}
+if (process.argv[4]) writeFileSync(process.argv[4], JSON.stringify(observations, null, 2));
+console.log(JSON.stringify(observations, null, 2));

--- a/test/dashboard-worker-queue-runtime.test.ts
+++ b/test/dashboard-worker-queue-runtime.test.ts
@@ -14244,7 +14244,7 @@ test("exact-review reconciliation cannot release a later attempt with the same r
   }
 });
 
-test("exact-review stats heals a missing or stale alarm and expired lease", async () => {
+test("exact-review stats heals a missing alarm and expired lease without postponing due alarms", async () => {
   const storage = new MemoryDurableStorage();
   await storage.put("exact-review-queue", {
     deliveries: {},
@@ -14330,11 +14330,11 @@ test("exact-review stats heals a missing or stale alarm and expired lease", asyn
   assert.ok(scheduledBeforePoll !== null && scheduledAfterPoll !== null);
   assert.ok(scheduledAfterPoll <= scheduledBeforePoll);
 
-  await storage.setAlarm(Date.now() - 1_000);
-  const staleAlarmPollStartedAt = Date.now();
+  const dueAlarm = Date.now() - 1_000;
+  await storage.setAlarm(dueAlarm);
   await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"));
-  const rescheduledAlarm = await storage.getAlarm();
-  assert.ok(rescheduledAlarm !== null && rescheduledAlarm > staleAlarmPollStartedAt);
+  // Due is not missing: Cloudflare may still be waiting to deliver this alarm.
+  assert.equal(await storage.getAlarm(), dueAlarm);
 });
 
 test("exact-review queue drops an expired failed-shard recovery unless a newer revision superseded it", async () => {

--- a/test/exact-review-alarm-deadline.test.ts
+++ b/test/exact-review-alarm-deadline.test.ts
@@ -87,3 +87,36 @@ test("due stored alarms survive repeated request scheduling until delivery", asy
   await internals.scheduleNext({ items: {}, deliveries: {} }, now);
   assert.equal(await storage.getAlarm(), now + 1_000);
 });
+
+test("stranded-alarm recovery is bounded and never rearms an active handler", async (t) => {
+  let now = NOW;
+  t.mock.method(Date, "now", () => now);
+  const storage = new TestStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  await queue.fetch(new Request("https://queue/stats"));
+  const internals = queue as unknown as {
+    commandIntakeStore: { nextAttemptAt(): number | null };
+    scheduleNext(state: { items: {}; deliveries: {} }, now: number): Promise<void>;
+    alarmInFlightAt: number | null;
+    scheduleSourceAuthorityVerification(next: number): Promise<void>;
+  };
+  t.mock.method(internals.commandIntakeStore, "nextAttemptAt", () => NOW - 7_200_000);
+  const stranded = NOW - 6 * 60_000;
+  await storage.setAlarm(stranded);
+  internals.alarmInFlightAt = NOW - 10_000;
+  await internals.scheduleNext({ items: {}, deliveries: {} }, now);
+  assert.equal(await storage.getAlarm(), stranded);
+  internals.alarmInFlightAt = null;
+  await Promise.all([
+    internals.scheduleNext({ items: {}, deliveries: {} }, now),
+    internals.scheduleNext({ items: {}, deliveries: {} }, now),
+    internals.scheduleSourceAuthorityVerification(NOW - 7_200_000),
+  ]);
+  const recovered = await storage.getAlarm();
+  assert.equal(recovered, NOW + 1_000);
+  for (let i = 0; i < 10; i++) {
+    now += 6 * 60_000;
+    await internals.scheduleNext({ items: {}, deliveries: {} }, now);
+    assert.equal(await storage.getAlarm(), recovered);
+  }
+});

--- a/test/exact-review-alarm-deadline.test.ts
+++ b/test/exact-review-alarm-deadline.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { ExactReviewQueue } from "../dashboard/exact-review-queue.ts";
+import { TestStorage } from "./exact-review-test-storage.ts";
+
+const NOW = Date.parse("2026-09-11T06:00:00Z");
+
+test("overdue command-intake wake uses a fresh deadline and polling preserves it", async (t) => {
+  t.mock.method(Date, "now", () => NOW);
+  const storage = new TestStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  await queue.fetch(new Request("https://queue/stats"));
+  const internals = queue as unknown as {
+    commandIntakeStore: { nextAttemptAt(): number | null };
+    scheduleNext(state: { items: {}; deliveries: {} }, now: number): Promise<void>;
+  };
+  t.mock.method(internals.commandIntakeStore, "nextAttemptAt", () => NOW - 7_200_000);
+  await storage.setAlarm(NOW - 60_000);
+  await internals.scheduleNext({ items: {}, deliveries: {} }, NOW);
+  assert.equal(await storage.getAlarm(), NOW + 1_000);
+  t.mock.method(Date, "now", () => NOW + 100);
+  await internals.scheduleNext({ items: {}, deliveries: {} }, NOW + 100);
+  assert.equal(await storage.getAlarm(), NOW + 1_000);
+});
+
+test("source-authority recovery clamps past deadlines but preserves an earlier future alarm", async (t) => {
+  t.mock.method(Date, "now", () => NOW);
+  const storage = new TestStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  await queue.fetch(new Request("https://queue/stats"));
+  const internals = queue as unknown as {
+    scheduleSourceAuthorityVerification(next: number): Promise<void>;
+  };
+  await internals.scheduleSourceAuthorityVerification(NOW - 7_200_000);
+  assert.equal(await storage.getAlarm(), NOW + 1_000);
+  await storage.setAlarm(NOW + 500);
+  await internals.scheduleSourceAuthorityVerification(NOW - 7_200_000);
+  assert.equal(await storage.getAlarm(), NOW + 500);
+  await storage.deleteAlarm();
+  await internals.scheduleSourceAuthorityVerification(NOW + 60_000);
+  assert.equal(await storage.getAlarm(), NOW + 60_000);
+});
+
+test("scheduling uses the current clock after asynchronous storage reads", async (t) => {
+  let now = NOW;
+  t.mock.method(Date, "now", () => now);
+  const storage = new TestStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  await queue.fetch(new Request("https://queue/stats"));
+  const internals = queue as unknown as {
+    commandIntakeStore: { nextAttemptAt(): number | null };
+    scheduleNext(state: { items: {}; deliveries: {} }, now: number): Promise<void>;
+  };
+  t.mock.method(internals.commandIntakeStore, "nextAttemptAt", () => NOW - 7_200_000);
+  await storage.setAlarm(NOW + 500);
+  const getAlarm = storage.getAlarm.bind(storage);
+  t.mock.method(storage, "getAlarm", async () => {
+    const value = await getAlarm();
+    now = NOW + 2_000;
+    return value;
+  });
+  await internals.scheduleNext({ items: {}, deliveries: {} }, NOW);
+  assert.equal(await getAlarm(), NOW + 3_000);
+});

--- a/test/exact-review-alarm-deadline.test.ts
+++ b/test/exact-review-alarm-deadline.test.ts
@@ -120,3 +120,67 @@ test("stranded-alarm recovery is bounded and never rearms an active handler", as
     assert.equal(await storage.getAlarm(), recovered);
   }
 });
+
+test("request recovery does not block callers and native delivery joins one processor", async (t) => {
+  t.mock.method(Date, "now", () => NOW);
+  const storage = new TestStorage();
+  const background: Promise<void>[] = [];
+  const queue = new ExactReviewQueue(
+    { storage, waitUntil: (p: Promise<void>) => background.push(p) },
+    {},
+  );
+  await queue.fetch(new Request("https://queue/stats"));
+  const internals = queue as unknown as {
+    commandIntakeStore: { nextAttemptAt(): number | null };
+    scheduleNext(state: { items: {}; deliveries: {} }, now: number): Promise<void>;
+    handleAlarm(): Promise<void>;
+  };
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  let executions = 0;
+  t.mock.method(internals, "handleAlarm", async () => {
+    executions++;
+    await gate;
+  });
+  t.mock.method(internals.commandIntakeStore, "nextAttemptAt", () => NOW - 7_200_000);
+  await storage.setAlarm(NOW - 6 * 60_000);
+  await internals.scheduleNext({ items: {}, deliveries: {} }, NOW);
+  assert.equal(executions, 1);
+  assert.equal(background.length, 1);
+  const native = queue.alarm();
+  await internals.scheduleNext({ items: {}, deliveries: {} }, NOW);
+  assert.equal(executions, 1);
+  assert.equal(background.length, 1);
+  release();
+  await Promise.all([native, ...background]);
+});
+
+test("failed request-driven recovery leaves a durable future retry", async (t) => {
+  t.mock.method(Date, "now", () => NOW);
+  const storage = new TestStorage();
+  const background: Promise<void>[] = [];
+  const queue = new ExactReviewQueue(
+    { storage, waitUntil: (p: Promise<void>) => background.push(p) },
+    {},
+  );
+  await queue.fetch(new Request("https://queue/stats"));
+  const internals = queue as unknown as {
+    commandIntakeStore: { nextAttemptAt(): number | null };
+    scheduleNext(state: { items: {}; deliveries: {} }, now: number): Promise<void>;
+    handleAlarm(): Promise<void>;
+  };
+  t.mock.method(internals.commandIntakeStore, "nextAttemptAt", () => NOW - 7_200_000);
+  t.mock.method(internals, "handleAlarm", async () => {
+    await storage.deleteAlarm();
+    throw new Error("synthetic processor failure");
+  });
+  await storage.setAlarm(NOW + 500);
+  await internals.scheduleNext({ items: {}, deliveries: {} }, NOW);
+  assert.equal(background.length, 0);
+  await storage.setAlarm(NOW - 6 * 60_000);
+  await internals.scheduleNext({ items: {}, deliveries: {} }, NOW);
+  await Promise.all(background);
+  assert.equal(await storage.getAlarm(), NOW + 60_000);
+});

--- a/test/exact-review-alarm-deadline.test.ts
+++ b/test/exact-review-alarm-deadline.test.ts
@@ -15,7 +15,7 @@ test("overdue command-intake wake uses a fresh deadline and polling preserves it
     scheduleNext(state: { items: {}; deliveries: {} }, now: number): Promise<void>;
   };
   t.mock.method(internals.commandIntakeStore, "nextAttemptAt", () => NOW - 7_200_000);
-  await storage.setAlarm(NOW - 60_000);
+  await storage.deleteAlarm();
   await internals.scheduleNext({ items: {}, deliveries: {} }, NOW);
   assert.equal(await storage.getAlarm(), NOW + 1_000);
   t.mock.method(Date, "now", () => NOW + 100);
@@ -41,7 +41,7 @@ test("source-authority recovery clamps past deadlines but preserves an earlier f
   assert.equal(await storage.getAlarm(), NOW + 60_000);
 });
 
-test("scheduling uses the current clock after asynchronous storage reads", async (t) => {
+test("a pending alarm that becomes due during storage reads is not postponed", async (t) => {
   let now = NOW;
   t.mock.method(Date, "now", () => now);
   const storage = new TestStorage();
@@ -60,5 +60,30 @@ test("scheduling uses the current clock after asynchronous storage reads", async
     return value;
   });
   await internals.scheduleNext({ items: {}, deliveries: {} }, NOW);
-  assert.equal(await getAlarm(), NOW + 3_000);
+  assert.equal(await getAlarm(), NOW + 500);
+});
+
+test("due stored alarms survive repeated request scheduling until delivery", async (t) => {
+  let now = NOW;
+  t.mock.method(Date, "now", () => now);
+  const storage = new TestStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  await queue.fetch(new Request("https://queue/stats"));
+  const internals = queue as unknown as {
+    commandIntakeStore: { nextAttemptAt(): number | null };
+    scheduleNext(state: { items: {}; deliveries: {} }, now: number): Promise<void>;
+    scheduleSourceAuthorityVerification(next: number): Promise<void>;
+  };
+  t.mock.method(internals.commandIntakeStore, "nextAttemptAt", () => NOW - 7_200_000);
+  await storage.setAlarm(NOW - 60_000);
+  for (let i = 0; i < 20; i++) {
+    now += 2000;
+    await internals.scheduleNext({ items: {}, deliveries: {} }, now);
+    await internals.scheduleSourceAuthorityVerification(NOW - 7_200_000);
+    assert.equal(await storage.getAlarm(), NOW - 60_000);
+  }
+  // Once consumed or missing, the next wake is still created normally.
+  await storage.deleteAlarm();
+  await internals.scheduleNext({ items: {}, deliveries: {} }, now);
+  assert.equal(await storage.getAlarm(), now + 1_000);
 });

--- a/test/exact-review-publication-batches.test.ts
+++ b/test/exact-review-publication-batches.test.ts
@@ -3115,7 +3115,9 @@ test("rollout dispatches one full batch workflow without admitting legacy publis
     assert.equal(stats.lanes.publication.batches.last_dispatch_succeeded, true);
     assert.equal(stats.lanes.publication.batches.dispatch_pending_until, null);
     assert.equal(regularDispatches.length, 1);
-    assert.equal(storage.scheduledAlarm(), 7_031_000);
+    // A concurrent request installed this wake while dispatch was in flight. It is now
+    // due but still pending delivery, so later scheduling must not postpone it.
+    assert.equal(storage.scheduledAlarm(), 7_001_000);
 
     await queue.alarm();
     assert.equal(dispatches.length, 1);


### PR DESCRIPTION
## Summary

Prevent ordinary queue requests from repeatedly replacing an alarm that is already pending delivery. Preserve an existing earlier alarm, including one whose timestamp has just passed; install a new alarm when none exists or the selected deadline is earlier. A separate one-shot recovery rearms an alarm over five minutes overdue when no handler is active and starts the existing processor in the background. Native and background entry join one promise; processing failure retains a future retry. Ordinary requests cannot slide the alarm deadline. Clamp overdue auxiliary work to a fresh deadline when installing an alarm.

This addresses an observed scheduling defect and adds a guarded request-driven recovery for unavailable alarm delivery, not a claim that Cloudflare platform delivery itself is repaired. Live recovery is now observed: request-driven recovery started at 07:08:34 UTC, native alarm delivery also completed, and real exact-review workflows began taking leases. Numeric in-flight phase diagnostics distinguished active processing from the earlier stall.

## Evidence and cause

On the global ExactReviewQueue, live numeric-only traces showed overdue command-intake work selecting a timestamp nearly two hours old. Requests repeatedly replaced the stored alarm while there were 44 admissible reviews and zero active reviews. The first deadline-floor patch still postponed already-due pending alarms. This PR also removes that postponement: a due stored alarm is not a missing alarm. Cloudflare can deliver it asynchronously; the handler clears its alarm before scheduling its next wake.

No queued records, admission rules, workflow capabilities, credentials, capacities, or manual-publication policies are changed. Temporary initialization and status tracing used during diagnosis has been removed. The bounded stranded-alarm recovery warning contains numeric timestamps only and writes to stderr, preserving CLI JSON stdout.

## pr-behavior-proof

- Claim: request-driven scheduling retains an earlier pending alarm, even when delivery has been delayed past its deadline; absent alarms still receive a future wake.
- Surface/environment: real workerd, SQLite Durable Object, Node 24, Wrangler 4.107.0's Miniflare/esbuild installation.
- Command: `node scripts/e2e/exact-review-alarm-deadlines.mjs <directory-containing-installed-miniflare-and-esbuild> d55f1be <output.json>`.
- Fixture: synthetic overdue command intake; real storage; a held input gate lets a real stored alarm become due before the request schedules again. Outbound calls throw; the local alarm handler is a no-op terminal sink.
- Before: the due stored deadline 1789109480819 was moved to 1789109480880. The separate future-deadline cases were also replaced by an overdue auxiliary deadline.
- After: due deadline 1789109481082 remained exactly 1789109481082 after the gate released at 1789109481143; future earlier alarms were preserved and missing alarms received a deadline at least 1000ms ahead.
- Reproducible artifact: the committed proof driver emits complete before/after JSON; saved local result is `due-preservation-proof.json`.
- Limits: this proves real scheduling/storage semantics, not production review execution. Production dispatch was separately observed as described below. Completed review publication is still being verified.

Recovery proof also advances the application clock by six minutes while using real workerd alarm storage: the first call rearms once; another six minutes later the second call preserves the same deadline. This is explicitly clock-controlled and does not prove live delivery. The five-minute threshold is an operational choice, not a Cloudflare delivery guarantee.

Additional real-runtime recovery proof: `node scripts/e2e/exact-review-alarm-recovery.mjs <tool-directory> e522ad2 <output.json>`. It keeps the actual alarm wrapper, scheduler, storage and request/background lifecycle. Application time is advanced and the processor is a controlled delayed success/failure sink. Base executes zero processors; head executes exactly one, returns the request while still processing, joins the native-entry method race, and leaves a future alarm after failure. The race is a method call, not a claim of native platform delivery. Full queue-runtime tests retain the actual production admission/dispatch behavior.

## Validation

- 352 queue-runtime, deadline/recovery, and publication-batch tests pass.
- Both actual compiled-consumer CLI proof tests pass with clean JSON stdout.
- 25 CPU tests previously passed; four existing opt-in benchmarks skipped.
- Dashboard TypeScript build, scoped lint, formatting and diff checks pass.
- Fresh independent Codex review completed before each commit and against the committed branch: no actionable findings.
- Full `pnpm run check` was run. The local macOS system Bash 3.2 lacks `mapfile`, causing the unrelated apply-drift-refresh integration test to fail; The initial Linux CI then found temporary diagnostic stdout breaking three JSON consumers and one old batch-alarm postponement expectation. This cleanup removes those diagnostic logs and corrects the assertion without weakening the subsequent no-double-dispatch check. All affected locally runnable suites and compiled CLI proofs pass; current-head Linux CI is pending.

## OpenClaw Bay

No Bay change is required. Its observer-only public contract and data shape are unchanged; this fixes the scheduler beneath it and adds private Worker logs, not dashboard mutation controls.

## Operations

Head `d94e3726e769e7c2960cc239162fcc52653e48ae` was deployed through the existing dashboard workflow, with successful deployment and smoke checks: https://github.com/openclaw/clawsweeper/actions/runs/34572524367. Existing variables, secrets, records, and admission controls were preserved.

Sanitized live trace records the request-driven recovery at 2026-09-11 07:08:34.950 UTC, command-intake processing at 07:09:02, and a native ExactReviewQueue alarm at 07:08:35.980 completing successfully after 43.473 seconds. Public status then changed from zero active reviews to three leased reviews at 07:09:38; additional reviews were dispatched at 07:10:37. Actual exact-review runs include https://github.com/openclaw/clawsweeper/actions/runs/34573072578 and https://github.com/openclaw/clawsweeper/actions/runs/34573070942. These are review execution runs, not enqueue-only workflows. Completed review publication remains under observation.

The original cause of native Cloudflare delivery remaining stranded after the historical scheduling defect is not independently established. This patch fixes the demonstrated deadline replacement and recovers through the existing processor. Prior Worker versions remain available for rollback.

Final cleanup head `a42843b` removes only temporary incident logs and corrects the batch-test expectation. The restored live deployment remains `d94e372` to avoid interrupting active reviews; scheduling and admission behavior are identical.
