### PR TITLE
docs(changelog): consolidate phase-four batch-two notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
-- Start fresh replacement repairs from the fetched base when the target branch advances during startup, retaining dirty-checkout and concurrent-head safeguards.
+- Fetch and materialize the pinned commit before creating or resuming replacement repair branches, preserving dirty-checkout and concurrent-head safeguards.
 - Keep dashboard publication counts and time windows through refresh and cached reload, preserving explicit zeroes and incomplete data; thanks @vincentkoc.
 - Preserve PR versus issue identity and retained source provenance in failed-shard recovery; thanks @yetval.
 - Extend strict TypeScript checks over review-failure telemetry and source/storage helpers without changing their runtime behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Keep dashboard publication counts and time windows through refresh and cached reload, preserving explicit zeroes and incomplete data; thanks @vincentkoc.
+- Preserve PR versus issue identity and retained source provenance in failed-shard recovery; thanks @yetval.
+- Extend strict TypeScript checks over review-failure telemetry and source/storage helpers without changing their runtime behavior.
+
 - Refresh Node 24 type definitions, the Oxc lint/format toolchain, and immutable checkout pins to v7.0.1 while retaining the 48-hour release-age policy and Node 24 minimum.
 
 - Isolate the GitHub ETag cache in repository-sharded Durable Objects so cache reads and writes no longer compete with exact-review admission, claims, or webhooks.


### PR DESCRIPTION
## What Problem This Solves

Consolidates the ready phase-four batch-two maintenance notes without conflicts among this batch's implementation PRs. The refresh preserves the Vite entry independently landed on main.

## Why This Change Was Made

Add four notes: fresh and recovered pinned-commit hydration, dashboard publication counts, recovery item identity, and three dashboard strict roots. Preserve all existing main and released content and contributor credit.

Land after https://github.com/openclaw/clawsweeper/pull/1542, https://github.com/openclaw/clawsweeper/pull/1535, https://github.com/openclaw/clawsweeper/pull/1537, and https://github.com/openclaw/clawsweeper/pull/1538. The notifier change remains outside these ready notes because deployed compatibility is unverified.

## User Impact

Pending release notes accurately describe the prepared maintenance changes. No version, tag, publication, runtime or configuration change.

## Evidence

The conflict with newer main is resolved, retaining its Vite and host-fixture changes. The main-relative diff changes only CHANGELOG.md. Both refreshed independent reviews are clean through P2. Exact-head CI passed for `596fdc1b10b14721822acd65565ce61cbd536be5`: https://github.com/openclaw/clawsweeper/actions/runs/34659856702.

## Real Behavior Proof

This documentation-only artifact check follows AGENTS.md's docs-only exception. Reading the committed base and candidate found exactly four added notes; the complete released suffix is byte-identical. The committed `git diff --check` passed. Captured result:

```json
{
  "head": "596fdc1b10b14721822acd65565ce61cbd536be5",
  "base": "6bc31fc32aee440a3a2ae2a75431df508ef6c563",
  "artifact": "CHANGELOG.md",
  "added_notes": [
    "- Fetch and materialize the pinned commit before creating or resuming replacement repair branches, preserving dirty-checkout and concurrent-head safeguards.",
    "- Keep dashboard publication counts and time windows through refresh and cached reload, preserving explicit zeroes and incomplete data; thanks @vincentkoc.",
    "- Preserve PR versus issue identity and retained source provenance in failed-shard recovery; thanks @yetval.",
    "- Extend strict TypeScript checks over review-failure telemetry and source/storage helpers without changing their runtime behavior."
  ],
  "released_sections_unchanged": true,
  "released_sections_sha256": "6b9584e51f724625b9cd922bc75fade47bea5da18521c95dffe9feeaa376c873",
  "changed_files": [
    "CHANGELOG.md"
  ],
  "whitespace_check": "passed",
  "runtime_files_changed": false
}
```

Limits: this checks changelog content, not application runtime. Each linked implementation PR owns its runtime proof. Those four PRs must land before these notes.
