### PR TITLE
fix(ci): refresh intake tooling and verify terminal teardown

### DIFF
--- a/.github/workflows/repair-cluster-intake.yml
+++ b/.github/workflows/repair-cluster-intake.yml
@@ -248,7 +248,7 @@ jobs:
           materializer="${intake_dir}/portable-artifact.mjs"
           # Snapshot publishing must not authorize new code on the runner.
           install -m 600 gitcrawl-store/scripts/portable-artifact.mjs "$materializer"
-          if ! printf '%s  %s\n' 'd3e7678faa48554e091ea51666692643e97cfab437bb23c44f59c139b7e0ebfa' "$materializer" | sha256sum --check --status; then
+          if ! printf '%s  %s\n' 'b0f07c66b289255dd708bc6ef50771b1c057ef36f5bc647d8fa7ffa66be44cb1' "$materializer" | sha256sum --check --status; then
             echo "::error::gitcrawl-store materializer does not match the reviewed digest" >&2
             exit 1
           fi

--- a/docs/proof/cluster-intake-portable/README.md
+++ b/docs/proof/cluster-intake-portable/README.md
@@ -31,6 +31,13 @@ on empty portable tables; the candidate accepts both, preserves raw input and
 forced reimports, skips processed snapshots before decompression, and rejects
 unreviewed materializer code and archive/decoded hash mismatches.
 
+The reviewed materializer pin also enforces the store's current archive-size
+contract and bounds decompression. The fixture uses a maximum archive size below
+100 MB and verifies that expansion beyond the declared output size is rejected
+before import. Refresh the digest only after reviewing the changed helper and
+rerunning this proof; an upstream helper update must never silently authorize
+new executable code.
+
 This is controlled runtime proof, not a production intake or inference call.
 It does not restore clusters omitted by an upstream export, verify raw database
 hashes beyond the store helper's contract, or exercise live GitHub publication.

--- a/docs/proof/cluster-intake-portable/run-proof.mjs
+++ b/docs/proof/cluster-intake-portable/run-proof.mjs
@@ -20,7 +20,8 @@ const source = baselineRef
   ? execFileSync("git", ["show", `${baselineRef}:${workflowPath}`], { encoding: "utf8" })
   : fs.readFileSync(workflowPath, "utf8");
 const prepare = parse(source).jobs.intake.steps.find((step) => step.name === "Prepare intake").run;
-const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "cluster-intake-proof-"));
+// Keep argv and import.meta.url on the same canonical path on macOS.
+const fixtureRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "cluster-intake-proof-")));
 const importer = path.join(
   root,
   "dist/repair",
@@ -44,6 +45,7 @@ try {
     scenario("unreviewed-materializer", { compression: true, corruptMaterializer: true });
     scenario("archive-hash-mismatch", { compression: true, corruptArchiveHash: true });
     scenario("decoded-hash-mismatch", { compression: true, corruptDecodedHash: true });
+    scenario("expanded-size-exceeded", { compression: true, undersizedOutput: true });
     scenario("already-processed", { compression: true, processed: true, corruptArchiveHash: true });
     scenario("forced-reimport", { compression: true, processed: true, force: true });
   }
@@ -117,12 +119,13 @@ function scenario(name, options) {
       archivePath: `${dbName}.gz`,
       archiveBytes: archive.length,
       archiveSha256: options.corruptArchiveHash ? "0".repeat(64) : sha256(archive),
-      maxArchiveBytes: 100000000,
+      maxArchiveBytes: 99999999,
     });
     fs.writeFileSync(`${dbPath}.gz`, archive);
     fs.rmSync(dbPath);
   }
   if (options.corruptDecodedHash) manifest.sha256 = "0".repeat(64);
