### PR TITLE
fix(dashboard): preserve publication counts across refresh

### DIFF
--- a/dashboard/dashboard-pages.ts
+++ b/dashboard/dashboard-pages.ts
@@ -2210,7 +2210,7 @@ function dashboardStatusSnapshot(value) {
     },
     dashboard_health: source.dashboard_health || { conclusion: "needs_attention", severity: "amber" },
     exact_review_queue: exactReviewQueue,
-    recent_durable_publication_events: source.recent_durable_publication_events ?? null,
+    recent_durable_publication_events: dashboardPublicationEvents(value.recent_durable_publication_events),
     freshness: dashboardStatusFreshness(source)
   };
 }
@@ -2620,6 +2620,23 @@ function dashboardObservabilityNullableCount(value, maximum = DASHBOARD_OBSERVAB
   if (value === null) return null;
   const parsed = dashboardObservabilityCount(value, maximum);
   return parsed === null ? undefined : parsed;
+}
+function dashboardPublicationEvents(value) {
+  const source = dashboardObservabilityObject(value);
+  if (!source) return null;
+  const windowId = dashboardObservabilityMember(DASHBOARD_OBSERVABILITY_RANGES, source.window?.id)
+    ? source.window.id : null;
+  const accepted = dashboardObservabilityCount(source.direct?.counts?.accepted, 10000);
+  const retryable = dashboardObservabilityCount(source.batch?.counts?.retryable, 10000);
+  const state = dashboardObservabilityMember(["complete", "mixed", "unknown"], source.collection?.state)
+    ? source.collection.state : "unknown";
+  // Keep only rendered fields in a shape that survives fetch, render and localStorage reprojection.
+  return {
+    window: { id: windowId },
+    collection: { state: state === "complete" && (windowId === null || accepted === null || retryable === null) ? "unknown" : state },
+    direct: { counts: { accepted } },
+    batch: { counts: { retryable } }
+  };
 }
 function dashboardObservabilityNullableSignedCount(value) {
   if (value === null) return null;

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -3338,6 +3338,11 @@ export function publicStatusProjection(
     documentQueue.bay_projection = publicBayProjection;
     document.exact_review_queue = documentQueue;
   }
+  if (Object.hasOwn(source, "recent_durable_publication_events")) {
+    document.recent_durable_publication_events = publicRecentDurablePublicationEventsProjection(
+      source.recent_durable_publication_events,
+    );
+  }
   return document;
 }
 

--- a/docs/proof/status-publication-outcomes/README.md
+++ b/docs/proof/status-publication-outcomes/README.md
@@ -1,0 +1,79 @@
+# Publication Status Proof
+
+Status: active validation recipe. Owner: dashboard status and presentation.
+Source: `dashboard/worker.ts`, `dashboard/dashboard-pages.ts`, and the unchanged
+publication validator in `dashboard/public-observability.ts`.
+Baseline: `49446cd30622e642efceb80e1c0347b2602a0117`.
+Last verified: September 11, 2026. Exact candidate identity and dirty-patch digest
+are recorded by each run, not inferred from this document.
+Update when composition, display fields, cache paths or the proof runtime changes.
+
+## Contract
+
+The composed API preserves the dedicated endpoint's full closed publication
+contract through cold, durable, fresh and stale paths. The browser retains only
+its four displayed fields through fetch, render and localStorage reload.
+Explicit zeroes remain zero. Malformed or stripped counts do not imply zero or
+a complete collection. Unknown collections are distinct from a null projection.
+
+Run from a task-owned checkout with Node 24+, installed frozen dependencies and
+the Chromium build matching `playwright-core` available locally:
+
+```sh
+node docs/proof/status-publication-outcomes/run-proof.mjs 49446cd30622e642efceb80e1c0347b2602a0117
+```
+
+The runner archives the baseline, starts isolated local Wrangler 4.107.0
+previews, and compares them with the candidate. It writes receipts and
+desktop/mobile PNGs to `.artifacts/status-publication-outcomes/`.
+It closes its browsers, process groups and temporary state on success or failure.
+The npm tool acquisition may need network; Worker outbound fetch is denied,
+browser requests are restricted to the local preview, and production config,
+credentials and bindings are not supplied.
+
+Use `--worker-only` for the paired Worker scenarios without browser automation.
+Use `--serve-browser` to keep both loopback previews running after those checks;
+the runner prints their origins for validation in an existing browser profile.
+Stop the runner with SIGINT or SIGTERM after the browser proof. Browser results
+from this mode must be recorded separately; the Worker receipt does not claim
+browser validation.
+An already installed Wrangler can be selected with
+`PUBLICATION_PROOF_WRANGLER=/absolute/path/to/wrangler`; its reported version is
+recorded in the receipt, avoiding a new package download for each preview.
+
+## Automated harness coverage
+
+- Worker: 18 paired scenarios, 36 runs. The baseline loses counts and window
+  metadata; the candidate matches the dedicated typed endpoint. Lossy edge
+  cache values become null. Durable reuse skips external collection.
+- Browser: 22 paired scenarios, 44 runs, across desktop and mobile. Corrected
+  fixture responses isolate browser ingestion; a separate observed case uses
+  the real Worker `/api/status` route. Every fetched case is reloaded with a
+  controlled HTTP 503 to exercise localStorage. A separately seeded legacy
+  cache reproduces the misleading complete badge.
+- `observed-publication-events.json` preserves an already captured public
+  aggregate from September 8, 2026 at 06:32:10.270 UTC. It contains no target
+  identities. Its 584 direct accepted and 20 batch retryable events are not
+  counts of successful reviews or published comments. No fresh production
+  read is required for replay.
+- `projection_is_null` describes the whole nested API projection;
+  `collection_state` separately describes a valid unknown collection.
+- Screenshots exercise the actual served HTML and scripts, not a recreated UI.
+  Synthetic unavailable sibling sections are expected; no production-health
+  or latency claim follows from this proof.
+
+The September 11 refresh separately exercised all 18 paired Worker scenarios
+and the existing Chrome profile through the authenticated extension relay.
+That browser pass verified observed, zero, mixed, unknown and lossy desktop
+inputs, a mobile observed input, and HTTP 503 reload persistence. Its
+before/after screenshots contain only the synthetic local dashboard. Further
+mobile permutations were interrupted by local relay and preview failures;
+they are not claimed as part of that pass.
+
+Bay consumes `/api/status` but its `publicBayStatus` reader does not select this
+field. No Bay controls or rendering change is required. Shared privacy/Bay
+tests accompany the API and browser regressions.
+
+Named follow-up: `publicationSource` may accept null bucket counts in an
+otherwise complete zero-count source. That preexisting server-validator issue
+is not changed or certified by this composition repair.

