### PR TITLE
fix(queue): retry replay-safe batch lifecycle post-effects

### DIFF
--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -678,10 +678,12 @@ up to 10 seconds, and stop at the last confirmed server lease expiry.
 Validation, authentication, and fence rejections are never retried.
 Periodic workflow heartbeats use `--tolerate-until-lease` to tolerate exhausted transport failures only while the confirmed lease has more than `EXACT_REVIEW_BATCH_HEARTBEAT_SAFETY_MS` (default 180,000 ms) remaining. Claim, fetch, and heartbeat responses include an internal `server_time`; the manifest saves `leaseTtlMs` as `lease_expires_at - server_time`, `leaseTtlSource: "server"`, and `leaseConfirmedAtLocal`. Retry deadlines and tolerance subtract only local elapsed time from that TTL, so a runner clock offset cannot extend or shorten the lease. Older Workers without `server_time` use the local clock at confirmation and mark `leaseTtlSource: "local"`; tolerance is forbidden once that confirmation is older than one safety margin. Manifests without confirmation metadata require a successful heartbeat before tolerance is available. Each pre-loop heartbeat stays strict to establish live ownership, and 4xx/fence rejections remain fatal. The public projection and OpenClaw Bay are unchanged.
 
-Post-effect enqueue, router-receipt, and terminal-disposition POSTs are
-deliberately one-shot until Worker replay ordering is repaired. An ambiguous
-failure ends the publication run so scheduled recovery can replay it without an
-in-process retry arriving after newer queue state.
+Batch post-effect router-receipt and terminal-disposition POSTs retry transient
+transport failures up to three times within 45 seconds, preserving the signed
+bytes and stable operation identity. Durable Worker replay handling preserves
+newer requeues. Publication enqueue remains one-shot. Other client callers,
+including operator retirement, retain the single-attempt default.
+Legacy lifecycle payloads without their route's replay identity also remain one-shot.
 
 Lifecycle receipt replays are no-ops for the whole operation, including terminal
 transitions and acknowledgement drivers. Terminal-disposition requests from the

--- a/docs/proof/lifecycle-post-effect-retries/README.md
+++ b/docs/proof/lifecycle-post-effect-retries/README.md
@@ -1,0 +1,28 @@
+# Lifecycle post-effect retry proof
+
+Claim: the compiled batch client recovers transient failures for router receipts
+and terminal dispositions with byte-identical signed requests. The real Worker
+and SQLite-backed queue deduplicate a committed operation after its response is
+lost, including when a newer requeue arrives before the retry. Publication
+enqueue remains single-attempt.
+
+Run on Node 24+ after `pnpm run build:node`:
+
+```sh
+node docs/proof/lifecycle-post-effect-retries/run-proof.mjs
+```
+
+The driver starts a local Wrangler Worker and a loopback fault proxy. It uses
+synthetic lifecycle admissions, real HTTP requests, the production signature
+validator, and the production queue/storage implementation. The proxy either
+returns one HTTP 500 before forwarding or drops a response after the queue has
+committed it. In the latter case, the queue instance is reconstructed over the
+same SQLite storage before retry; a paired scenario also submits a newer requeue.
+The receipt records each request count and final persisted lifecycle/driver state.
+
+Fixture-only routes seed and inspect state. The fixture blocks all outbound
+Worker fetches and suppresses alarm dispatch; no GitHub, model, or production
+state is accessed. A client fetch adapter changes only the HTTPS origin to the
+loopback HTTP fault proxy. This proves replay semantics, not production outage
+recovery or throughput. OpenClaw Bay's data contract is unchanged; replay uses
+the existing lifecycle projection without duplicating or reviving terminal work.

--- a/docs/proof/lifecycle-post-effect-retries/README.md
+++ b/docs/proof/lifecycle-post-effect-retries/README.md
@@ -4,7 +4,8 @@ Claim: the compiled batch client recovers transient failures for router receipts
 and terminal dispositions with byte-identical signed requests. The real Worker
 and SQLite-backed queue deduplicate a committed operation after its response is
 lost, including when a newer requeue arrives before the retry. Publication
-enqueue remains single-attempt.
+enqueue remains single-attempt. The batch CLI opts into lifecycle retries;
+other callers, including operator retirement, keep the single-attempt default.
 
 Run on Node 24+ after `pnpm run build:node`:
 

--- a/docs/proof/lifecycle-post-effect-retries/README.md
+++ b/docs/proof/lifecycle-post-effect-retries/README.md
@@ -7,7 +7,10 @@ lost, including when a newer requeue arrives before the retry. Publication
 enqueue remains single-attempt. The batch CLI opts into lifecycle retries;
 other callers, including operator retirement, keep the single-attempt default.
 
