### PR TITLE
fix(review): retain item identity during shard recovery

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -6044,17 +6044,19 @@ jobs:
               --target-repo "${{ needs.plan.outputs.target_repo }}" --shard "$shard" \
               --shard-count "${{ needs.plan.outputs.planned_shards }}" --item-numbers "$planned_items")"
             echo "$result" | jq -r '.items[] | "Item #\(.number): \(.disposition) (\(.reason))"' | tee -a "$GITHUB_STEP_SUMMARY"
-            while IFS= read -r item_number; do
-              recovery_items+=("$item_number")
-            done < <(jq -r '.retryable[]' <<<"$result")
+            while IFS= read -r recovery_item; do
+              recovery_items+=("$recovery_item")
+            done < <(jq -c 'if .evidence_complete then .items[] | select(.disposition == "retryable") | {number, kind} else empty end' <<<"$result")
           done < <(jq -r --arg failed ",$failed_shards," '.[] | select(.shard as $s | $failed | contains("," + ($s | tostring) + ",")) | [.shard, .item_numbers] | @tsv' <<<"$MATRIX_JSON")
-          item_numbers="$(IFS=,; echo "${recovery_items[*]}")"
-          if [ -z "$item_numbers" ]; then
+          if [ "${#recovery_items[@]}" -eq 0 ]; then
             echo "No evidence-backed retryable item terminals; failed review work remains terminal, completed, or held." | tee -a "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
+          item_numbers="$(printf '%s\n' "${recovery_items[@]}" | jq -r '.number' | paste -sd, -)"
           failed_recovery_dispatches=()
-          for item_number in "${recovery_items[@]}"; do
+          for recovery_item in "${recovery_items[@]}"; do
+            item_number="$(jq -er '.number' <<<"$recovery_item")"
+            item_kind="$(jq -er '.kind | select(. == "issue" or . == "pull_request")' <<<"$recovery_item")"
             if ! [[ "$item_number" =~ ^[0-9]+$ ]]; then
               echo "Invalid failed-review recovery item number: $item_number" >&2
               exit 1
@@ -6064,6 +6066,7 @@ jobs:
               --arg target_repo "${{ needs.plan.outputs.target_repo }}" \
               --arg target_branch "${{ needs.plan.outputs.target_branch }}" \
               --arg item_number "$item_number" \
+              --arg item_kind "$item_kind" \
               --arg dispatch_key "$dispatch_key" \
               --arg codex_timeout_ms "${{ needs.plan.outputs.codex_timeout_ms }}" \
               --arg additional_prompt "$recovery_prompt" \
@@ -6073,8 +6076,8 @@ jobs:
                   targetRepo: $target_repo,
                   targetBranch: $target_branch,
                   itemNumber: ($item_number | tonumber),
-                  itemKind: "issue",
-                  sourceEvent: "issues",
+                  itemKind: $item_kind,
+                  sourceEvent: (if $item_kind == "pull_request" then "pull_request" else "issues" end),
                   sourceAction: "failed_review_shard_recovery",
                   supersedesInProgress: false,
                   codexTimeoutMs: ($codex_timeout_ms | tonumber),

--- a/docs/proof/aggregate-review-recovery/fixture.mjs
+++ b/docs/proof/aggregate-review-recovery/fixture.mjs
@@ -64,7 +64,7 @@ export async function fixture(root, kind = "mixed") {
   const items = planned.map((number) => ({
     repo: targetRepo,
     number,
-    kind: "issue",
+    kind: kind === "mixed-identities" && [3, 7].includes(number) ? "pull_request" : "issue",
     title: "Synthetic recovery fixture",
     updatedAt: producerEnv.GITHUB_RUN_STARTED_AT,
   }));
@@ -83,7 +83,7 @@ export async function fixture(root, kind = "mixed") {
     itemsDir: reports,
   });
   const originalEnv = process.env;