--- a/docs/proof/status-publication-outcomes/browser-proof.mjs
+++ b/docs/proof/status-publication-outcomes/browser-proof.mjs
@@ -1,0 +1,196 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { chromium } from "playwright-core";
+
+export async function proveBrowser(origin, revision, artifacts, now) {
+  const browser = await chromium.launch({ headless: true });
+  const results = [];
+  try {
+    for (const [viewportName, viewport] of [
+      ["desktop", { width: 1440, height: 1000 }],
+      ["mobile", { width: 390, height: 844 }],
+    ]) {
+      for (const kind of [
+        "observed",
+        "captured",
+        "idle",
+        "mixed",
+        "mixed-batch",
+        "unknown",
+        "missing",
+        "null",
+        "lossy",
+      ]) {
+        for (const flow of kind === "observed"
+          ? ["corrected-input", "worker-route"]
+          : ["corrected-input"]) {
+          await post("/__proof/seed", {
+            mode: flow === "worker-route" ? "fresh" : "browser",
+            kind,
+            now,
+          });
+          const context = await browser.newContext({ viewport });
+          const denied = [];
+          const errors = [];
+          await context.route("**/*", async (route) => {
+            const request = route.request();
+            if (new URL(request.url()).origin !== origin || request.method() !== "GET") {
+              denied.push(new URL(request.url()).protocol);
+              return route.abort();
+            }
+            return route.continue();
+          });
+          const page = await context.newPage();
+          page.on("pageerror", (error) => errors.push(error.message));
+          await page.goto(origin, { waitUntil: "domcontentloaded" });
+          const target = page.locator("#recent-durable-publication-events");
+          await target.locator(".handoff-phase strong").first().waitFor();
+          const beforeReload = await readDisplay(page);
+          const isCandidate = revision === "candidate";
+          const expected = expectedDisplay(kind);
+          if (isCandidate)
+            assert.deepEqual(beforeReload, expected, `${viewportName}/${kind}/${flow}`);
+          else {
+            assert.deepEqual(beforeReload.counts, ["unknown", "unknown"]);
+            assert.equal(
+              beforeReload.window,
+              "Trailing unknown window; publication attempts only.",
+            );
+          }
+          const stored = await page.evaluate(() => localStorage.getItem("clawsweeper:last-status"));
+          assert.ok(stored, "successful status fetch must be persisted");
+          assert.equal(stored.includes("withheld-publication-identity"), false);
+          const storedProjection = JSON.parse(stored).recent_durable_publication_events;
+          if (isCandidate) {
+            assert.deepEqual(
+              await page.evaluate(
+                () =>
+                  dashboardStatusSnapshot(
+                    dashboardStatusSnapshot(
+                      JSON.parse(localStorage.getItem("clawsweeper:last-status")),
+                    ),
+                  ).recent_durable_publication_events,
+              ),
+              storedProjection,
+            );
+          }
+          await post("/__proof/status-offline");
+          await page.reload({ waitUntil: "domcontentloaded" });
+          await page.waitForFunction(() =>
+            document.getElementById("updated").textContent.includes("showing last good status"),
+          );
+          assert.deepEqual(
+            await readDisplay(page),
+            beforeReload,
+            "offline reload must retain display values",
+          );
+          assert.match(await page.locator("#updated").textContent(), /showing last good status/);
+          assert.equal(
+            (await page.evaluate(() => localStorage.getItem("clawsweeper:last-status"))).includes(
+              "withheld-publication-identity",
+            ),
+            false,
+          );
+          assert.deepEqual(errors, [], "served scripts must execute without browser errors");
+          let screenshot = null;
+          if ((kind === "observed" && flow === "worker-route") || kind === "lossy") {
+            await target.scrollIntoViewIfNeeded();
+            screenshot = `${revision}-${viewportName}-${kind}.png`;
+            await page.screenshot({ path: path.join(artifacts, screenshot) });
+            const bounds = await target.boundingBox();
+            assert.ok(bounds && bounds.width > 0 && bounds.height > 0);
+            assert.ok(bounds.x >= 0 && bounds.x + bounds.width <= viewport.width + 1);
+          }
+          results.push({
+            revision,
+            viewport: viewportName,
+            kind,
+            flow,
+            display: beforeReload,
+            offline_reload: "identical",
+            script_errors: errors.length,
+            external_browser_requests_denied: denied.length,
+            screenshot,
+          });
+          await context.close();
+        }
+      }
+
+      // Reproduce the observed legacy cache directly, before any repaired Worker response.
+      await post("/__proof/seed", { mode: "browser", kind: "lossy", now, offline: true });
+      const cached = await (await fetch(origin + "/__proof/browser-snapshot")).json();
+      const context = await browser.newContext({ viewport });
+      await context.route("**/*", (route) =>
+        new URL(route.request().url()).origin === origin && route.request().method() === "GET"
+          ? route.continue()
+          : route.abort(),
+      );
+      await context.addInitScript((snapshot) => {
+        localStorage.setItem("clawsweeper:last-status", JSON.stringify(snapshot));
+      }, cached);
+      const page = await context.newPage();
+      await page.goto(origin, { waitUntil: "domcontentloaded" });
+      await page.waitForFunction(() =>
+        document.getElementById("updated").textContent.includes("showing last good status"),
+      );
+      const display = await readDisplay(page);
+      if (revision === "candidate") assert.deepEqual(display, expectedDisplay("lossy"));
+      else
+        assert.equal(display.state, "complete", "baseline exposes the misleading complete badge");
+      const stored = await page.evaluate(() => localStorage.getItem("clawsweeper:last-status"));
+      assert.equal(stored.includes("withheld-publication-identity"), false);
+      results.push({
+        revision,
+        viewport: viewportName,
+        kind: "legacy-cache",
+        flow: "offline-localStorage",
+        display,
+      });
+      await context.close();
+    }
+    return { browser: browser.version(), results };
+  } finally {
+    await browser.close();
+  }
+
+  async function post(route, body) {
+    const response = await fetch(origin + route, {
+      method: "POST",
+      body: JSON.stringify(body ?? {}),
+    });
+    assert.equal(response.status, 200);
+  }
+}
+
+async function readDisplay(page) {
+  const target = page.locator("#recent-durable-publication-events");
+  return {
+    counts: await target.locator(".handoff-phase strong").allTextContents(),
+    state: await target.locator(".health-badge").textContent(),
+    window: await target.locator(".exact-handoff-title span").textContent(),
+  };
+}
+
+function expectedDisplay(kind) {
+  if (kind === "captured")
+    return {
+      counts: ["584", "20"],
+      state: "complete",
+      window: "Trailing 6h window; publication attempts only.",
+    };
+  const missing = kind === "missing" || kind === "null";
+  const unknown = missing || kind === "unknown" || kind === "lossy";
+  return {
+    counts: unknown
+      ? ["unknown", "unknown"]
+      : kind === "idle"
+        ? ["0", "0"]
+        : kind === "mixed"
+          ? ["1", "unknown"]
+          : kind === "mixed-batch"
+            ? ["unknown", "1"]
+            : ["1", "1"],
+    state: unknown ? "unknown" : kind.startsWith("mixed") ? "mixed" : "complete",
+    window: `Trailing ${missing ? "unknown" : "24h"} window; publication attempts only.`,
+  };
+}