+  if (options.undersizedOutput) manifest.outputBytes = bytes.length - 1;
   fs.writeFileSync(`${dbPath}.manifest.json`, JSON.stringify(manifest));
   if (options.processed) {
     const ledger = path.join(cwd, "results/cluster-repair-intake/openclaw-fixture.json");
@@ -136,6 +139,7 @@ function scenario(name, options) {
     timeout: 30000,
     env: {
       PATH: process.env.PATH,
+      TMPDIR: process.env.TMPDIR,
       ENABLED: "1",
       SCHEDULE_ENABLED: "0",
       TARGET_REPO: "openclaw/fixture",
@@ -161,7 +165,10 @@ function scenario(name, options) {
   const rejected = baselineRef
     ? options.compression
     : !options.processed &&
-      (options.corruptMaterializer || options.corruptArchiveHash || options.corruptDecodedHash);
+      (options.corruptMaterializer ||
+        options.corruptArchiveHash ||
+        options.corruptDecodedHash ||
+        options.undersizedOutput);
   if (rejected) {
     assert.notEqual(prepared.status, 0, name);
     assert.notEqual(outputs.should_import, "true", name);
@@ -172,7 +179,9 @@ function scenario(name, options) {
         ? /Missing gitcrawl-store DB/
         : options.corruptMaterializer
           ? /materializer does not match the reviewed digest/
-          : /manifest (?:archiveSha256|sha256) mismatch/,
+          : options.undersizedOutput
+            ? /manifest outputBytes exceeded during expansion/
+            : /manifest (?:archiveSha256|sha256) mismatch/,
     );
     assert.equal(fs.existsSync(path.join(cwd, "gitcrawl-store/unreviewed-code-ran")), false);
     results.push({ name, admission: "rejected", jobs: 0 });
@@ -210,7 +219,7 @@ function scenario(name, options) {
       cwd,
       encoding: "utf8",
       timeout: 30000,
-      env: { PATH: process.env.PATH, NODE_NO_WARNINGS: "1" },
+      env: { PATH: process.env.PATH, TMPDIR: process.env.TMPDIR, NODE_NO_WARNINGS: "1" },
     },
   );
   if (baselineRef && options.empty) {
@@ -244,7 +253,7 @@ function scenario(name, options) {
         cwd,
         encoding: "utf8",
         timeout: 30000,
-        env: { PATH: process.env.PATH, NODE_NO_WARNINGS: "1" },
+        env: { PATH: process.env.PATH, TMPDIR: process.env.TMPDIR, NODE_NO_WARNINGS: "1" },
       },
     );
     assert.equal(selected.status, 0, selected.stderr);

--- a/docs/proof/hosted-terminal-query-race/README.md
+++ b/docs/proof/hosted-terminal-query-race/README.md
@@ -1,0 +1,24 @@
+# Hosted terminal query race
+
+Claim: after a validated DONE receipt, an empty successful tmux query is accepted
+only when fresh matching receipts and server/socket quiescence prove that the
+controller completed teardown. A live server or altered receipt still fails,
+and no extra kill command is sent after the mismatched query.
+
+On Linux with Node 24+, tmux, and a built checkout:
+
+```sh
+node docs/proof/hosted-terminal-query-race/run-proof.mjs
+```
+
+The driver creates real private tmux sessions and a foreign sentinel process.
+A query wrapper injects tmux's empty successful result while the owner session
+exits, remains live, or its receipt changes. It invokes the production cleanup
+helper, verifies each result, and cleans up only its own sessions. The output is
+three scenario receipts. No hosted service, credentials, GitHub, or model calls
+are used. This is controlled teardown proof, not a claim to reproduce the
+scheduler timing of every production race. OpenClaw Bay is unaffected.
+
+For a paired baseline, place the pre-fix helper alongside the current helper
+in `scripts/` and pass `--module <baseline-helper> --expect-unfixed`; remove that
+temporary copy afterward. The baseline rejects the completed empty-query case.

--- a/docs/proof/hosted-terminal-query-race/run-proof.mjs
+++ b/docs/proof/hosted-terminal-query-race/run-proof.mjs
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+assert.equal(process.platform, "linux", "this proof needs /proc and tmux");
+const args = process.argv.slice(2);
+const index = args.indexOf("--module");
+const modulePath = index < 0 ? "scripts/hosted-review-canary-proof.mjs" : args[index + 1];
+const { stopHostedTerminal, hostedProcessIdentity, recordHostedLifecycle } = await import(
+  pathToFileURL(path.resolve(modulePath)).href
+);
+const baseline = args.includes("--expect-unfixed");
+const tmux = execFileSync("which", ["tmux"], { encoding: "utf8" }).trim();
+const foreign = spawn("sleep", ["60"]);
+const foreignIdentity = hostedProcessIdentity(foreign.pid);
+const results = [];
+try {
+  for (const scenario of ["gone", "live", "changed-receipt"]) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "hosted-query-proof-"));
+    const socket = path.join(root, "tmux.sock");
+    const receipt = path.join(root, "receipt.jsonl");
+    const wrapper = path.join(root, "query.mjs");
+    const command = (...words) =>
+      execFileSync(tmux, ["-S", socket, ...words], { encoding: "utf8" }).trim();
+    let server;
+    try {
+      command("-f", "/dev/null", "new-session", "-d", "-s", "proof", "sleep 60");
+      const [serverPid, panePid, tty, session] = command(
+        "display-message",
+        "-p",
+        "-t",
+        "proof:0.0",
+        "#{pid}|#{pane_pid}|#{pane_tty}|#{session_id}",
+      ).split("|");
+      server = hostedProcessIdentity(Number(serverPid));
+      const stat = fs.lstatSync(socket);
+      const nonce = randomUUID();
+      const identity = `${randomUUID()}|${panePid}|${tty}|1:2`;
+      const shared = {
+        kind: "terminal",
+        fixtureNonce: nonce,
+        socket,
+        socketIdentity: `${stat.dev}:${stat.ino}`,
+        server,
+        session,
+        lease: path.join(root, "proof.lease"),
+        request: path.join(root, "proof.start"),
+        result: path.join(root, "proof.cleanup.result"),
+      };
+      const records = [
+        {
+          ...shared,
+          publication: `v1|armed|${identity}|${process.pid}\n`,
+          watchdog: hostedProcessIdentity(process.pid),
+        },
+        { ...shared, publication: `v1|done|${identity}|controller|ok|0\n` },
+      ];
+      for (const record of records) recordHostedLifecycle(receipt, record);
+      fs.writeFileSync(
+        wrapper,
+        `#!${process.execPath}
+import fs from 'node:fs';
+import {execFileSync} from 'node:child_process';
+import {hostedProcessIdentity} from ${JSON.stringify(pathToFileURL(path.resolve(modulePath)).href)};
+const args = process.argv.slice(2);
+if (args[2] !== 'display-message') throw new Error('unexpected mutation after query');
+if (${JSON.stringify(scenario)} !== 'live') {
+  execFileSync(${JSON.stringify(tmux)}, ['-S', ${JSON.stringify(socket)}, 'kill-session', '-t', ${JSON.stringify(session)}]);
+  const deadline = Date.now() + 2000;
+  while (hostedProcessIdentity(${server.pid})) {
+    if (Date.now() > deadline) throw new Error('fixture server did not exit');
+    await new Promise(resolve => setTimeout(resolve, 10));
+  }
+  fs.rmSync(${JSON.stringify(socket)}, {force:true});
+}
+if (${JSON.stringify(scenario)} === 'changed-receipt') {
+  const records = ${JSON.stringify(records)};
+  records[1].session = '$999';
+  fs.writeFileSync(${JSON.stringify(receipt)}, records.map(r => JSON.stringify(r) + '\\n').join(''));
+}
+process.stdout.write('|');
+`,
+        { mode: 0o700 },
+      );
+      const operation = stopHostedTerminal({ path: receipt, nonce, tmux: wrapper });
+      const rejected = scenario !== "gone" || baseline;
+      if (rejected) await assert.rejects(operation);
+      else await operation;
+      assert.deepEqual(hostedProcessIdentity(foreign.pid), foreignIdentity);
+      if (scenario === "live") assert.deepEqual(hostedProcessIdentity(server.pid), server);
+      results.push({
+        scenario,
+        outcome: rejected ? "refused" : "verified_quiescent",
+        foreignPreserved: true,
+      });
+    } finally {
+      if (server && hostedProcessIdentity(server.pid)) {
+        assert.deepEqual(hostedProcessIdentity(server.pid), server);
+        command("kill-session", "-t", "proof");
+      }
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  }
+} finally {
+  assert.deepEqual(hostedProcessIdentity(foreign.pid), foreignIdentity);
+  foreign.kill("SIGTERM");
+}
+console.log(
+  JSON.stringify(
+    { baseline, node: process.version, platform: process.platform, results, pass: true },
+    null,
+    2,
+  ),
+);

--- a/scripts/hosted-review-canary-proof.mjs
+++ b/scripts/hosted-review-canary-proof.mjs
@@ -531,7 +531,11 @@ export async function stopHostedTerminal({ path, nonce, tmux }) {
       await proveCompleted();
       return;
     }
-    assert.equal(paneIdentity, `${fields[3]}|${fields[4]}`);
+    if (paneIdentity !== `${fields[3]}|${fields[4]}`) {
+      // tmux can also succeed with empty pane fields during owner teardown.
+      await proveCompleted();
+      return;
+    }
     try {
       command("kill-session", "-t", armed.session);
     } catch {

--- a/test/hosted-review-canary-proof.test.ts
+++ b/test/hosted-review-canary-proof.test.ts
@@ -2055,7 +2055,16 @@ test("hosted terminal cleanup requires its exact armed and successful done publi
     assert.throws(() => assertHostedTerminalDone(changed));
 });
 
-for (const scenario of ["finished", "query", "kill", "live", "mismatch"] as const) {
+for (const scenario of [
+  "finished",
+  "query",
+  "kill",
+  "live",
+  "mismatch",
+  "empty",
+  "empty-live",
+  "empty-mismatch",
+] as const) {
   test(
     `hosted terminal post-DONE ${scenario} requires fresh receipts and quiescence without retry`,
     { skip: process.platform !== "linux", timeout: 10_000 },
@@ -2137,13 +2146,14 @@ if (process.argv[2] === "finish") {
   if (race === "kill" && args[2] === "display-message") {
     process.stdout.write(execFileSync(${JSON.stringify(tmux)}, args));
   } else {
-    if (race !== "live") await finish();
-    if (race === "mismatch") {
+    if (race !== "live" && race !== "empty-live") await finish();
+    if (race === "mismatch" || race === "empty-mismatch") {
       const records = ${JSON.stringify(records)};
       records[1].session = "$999";
       fs.writeFileSync(${JSON.stringify(receipt)}, records.map(value => JSON.stringify(value) + "\\n").join(""));
     }
-    process.exitCode = 1;
+    if (race.startsWith("empty")) process.stdout.write("|");
+    else process.exitCode = 1;
   }
 }
 `,
@@ -2154,7 +2164,13 @@ if (process.argv[2] === "finish") {
           assert.equal(existsSync(live), false);
         }
         const operation = stopHostedTerminal({ path: receipt, nonce, tmux: wrapper });
-        if (scenario === "live" || scenario === "mismatch") await assert.rejects(operation);
+        if (
+          scenario === "live" ||
+          scenario === "mismatch" ||
+          scenario === "empty-live" ||
+          scenario === "empty-mismatch"
+        )
+          await assert.rejects(operation);
         else await operation;
         const observed = existsSync(calls)
           ? readFileSync(calls, "utf8")
@@ -2171,7 +2187,8 @@ if (process.argv[2] === "finish") {
               : ["display-message"],
         );
         assert.deepEqual(hostedProcessIdentity(foreign.identity.pid), foreign.identity);
-        if (scenario === "live") assert.deepEqual(hostedProcessIdentity(server.pid), server);
+        if (scenario === "live" || scenario === "empty-live")
+          assert.deepEqual(hostedProcessIdentity(server.pid), server);
         else assert.equal(hostedProcessIdentity(server.pid), null);
       } finally {
         let quiescent = !started;


### PR DESCRIPTION
Fix two CI failures discovered during the sweep.

Scheduled cluster intake rejects the updated snapshot materializer because its reviewed checksum is stale. Refresh the pin after reviewing the new CLI bytes and prove valid imports plus rejection of changed code, corrupt hashes, and excessive expansion. The private-copy and checksum-before-execution boundary stays intact.

Full CI also exposed a hosted-canary teardown race: tmux can return an empty pane identity (`|`) with exit status zero after the controller removes its pane. Treat that as a possible completed teardown, requiring fresh unchanged DONE receipts and server/socket quiescence. A live server or altered receipt still fails, and no kill is attempted after a mismatched query.

## Current validation

Head: `00e55820c526b05c4bb5cc2bd59ecee6d9286401`.

- The actual cluster-intake preparation shell, compiled importer, SQLite, and empty selector passed ten synthetic scenarios on Node 24.20.0/macOS. The previous checksum reproduced the admission failure. The committed recipe is `docs/proof/cluster-intake-portable/run-proof.mjs`.
- The terminal teardown driver ran on configured AWS Crabbox, Linux amd64/Node 24.18.1, lease `cbx_8beb1a5c9a6b` (released). Both baseline/candidate observations passed: the old helper rejects an already-completed empty query; the candidate verifies it. Both refuse a live server or changed receipt and preserve an unrelated sentinel process. All nine focused Linux canary tests passed, including the actual review CLI/watchdog path. [Runtime trace](https://crabbox.openclaw.ai/portal/runs/run_a57df116bf70822374d284f9f05ecb8a). The tested working-tree bytes were committed unchanged in this head.
- New regression coverage retains the existing failed-query, identity, and quiescence controls. No test is removed or skipped.
- Fresh precommit Codex autoreview found no actionable P0–P2 findings. Committed-range review and fresh exact-head CI remain landing requirements.

The teardown recipe is `node docs/proof/hosted-terminal-query-race/run-proof.mjs`. It uses real private tmux sessions with controlled query outcomes, not a production session. The intake proof does not dispatch jobs, call a model, or mutate GitHub/production state. OpenClaw Bay's runtime/data contract is unchanged. Changelog context is consolidated in the final notes PR.

## Review disposition

The earlier durable review could not inspect the private upstream helper. A separate authenticated, isolated Codex autoreview received its complete before/after bytes alongside this branch and found no actionable P0–P2 security or correctness issue. The proof uses those exact bytes and checks the digest before execution; the dependency source stays in its owning repository.