-Run on Node 24+ after `pnpm run build:node`:
+Run on Linux or macOS with Node 24+ and pnpm after `pnpm run build:node`.
+The driver resolves the repository's pinned Wrangler 4.107.0 through `pnpm dlx`.
+Only Wrangler's esbuild, sharp, and workerd setup scripts are allowed for that
+invocation, using packaged libvips rather than a host-installed copy.
 
 ```sh
 node docs/proof/lifecycle-post-effect-retries/run-proof.mjs

--- a/docs/proof/lifecycle-post-effect-retries/run-proof.mjs
+++ b/docs/proof/lifecycle-post-effect-retries/run-proof.mjs
@@ -158,8 +158,15 @@ try {
             : { kind: "policy_noop", operation_id: `operation:${identity.fenceKey}` }),
         });
         if (arm === "baseline")
-          await assert.rejects(client.postEffect(route, payload), /HTTP 500|network_error/);
-        else assert.equal((await client.postEffect(route, payload)).ok, true);
+          await assert.rejects(
+            client.postEffect(route, payload, { retryLifecycle: true }),
+            /HTTP 500|network_error/,
+          );
+        else
+          assert.equal(
+            (await client.postEffect(route, payload, { retryLifecycle: true })).ok,
+            true,
+          );
         assert.equal(active.error, undefined);
         assert.equal(active.calls.length, arm === "baseline" ? 1 : 2);
         for (const request of active.calls) {

--- a/docs/proof/lifecycle-post-effect-retries/run-proof.mjs
+++ b/docs/proof/lifecycle-post-effect-retries/run-proof.mjs
@@ -86,8 +86,16 @@ const proxy = createServer(async (req, res) => {
 });
 const log = fs.openSync(path.join(output, "worker.log"), "w");
 const child = spawn(
-  "wrangler",
+  "pnpm",
   [
+    "dlx",
+    "--allow-build",
+    "esbuild",
+    "--allow-build",
+    "sharp",
+    "--allow-build",
+    "workerd",
+    "wrangler@4.107.0",
     "dev",
     "--config",
     "docs/proof/lifecycle-post-effect-retries/wrangler.toml",
@@ -106,7 +114,12 @@ const child = spawn(
   {
     detached: true,
     stdio: ["ignore", log, log],
-    env: { ...process.env, CI: "1", WRANGLER_SEND_METRICS: "false" },
+    env: {
+      ...process.env,
+      CI: "1",
+      WRANGLER_SEND_METRICS: "false",
+      SHARP_IGNORE_GLOBAL_LIBVIPS: "1",
+    },
   },
 );
 fs.closeSync(log);

--- a/docs/proof/lifecycle-post-effect-retries/run-proof.mjs
+++ b/docs/proof/lifecycle-post-effect-retries/run-proof.mjs
@@ -1,0 +1,220 @@
+import assert from "node:assert/strict";
+import { createHmac, randomUUID } from "node:crypto";
+import { createServer } from "node:http";
+import { once } from "node:events";
+import { spawn, execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { ExactReviewBatchQueueClient } from "../../../dist/repair/exact-review-batch-queue-client.js";
+
+const args = process.argv.slice(2);
+const baselineIndex = args.indexOf("--baseline-client");
+const baseline =
+  baselineIndex < 0
+    ? null
+    : (await import(pathToFileURL(path.resolve(args[baselineIndex + 1])).href))
+        .ExactReviewBatchQueueClient;
+const output = path.resolve(
+  process.env.LIFECYCLE_PROOF_OUTPUT || ".artifacts/lifecycle-post-effect-retries",
+);
+fs.mkdirSync(output, { recursive: true });
+const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "lifecycle-retry-proof-"));
+const secret = "synthetic-lifecycle-proof";
+const reservation = createServer();
+await new Promise((resolve) => reservation.listen(0, "127.0.0.1", resolve));
+const port = reservation.address().port;
+await new Promise((resolve) => reservation.close(resolve));
+const nonce = randomUUID();
+const origin = `http://127.0.0.1:${port}`;
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const sign = (body) => `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
+async function call(route, body) {
+  const raw = JSON.stringify(body);
+  const response = await fetch(origin + route, {
+    method: "POST",
+    headers: { "x-clawsweeper-exact-review-signature": sign(raw) },
+    body: raw,
+    signal: AbortSignal.timeout(10_000),
+  });
+  assert.equal(response.status, 200, `${route}: ${await response.clone().text()}`);
+  return response.json();
+}
+let active;
+const proxy = createServer(async (req, res) => {
+  try {
+    let body = "";
+    for await (const chunk of req) body += chunk;
+    const s = active;
+    assert.ok(s);
+    s.calls.push({ body, signature: req.headers["x-clawsweeper-exact-review-signature"] });
+    if (s.kind === "before" && s.calls.length === 1) {
+      res.writeHead(500);
+      res.end("temporary queue failure");
+      return;
+    }
+    const response = await fetch(origin + req.url, {
+      method: "POST",
+      headers: req.headers,
+      body,
+      signal: AbortSignal.timeout(10_000),
+    });
+    const result = await response.text();
+    if (s.kind !== "before" && s.calls.length === 1) {
+      assert.equal(response.status, 200, result);
+      if (s.kind === "newer-requeue") {
+        await sleep(5);
+        await call("/internal/exact-review/lifecycle/terminal-disposition", {
+          ...s.wire,
+          kind: "requeue",
+          operation_id: `newer:${s.identity.fenceKey}`,
+        });
+      }
+      s.committed = await call("/__proof/read", s.identity);
+      await call("/__proof/reconstruct", {});
+      res.destroy();
+      return;
+    }
+    res.writeHead(response.status, { "content-type": "application/json" });
+    res.end(result);
+  } catch (error) {
+    active.error = error;
+    res.writeHead(500);
+    res.end("proof proxy failure");
+  }
+});
+const log = fs.openSync(path.join(output, "worker.log"), "w");
+const child = spawn(
+  "wrangler",
+  [
+    "dev",
+    "--config",
+    "docs/proof/lifecycle-post-effect-retries/wrangler.toml",
+    "--local",
+    "--persist-to",
+    path.join(scratch, "state"),
+    "--ip",
+    "127.0.0.1",
+    "--port",
+    String(port),
+    "--inspector-port",
+    "0",
+    "--var",
+    `PROOF_NONCE:${nonce}`,
+  ],
+  {
+    detached: true,
+    stdio: ["ignore", log, log],
+    env: { ...process.env, CI: "1", WRANGLER_SEND_METRICS: "false" },
+  },
+);
+fs.closeSync(log);
+const childExit = once(child, "exit");
+const results = [];
+try {
+  await new Promise((resolve) => proxy.listen(0, "127.0.0.1", resolve));
+  const proxyOrigin = `http://127.0.0.1:${proxy.address().port}`;
+  let ready = false;
+  for (let attempt = 0; attempt < 100; attempt++) {
+    if (child.exitCode !== null) throw new Error("local Worker exited; inspect worker.log");
+    try {
+      const response = await fetch(origin + "/__proof/ready", {
+        signal: AbortSignal.timeout(1_000),
+      });
+      ready = response.ok && (await response.json()).nonce === nonce;
+      if (ready) break;
+    } catch {}
+    await sleep(300);
+  }
+  assert.ok(ready, "local Worker ready");
+  for (const [arm, Client] of [
+    ...(baseline ? [["baseline", baseline]] : []),
+    ["candidate", ExactReviewBatchQueueClient],
+  ]) {
+    for (const route of ["router-receipt", "terminal-disposition"]) {
+      for (const kind of ["before", "lost-response", "newer-requeue"]) {
+        const identity = {
+          canonicalTargetKey: "openclaw/clawsweeper#706",
+          fenceKey: `proof:${arm}:${route}:${kind}`,
+          revision: 1,
+        };
+        const wire = {
+          canonical_target_key: identity.canonicalTargetKey,
+          fence_key: identity.fenceKey,
+          revision: identity.revision,
+        };
+        await call("/__proof/seed", identity);
+        active = { kind, calls: [], identity, wire };
+        const client = new Client({
+          baseUrl: "https://queue.example.test",
+          webhookSecret: secret,
+          fetch: (url, init) => fetch(proxyOrigin + new URL(url).pathname, init),
+        });
+        const payload = JSON.stringify({
+          ...wire,
+          ...(route === "router-receipt"
+            ? { outcome: "durable", receipt_id: `receipt:${identity.fenceKey}` }
+            : { kind: "policy_noop", operation_id: `operation:${identity.fenceKey}` }),
+        });
+        if (arm === "baseline")
+          await assert.rejects(client.postEffect(route, payload), /HTTP 500|network_error/);
+        else assert.equal((await client.postEffect(route, payload)).ok, true);
+        assert.equal(active.error, undefined);
+        assert.equal(active.calls.length, arm === "baseline" ? 1 : 2);
+        for (const request of active.calls) {
+          assert.equal(request.body, payload);
+          assert.equal(request.signature, sign(payload));
+        }
+        const state = await call("/__proof/read", identity);
+        assert.equal(state.outbound, 0);
+        if (active.committed)
+          assert.deepEqual(
+            state,
+            active.committed,
+            "replay preserves durable state after reconstruction",
+          );
+        if (kind === "newer-requeue") {
+          assert.equal(state.projection.terminalDisposition.kind, "requeue");
+          assert.deepEqual(state.drivers, []);
+        } else if (arm === "candidate") {
+          assert.equal(state.drivers.length, 1);
+        }
+        results.push({
+          arm,
+          route,
+          kind,
+          attempts: active.calls.length,
+          drivers: state.drivers.length,
+          terminal: state.projection.terminalDisposition?.kind ?? null,
+          routerReceipts: state.projection.routerReceipts.length,
+          outbound: state.outbound,
+        });
+      }
+    }
+  }
+  console.log(JSON.stringify(results, null, 2));
+  fs.writeFileSync(
+    path.join(output, "summary.json"),
+    JSON.stringify(
+      {
+        head: execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim(),
+        node: process.version,
+        platform: process.platform,
+        results,
+        pass: true,
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+} finally {
+  proxy.closeAllConnections();
+  await new Promise((resolve) => proxy.close(resolve));
+  if (child.exitCode === null) {
+    process.kill(-child.pid, "SIGTERM");
+    await Promise.race([childExit, sleep(5_000)]);
+    if (child.exitCode === null && child.signalCode === null) process.kill(-child.pid, "SIGKILL");
+  }
+  fs.rmSync(scratch, { recursive: true, force: true });
+}

--- a/docs/proof/lifecycle-post-effect-retries/worker.ts
+++ b/docs/proof/lifecycle-post-effect-retries/worker.ts
@@ -1,0 +1,74 @@
+// Fixture-only entrypoint; never deploy this Worker.
+import application, { StatusStore } from "../../../dashboard/worker.ts";
+import { ExactReviewQueue as ProductionQueue } from "../../../dashboard/exact-review-queue.ts";
+export { StatusStore };
+let outbound = 0;
+globalThis.fetch = async () => {
+  outbound += 1;
+  throw new Error("proof forbids outbound fetch");
+};
+export class ExactReviewQueue {
+  constructor(state, env) {
+    this.state = state;
+    this.env = {
+      ...env,
+      hostedTargetPredicate: () => true,
+      hostedPublicTargetProbe: async () => "public",
+    };
+    this.queue = new ProductionQueue(state, this.env);
+  }
+  async alarm() {
+    // This proof ends at durable finalization-driver creation, before dispatch.
+    await this.state.storage.deleteAlarm();
+  }
+  async fetch(request) {
+    const path = new URL(request.url).pathname;
+    if (!path.startsWith("/__proof/")) return this.queue.fetch(request);
+    await this.queue.fetch(new Request("https://queue/status"));
+    if (path === "/__proof/ready") return Response.json({ nonce: this.env.PROOF_NONCE });
+    const input = await request.json();
+    if (path === "/__proof/reconstruct") {
+      this.queue = new ProductionQueue(this.state, this.env);
+      await this.queue.fetch(new Request("https://queue/status"));
+      return Response.json({ ok: true });
+    }
+    const q = this.queue;
+    const store = q["lifecycleProjectionStore"];
+    if (path === "/__proof/seed") {
+      store.recordAdmission({
+        ...input,
+        deliveryId: input.fenceKey,
+        sourceAction: "legacy_dispatch",
+        commandOriginated: true,
+        statusMarker:
+          "<!-- clawsweeper-command-status:706:re_review:0123456789abcdef0123456789abcdef01234567 -->",
+        statusCommentId: 7061,
+        observedAt: Date.now(),
+      });
+      store.recordCanonicalReceipt({
+        ...input,
+        outcome: "accepted",
+        receiptId: `canonical:${input.fenceKey}`,
+        observedAt: Date.now(),
+      });
+      return Response.json({ ok: true });
+    }
+    if (path === "/__proof/read") {
+      return Response.json({
+        projection: store.read(input.canonicalTargetKey, input.fenceKey, input.revision),
+        drivers: Object.keys(q["readStateSync"]().items).filter((key) =>
+          key.includes(input.fenceKey),
+        ),
+        outbound,
+      });
+    }
+    return Response.json({ error: "unknown proof route" }, { status: 404 });
+  }
+}
+export default {
+  fetch(request, env, ctx) {
+    if (new URL(request.url).pathname.startsWith("/__proof/"))
+      return env.EXACT_REVIEW_QUEUE.get(env.EXACT_REVIEW_QUEUE.idFromName("global")).fetch(request);
+    return application.fetch(request, env, ctx);
+  },
+};

--- a/docs/proof/lifecycle-post-effect-retries/wrangler.toml
+++ b/docs/proof/lifecycle-post-effect-retries/wrangler.toml
@@ -1,0 +1,18 @@
+name = "lifecycle-post-effect-local-proof"
+main = "worker.ts"
+compatibility_date = "2026-05-11"
+
+[[durable_objects.bindings]]
+name = "EXACT_REVIEW_QUEUE"
+class_name = "ExactReviewQueue"
+
+[[durable_objects.bindings]]
+name = "STATUS_STORE"
+class_name = "StatusStore"
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["ExactReviewQueue", "StatusStore"]
+
+[vars]
+CLAWSWEEPER_WEBHOOK_SECRET = "synthetic-lifecycle-proof"

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -676,8 +676,11 @@ bypassing the rate limiter.
 Scheduled review ingress requires
 `scheduled_feed.enqueue_replay: scheduled_disposition_v1` before retrying
 transient transport or HTTP 5xx failures with the same signed delivery bytes;
-legacy ambiguous receipts fail closed, and publication post-effects remain
-single-attempt.
+legacy ambiguous receipts fail closed. Publication enqueue remains single-attempt;
+batch lifecycle router receipts and terminal dispositions use bounded,
+byte-identical retries backed by durable operation identities. Operator
+retirement and other callers retain their single-attempt default.
+Legacy lifecycle payloads without replay identities remain single-attempt as well.
 
 Normal fanout ordinarily divides one live queue-advertised candidate-capacity
 budget across the selected repositories; it does not grant 50 candidates to

--- a/src/repair/exact-review-batch-cli.ts
+++ b/src/repair/exact-review-batch-cli.ts
@@ -123,6 +123,7 @@ async function postEffect() {
   const response = await client.postEffect(
     values.route as ExactReviewBatchPostEffectRoute,
     payload,
+    { retryLifecycle: true },
   );
   console.log(JSON.stringify(response));
 }

--- a/src/repair/exact-review-batch-queue-client.ts
+++ b/src/repair/exact-review-batch-queue-client.ts
@@ -318,7 +318,14 @@ export class ExactReviewBatchQueueClient implements ExactReviewBatchQueue {
   async postEffect(route: ExactReviewBatchPostEffectRoute, payload: string) {
     if (!Object.hasOwn(POST_EFFECT_ROUTES, route))
       throw new Error("Invalid batch post-effect route");
-    return this.postUrl(POST_EFFECT_ROUTES[route], payload);
+    // These lifecycle routes persist replay identity and preserve newer requeues.
+    // Publication enqueue still has no equivalent replay contract.
+    const retryable = route === "router-receipt" || route === "terminal-disposition";
+    return this.postUrl(
+      POST_EFFECT_ROUTES[route],
+      payload,
+      retryable ? Date.now() + RETRY_DEADLINE_MS : undefined,
+    );
   }
 
   async enqueueScheduledReview(payload: string) {

--- a/src/repair/exact-review-batch-queue-client.ts
+++ b/src/repair/exact-review-batch-queue-client.ts
@@ -315,12 +315,18 @@ export class ExactReviewBatchQueueClient implements ExactReviewBatchQueue {
     return parseLease(response.batch);
   }
 
-  async postEffect(route: ExactReviewBatchPostEffectRoute, payload: string) {
+  async postEffect(
+    route: ExactReviewBatchPostEffectRoute,
+    payload: string,
+    options: { retryLifecycle?: boolean } = {},
+  ) {
     if (!Object.hasOwn(POST_EFFECT_ROUTES, route))
       throw new Error("Invalid batch post-effect route");
     // These lifecycle routes persist replay identity and preserve newer requeues.
     // Publication enqueue still has no equivalent replay contract.
-    const retryable = route === "router-receipt" || route === "terminal-disposition";
+    const retryable =
+      options.retryLifecycle === true &&
+      (route === "router-receipt" || route === "terminal-disposition");
     return this.postUrl(
       POST_EFFECT_ROUTES[route],
       payload,

--- a/src/repair/exact-review-batch-queue-client.ts
+++ b/src/repair/exact-review-batch-queue-client.ts
@@ -324,9 +324,15 @@ export class ExactReviewBatchQueueClient implements ExactReviewBatchQueue {
       throw new Error("Invalid batch post-effect route");
     // These lifecycle routes persist replay identity and preserve newer requeues.
     // Publication enqueue still has no equivalent replay contract.
+    const lifecycle = route === "router-receipt" || route === "terminal-disposition";
+    const operation =
+      options.retryLifecycle === true && lifecycle ? objectValue(JSON.parse(payload)) : null;
+    const identity = operation?.[route === "router-receipt" ? "receipt_id" : "operation_id"];
     const retryable =
-      options.retryLifecycle === true &&
-      (route === "router-receipt" || route === "terminal-disposition");
+      typeof identity === "string" &&
+      identity.length > 0 &&
+      identity.length <= 300 &&
+      !/[\r\n]/.test(identity);
     return this.postUrl(
       POST_EFFECT_ROUTES[route],
       payload,

--- a/test/repair/exact-review-batch-cli.test.ts
+++ b/test/repair/exact-review-batch-cli.test.ts
@@ -1183,8 +1183,18 @@ for (const [route, endpoint] of [
   ["terminal-disposition", "/internal/exact-review/lifecycle/terminal-disposition"],
 ]) {
   for (const [scenario, statuses, exitCode, expectedAttempts] of [
-    ["fails after the first 500 in a recovery sequence", [500, 200], 1, 1],
-    ["fails after the first 500 in a repeated failure sequence", [500, 500, 500], 1, 1],
+    [
+      "handles transient recovery within the route's retry contract",
+      [500, 200],
+      route === "enqueue" ? 1 : 0,
+      route === "enqueue" ? 1 : 2,
+    ],
+    [
+      "bounds repeated failures within the route's retry contract",
+      [500, 500, 500],
+      1,
+      route === "enqueue" ? 1 : 3,
+    ],
     ["fails immediately on 409", [409], 1, 1],
   ]) {
     test(`batch post-effect ${route} ${scenario}`, () => {
@@ -1241,7 +1251,8 @@ globalThis.fetch = async (url, init) => {
           : [];
         assert.equal(posts.length, expectedAttempts, result.stderr);
         assert.equal(result.status, exitCode, result.stderr);
-        assert.equal(result.stdout, "");
+        if (exitCode === 0) assert.deepEqual(JSON.parse(result.stdout), { ok: true, queued: true });
+        else assert.equal(result.stdout, "");
         assert.ok(posts.every((post) => post.url === `https://queue.example.test${endpoint}`));
         assert.ok(posts.every((post) => post.body === payload));
         assert.ok(
@@ -1256,8 +1267,9 @@ globalThis.fetch = async (url, init) => {
         );
         assert.doesNotMatch(result.stderr, /proof-secret|stable-fixture|sha256=/);
         if (statuses[0] === 500) {
-          assert.match(result.stderr, /HTTP 500/);
-          assert.doesNotMatch(result.stderr, /Batch queue retry/);
+          if (exitCode !== 0) assert.match(result.stderr, /HTTP 500/);
+          if (expectedAttempts > 1) assert.match(result.stderr, /Batch queue retry/);
+          else assert.doesNotMatch(result.stderr, /Batch queue retry/);
         }
       } finally {
         rmSync(root, { recursive: true, force: true });

--- a/test/repair/exact-review-batch-cli.test.ts
+++ b/test/repair/exact-review-batch-cli.test.ts
@@ -1203,7 +1203,8 @@ for (const [route, endpoint] of [
         const payloadPath = join(root, "payload.json");
         const postsPath = join(root, "posts.jsonl");
         const preloadPath = join(root, "fetch-preload.cjs");
-        const payload = '{ "receipt_id": "stable-fixture", "kind": "policy_noop" }\n';
+        const payload =
+          '{ "receipt_id": "stable-fixture", "operation_id": "stable-operation", "kind": "policy_noop" }\n';
         writeFileSync(payloadPath, payload);
         writeFileSync(
           preloadPath,

--- a/test/repair/exact-review-batch-queue-client.test.ts
+++ b/test/repair/exact-review-batch-queue-client.test.ts
@@ -159,13 +159,20 @@ test("publication enqueue HTTP 500 is attempted once", async (t) => {
 });
 
 for (const route of ["router-receipt", "terminal-disposition"] as const) {
+  test(`${route} retains single-attempt behavior without batch retry opt-in`, async (t) => {
+    const { client, calls, logs } = fixture(t, () => unavailable());
+    await assert.rejects(client.postEffect(route, payload), /HTTP 500/);
+    assert.equal(calls.length, 1);
+    assert.deepEqual(logs, []);
+  });
+
   test(`${route} retries transient failures with byte-identical signed operations`, async (t) => {
     const { client, calls } = fixture(t, (attempt) => {
       if (attempt === 1) return unavailable();
       if (attempt === 2) throw new TypeError("lost response");
       return Response.json({ ok: true });
     });
-    const result = client.postEffect(route, payload);
+    const result = client.postEffect(route, payload, { retryLifecycle: true });
     await flush();
     t.mock.timers.tick(1_000);
     await flush();
@@ -179,7 +186,10 @@ for (const route of ["router-receipt", "terminal-disposition"] as const) {
 
   test(`${route} stops after three unavailable responses`, async (t) => {
     const { client, calls } = fixture(t, () => unavailable());
-    const result = assert.rejects(client.postEffect(route, payload), /HTTP 500/);
+    const result = assert.rejects(
+      client.postEffect(route, payload, { retryLifecycle: true }),
+      /HTTP 500/,
+    );
     await flush();
     t.mock.timers.tick(1_000);
     await flush();
@@ -191,7 +201,10 @@ for (const route of ["router-receipt", "terminal-disposition"] as const) {
   for (const status of [401, 409, 429]) {
     test(`${route} never retries HTTP ${status}`, async (t) => {
       const { client, calls, logs } = fixture(t, () => new Response(null, { status }));
-      await assert.rejects(client.postEffect(route, payload), new RegExp(`HTTP ${status}`));
+      await assert.rejects(
+        client.postEffect(route, payload, { retryLifecycle: true }),
+        new RegExp(`HTTP ${status}`),
+      );
       assert.equal(calls.length, 1);
       assert.deepEqual(logs, []);
     });

--- a/test/repair/exact-review-batch-queue-client.test.ts
+++ b/test/repair/exact-review-batch-queue-client.test.ts
@@ -5,7 +5,8 @@ import test from "node:test";
 import { ExactReviewBatchQueueClient } from "../../dist/repair/exact-review-batch-queue-client.js";
 
 const now = Date.UTC(2026, 8, 2);
-const payload = '{ "receipt_id": "stable-receipt", "outcome": "durable" }\n';
+const payload =
+  '{ "receipt_id": "stable-receipt", "operation_id": "stable-operation", "outcome": "durable" }\n';
 const heartbeat = {
   batchId: "batch-proof",
   leaseOwner: "worker-proof",
@@ -159,6 +160,16 @@ test("publication enqueue HTTP 500 is attempted once", async (t) => {
 });
 
 for (const route of ["router-receipt", "terminal-disposition"] as const) {
+  test(`${route} never retries a legacy payload without a replay identity`, async (t) => {
+    const { client, calls, logs } = fixture(t, () => unavailable());
+    await assert.rejects(
+      client.postEffect(route, '{"kind":"policy_noop"}', { retryLifecycle: true }),
+      /HTTP 500/,
+    );
+    assert.equal(calls.length, 1);
+    assert.deepEqual(logs, []);
+  });
+
   test(`${route} retains single-attempt behavior without batch retry opt-in`, async (t) => {
     const { client, calls, logs } = fixture(t, () => unavailable());
     await assert.rejects(client.postEffect(route, payload), /HTTP 500/);

--- a/test/repair/exact-review-batch-queue-client.test.ts
+++ b/test/repair/exact-review-batch-queue-client.test.ts
@@ -151,12 +151,52 @@ test("undispatched claim and completion remain single-attempt", async (t) => {
   assert.deepEqual(logs, []);
 });
 
-test("post-effect HTTP 500 is attempted once", async (t) => {
+test("publication enqueue HTTP 500 is attempted once", async (t) => {
   const { client, calls, logs } = fixture(t, () => unavailable());
-  await assert.rejects(client.postEffect("router-receipt", payload), /HTTP 500/);
+  await assert.rejects(client.postEffect("enqueue", payload), /HTTP 500/);
   assert.equal(calls.length, 1);
   assert.deepEqual(logs, []);
 });
+
+for (const route of ["router-receipt", "terminal-disposition"] as const) {
+  test(`${route} retries transient failures with byte-identical signed operations`, async (t) => {
+    const { client, calls } = fixture(t, (attempt) => {
+      if (attempt === 1) return unavailable();
+      if (attempt === 2) throw new TypeError("lost response");
+      return Response.json({ ok: true });
+    });
+    const result = client.postEffect(route, payload);
+    await flush();
+    t.mock.timers.tick(1_000);
+    await flush();
+    t.mock.timers.tick(2_000);
+    assert.deepEqual(await result, { ok: true });
+    assert.equal(calls.length, 3);
+    assert.ok(calls.every((call) => call.body === payload));
+    assert.ok(calls.every((call) => call.url.endsWith(`/lifecycle/${route}`)));
+    for (const call of calls) assert.deepEqual(call.headers, calls[0].headers);
+  });
+
+  test(`${route} stops after three unavailable responses`, async (t) => {
+    const { client, calls } = fixture(t, () => unavailable());
+    const result = assert.rejects(client.postEffect(route, payload), /HTTP 500/);
+    await flush();
+    t.mock.timers.tick(1_000);
+    await flush();
+    t.mock.timers.tick(2_000);
+    await result;
+    assert.equal(calls.length, 3);
+  });
+
+  for (const status of [401, 409, 429]) {
+    test(`${route} never retries HTTP ${status}`, async (t) => {
+      const { client, calls, logs } = fixture(t, () => new Response(null, { status }));
+      await assert.rejects(client.postEffect(route, payload), new RegExp(`HTTP ${status}`));
+      assert.equal(calls.length, 1);
+      assert.deepEqual(logs, []);
+    });
+  }
+}
 
 test("post-effect network failure is attempted once", async (t) => {
   const { client, calls, logs } = fixture(t, () => {


### PR DESCRIPTION
A transient HTTP 500 or lost response currently aborts batch lifecycle finalization even though the Worker persists replay identities for these operations. The batch post-effect CLI now opts into bounded retries for router receipts and terminal dispositions that carry a valid stable replay identity: at most three attempts within 45 seconds, with identical bytes and signature.

Publication enqueue, legacy lifecycle payloads without replay identities, and other client callers—including operator retirement—remain single-attempt. Authentication/fence/other 4xx rejections are not retried. This implements the narrow follow-up in https://github.com/openclaw/clawsweeper/issues/1372; the broader queue-availability incident remains open.

## Current behavior proof

Head: `1ee98ac2c4e53502d64e8c59dc0e9effefbd9f37`. Node 24.20.0, macOS arm64, pnpm 11.10.0, pinned Wrangler 4.107.0.

The committed driver starts the real local Worker and SQLite-backed production queue behind a loopback fault proxy. Both lifecycle endpoints are exercised with a 500 before application, a lost response after application, and a lost response followed by a newer requeue. It reconstructs the queue instance over the same storage before retry.

All twelve baseline/candidate scenarios pass. Baseline calls fail after one request; candidate calls recover after two byte-identical signed requests. Replay preserves the exact committed lifecycle state, and a newer requeue retains zero finalization drivers. Worker outbound requests: zero. This proof was repeated on the committed head.

```sh
pnpm run build:node
node --test test/repair/exact-review-batch-queue-client.test.ts test/repair/exact-review-batch-cli.test.ts
node docs/proof/lifecycle-post-effect-retries/run-proof.mjs --baseline-client <built-main-client>
```

All 91 client/batch CLI tests pass, including 45 client tests covering explicit opt-in, missing replay identities, attempt bounds, unchanged signatures, and permanent errors. The separate operator-maintenance workflow suite retains its original one-attempt assertions. Its Mac run hit a subprocess startup deadline; fresh exact-head full CI is the remaining platform gate.

The driver resolves Wrangler through pnpm instead of requiring a global installation. It allows only the tool's three native setup scripts for that invocation and uses packaged libvips, avoiding host-specific builds. No persistent package-policy change is made.

## Review disposition and limits

The full-suite integration failure exposed the operator caller's one-attempt contract; retries are now opt-in from the batch CLI and operator behavior is preserved. The operator guides in `docs/live-dashboard.md` and `docs/scheduler.md` now distinguish lifecycle retries, legacy calls, and one-shot enqueue. The proof-driver dependency-resolution finding is also resolved. Fresh precommit and committed-range Codex autoreviews are clean through P3; fresh exact-head CI is the remaining landing gate.

Proof inputs and credentials are synthetic. The client adapter changes only the origin to loopback; fixture routes seed/read state and suppress alarm dispatch. No production mutation, GitHub request, model call, or production-load recovery is claimed. OpenClaw Bay's schema and observer-only contract are unchanged. Changelog context is consolidated in the final notes PR.