--- a/docs/proof/status-publication-outcomes/fixture-worker.ts
+++ b/docs/proof/status-publication-outcomes/fixture-worker.ts
@@ -1,0 +1,123 @@
+import worker, { StatusStore } from "../../../dashboard/worker.ts";
+import capturedEvents from "./observed-publication-events.json";
+import {
+  publicationEventsFixture,
+  publicationStatusFixture,
+} from "../../../test/helpers/publication-status-fixture.ts";
+
+export { StatusStore };
+
+let events = publicationEventsFixture();
+let generation = 0;
+let blockedRequests = 0;
+let storeReads = 0;
+let browserSnapshot = null;
+let statusOffline = false;
+
+globalThis.fetch = async () => {
+  blockedRequests += 1;
+  throw new Error("external network denied by publication proof");
+};
+
+export default {
+  async fetch(request, bindings) {
+    const url = new URL(request.url);
+    if (url.hostname !== "127.0.0.1") return new Response(null, { status: 403 });
+    const store = {
+      idFromName: (name) => bindings.LOCAL_STATUS_STORE.idFromName(`${generation}:${name}`),
+      get: (id) => ({
+        fetch(input, init) {
+          if (input.method === "GET") storeReads += 1;
+          return bindings.LOCAL_STATUS_STORE.get(id).fetch(input, init);
+        },
+      }),
+    };
+    if (url.pathname === "/__proof/ready") return Response.json({ ready: true });
+    if (url.pathname === "/__proof/seed" && request.method === "POST") {
+      const { mode, kind, now, offline = false } = await request.json();
+      generation += 1;
+      blockedRequests = 0;
+      storeReads = 0;
+      browserSnapshot = null;
+      statusOffline = offline;
+      events = publicationEventsFixture(
+        now,
+        kind === "mixed"
+          ? [true, false]
+          : kind === "mixed-batch"
+            ? [false, true]
+            : kind === "unknown"
+              ? [false, false]
+              : [true, true],
+        kind === "idle",
+      );
+      if (kind === "captured") events = structuredClone(capturedEvents);
+      const snapshot = publicationStatusFixture(events);
+      snapshot.fleet = { active_codex_jobs: 17 };
+      snapshot.recent_durable_publication_events = {
+        ...events,
+        private_marker: "withheld-publication-identity",
+        direct: { ...events.direct, private_marker: "withheld-publication-identity" },
+      };
+      if (kind === "lossy") snapshot.recent_durable_publication_events.direct.counts = {};
+      if (mode === "browser") {
+        if (kind === "lossy") snapshot.recent_durable_publication_events.batch.counts = {};
+        if (kind === "missing") delete snapshot.recent_durable_publication_events;
+        if (kind === "null") snapshot.recent_durable_publication_events = null;
+        browserSnapshot = snapshot;
+      }
+      for (const bucket of ["fresh", "stale"]) {
+        await caches.default.delete(new Request(`${url.origin}/api/status-cache/v7/_/${bucket}`));
+      }
+      if (mode === "fresh" || mode === "stale") {
+        await caches.default.put(
+          new Request(`${url.origin}/api/status-cache/v7/_/${mode}`),
+          Response.json(snapshot, { headers: { "cache-control": "public, max-age=3600" } }),
+        );
+      }
+      if (mode === "durable") {
+        const response = await store.get(store.idFromName("global")).fetch(
+          new Request("https://clawsweeper-status-store/snapshot%3Abay-scope%3Av1%3A_", {
+            method: "PUT",
+            body: JSON.stringify({ value: JSON.stringify(snapshot) }),
+          }),
+        );
+        if (!response.ok) throw new Error("local StatusStore seed failed");
+      }
+      return Response.json({ seeded: true });
+    }
+    if (url.pathname === "/__proof/observations") {
+      return Response.json({ blocked_requests: blockedRequests, store_reads: storeReads });
+    }
+    if (url.pathname === "/__proof/status-offline" && request.method === "POST") {
+      statusOffline = true;
+      return Response.json({ offline: true });
+    }
+    if (url.pathname === "/__proof/browser-snapshot") return Response.json(browserSnapshot);
+    if (request.method !== "GET") return new Response(null, { status: 405 });
+    if (url.pathname === "/api/status" && statusOffline)
+      return Response.json({ error: "controlled offline refresh" }, { status: 503 });
+    if (url.pathname === "/api/status" && browserSnapshot)
+      return Response.json(browserSnapshot, { headers: { "x-clawsweeper-cache": "fresh" } });
+    const env = {
+      STATUS_STORE: store,
+      EXACT_REVIEW_QUEUE: {
+        idFromName: (name) => name,
+        get: () => ({
+          async fetch(input) {
+            return new URL(input.url).pathname === "/recent-durable-publication-events"
+              ? Response.json({ recent_durable_publication_events: events })
+              : Response.json({ error: "unavailable in publication proof" }, { status: 503 });
+          },
+        }),
+      },
+    };
+    const pending = [];
+    const response = await worker.fetch(request, env, {
+      waitUntil: (promise) => pending.push(promise),
+    });
+    // Drain the real stale refresh before reseeding the next isolated scenario.
+    await Promise.all(pending);
+    return response;
+  },
+};

