### PR TITLE
fix(test): prevent host settings from breaking validation fixtures

### DIFF
--- a/test/agent-input-scan.test.ts
+++ b/test/agent-input-scan.test.ts
@@ -10,11 +10,12 @@ import {
   readFileSync,
   realpathSync,
   rmSync,
+  statSync,
   symlinkSync,
   truncateSync,
   writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
+import { devNull, tmpdir } from "node:os";
 import { syncBuiltinESMExports } from "node:module";
 import { dirname, join } from "node:path";
 import test from "node:test";
@@ -522,16 +523,61 @@ test("repair admission includes staged bytes when working bytes were restored", 
 
 function useGitConfigHome(t: test.TestContext, root: string) {
   const home = join(root, "home");
-  mkdirSync(home);
-  const previous = new Map(["HOME", "XDG_CONFIG_HOME"].map((key) => [key, process.env[key]]));
-  for (const key of previous.keys()) process.env[key] = home;
+  const globalConfig = join(home, ".gitconfig");
+  const previous = new Map(
+    ["HOME", "XDG_CONFIG_HOME", "GIT_CONFIG_GLOBAL"].map((key) => [key, process.env[key]]),
+  );
   t.after(() => {
     for (const [key, original] of previous) {
       if (original === undefined) delete process.env[key];
       else process.env[key] = original;
     }
   });
+  mkdirSync(home);
+  writeFileSync(globalConfig, "", { mode: 0o600 });
+  process.env.HOME = home;
+  process.env.XDG_CONFIG_HOME = home;
+  // GIT_CONFIG_GLOBAL overrides HOME, including a host's read-only /dev/null binding.
+  process.env.GIT_CONFIG_GLOBAL = globalConfig;
 }
+
+test("Git config fixtures restore unset, empty, and disabled global bindings", async (t) => {
+  const previous = process.env.GIT_CONFIG_GLOBAL;
+  t.after(() => {
+    if (previous === undefined) delete process.env.GIT_CONFIG_GLOBAL;
+    else process.env.GIT_CONFIG_GLOBAL = previous;
+  });
+  for (const original of [undefined, "", devNull]) {
+    if (original === undefined) delete process.env.GIT_CONFIG_GLOBAL;
+    else process.env.GIT_CONFIG_GLOBAL = original;
+    const home = process.env.HOME;
+    const xdgConfigHome = process.env.XDG_CONFIG_HOME;
+    await t.test(original === undefined ? "unset" : original === "" ? "empty" : "disabled", (t) => {
+      const root = mkdtempSync(join(tmpdir(), "clawsweeper-git-config-test-"));
+      t.after(() => rmSync(root, { recursive: true, force: true }));
+      useGitConfigHome(t, root);
+      const config = join(root, "home", ".gitconfig");
+      assert.equal(process.env.HOME, join(root, "home"));
+      assert.equal(process.env.XDG_CONFIG_HOME, process.env.HOME);
+      assert.equal(process.env.GIT_CONFIG_GLOBAL, config);
+      assert.equal(readFileSync(config, "utf8"), "");
+      if (process.platform !== "win32") assert.equal(statSync(config).mode & 0o777, 0o600);
+      execFileSync("git", ["config", "--global", "fixture.scope", "private"], { cwd: root });
+      assert.equal(
+        execFileSync("git", ["config", "--global", "--get", "fixture.scope"], {
+          cwd: root,
+          encoding: "utf8",
+        }).trim(),
+        "private",
+      );
+      assert.match(readFileSync(config, "utf8"), /scope = private/);
+    });
+    assert.equal(process.env.GIT_CONFIG_GLOBAL, original);
+    assert.equal(Object.hasOwn(process.env, "GIT_CONFIG_GLOBAL"), original !== undefined);
+    assert.equal(process.env.HOME, home);
+    assert.equal(process.env.XDG_CONFIG_HOME, xdgConfigHome);
+  }
+});
 
 for (const { scope, value } of [
   { scope: "repository", value: "true" },

--- a/test/repair/exact-review-queue-maintenance-workflow.test.ts
+++ b/test/repair/exact-review-queue-maintenance-workflow.test.ts
@@ -1,10 +1,19 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
 import { createHash, createHmac } from "node:crypto";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  accessSync,
+  constants,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { createServer } from "node:https";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, isAbsolute, join } from "node:path";
 import test from "node:test";
 import { promisify } from "node:util";
 import YAML from "yaml";
@@ -369,9 +378,67 @@ test("maintenance CLI signs one HTTPS dry run, redacts identities, and refuses r
     mergeCommitSha: "c".repeat(40),
   };
   writeFileSync(join(directory, "closed-publication-retirement.json"), JSON.stringify(plan));
-  assert.equal((await promisify(execFile)("pnpm", ["--version"])).stdout.trim(), "11.10.0");
+  const runtimeEnv: NodeJS.ProcessEnv = {
+    TMPDIR: directory,
+    TMP: directory,
+    TEMP: directory,
+    BASH_ENV: "/dev/null",
+    COREPACK_ENV_FILE: "0",
+    COREPACK_ENABLE_NETWORK: "0",
+    COREPACK_ENABLE_DOWNLOAD_PROMPT: "0",
+    COREPACK_DEFAULT_TO_LATEST: "0",
+  };
+  // Keep pnpm's install context so its dependency check does not see a different
+  // virtual-store setting and try to reinstall before the workflow CLI starts.
+  for (const key of [
+    "CI",
+    "PATH",
+    "HOME",
+    "USERPROFILE",
+    "XDG_CACHE_HOME",
+    "LOCALAPPDATA",
+    "COREPACK_HOME",
+    "PNPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE",
+    "pnpm_config_enable_global_virtual_store",
+  ]) {
+    const value = process.env[key];
+    if (value !== undefined) runtimeEnv[key] = value;
+  }
+  const searchPath = runtimeEnv.PATH;
+  assert.ok(searchPath, "the real pnpm and Bash probes require the current toolchain PATH");
+  const bashCandidate = searchPath
+    .split(delimiter)
+    .filter(isAbsolute)
+    .map((directory) => join(directory, process.platform === "win32" ? "bash.exe" : "bash"))
+    .find((candidate) => {
+      try {
+        accessSync(candidate, constants.X_OK);
+        return statSync(candidate).isFile();
+      } catch {
+        return false;
+      }
+    });
+  assert.ok(bashCandidate, "an executable Bash must be available on the same toolchain PATH");
+  const bash = realpathSync(bashCandidate);
+  assert.ok(isAbsolute(bash));
+  const bashArgs = ["--noprofile", "--norc", "-euo", "pipefail", "-c"];
+  const runtime = { cwd: process.cwd(), env: runtimeEnv, timeout: 10_000 };
+  assert.equal(
+    (
+      await promisify(execFile)(
+        process.execPath,
+        ["-e", "process.stdout.write(require('node:os').tmpdir())"],
+        runtime,
+      )
+    ).stdout,
+    directory,
+  );
+  assert.equal(
+    (await promisify(execFile)(bash, [...bashArgs, "pnpm --version"], runtime)).stdout.trim(),
+    "11.10.0",
+  );
   const env = {
-    PATH: process.env.PATH,
+    ...runtimeEnv,
     NODE_EXTRA_CA_CERTS: cert,
     EXACT_REVIEW_QUEUE_URL: endpoint,
     CLAWSWEEPER_WEBHOOK_SECRET: secret,
@@ -387,12 +454,13 @@ test("maintenance CLI signs one HTTPS dry run, redacts identities, and refuses r
     (step) => step.name === "Prepare closed publication retirement",
   )!;
   const executeWorkflowStep = () =>
-    promisify(execFile)("bash", ["-euo", "pipefail", "-c", execute.run!], {
+    promisify(execFile)(bash, [...bashArgs, execute.run!], {
+      ...runtime,
       env,
-      timeout: 10_000,
     });
   await assert.rejects(
-    promisify(execFile)("bash", ["-euo", "pipefail", "-c", prepare.run!], {
+    promisify(execFile)(bash, [...bashArgs, prepare.run!], {
+      ...runtime,
       env: {
         ...env,
         GH_TOKEN: "synthetic-token",
@@ -401,7 +469,6 @@ test("maintenance CLI signs one HTTPS dry run, redacts identities, and refuses r
         PUBLICATION_KEY_SHA256: plan.publicationKeySha256,
         QUEUE_REVISION: "8",
       },
-      timeout: 10_000,
     }),
     (error: Error & { stdout: string; stderr: string }) => {
       assert.match(error.stderr, /"status":"retirement_failed"/);
@@ -418,7 +485,7 @@ test("maintenance CLI signs one HTTPS dry run, redacts identities, and refuses r
       promisify(execFile)(
         "pnpm",
         ["run", "--silent", "repair:exact-review-queue-maintenance", ...args],
-        { env, timeout: 10_000 },
+        { ...runtime, env },
       ),
       (error: Error & { stderr: string }) => {
         assert.match(error.stderr, /invalid arguments/);


### PR DESCRIPTION
## What Problem This Solves

Resolves validation fixtures failing under isolated runners when inherited Git configuration, Corepack locations, or pnpm installation settings differ from an interactive shell. The maintenance fixture could otherwise attempt dependency reconciliation before reaching the workflow behavior being tested.

## Why This Change Was Made

Give Git fixtures a private global configuration and restore unset, empty, and disabled bindings exactly. Run maintenance subprocesses with a bounded environment that retains the installed toolchain context, private temporary storage, offline Corepack, and an explicitly resolved non-interactive Bash. Production behavior and dependency-verification policy are unchanged.

## User Impact

More reliable local and isolated validation. No shipped runtime change. Production LOC delta: 0; tests: +126/-13.

## OpenClaw Bay Impact

None. These test fixtures do not change queue, publication, telemetry, or dashboard contracts.

## Documentation Impact

Reviewed `CONTRIBUTING.md` and `docs/repair/README.md`. Existing toolchain and validation instructions remain accurate; no documentation or release-note change is required for this test-only repair.

## Evidence

- Signed head: `10a89bab2862d242415e219f5ee909250610c16f`.
- Patch SHA-256: `49bc535f881c9b6c54d9af29a3c763a7a2a8af58685d43a5ca4de25970abb9b5`.
- Fresh native precommit review: no actionable findings. Committed review and current-head CI remain required before merge.
- Full `pnpm run check` passed on the prerequisite plus Vite composite tree `76344ac99f7b2a913a1ce4163f4dd3729433018c`: exit 0 in 342512ms, output SHA-256 `16f6e6833623527a8bdffe47d2d91fec33b70b4a946d40bc9efac1b567543a29`.

## Real Behavior Proof

**Claim:** the fixtures exercise real Git and the maintenance CLI in isolated runner profiles without depending on the operator's global configuration or leaking temporary storage.

**Command:**

```sh
node --test --test-reporter=tap --test-concurrency=1 test/agent-input-scan.test.ts test/repair/exact-review-queue-maintenance-workflow.test.ts
```

**Environment/scenarios:** Linux Blacksmith Testbox; Node 24.18.1, pnpm 11.10.0, Corepack 0.36.0; private HOME/XDG storage; umask 0077; native read-only mounts and isolated network namespace. Both explicit `COREPACK_HOME` and the default branch-owned Corepack cache route passed, with unchanged prepared bytes/source and zero background processes. Real Git writes a private 0600 global config and restores unset, empty, and `/dev/null` bindings.

The real maintenance command used Node, pnpm, OpenSSL, resolved Bash, and a loopback HTTPS server. Assertions cover private TMPDIR, HMAC signing, one reconciliation pass, redacted output, invalid arguments, and refusal of redirects, HTTP 500, and array responses. It does not inherit a dependency-verification override. The separate fake-pnpm argv test is supplemental, not native behavior proof.

**Trace:** [run 34623068156, attempt 1](https://github.com/openclaw/openclaw/actions/runs/34623068156), job `103341476410`, records maintenance-first and both Vite prerequisite routes. [Run 34654403457, attempt 1](https://github.com/openclaw/openclaw/actions/runs/34654403457), job `103443546801`, repeats both prerequisite routes on the Knip composite and records the passing full Vite gate. Required native capture SHA-256: `5740bc0b0a87c9c352b50dc4309e7560d2d247604d5cc34fd0e86b23218f0835`.

**Limits:** synthetic HTTPS credentials/responses; no production queue or GitHub mutation. Landlock was unavailable; native read-only mounts were observed. The full check was not network-isolated. Both overall proof runs failed later in separate native-helper stages; only their individually verified passing receipts are claimed here. Current PR CI must qualify the merge with current main.