-  process.env = { ...producerEnv };
+  process.env = { ...producerEnv, ...(originalEnv.TMPDIR ? { TMPDIR: originalEnv.TMPDIR } : {}) };
   try {
     const owner = createReviewActionLedger({
       root,
@@ -178,7 +178,7 @@ Complete retained review.
       }
       const retryable = start(3);
       if (kind === "accepted-mutation") mutation(retryable, "accepted");
-      finish(retryable, "failed", true);
+      finish(retryable, "failed", true, kind === "mixed-identities" ? { sourceRevision: digest("reviewed discussion") } : {});
       const deferred = start(4);
       mutation(deferred, "rejected");
       finish(deferred, "blocked", true, { completionReason: "coordination_deferred" });

--- a/docs/proof/aggregate-review-recovery/run-proof.mjs
+++ b/docs/proof/aggregate-review-recovery/run-proof.mjs
@@ -43,6 +43,7 @@ const receipt = {
 async function scenario(kind, ack = "accepted") {
   const root = join(temp, `${kind}-${ack}`);
   mkdirSync(root, { recursive: true });
+  cpSync(join(repo, "scripts/control-plane-curl.sh"), join(root, "control-plane-curl.sh"));
   const produced = await run(
     process.execPath,
     [
@@ -53,7 +54,7 @@ async function scenario(kind, ack = "accepted") {
     ],
     {
       cwd: repo,
-      env: { PATH: process.env.PATH, HOME: root },
+      env: { PATH: process.env.PATH, TMPDIR: process.env.TMPDIR, HOME: root },
     },
   );
   assert.equal(produced.code, 79, produced.stderr);
@@ -70,6 +71,7 @@ async function scenario(kind, ack = "accepted") {
     recursive: true,
   });
   const requests = [];
+  const requestDecisions = [];
   const failures = [];
   const comments = new Map();
   const recordKeys = new Set();
@@ -186,6 +188,14 @@ async function scenario(kind, ack = "accepted") {
         `router:failed-review-recovery-123456-1-${body.decision.itemNumber}`,
       );
       requests.push(body.decision.itemNumber);
+      requestDecisions.push(body.decision);
+      if (kind === "mixed-identities") {
+        const expectedKind = body.decision.itemNumber === 3 ? "pull_request" : "issue";
+        assert.equal(body.decision.itemKind, expectedKind);
+        assert.equal(body.decision.sourceEvent, expectedKind === "issue" ? "issues" : "pull_request");
+        assert.equal(Object.hasOwn(body.decision, "sourceHeadSha"), false);
+        assert.equal(Object.hasOwn(body.decision, "sourceContentRevision"), false);
+      }
       response.writeHead(200, { "content-type": "application/json" });
       response.end(
         JSON.stringify(
@@ -227,7 +237,9 @@ async function scenario(kind, ack = "accepted") {
     const endpoint = `http://127.0.0.1:${server.address().port}`;
     const env = {
       PATH: process.env.PATH,
+      TMPDIR: process.env.TMPDIR,
       HOME: root,
+      RUNNER_TEMP: root,
       ...producerEnv,
       GH_TOKEN: "synthetic",
       QUEUE_URL: endpoint,
@@ -467,6 +479,7 @@ async function scenario(kind, ack = "accepted") {
       original_review_exit: produced.code,
       recovery_exit: code,
       requests,
+      requestDecisions,
       retained_reports: staged,
       published_records: [...recordKeys].sort(),
       published_comments: [...comments.keys()].sort(),
@@ -504,6 +517,9 @@ function run(command, args, options) {
 }
 
 try {
+  if (process.argv.includes("--identity-only")) {
+    await scenario("mixed-identities");
+  } else {
   await scenario("mixed");
   await scenario("filtered");
   if (!baseline) {
@@ -528,6 +544,7 @@ try {
     ]) {
       await scenario(kind);
     }
+  }
   }
   const output = process.argv.indexOf("--output");
   if (output >= 0)

--- a/docs/proof/recovery-item-identity/README.md
+++ b/docs/proof/recovery-item-identity/README.md
@@ -1,0 +1,33 @@
+# Recovery item identity proof
+
+Status: active validation recipe. Owner: review recovery.
+Source: `src/review-recovery.ts` and `.github/workflows/sweep.yml`.
+Baseline: `49446cd30622e642efceb80e1c0347b2602a0117`.
+Update when ledger classification, recovery output, or enqueue payloads change.
+
+## Contract
+
+A mixed manifest-backed shard preserves issue versus PR identity through the
+built recovery CLI and the actual workflow shell. Only retryable item terminals
+produce signed enqueue requests. A terminal scanner refusal and held neighbors
+remain excluded. An opaque discussion revision is never passed as a head SHA
+or queue content hash.
+
+With Node 24+, Bash 4+, jq and frozen dependencies installed, run:
+
+```sh
+pnpm run build:node
+node docs/proof/aggregate-review-recovery/run-proof.mjs --identity-only --output .artifacts/recovery-identity.json
+node --test test/repair/review-recovery.test.ts
+```
+
+The fixture drives the production review-ledger writer, importer, recovery CLI,
+and workflow shell. A real loopback HTTP receiver verifies request signatures
+and records the actual outgoing decisions: PR 3 and issue 4, once each. PR 7's
+terminal refusal remains excluded. Completed reports 1 and 2 retain the existing
+staging and publisher checks. The fixture has no production credentials.
+
+Limits: the queue response and GitHub boundary are synthetic. This proves
+producer routing and terminal selection, not queue availability or a complete
+cross-lane refusal fence. Bay receives the existing correct item-kind contract;
+no public fields, observer controls, or Bay rendering change is needed.

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -964,6 +964,13 @@ Each item has a visible disposition; queue acknowledgements distinguish queued,
 deduplicated, shed, disabled, and failed admission. None means review or
 publication succeeded.
 
+Validated recovery entries retain the item kind and any owner-recorded source
+revision. PR retries use PR routing rather than issue routing. The source
+revision remains opaque diagnostic provenance: it may include discussion and
+must not be reused as a PR head SHA or the queue's narrower content hash.
+This does not establish a cross-producer terminal-refusal fence; matching that
+fence requires the same complete scanned-input identity at both boundaries.
+
 Before uploading a failed shard, the same projection stages only completed
 reports whose native terminal digest, repository/item/source identity, complete
 review status, and verified checkout provenance match. The existing publisher

--- a/src/review-recovery.ts
+++ b/src/review-recovery.ts
@@ -18,6 +18,8 @@ import { readReportFrontMatterField } from "./report-front-matter.js";
 type Disposition = "completed" | "terminal" | "retryable" | "held";
 type RecoveryItem = {
   number: number;
+  kind?: "issue" | "pull_request";
+  sourceRevision?: string;
   disposition: Disposition;
   reason: string;
   publication: "not_requested" | "staged" | "held";
@@ -353,6 +355,13 @@ export function recoverReviewShard(options: ReviewRecoveryOptions) {
       );
       item.disposition = result.disposition;
       item.reason = result.reason;
+      if (result.terminal) {
+        const subject = result.terminal.subject;
+        if (subject.kind === "issue" || subject.kind === "pull_request") {
+          item.kind = subject.kind;
+          if (subject.source_revision) item.sourceRevision = subject.source_revision;
+        }
+      }
       if (options.stageDir && result.disposition === "completed" && result.terminal) {
         try {
           stageReport(options, result.terminal);

--- a/test/repair/review-recovery.test.ts
+++ b/test/repair/review-recovery.test.ts
@@ -109,6 +109,33 @@ for (const [key, value] of [
   });
 }
 
+test("recovery CLI retains validated item kinds and opaque source revisions", async (t) => {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "review-recovery-kinds-")));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const seeded = await fixture(root);
+  const revision = "b".repeat(64);
+  rewriteLedger(seeded.ledgerDir, (events) =>
+    events.map((event) =>
+      [3, 7].includes(event.subject.number)
+        ? {
+            ...event,
+            subject: { ...event.subject, kind: "pull_request", source_revision: revision },
+          }
+        : event,
+    ),
+  );
+  const result = recover(root, seeded);
+  assert.deepEqual(result.retryable, [3, 4]);
+  const item = (number) => result.items.find((entry) => entry.number === number);
+  assert.equal(item(3).kind, "pull_request");
+  assert.equal(item(3).sourceRevision, revision);
+  assert.equal(item(4).kind, "issue");
+  assert.equal(item(4).sourceRevision, undefined);
+  assert.equal(item(7).kind, "pull_request");
+  assert.equal(item(7).disposition, "terminal");
+  for (const number of [5, 6, 8]) assert.equal(item(number).kind, undefined);
+});
+
 test("recovery CLI holds corrupted ledger bytes and never follows a report symlink", async (t) => {
   const root = realpathSync(mkdtempSync(join(tmpdir(), "review-recovery-files-")));
   t.after(() => rmSync(root, { recursive: true, force: true }));
@@ -159,7 +186,7 @@ function recover(root, seeded) {
         "--stage-dir",
         join(root, "staged"),
       ],
-      { env: { PATH: process.env.PATH }, encoding: "utf8" },
+      { env: { PATH: process.env.PATH, TMPDIR: process.env.TMPDIR }, encoding: "utf8" },
     ),
   );
 }


### PR DESCRIPTION
## What Problem This Solves

Failed-shard recovery converts every retry into an issue event, including pull requests. That bypasses the existing PR-specific review/status path and discards the ledger's verified subject identity. This is a bounded repair for https://github.com/openclaw/clawsweeper/issues/1455; the complete cross-lane refusal fence remains open.

## Why This Change Was Made

Recovery retains the terminal chain's item kind and optional source revision. The workflow carries validated item objects through selection and derives the event kind from the subject instead of hardcoding issues. Complete evidence and a retryable terminal remain mandatory. The opaque source revision is diagnostic data, never a substitute for a head SHA or queue content hash.

The existing real-workflow harness now includes mixed identities and mirrors the current runner-temp/control-plane helper setup.

## User Impact

Retryable PRs stay on the PR path. Terminal scanner refusals, uncertain mutations, corrupt ledgers, and unstarted work remain excluded. No review/close/merge policy changes. Bay uses the existing correctly typed decision and needs no rendering or controls change.

## Evidence

- 24 recovery CLI tests passed on AWS Linux, including PR/issue identity, 64-character source revision, missing revision, terminal exclusion, corruption and foreign producer checks.
- Format, lint, docs and diff checks passed. Precommit autoreview is clean through P2.
- Full AWS `pnpm run check` passed: 6,042 tests passed, 18 skipped, zero failures. Exact-head CI passed at https://github.com/openclaw/clawsweeper/actions/runs/34656004059. Both precommit and committed-branch autoreviews are clean through P2.
- Changelog context is consolidated in the final notes PR.

## Real Behavior Proof

Command: `node docs/proof/aggregate-review-recovery/run-proof.mjs --identity-only` after `pnpm run build:node`.

The production ledger writer, manifest importer, built recovery CLI, and actual workflow shell ran against a mixed synthetic shard. A real loopback HTTP receiver verified signatures and observed exactly two requests: PR 3 with `itemKind/sourceEvent=pull_request`, and issue 4 with `itemKind=issue/sourceEvent=issues`. Completed reports 1 and 2 were retained; terminal PR 7 and held neighbors were excluded. No source revision was misused as a head SHA or queue content hash.

Provider: AWS, lease `cbx_edaec2595b55`, c7a.8xlarge. [Runtime and validation trace](https://crabbox.openclaw.ai/portal/runs/run_6aa57ce21d4f00c4622b2134dc14af4b). The receipt records workflow, fixture, harness and recovery-source hashes. The workflow and recovery source hashes were checked against committed head `913944a0b0fe4f210b927dd6dc03749c1938ff60`.

Limits: GitHub and queue responses are synthetic; no production mutation. This establishes producer routing and retained terminal filtering, not queue availability or a full automatic-refusal fence. A complete fence must compare the same reviewer-observed input at both boundaries, including discussion and policy changes; the current queue metadata hash cannot safely stand in for it.