--- a/docs/proof/status-publication-outcomes/observed-publication-events.json
+++ b/docs/proof/status-publication-outcomes/observed-publication-events.json
@@ -1,0 +1,82 @@
+{
+  "version": 1,
+  "captured_at": "2026-09-08T06:32:10.270Z",
+  "window": {
+    "id": "6h",
+    "start_at": "2026-09-08T00:32:10.270Z",
+    "end_at": "2026-09-08T06:32:10.270Z",
+    "bucket_seconds": 900,
+    "bucket_count": 24
+  },
+  "collection": { "state": "complete", "complete": true, "scan_limit": 10000 },
+  "activity": { "state": "observed" },
+  "direct": {
+    "complete": true,
+    "rows": 678,
+    "latest_observed_at": "2026-09-08T06:32:05.397Z",
+    "counts": { "accepted": 584, "deduped": 0, "superseded": 59, "fallback": 35 },
+    "buckets": [
+      { "index": 0, "counts": { "accepted": 31, "deduped": 0, "superseded": 0, "fallback": 0 } },
+      { "index": 1, "counts": { "accepted": 34, "deduped": 0, "superseded": 5, "fallback": 0 } },
+      { "index": 2, "counts": { "accepted": 33, "deduped": 0, "superseded": 5, "fallback": 2 } },
+      { "index": 3, "counts": { "accepted": 29, "deduped": 0, "superseded": 3, "fallback": 2 } },
+      { "index": 4, "counts": { "accepted": 23, "deduped": 0, "superseded": 5, "fallback": 0 } },
+      { "index": 5, "counts": { "accepted": 19, "deduped": 0, "superseded": 2, "fallback": 0 } },
+      { "index": 6, "counts": { "accepted": 32, "deduped": 0, "superseded": 4, "fallback": 5 } },
+      { "index": 7, "counts": { "accepted": 27, "deduped": 0, "superseded": 0, "fallback": 3 } },
+      { "index": 8, "counts": { "accepted": 29, "deduped": 0, "superseded": 3, "fallback": 0 } },
+      { "index": 9, "counts": { "accepted": 24, "deduped": 0, "superseded": 1, "fallback": 1 } },
+      { "index": 10, "counts": { "accepted": 16, "deduped": 0, "superseded": 4, "fallback": 2 } },
+      { "index": 11, "counts": { "accepted": 26, "deduped": 0, "superseded": 2, "fallback": 3 } },
+      { "index": 12, "counts": { "accepted": 23, "deduped": 0, "superseded": 3, "fallback": 1 } },
+      { "index": 13, "counts": { "accepted": 19, "deduped": 0, "superseded": 1, "fallback": 0 } },
+      { "index": 14, "counts": { "accepted": 18, "deduped": 0, "superseded": 2, "fallback": 2 } },
+      { "index": 15, "counts": { "accepted": 13, "deduped": 0, "superseded": 5, "fallback": 3 } },
+      { "index": 16, "counts": { "accepted": 14, "deduped": 0, "superseded": 4, "fallback": 1 } },
+      { "index": 17, "counts": { "accepted": 26, "deduped": 0, "superseded": 2, "fallback": 0 } },
+      { "index": 18, "counts": { "accepted": 26, "deduped": 0, "superseded": 0, "fallback": 2 } },
+      { "index": 19, "counts": { "accepted": 25, "deduped": 0, "superseded": 1, "fallback": 1 } },
+      { "index": 20, "counts": { "accepted": 34, "deduped": 0, "superseded": 2, "fallback": 5 } },
+      { "index": 21, "counts": { "accepted": 25, "deduped": 0, "superseded": 2, "fallback": 1 } },
+      { "index": 22, "counts": { "accepted": 14, "deduped": 0, "superseded": 3, "fallback": 1 } },
+      { "index": 23, "counts": { "accepted": 24, "deduped": 0, "superseded": 0, "fallback": 0 } }
+    ]
+  },
+  "batch": {
+    "complete": true,
+    "rows": 69,
+    "latest_observed_at": "2026-09-08T06:26:13.242Z",
+    "counts": { "superseded": 48, "retryable": 20, "permanent": 1 },
+    "buckets": [
+      { "index": 0, "counts": { "superseded": 2, "retryable": 1, "permanent": 0 } },
+      { "index": 1, "counts": { "superseded": 0, "retryable": 0, "permanent": 0 } },
+      { "index": 2, "counts": { "superseded": 1, "retryable": 0, "permanent": 0 } },
+      { "index": 3, "counts": { "superseded": 2, "retryable": 0, "permanent": 0 } },
+      { "index": 4, "counts": { "superseded": 1, "retryable": 0, "permanent": 0 } },
+      { "index": 5, "counts": { "superseded": 1, "retryable": 1, "permanent": 0 } },
+      { "index": 6, "counts": { "superseded": 5, "retryable": 3, "permanent": 0 } },
+      { "index": 7, "counts": { "superseded": 1, "retryable": 0, "permanent": 0 } },
+      { "index": 8, "counts": { "superseded": 5, "retryable": 2, "permanent": 0 } },
+      { "index": 9, "counts": { "superseded": 1, "retryable": 0, "permanent": 0 } },
+      { "index": 10, "counts": { "superseded": 1, "retryable": 0, "permanent": 0 } },
+      { "index": 11, "counts": { "superseded": 3, "retryable": 3, "permanent": 0 } },
+      { "index": 12, "counts": { "superseded": 2, "retryable": 1, "permanent": 0 } },
+      { "index": 13, "counts": { "superseded": 0, "retryable": 0, "permanent": 1 } },
+      { "index": 14, "counts": { "superseded": 0, "retryable": 1, "permanent": 0 } },
+      { "index": 15, "counts": { "superseded": 2, "retryable": 1, "permanent": 0 } },
+      { "index": 16, "counts": { "superseded": 3, "retryable": 1, "permanent": 0 } },
+      { "index": 17, "counts": { "superseded": 0, "retryable": 0, "permanent": 0 } },
+      { "index": 18, "counts": { "superseded": 1, "retryable": 1, "permanent": 0 } },
+      { "index": 19, "counts": { "superseded": 4, "retryable": 0, "permanent": 0 } },
+      { "index": 20, "counts": { "superseded": 0, "retryable": 0, "permanent": 0 } },
+      { "index": 21, "counts": { "superseded": 8, "retryable": 2, "permanent": 0 } },
+      { "index": 22, "counts": { "superseded": 1, "retryable": 3, "permanent": 0 } },
+      { "index": 23, "counts": { "superseded": 4, "retryable": 0, "permanent": 0 } }
+    ]
+  },
+  "provenance": {
+    "durable_server_observed": true,
+    "public_aggregate_only": true,
+    "retention_seconds": 604800
+  }
+}

--- a/docs/proof/status-publication-outcomes/run-proof.mjs
+++ b/docs/proof/status-publication-outcomes/run-proof.mjs
@@ -1,0 +1,254 @@
+import assert from "node:assert/strict";
+import { spawn, execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { createWriteStream } from "node:fs";
+import { cp, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const root = process.cwd();
+const base = process.argv[2];
+const serveBrowser = process.argv.includes("--serve-browser");
+const workerOnly = serveBrowser || process.argv.includes("--worker-only");
+const wranglerBin = process.env.PUBLICATION_PROOF_WRANGLER;
+const wranglerVersion = wranglerBin
+  ? execFileSync(wranglerBin, ["--version"], { encoding: "utf8" }).trim()
+  : "4.107.0";
+assert.match(base ?? "", /^[a-f0-9]{40}$/, "pass the full approved baseline SHA");
+const proofPath = "docs/proof/status-publication-outcomes";
+const artifacts = path.join(root, ".artifacts/status-publication-outcomes");
+const scratch = await mkdtemp(path.join(tmpdir(), "publication-proof-"));
+const beforeRoot = path.join(scratch, "base");
+const children = [];
+const now = Date.now() - 1_000;
+const head = git(["rev-parse", "HEAD"]).trim();
+const dirty = git(["status", "--porcelain"]).trim() !== "";
+const patchSha256 = sha256(git(["diff", "--binary", base, "--", "dashboard"]));
+await mkdir(artifacts, { recursive: true });
+
+try {
+  await mkdir(beforeRoot);
+  execFileSync("git", ["archive", "-o", path.join(scratch, "base.tar"), base], { cwd: root });
+  execFileSync("tar", ["-xf", path.join(scratch, "base.tar"), "-C", beforeRoot]);
+  await symlink(path.join(root, "node_modules"), path.join(beforeRoot, "node_modules"));
+  await cp(path.join(root, proofPath), path.join(beforeRoot, proofPath), { recursive: true });
+  await cp(
+    path.join(root, "test/helpers/publication-status-fixture.ts"),
+    path.join(beforeRoot, "test/helpers/publication-status-fixture.ts"),
+  );
+  const results = [];
+  const browserResults = [];
+  for (const [label, source] of [
+    ["base", beforeRoot],
+    ["candidate", root],
+  ]) {
+    const preview = await startWorker(label, source);
+    for (const mode of ["cold", "durable", "fresh", "stale"]) {
+      for (const kind of ["observed", "idle", "mixed", "unknown", "lossy"]) {
+        if (kind === "lossy" && (mode === "cold" || mode === "durable")) continue;
+        await json(preview.origin, "/__proof/seed", {
+          method: "POST",
+          body: JSON.stringify({ mode, kind, now: Date.now() - 1_000 }),
+        });
+        const dedicated = await json(preview.origin, "/api/recent-durable-publication-events");
+        const response = await fetch(`${preview.origin}/api/status`);
+        assert.equal(response.status, 200);
+        const status = await response.json();
+        const nested = status.recent_durable_publication_events;
+        const expected = kind === "lossy" ? null : dedicated.recent_durable_publication_events;
+        const observations = await json(preview.origin, "/__proof/observations");
+        assert.equal(
+          response.headers.get("x-clawsweeper-cache"),
+          mode === "fresh" || mode === "stale" ? mode : "miss",
+        );
+        assert.equal(JSON.stringify(status).includes("withheld-publication-identity"), false);
+        if (mode === "durable") {
+          assert.equal(status.fleet.active_codex_jobs, 17);
+          assert.ok(observations.store_reads > 0);
+          assert.equal(observations.blocked_requests, 0);
+        }
+        if (label === "candidate") {
+          assert.deepEqual(nested, expected, `${mode}/${kind}: typed publication parity`);
+        } else {
+          assert.notDeepEqual(nested, expected, `${mode}/${kind}: baseline must reproduce loss`);
+          if (kind !== "lossy") {
+            assert.deepEqual(nested.direct.counts, {});
+            assert.equal(nested.captured_at, undefined);
+          }
+        }
+        results.push({
+          revision: label,
+          mode,
+          kind,
+          cache: response.headers.get("x-clawsweeper-cache"),
+          nested_sha256: sha256(JSON.stringify(nested)),
+          direct_accepted: nested?.direct?.counts?.accepted ?? null,
+          batch_retryable: nested?.batch?.counts?.retryable ?? null,
+          window: nested?.window?.id ?? null,
+          captured_at: nested?.captured_at ?? null,
+          projection_is_null: nested === null,
+          collection_state: nested?.collection?.state ?? null,
+          ...observations,
+        });
+      }
+    }
+    if (workerOnly) {
+      browserResults.push({ revision: label, origin: preview.origin, automated_browser: false });
+    } else {
+      const { proveBrowser } = await import("./browser-proof.mjs");
+      browserResults.push(await proveBrowser(preview.origin, label, artifacts, now));
+    }
+    if (!serveBrowser) await stopWorker(preview);
+  }
+  const summary = {
+    schema: "status-publication-outcomes-proof/v1",
+    base,
+    candidate_head: head,
+    candidate_dirty: dirty,
+    dashboard_patch_sha256: patchSha256,
+    runtime: {
+      node: process.version,
+      wrangler: wranglerVersion,
+      transport: "real loopback HTTP",
+      storage: "local SQLite-backed StatusStore",
+      synthetic_queue_binding: true,
+    },
+    generated_at: new Date().toISOString(),
+    paired_scenarios: results.filter((result) => result.revision === "candidate").length,
+    runs: results.length,
+    results,
+    production_mutations: 0,
+    worker_outbound_network: "denied by fixture",
+    browser_proof: browserResults,
+    limits: [
+      "Synthetic inputs; no production state or timing claim.",
+      "Corrected-input browser cases isolate browser ingestion using a fixture status route.",
+      "Worker-route browser cases fetch the real Worker status route; cached reload uses a controlled HTTP 503.",
+    ],
+  };
+  await writeFile(
+    path.join(artifacts, "worker-summary.json"),
+    JSON.stringify(summary, null, 2) + "\n",
+  );
+  console.log(
+    JSON.stringify({
+      base,
+      head,
+      dirty,
+      paired_scenarios: summary.paired_scenarios,
+      runs: summary.runs,
+      result: "passed",
+    }),
+  );
+  if (serveBrowser) {
+    console.log(JSON.stringify({ browser_previews: browserResults }));
+    await new Promise((resolve) => {
+      process.once("SIGINT", resolve);
+      process.once("SIGTERM", resolve);
+    });
+  }
+} finally {
+  for (const child of children) await stopWorker(child);
+  await rm(scratch, { recursive: true, force: true });
+}
+
+function git(args) {
+  return execFileSync("git", args, { cwd: root, encoding: "utf8" });
+}
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+async function json(origin, route, init) {
+  const response = await fetch(origin + route, init);
+  assert.equal(response.status, 200, `${route}: ${await response.clone().text()}`);
+  return response.json();
+}
+async function availablePort() {
+  const server = createServer();
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = server.address().port;
+  await new Promise((resolve) => server.close(resolve));
+  return port;
+}
+async function startWorker(label, source) {
+  const port = await availablePort();
+  const config = path.join(scratch, `${label}.json`);
+  await writeFile(
+    config,
+    JSON.stringify({
+      name: `publication-proof-${label}`,
+      main: path.join(source, proofPath, "fixture-worker.ts"),
+      compatibility_date: "2026-05-11",
+      send_metrics: false,
+      durable_objects: { bindings: [{ name: "LOCAL_STATUS_STORE", class_name: "StatusStore" }] },
+      migrations: [{ tag: "proof-v1", new_sqlite_classes: ["StatusStore"] }],
+    }),
+  );
+  const logPath = path.join(scratch, `${label}.log`);
+  const log = createWriteStream(logPath);
+  const child = spawn(
+    wranglerBin || "npx",
+    [
+      ...(wranglerBin ? [] : ["--yes", "wrangler@4.107.0"]),
+      "dev",
+      "--local",
+      "--config",
+      config,
+      "--ip",
+      "127.0.0.1",
+      "--port",
+      String(port),
+      "--persist-to",
+      path.join(scratch, `${label}-state`),
+    ],
+    {
+      cwd: scratch,
+      detached: true,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: {
+        PATH: process.env.PATH,
+        HOME: process.env.HOME,
+        TMPDIR: process.env.TMPDIR,
+        NO_COLOR: "1",
+        XDG_CONFIG_HOME: path.join(scratch, "config"),
+        WRANGLER_SEND_METRICS: "false",
+        WRANGLER_LOG_PATH: path.join(scratch, "logs"),
+        CI: "1",
+      },
+    },
+  );
+  child.stdout.pipe(log);
+  child.stderr.pipe(log);
+  const preview = { child, log, origin: `http://127.0.0.1:${port}`, stopped: false };
+  children.push(preview);
+  const deadline = Date.now() + 60_000;
+  while (Date.now() < deadline && child.exitCode === null) {
+    try {
+      if ((await fetch(`${preview.origin}/__proof/ready`)).ok) return preview;
+    } catch {}
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+  const output = (await readFile(logPath, "utf8"))
+    .replaceAll(root, "<checkout>")
+    .replaceAll(scratch, "<proof>");
+  throw new Error(`local ${label} Worker failed to start:\n${output}`);
+}
+async function stopWorker(preview) {
+  if (preview.stopped) return;
+  preview.stopped = true;
+  for (const signal of ["SIGTERM", "SIGKILL"]) {
+    try {
+      process.kill(-preview.child.pid, signal);
+    } catch (error) {
+      if (error.code !== "ESRCH") throw error;
+    }
+    if (signal === "SIGTERM" && preview.child.exitCode === null) {
+      await Promise.race([
+        new Promise((resolve) => preview.child.once("exit", resolve)),
+        new Promise((resolve) => setTimeout(resolve, 2_000)),
+      ]);
+    }
+  }
+  await new Promise((resolve) => preview.log.end(resolve));
+}

--- a/test/dashboard-worker-dashboard-status.test.ts
+++ b/test/dashboard-worker-dashboard-status.test.ts
@@ -21,6 +21,11 @@ import {
   buildExactReviewQueueRequest,
 } from "./dashboard-worker-harness.ts";
 import { publicHealthHistoryContract } from "../dashboard/worker.ts";
+import { publicRecentDurablePublicationEventsProjection } from "../dashboard/public-observability.ts";
+import {
+  publicationEventsFixture,
+  publicationStatusFixture,
+} from "./helpers/publication-status-fixture.ts";
 
 const ISSUE_TRIAGE_VIEW_IDS = [
   "clawsweeper",
@@ -924,7 +929,7 @@ test("dashboard sanitizes stored status immediately and never renders transport 
   assert.ok(script);
   const marker = "synthetic-browser-storage-marker";
 
-  const run = async (cachedStatus: string | null) => {
+  const run = async (cachedStatus: string | null, fetchedStatus?: unknown) => {
     const elements = new Map<string, Record<string, unknown>>();
     const elementFor = (id: string) => {
       if (!elements.has(id)) {
@@ -962,6 +967,7 @@ test("dashboard sanitizes stored status immediately and never renders transport 
       fetch: async () => ({
         headers: { get: () => null },
         json: async () => {
+          if (fetchedStatus !== undefined) return structuredClone(fetchedStatus);
           throw new Error(`${marker} https://invalid.example/private?item=1`);
         },
         ok: true,
@@ -983,7 +989,7 @@ test("dashboard sanitizes stored status immediately and never renders transport 
     });
     new Script(script).runInContext(context);
     await new Promise((resolve) => setTimeout(resolve, 0));
-    return { elements, removed, writes };
+    return { context, elements, removed, writes };
   };
 
   const cached = JSON.stringify({
@@ -1038,6 +1044,105 @@ test("dashboard sanitizes stored status immediately and never renders transport 
   assert.equal(invalidCache.removed, true);
   assert.equal(invalidCache.writes.length, 0);
   assert.doesNotMatch(JSON.stringify([...invalidCache.elements.values()]), new RegExp(marker, "i"));
+
+  for (const complete of [
+    [true, true],
+    [true, false],
+    [false, true],
+    [false, false],
+  ]) {
+    for (const idle of [false, true]) {
+      const events = publicRecentDurablePublicationEventsProjection(
+        publicationEventsFixture(Date.now(), complete, idle),
+      )!;
+      const expected = {
+        window: { id: events.window.id },
+        collection: { state: events.collection.state },
+        direct: { counts: { accepted: events.direct.counts.accepted } },
+        batch: { counts: { retryable: events.batch.counts.retryable } },
+      };
+      const status = {
+        ...publicationStatusFixture(),
+        recent_durable_publication_events: { ...events, private_marker: marker },
+      };
+      const fetched = await run(null, status);
+      const stored = fetched.writes.at(-1)!;
+      assert.deepEqual(JSON.parse(stored).recent_durable_publication_events, expected);
+      assert.equal(stored.includes(marker), false);
+      const reloaded = await run(stored);
+      assert.deepEqual(
+        JSON.parse(reloaded.writes.at(-1)!).recent_durable_publication_events,
+        expected,
+      );
+      for (const result of [fetched, reloaded]) {
+        const rendered = String(
+          result.elements.get("recent-durable-publication-events")?.innerHTML,
+        );
+        assert.match(rendered, /Trailing 24h window/);
+        assert.ok(
+          rendered.includes(`<strong>${expected.direct.counts.accepted ?? "unknown"}</strong>`),
+        );
+        assert.ok(
+          rendered.includes(`<strong>${expected.batch.counts.retryable ?? "unknown"}</strong>`),
+        );
+        assert.deepEqual(
+          JSON.parse(
+            JSON.stringify(
+              result.context.dashboardStatusSnapshot(result.context.dashboardStatusSnapshot(status))
+                .recent_durable_publication_events,
+            ),
+          ),
+          expected,
+        );
+      }
+    }
+  }
+
+  const browser = withoutCache.context;
+  const project = (events: unknown) =>
+    JSON.parse(
+      JSON.stringify(
+        browser.dashboardStatusSnapshot({
+          ...publicationStatusFixture(),
+          recent_durable_publication_events: events,
+        }).recent_durable_publication_events,
+      ),
+    );
+  assert.equal(project(null), null);
+  assert.equal(project(undefined), null);
+  for (const count of [undefined, null, -1, 0.5, 10_001, "1", NaN, Infinity]) {
+    for (const [lane, outcome] of [
+      ["direct", "accepted"],
+      ["batch", "retryable"],
+    ]) {
+      const events = publicationEventsFixture();
+      const projected = project({ ...events, [lane]: { counts: { [outcome]: count } } });
+      assert.equal(projected[lane].counts[outcome], null);
+      assert.equal(projected.collection.state, "unknown");
+      assert.deepEqual(project(projected), projected);
+    }
+  }
+  const bounded = project({
+    ...publicationEventsFixture(),
+    direct: { counts: { accepted: 10_000 } },
+    batch: { counts: { retryable: 10_000 } },
+  });
+  assert.equal(bounded.direct.counts.accepted, 10_000);
+  assert.equal(bounded.batch.counts.retryable, 10_000);
+  const closed = project({
+    ...publicationEventsFixture(),
+    window: { id: marker },
+    collection: { state: marker },
+    direct: { counts: {} },
+    batch: { counts: {} },
+  });
+  assert.deepEqual(closed, {
+    window: { id: null },
+    collection: { state: "unknown" },
+    direct: { counts: { accepted: null } },
+    batch: { counts: { retryable: null } },
+  });
+  assert.equal(JSON.stringify(closed).includes(marker), false);
 });
 
 test("dashboard reprojects separately fetched public observability before rendering", async () => {

--- a/test/dashboard-worker-status-privacy.test.ts
+++ b/test/dashboard-worker-status-privacy.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
+import { publicRecentDurablePublicationEventsProjection } from "../dashboard/public-observability.ts";
+import {
+  publicationEventsFixture,
+  publicationStatusFixture,
+} from "./helpers/publication-status-fixture.ts";
 
 import worker, {
   activeBayItemKeys,
@@ -1122,9 +1127,58 @@ test("public status freshness rejects a future generated timestamp", () => {
   );
 });
 
-test("public status filters a legacy cached body before it can be served", async () => {
+test("composed publication outcomes retain the dedicated projection through repeated sanitation", () => {
+  for (const complete of [
+    [true, true],
+    [true, false],
+    [false, true],
+    [false, false],
+  ]) {
+    for (const idle of [false, true]) {
+      const events = publicationEventsFixture(Date.parse(STATUS_NOW), complete, idle);
+      const expected = publicRecentDurablePublicationEventsProjection(events);
+      assert.ok(expected);
+      const projected = publicStatusProjection({
+        recent_durable_publication_events: {
+          ...events,
+          private_marker: "withheld-publication-identity",
+          direct: { ...events.direct, private_marker: "withheld-publication-identity" },
+        },
+      });
+      assert.deepEqual(projected.recent_durable_publication_events, expected);
+      assert.deepEqual(strictPublicStatusProjection(projected), projected);
+      assert.equal(JSON.stringify(projected).includes("withheld-publication-identity"), false);
+    }
+  }
+});
+
+test("composed publication outcomes reject lossy or inconsistent cached values", () => {
+  const valid = publicationEventsFixture(Date.parse(STATUS_NOW));
+  const malformed = [
+    { ...valid, direct: { ...valid.direct, counts: {} } },
+    { ...valid, captured_at: "not-a-timestamp" },
+    { ...valid, direct: { ...valid.direct, rows: 2 } },
+    { ...valid, batch: { ...valid.batch, buckets: valid.batch.buckets.slice(1) } },
+    { ...valid, direct: { ...valid.direct, counts: { ...valid.direct.counts, accepted: -1 } } },
+    null,
+  ];
+  for (const events of malformed) {
+    assert.equal(
+      publicStatusProjection({ recent_durable_publication_events: events })
+        .recent_durable_publication_events,
+      null,
+    );
+  }
+  assert.equal("recent_durable_publication_events" in publicStatusProjection({}), false);
+});
+
+test("public status filters a legacy cached body before it can be served", async (t) => {
   const originalCaches = globalThis.caches;
   const entries = new Map<string, Response>();
+  const pending: Promise<unknown>[] = [];
+  t.mock.method(globalThis, "fetch", async () => {
+    throw new Error("outbound network disabled in status fixture");
+  });
   Object.defineProperty(globalThis, "caches", {
     configurable: true,
     value: {
@@ -1150,6 +1204,7 @@ test("public status filters a legacy cached body before it can be served", async
           automatic_work: [],
           pipeline: [],
           recent: {},
+          recent_durable_publication_events: publicationEventsFixture(Date.parse(STATUS_NOW)),
           workers: [
             {
               workflow_title: "synthetic cache title",
@@ -1215,6 +1270,12 @@ test("public status filters a legacy cached body before it can be served", async
       errors: ["telemetry_unavailable"],
       error_count: 1,
     });
+    assert.deepEqual(
+      body.recent_durable_publication_events,
+      publicRecentDurablePublicationEventsProjection(
+        publicationEventsFixture(Date.parse(STATUS_NOW)),
+      ),
+    );
 
     entries.delete("https://clawsweeper.openclaw.ai/api/status-cache/v7/_/fresh");
     await globalThis.caches.default.put(
@@ -1229,6 +1290,7 @@ test("public status filters a legacy cached body before it can be served", async
           pipeline: [],
           bay: {},
           recent: {},
+          recent_durable_publication_events: publicationEventsFixture(Date.parse(STATUS_NOW)),
           diagnostics: { errors: [], error_count: 0 },
         }),
         {
@@ -1244,13 +1306,19 @@ test("public status filters a legacy cached body before it can be served", async
     const staleResponse = await worker.fetch(
       new Request("https://clawsweeper.openclaw.ai/api/status"),
       {},
-      { waitUntil: () => undefined },
+      { waitUntil: (promise: Promise<unknown>) => pending.push(promise) },
     );
     assert.equal(staleResponse.status, 200);
     assert.equal(staleResponse.headers.get("x-clawsweeper-cache"), "stale");
     assert.equal(staleResponse.headers.get("location"), null);
     assert.equal(staleResponse.headers.get("set-cookie"), null);
     assert.equal(staleResponse.headers.get("x-private-marker"), null);
+    const staleBody = await staleResponse.json();
+    assert.deepEqual(
+      staleBody.recent_durable_publication_events,
+      body.recent_durable_publication_events,
+    );
+    await Promise.all(pending);
 
     entries.delete("https://clawsweeper.openclaw.ai/api/status-cache/v7/_/stale");
     await globalThis.caches.default.put(
@@ -1301,7 +1369,65 @@ test("public status filters a legacy cached body before it can be served", async
     });
     assert.equal(malformedResponse.headers.get("x-private-marker"), null);
   } finally {
+    await Promise.allSettled(pending);
     Object.defineProperty(globalThis, "caches", { configurable: true, value: originalCaches });
+  }
+});
+
+test("cold and durable-cache status preserve the dedicated publication contract", async (t) => {
+  const originalCaches = globalThis.caches;
+  Object.defineProperty(globalThis, "caches", {
+    configurable: true,
+    value: { default: { match: async () => undefined, put: async () => undefined } },
+  });
+  const outbound: string[] = [];
+  t.mock.method(globalThis, "fetch", async (input: Request | string | URL) => {
+    outbound.push(String(input instanceof Request ? input.url : input));
+    throw new Error("outbound network disabled in status fixture");
+  });
+  t.after(() => {
+    Object.defineProperty(globalThis, "caches", { configurable: true, value: originalCaches });
+  });
+
+  for (const cached of [false, true]) {
+    const events = publicationEventsFixture();
+    const reads: string[] = [];
+    const env = {
+      STATUS_STORE: {
+        async get(key: string) {
+          reads.push(key);
+          return cached && key === "snapshot:bay-scope:v1:_"
+            ? JSON.stringify(publicationStatusFixture(events))
+            : null;
+        },
+        async put() {},
+      },
+      EXACT_REVIEW_QUEUE: {
+        idFromName: (name: string) => name,
+        get: () => ({
+          async fetch(request: Request) {
+            return new URL(request.url).pathname === "/recent-durable-publication-events"
+              ? Response.json({ recent_durable_publication_events: events })
+              : Response.json({ error: "unavailable in publication fixture" }, { status: 503 });
+          },
+        }),
+      },
+    };
+    outbound.length = 0;
+    const dedicated = await worker.fetch(
+      new Request("https://example.invalid/api/recent-durable-publication-events"),
+      env,
+    );
+    const response = await worker.fetch(new Request("https://example.invalid/api/status"), env);
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.deepEqual(
+      body.recent_durable_publication_events,
+      (await dedicated.json()).recent_durable_publication_events,
+    );
+    assert.equal(body.recent_durable_publication_events.direct.counts.accepted, 1);
+    assert.ok(reads.includes("snapshot:bay-scope:v1:_"));
+    assert.equal(outbound.length === 0, cached, "durable snapshot reuse must skip collection");
   }
 });
 

--- a/test/helpers/publication-status-fixture.ts
+++ b/test/helpers/publication-status-fixture.ts
@@ -1,0 +1,61 @@
+export function publicationEventsFixture(now = Date.now(), complete = [true, true], idle = false) {
+  const capturedAt = new Date(now).toISOString();
+  const source = (outcomes: string[], known: boolean) => ({
+    complete: known,
+    rows: known ? (idle ? 0 : 1) : null,
+    latest_observed_at: known && !idle ? capturedAt : null,
+    counts: Object.fromEntries(
+      outcomes.map((outcome, index) => [outcome, known ? Number(!idle && index === 0) : null]),
+    ),
+    buckets: Array.from({ length: 24 }, (_, index) => ({
+      index,
+      counts: Object.fromEntries(
+        outcomes.map((outcome, position) => [
+          outcome,
+          known ? Number(!idle && index === 23 && position === 0) : null,
+        ]),
+      ),
+    })),
+  });
+  return {
+    version: 1,
+    captured_at: capturedAt,
+    window: {
+      id: "24h",
+      start_at: new Date(now - 86_400_000).toISOString(),
+      end_at: capturedAt,
+      bucket_seconds: 3_600,
+      bucket_count: 24,
+    },
+    collection: {
+      state: complete.every(Boolean) ? "complete" : complete.some(Boolean) ? "mixed" : "unknown",
+      complete: complete.every(Boolean),
+      scan_limit: 10_000,
+    },
+    activity: { state: complete.every(Boolean) ? (idle ? "idle" : "observed") : "unknown" },
+    direct: source(["accepted", "deduped", "superseded", "fallback"], complete[0]!),
+    batch: source(["retryable", "superseded", "permanent"], complete[1]!),
+  };
+}
+
+export function publicationStatusFixture(events = publicationEventsFixture()) {
+  return {
+    schema_version: 1,
+    generated_at: events.captured_at,
+    fleet: {},
+    workers: [],
+    automatic_work: [],
+    pipeline: [],
+    bay: {
+      timings: {
+        sample_kind: "completed_review_journeys",
+        source: "durable_exact_review_lifecycles",
+        completion_source: "verified_final_review_receipts",
+        including_legacy_batch: { overall: {}, history: {} },
+      },
+    },
+    recent: {},
+    diagnostics: { errors: [], error_count: 0 },
+    recent_durable_publication_events: events,
+  };
+}


### PR DESCRIPTION
## What Problem This Solves

Publication counts and window labels disappear after dashboard status composition or browser reload. A legacy cached value can also display a complete badge beside unknown counts. This replaces https://github.com/openclaw/clawsweeper/pull/1491 on current main and preserves Vincent Koc's contribution.

## Why This Change Was Made

The Worker now reapplies its canonical publication projection after the general status sanitizer. The browser separately retains the four fields it renders, preserving explicit zeroes and incomplete collections without expanding the general public allowlist. No queue admission, publication, or API schema changes are introduced.

The proof runner can retain its local previews for validation in an existing Chrome profile and reuse an installed Wrangler while recording its version.

## User Impact

Known publication counts and time windows survive refresh and cached reload. Incomplete or malformed displayed counts remain unknown and cannot retain a misleading complete badge.

OpenClaw Bay consumes status but does not select this field; its observer-only rendering and controls are unaffected. Merging dashboard code uses the repository's normal Worker deployment workflow.

## Evidence

- Node 24.20.0; frozen pnpm 11.10.0 dependencies.
- 88 focused dashboard/status/privacy tests passed.
- Static checks, all builds, lint, and changed-file coverage passed locally. Exact-head CI passed at https://github.com/openclaw/clawsweeper/actions/runs/34655384968, including the full check. The Mac full-suite attempt and fresh-private-temp retry stalled; local full-suite completion is not claimed.
- Before/after desktop and repaired mobile screenshots below were inspected and contain only the synthetic local dashboard.
- Release notes are intentionally consolidated in the final batch notes PR.

## Real Behavior Proof

Claim: the real composed Worker status retains its canonical publication contract, and the served dashboard retains rendered counts through HTTP fetch, localStorage, and an HTTP 503 reload.

Command: `PUBLICATION_PROOF_WRANGLER=/opt/homebrew/bin/wrangler node docs/proof/status-publication-outcomes/run-proof.mjs 49446cd30622e642efceb80e1c0347b2602a0117 --serve-browser`.

Environment: local Wrangler 4.129.0 with a real SQLite-backed StatusStore; synthetic queue input; Worker outbound fetch denied. Browser proof used the existing Chrome profile through the authenticated OpenClaw extension relay, without production credentials or data.

Observed: 18 paired Worker scenarios / 36 runs passed across cold, durable, fresh and stale status paths. Main strips counts and metadata; the candidate exactly matches the dedicated endpoint and rejects lossy cached values. In the real browser, three desktop baseline cases reproduce unknown counts; repaired desktop observed, zero, mixed, unknown and lossy inputs plus an observed mobile case retain the expected values after HTTP 503 reload. No private fixture marker reaches browser storage. Screenshots show the actual served publication section.

Artifacts: `worker-summary.json` and `browser-summary.json` are retained with the batch report; the committed recipe reproduces the Worker scenarios. The tested dashboard patch digest matches committed head `ee9b75ed58b91d891ca694d52066667b17959843`; both precommit and committed-branch autoreviews are clean through P2.

Limits: synthetic local input, not production health or latency proof. Additional mobile permutations were interrupted by a local relay outage and preview process failure; those unfinished permutations are not claimed. Existing automated browser recipes remain available for environments that permit an isolated browser. No production mutation was performed by this proof.

![Before: current main loses publication counts and the window](https://github.com/user-attachments/assets/7efc011d-dd1a-4bae-a7a8-57f26ba32053)

![After: counts and window survive a cached reload](https://github.com/user-attachments/assets/024cb4fa-db5c-4b45-a5c8-4b91eb405abc)

![After: the real publication panel fits the mobile viewport](https://github.com/user-attachments/assets/0dc90e32-8253-4c45-8002-2f99945c8b8f)