### PR TITLE
fix: preserve checkout state after Vite validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Restore Vite config scratch after OpenClaw changed-gate validation so a successful cold run does not fail checkout identity checks; preserve cache and disposable-output permissions under restrictive umasks and cross-device moves without weakening unrelated runtime-input protection.
+
 - Refresh Node 24 type definitions, the Oxc lint/format toolchain, and immutable checkout pins to v7.0.1 while retaining the 48-hour release-age policy and Node 24 minimum.
 
 - Isolate the GitHub ETag cache in repository-sharded Durable Objects so cache reads and writes no longer compete with exact-review admission, claims, or webhooks.

--- a/docs/repair/README.md
+++ b/docs/repair/README.md
@@ -170,10 +170,12 @@ Target dependency metadata may retain npm's positive `min-release-age` and
 package-name `min-release-age-exclude[]` settings. Registry overrides and other
 active package-manager configuration remain rejected; every YAML lockfile
 document is checked against the approved destinations. OpenClaw changed-gate
-validation restores `.cache/vitest`, `node_modules/.cache`, and
-`node_modules/.vite` after success or failure. Neighboring ignored inputs remain
-protected. A pending runtime build also retains its bound output until archive
-smoke completes; cache restoration does not exempt that output from verification.
+validation restores `.cache/vitest`, `node_modules/.cache`, `node_modules/.vite`,
+and `node_modules/.vite-temp` after success or failure. Cache and disposable-output
+copies preserve file and directory permissions, including cross-device
+compiler-cache moves. Neighboring ignored inputs remain protected. A pending
+runtime build retains its bound output until archive smoke completes; cache
+restoration does not exempt that output from verification.
 
 If Codex itself fails an edit pass with a transient tool-transport error, such
 as a closed stdin session from the Codex tool router, the executor consumes an

--- a/src/repair/target-validation.ts
+++ b/src/repair/target-validation.ts
@@ -2987,6 +2987,7 @@ const OPENCLAW_CHANGED_GATE_CACHE_PATHS = [
   ".cache/vitest",
   "node_modules/.cache",
   "node_modules/.vite",
+  "node_modules/.vite-temp",
 ] as const;
 
 function prepareDisposableChangedGateState(
@@ -3049,7 +3050,7 @@ function prepareDisposableChangedGateState(
       if (outputStat) {
         const backup = path.join(backupRoot, relativePath);
         fs.mkdirSync(path.dirname(backup), { recursive: true });
-        fs.cpSync(output, backup, { recursive: true, verbatimSymlinks: true });
+        copyRuntimeTreeWithModes(output, backup);
       }
       snapshots.push({
         relativePath,
@@ -3092,10 +3093,7 @@ function prepareDisposableChangedGateState(
         }
         fs.rmSync(output, { recursive: true, force: true });
         if (snapshot.existed) {
-          fs.cpSync(path.join(backupRoot, snapshot.relativePath), output, {
-            recursive: true,
-            verbatimSymlinks: true,
-          });
+          copyRuntimeTreeWithModes(path.join(backupRoot, snapshot.relativePath), output);
         }
       } catch (error) {
         restorationFailure ??= error;
@@ -3158,12 +3156,33 @@ function prepareDisposableRuntimeBuildCache(
   };
 }
 
+function copyRuntimeTreeWithModes(source: string, destination: string) {
+  fs.cpSync(source, destination, { recursive: true, verbatimSymlinks: true });
+  // Recursive copies can apply the host umask. Restore identity-bound modes
+  // postorder, without following copied symlinks or changing their targets.
+  const restoreModes = (original: string, copied: string) => {
+    const originalStat = fs.lstatSync(original);
+    const copiedStat = fs.lstatSync(copied);
+    if ((originalStat.mode & fs.constants.S_IFMT) !== (copiedStat.mode & fs.constants.S_IFMT)) {
+      throw new Error(`runtime tree copy changed entry type: ${copied}`);
+    }
+    if (originalStat.isSymbolicLink()) return;
+    if (originalStat.isDirectory()) {
+      for (const entry of fs.readdirSync(original)) {
+        restoreModes(path.join(original, entry), path.join(copied, entry));
+      }
+    }
+    fs.chmodSync(copied, originalStat.mode);
+  };
+  restoreModes(source, destination);
+}
+
 function moveRuntimeBuildCache(source: string, destination: string) {
   try {
     fs.renameSync(source, destination);
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== "EXDEV") throw error;
-    fs.cpSync(source, destination, { recursive: true, verbatimSymlinks: true });
+    copyRuntimeTreeWithModes(source, destination);
     fs.rmSync(source, { recursive: true, force: true });
   }
 }

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -4771,7 +4771,12 @@ test("changed-gate caches restore while pending fresh runtime output stays prote
     git(cwd, "commit", "-m", "initial");
     attachOrigin(cwd);
     fs.writeFileSync(path.join(cwd, "test", "example.test.ts"), "export const value = 2;\n");
-    const caches = [".cache/vitest", "node_modules/.cache", "node_modules/.vite"];
+    const caches = [
+      ".cache/vitest",
+      "node_modules/.cache",
+      "node_modules/.vite",
+      "node_modules/.vite-temp",
+    ];
     for (const cache of caches) {
       fs.mkdirSync(path.join(cwd, cache), { recursive: true });
       fs.writeFileSync(path.join(cwd, cache, "previous.bin"), "trusted cache\n");
@@ -4953,45 +4958,47 @@ test("changed-gate output preparation failures preserve the existing compiler ca
 });
 
 test(
-  "changed-gate output restoration rejects replaced output roots before following symlinks",
+  "changed-gate restoration rejects replaced output and cache roots before following symlinks",
   { skip: process.platform === "win32" },
   () => {
-    const cwd = gitPackageFixture({ "check:changed": "node scripts/check-changed.mjs" });
-    fs.appendFileSync(path.join(cwd, ".gitignore"), "dist/\n");
-    git(cwd, "add", ".");
-    git(cwd, "commit", "-m", "initial");
-    attachOrigin(cwd);
+    for (const relativePath of ["dist", "node_modules/.vite-temp"]) {
+      const cwd = gitPackageFixture({ "check:changed": "node scripts/check-changed.mjs" });
+      fs.appendFileSync(path.join(cwd, ".gitignore"), "dist/\n");
+      git(cwd, "add", ".");
+      git(cwd, "commit", "-m", "initial");
+      attachOrigin(cwd);
 
-    const dist = path.join(cwd, "dist");
-    fs.mkdirSync(dist, { recursive: true });
-    fs.writeFileSync(path.join(dist, "runtime.js"), "trusted original\n");
-    const outside = makeFixtureDir("clawsweeper-protected-output-");
-    fs.writeFileSync(path.join(outside, "runtime.js"), "outside must survive\n");
+      const output = path.join(cwd, relativePath);
+      fs.mkdirSync(output, { recursive: true });
+      fs.writeFileSync(path.join(output, "runtime.js"), "trusted original\n");
+      const outside = makeFixtureDir("clawsweeper-protected-output-");
+      fs.writeFileSync(path.join(outside, "runtime.js"), "outside must survive\n");
 
-    const binDir = makeFixtureDir("clawsweeper-gate-build-symlink-");
-    writeNodeCommandShim(
-      binDir,
-      "pnpm",
-      [
-        'const fs = require("node:fs");',
-        'fs.rmSync("dist", { recursive: true, force: true });',
-        `fs.symlinkSync(${JSON.stringify(outside)}, "dist");`,
-      ].join("\n"),
-    );
+      const binDir = makeFixtureDir("clawsweeper-gate-build-symlink-");
+      writeNodeCommandShim(
+        binDir,
+        "pnpm",
+        [
+          'const fs = require("node:fs");',
+          `fs.rmSync(${JSON.stringify(relativePath)}, { recursive: true, force: true });`,
+          `fs.symlinkSync(${JSON.stringify(outside)}, ${JSON.stringify(relativePath)});`,
+        ].join("\n"),
+      );
 
-    assert.throws(
-      () => runOpenClawChangedGate(cwd, binDir),
-      (error: Error) =>
-        /validation command failed \(pnpm check:changed\)/.test(error.message) &&
-        /changed-gate validation produced an unsafe output: dist/.test(
-          String((error as Error & { cause?: unknown }).cause),
-        ),
-    );
-    assert.equal(
-      fs.readFileSync(path.join(outside, "runtime.js"), "utf8"),
-      "outside must survive\n",
-    );
-    assert.equal(fs.readFileSync(path.join(dist, "runtime.js"), "utf8"), "trusted original\n");
+      assert.throws(
+        () => runOpenClawChangedGate(cwd, binDir),
+        (error: Error) =>
+          /validation command failed \(pnpm check:changed\)/.test(error.message) &&
+          String((error as Error & { cause?: unknown }).cause).includes(
+            `changed-gate validation produced an unsafe ${relativePath === "dist" ? "output" : "cache"}: ${relativePath}`,
+          ),
+      );
+      assert.equal(
+        fs.readFileSync(path.join(outside, "runtime.js"), "utf8"),
+        "outside must survive\n",
+      );
+      assert.equal(fs.readFileSync(path.join(output, "runtime.js"), "utf8"), "trusted original\n");
+    }
   },
 );
 
@@ -5054,6 +5061,7 @@ test("OpenClaw changed-gate caches are disposable without exempting sibling runt
       [".cache/vitest/previous.bin", "previous Vitest cache\n"],
       ["node_modules/.cache/jiti/previous.mjs", "previous Jiti cache\n"],
       ["node_modules/.vite/vitest/results.json", "previous Vite cache\n"],
+      ["node_modules/.vite-temp/previous.mjs", "previous bundled Vite config\n"],
       [".cache/stable.txt", "trusted cache sibling\n"],
       ["node_modules/dependency/runtime.js", "trusted dependency\n"],
     ] as const;
@@ -5067,6 +5075,7 @@ test("OpenClaw changed-gate caches are disposable without exempting sibling runt
       ".cache/vitest/generated.bin",
       "node_modules/.cache/jiti/generated.mjs",
       "node_modules/.vite/vitest/generated.json",
+      "node_modules/.vite-temp/vitest.config.ts.timestamp-1234567890.mjs",
     ];
     const binDir = makeFixtureDir("clawsweeper-changed-gate-cache-");
     writeNodeCommandShim(
@@ -5090,7 +5099,7 @@ test("OpenClaw changed-gate caches are disposable without exempting sibling runt
     } else {
       assert.deepEqual(execute(), ["pnpm check:changed"]);
     }
-    for (const [relativePath, contents] of preserved.slice(0, 3)) {
+    for (const [relativePath, contents] of preserved.slice(0, 4)) {
       assert.equal(fs.readFileSync(path.join(cwd, relativePath), "utf8"), contents);
     }
     for (const relativePath of generated) {
@@ -5098,6 +5107,281 @@ test("OpenClaw changed-gate caches are disposable without exempting sibling runt
     }
   }
 });
+
+test("changed-gate Vite config scratch restores cold and warm caches after success or failure", () => {
+  for (const existingCache of [false, true]) {
+    for (const exitCode of [0, 23]) {
+      const cwd = gitPackageFixture({ "check:changed": "node scripts/check-changed.mjs" });
+      git(cwd, "add", ".");
+      git(cwd, "commit", "-m", "initial");
+      attachOrigin(cwd);
+      fs.mkdirSync(path.join(cwd, "node_modules"));
+      fs.writeFileSync(path.join(cwd, "node_modules", "stable.js"), "trusted dependency\n");
+      const cache = path.join(cwd, "node_modules", ".vite-temp");
+      if (existingCache) {
+        fs.mkdirSync(cache);
+        fs.writeFileSync(path.join(cache, "previous.mjs"), "trusted config\n", { mode: 0o640 });
+        fs.chmodSync(path.join(cache, "previous.mjs"), 0o640);
+      }
+      const binDir = makeFixtureDir("clawsweeper-vite-config-scratch-");
+      writeNodeCommandShim(
+        binDir,
+        "pnpm",
+        [
+          'const fs = require("node:fs");',
+          'const cache = "node_modules/.vite-temp";',
+          `if (fs.existsSync(cache) !== ${existingCache}) throw new Error("scratch survived previous attempt");`,
+          "fs.mkdirSync(cache, { recursive: true });",
+          "const bundled = `${cache}/vitest.config.ts.timestamp-1234567890.mjs`;",
+          'fs.writeFileSync(bundled, "export default {};\\n");',
+          // Vite removes its bundled config but leaves the scratch directory.
+          "fs.unlinkSync(bundled);",
+          ...(exitCode ? ['console.error("fixture validation failed");'] : []),
+          `process.exit(${exitCode});`,
+        ].join("\n"),
+      );
+      const execute = () => runOpenClawChangedGate(cwd, binDir);
+      if (exitCode) {
+        assert.throws(
+          execute,
+          (error: Error & { cause?: Error }) =>
+            /validation command failed \(pnpm check:changed\)/.test(error.message) &&
+            error.cause?.message === "fixture validation failed",
+        );
+      } else {
+        assert.deepEqual(execute(), ["pnpm check:changed"]);
+      }
+      if (existingCache) {
+        assert.deepEqual(fs.readdirSync(cache), ["previous.mjs"]);
+        assert.equal(fs.readFileSync(path.join(cache, "previous.mjs"), "utf8"), "trusted config\n");
+        if (process.platform !== "win32") {
+          assert.equal(fs.statSync(path.join(cache, "previous.mjs")).mode & 0o777, 0o640);
+        }
+      } else {
+        assert.equal(fs.existsSync(cache), false);
+      }
+    }
+  }
+});
+
+test(
+  "changed-gate copies preserve cache and output modes under a restrictive umask",
+  { skip: process.platform === "win32" },
+  (t) => {
+    // The body is synchronous: no other test callback can observe this umask.
+    const previousUmask = process.umask(0o077);
+    try {
+      for (const relativePath of ["node_modules/.vite-temp", "dist", ".artifacts/tsgo-cache"]) {
+        for (const exitCode of [0, 23]) {
+          const { cwd, root, target, linkText } = runtimeModeFixture(relativePath);
+          const binDir = makeFixtureDir("clawsweeper-copy-modes-");
+          writeNodeCommandShim(
+            binDir,
+            "pnpm",
+            [
+              'const fs = require("node:fs");',
+              `fs.mkdirSync(${JSON.stringify(relativePath)}, { recursive: true });`,
+              `fs.writeFileSync(${JSON.stringify(`${relativePath}/generated.mjs`)}, "scratch\\n");`,
+              ...(exitCode ? ['console.error("fixture validation failed");'] : []),
+              `process.exit(${exitCode});`,
+            ].join("\n"),
+          );
+          let backupsChecked = 0;
+          let crossDeviceMoves = 0;
+          const originalCopy = fs.cpSync;
+          const originalRename = fs.renameSync;
+          const originalChmod = fs.chmodSync;
+          const copy = t.mock.method(fs, "cpSync", (source, destination, options) => {
+            if (String(destination) === root) {
+              assertRuntimeModeTree(String(source), linkText);
+              backupsChecked += 1;
+            }
+            return originalCopy(source, destination, options);
+          });
+          const rename = t.mock.method(fs, "renameSync", (source, destination) => {
+            if (
+              relativePath === ".artifacts/tsgo-cache" &&
+              (String(source) === root || String(destination) === root)
+            ) {
+              crossDeviceMoves += 1;
+              throw Object.assign(new Error("fixture cross-device move"), { code: "EXDEV" });
+            }
+            return originalRename(source, destination);
+          });
+          const chmod = t.mock.method(fs, "chmodSync", (filePath, mode) => {
+            assert.notEqual(String(filePath), target);
+            assert.equal(fs.lstatSync(filePath).isSymbolicLink(), false);
+            return originalChmod(filePath, mode);
+          });
+          try {
+            const execute = () => runOpenClawChangedGate(cwd, binDir);
+            if (exitCode) {
+              assert.throws(
+                execute,
+                (error: Error & { cause?: Error }) =>
+                  /validation command failed \(pnpm check:changed\)/.test(error.message) &&
+                  error.cause?.message === "fixture validation failed",
+              );
+            } else {
+              assert.deepEqual(execute(), ["pnpm check:changed"]);
+            }
+          } finally {
+            copy.mock.restore();
+            rename.mock.restore();
+            chmod.mock.restore();
+          }
+          assert.ok(backupsChecked > 0);
+          assert.equal(
+            crossDeviceMoves,
+            relativePath === ".artifacts/tsgo-cache" ? backupsChecked * 2 : 0,
+          );
+          assertRuntimeModeTree(root, linkText);
+          assert.equal(fs.statSync(target).mode & 0o777, 0o604);
+          assert.equal(fs.existsSync(path.join(root, "generated.mjs")), false);
+        }
+      }
+    } finally {
+      process.umask(previousUmask);
+    }
+  },
+);
+
+test(
+  "changed-gate copy failures preserve original or recoverable state",
+  { skip: process.platform === "win32" },
+  (t) => {
+    for (const relativePath of ["node_modules/.vite-temp", ".artifacts/tsgo-cache"]) {
+      for (const phase of ["backup", "restore"]) {
+        if (relativePath === ".artifacts/tsgo-cache" && phase === "restore") continue;
+        for (const fault of ["copy", "chmod", "directory type", "file type", "symlink type"]) {
+          if (relativePath === ".artifacts/tsgo-cache" && fault.endsWith("type")) continue;
+          const { cwd, root, target, linkText } = runtimeModeFixture(relativePath);
+          const binDir = makeFixtureDir("clawsweeper-copy-failure-");
+          writeNodeCommandShim(binDir, "pnpm", "");
+          let backup: string | undefined;
+          const backups = new Set<string>();
+          let faultDestination: string | undefined;
+          let faultInjected = false;
+          const originalCopy = fs.cpSync;
+          const originalRename = fs.renameSync;
+          const originalChmod = fs.chmodSync;
+          const copy = t.mock.method(fs, "cpSync", (source, destination, options) => {
+            if (String(source) === root) {
+              backup = String(destination);
+              backups.add(backup);
+            }
+            const selected =
+              phase === "backup" ? String(source) === root : String(destination) === root;
+            if (selected && fault === "copy") {
+              faultInjected = true;
+              throw new Error("injected copy failure");
+            }
+            originalCopy(source, destination, options);
+            if (!selected) return;
+            faultDestination = String(destination);
+            if (fault.endsWith("type")) {
+              faultInjected = true;
+              const entry =
+                fault === "directory type"
+                  ? "nested"
+                  : fault === "file type"
+                    ? "previous.mjs"
+                    : "link";
+              const replaced = path.join(faultDestination, entry);
+              fs.rmSync(replaced, { recursive: true, force: true });
+              if (fault === "symlink type") fs.writeFileSync(replaced, "not a symlink\n");
+              else fs.symlinkSync(target, replaced);
+            }
+          });
+          const rename = t.mock.method(fs, "renameSync", (source, destination) => {
+            if (relativePath === ".artifacts/tsgo-cache" && String(source) === root) {
+              throw Object.assign(new Error("fixture cross-device move"), { code: "EXDEV" });
+            }
+            return originalRename(source, destination);
+          });
+          const chmod = t.mock.method(fs, "chmodSync", (filePath, mode) => {
+            if (
+              fault === "chmod" &&
+              faultDestination &&
+              String(filePath) === path.join(faultDestination, "previous.mjs")
+            ) {
+              faultInjected = true;
+              throw new Error("injected chmod failure");
+            }
+            return originalChmod(filePath, mode);
+          });
+          try {
+            assert.throws(
+              () => runOpenClawChangedGate(cwd, binDir),
+              (error: Error & { cause?: Error }) =>
+                /injected (copy|chmod) failure|runtime tree copy changed entry type|unsafe validation command mutated checkout identity/.test(
+                  String(error.cause ?? error),
+                ),
+            );
+            assert.equal(faultInjected, true);
+            assert.ok(backup);
+            assertRuntimeModeTree(phase === "backup" ? root : backup, linkText);
+            assert.equal(fs.statSync(target).mode & 0o777, 0o604);
+            if (phase === "backup") assert.equal(fs.existsSync(backup), false);
+          } finally {
+            copy.mock.restore();
+            rename.mock.restore();
+            chmod.mock.restore();
+            if (relativePath === "node_modules/.vite-temp") {
+              for (const saved of backups) {
+                const backupRoot = path.resolve(saved, "../..");
+                assert.ok(path.basename(backupRoot).startsWith("clawsweeper-changed-gate-state-"));
+                fs.rmSync(backupRoot, { recursive: true, force: true });
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+);
+
+test(
+  "changed-gate Vite scratch rejects unsafe existing cache and parent paths",
+  { skip: process.platform === "win32" },
+  () => {
+    for (const [relativePath, kind] of [
+      ["node_modules/.vite-temp", "file"],
+      ["node_modules/.vite-temp", "symlink"],
+      ["node_modules", "file"],
+      ["node_modules", "symlink"],
+    ]) {
+      const cwd = gitPackageFixture({ "check:changed": "node scripts/check-changed.mjs" });
+      fs.appendFileSync(path.join(cwd, ".gitignore"), "cache-sibling/\n");
+      git(cwd, "add", ".");
+      git(cwd, "commit", "-m", "initial");
+      attachOrigin(cwd);
+      const cache = path.join(cwd, relativePath);
+      const sibling = path.join(cwd, "cache-sibling");
+      fs.mkdirSync(sibling, { recursive: true });
+      fs.writeFileSync(path.join(sibling, "previous.mjs"), "sibling must survive\n");
+      fs.mkdirSync(path.dirname(cache), { recursive: true });
+      const link = path.relative(path.dirname(cache), sibling);
+      if (kind === "file") fs.writeFileSync(cache, "not a cache directory\n");
+      else fs.symlinkSync(link, cache);
+      const binDir = makeFixtureDir("clawsweeper-vite-unsafe-cache-");
+      writeNodeCommandShim(binDir, "pnpm", 'throw new Error("validation must not run");');
+
+      assert.throws(
+        () => runOpenClawChangedGate(cwd, binDir),
+        relativePath === "node_modules"
+          ? /changed-gate validation has an unsafe cache parent: node_modules\/\.cache/
+          : /changed-gate validation has an unsafe existing cache: node_modules\/\.vite-temp/,
+      );
+      assert.equal(
+        fs.readFileSync(path.join(sibling, "previous.mjs"), "utf8"),
+        "sibling must survive\n",
+      );
+      if (kind === "file") assert.equal(fs.readFileSync(cache, "utf8"), "not a cache directory\n");
+      else assert.equal(fs.readlinkSync(cache), link);
+    }
+  },
+);
 
 test("OpenClaw validation disables shard timing writes without weakening ignored-input protection", () => {
   for (const existingTimingArtifact of [false, true]) {
@@ -5618,6 +5902,8 @@ test("changed-gate merge-base fallback also isolates its disposable compiler cac
   const artifacts = path.join(cwd, ".artifacts");
   fs.mkdirSync(artifacts, { recursive: true });
   fs.writeFileSync(path.join(artifacts, "stable.txt"), "existing artifact\n");
+  fs.mkdirSync(path.join(cwd, "node_modules"));
+  fs.writeFileSync(path.join(cwd, "node_modules", "stable.js"), "trusted dependency\n");
   const binDir = makeFixtureDir("clawsweeper-tsgo-fallback-");
   const attemptPath = path.join(binDir, "attempt");
   writeNodeCommandShim(
@@ -5628,6 +5914,8 @@ test("changed-gate merge-base fallback also isolates its disposable compiler cac
       `const attemptPath = ${JSON.stringify(attemptPath)};`,
       'const attempt = fs.existsSync(attemptPath) ? Number(fs.readFileSync(attemptPath, "utf8")) : 0;',
       "fs.writeFileSync(attemptPath, String(attempt + 1));",
+      'if (fs.existsSync("node_modules/.vite-temp")) throw new Error("scratch survived previous attempt");',
+      'fs.mkdirSync("node_modules/.vite-temp");',
       "if (attempt === 0) {",
       '  console.error("fatal: no merge base");',
       "  process.exit(1);",
@@ -5641,6 +5929,7 @@ test("changed-gate merge-base fallback also isolates its disposable compiler cac
   assert.equal(fs.readFileSync(attemptPath, "utf8"), "2");
   assert.equal(fs.readFileSync(path.join(artifacts, "stable.txt"), "utf8"), "existing artifact\n");
   assert.equal(fs.existsSync(path.join(artifacts, "tsgo-cache")), false);
+  assert.equal(fs.existsSync(path.join(cwd, "node_modules", ".vite-temp")), false);
 });
 
 test("OpenClaw archive smoke cannot pass by reusing a pre-existing stale build", () => {
@@ -9207,6 +9496,49 @@ function withVirtualDeadlineCommands(t, now, onCommand, callback) {
     clock.mock.restore();
     fs.rmSync(binDir, { recursive: true, force: true });
   }
+}
+
+const RUNTIME_MODE_FIXTURE_ENTRIES = [
+  ["", 0o750],
+  ["nested", 0o710],
+  ["previous.mjs", 0o640],
+  ["nested/readonly.mjs", 0o440],
+] as const;
+
+function runtimeModeFixture(relativePath: string) {
+  const cwd = fs.realpathSync(
+    gitPackageFixture({ "check:changed": "node scripts/check-changed.mjs" }),
+  );
+  fs.appendFileSync(path.join(cwd, ".gitignore"), "dist/\n.artifacts/\n");
+  git(cwd, "add", ".");
+  git(cwd, "commit", "-m", "initial");
+  attachOrigin(cwd);
+  const target = path.join(cwd, "node_modules", "stable.js");
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, "trusted dependency\n");
+  fs.chmodSync(target, 0o604);
+  const root = path.join(cwd, relativePath);
+  fs.mkdirSync(path.join(root, "nested"), { recursive: true });
+  fs.writeFileSync(path.join(root, "previous.mjs"), "trusted config\n");
+  fs.writeFileSync(path.join(root, "nested", "readonly.mjs"), "readonly config\n");
+  for (const [entry, mode] of RUNTIME_MODE_FIXTURE_ENTRIES) {
+    fs.chmodSync(path.join(root, entry), mode);
+  }
+  const linkText = path.relative(root, target);
+  fs.symlinkSync(linkText, path.join(root, "link"));
+  return { cwd, root, target, linkText };
+}
+
+function assertRuntimeModeTree(root: string, linkText: string) {
+  for (const [entry, mode] of RUNTIME_MODE_FIXTURE_ENTRIES) {
+    assert.equal(fs.lstatSync(path.join(root, entry)).mode & 0o777, mode, entry || "root");
+  }
+  assert.equal(fs.readFileSync(path.join(root, "previous.mjs"), "utf8"), "trusted config\n");
+  assert.equal(
+    fs.readFileSync(path.join(root, "nested", "readonly.mjs"), "utf8"),
+    "readonly config\n",
+  );
+  assert.equal(fs.readlinkSync(path.join(root, "link")), linkText);
 }
 
 function runOpenClawChangedGate(cwd: string, binDir: string): string[] {


### PR DESCRIPTION
## What Problem This Solves

Resolves successful OpenClaw changed-gate validation being rejected as a checkout mutation after Vite creates `node_modules/.vite-temp`. Restrictive umasks or cross-device cache moves could also change restored permissions.

## Why This Change Was Made

Extend the existing snapshot/restore owner to Vite's named scratch directory. One shared copy helper restores original file/directory modes after copying, including the existing cross-device compiler-cache fallback, without following symlinks. Neighboring ignored inputs and pending build outputs remain identity-bound.

Landed prerequisite: https://github.com/openclaw/clawsweeper/pull/1536.

## User Impact

Cold and warm Vite validation can finish without retaining new scratch or changing an existing cache's bytes and permissions. No configuration or storage-format change. Production: +25/-6 (net +19 for the dependency permission contract); tests: +369/-37.

## OpenClaw Bay Impact

None. The change owns disposable validation state, not queue, publication, telemetry, or dashboard contracts.

## Documentation Impact

Updated the active validation contract in `docs/repair/README.md` and the ClawSweeper changelog. No new runbook or operator setting. Reviewed `CONTRIBUTING.md`.

## Evidence

- Signed current head: `fbfafdd9b037b570a9a6e3d00031496f0a5fa0c3`.
- Base: `49446cd30622e642efceb80e1c0347b2602a0117`; current patch SHA-256 `3e1acda1ba2acee45d52af8e01753c8594efd6cd5dcfa84b7c184174c9c4cc81`.
- Rebase changed only changelog context. All existing main changelog bytes were preserved; production, test, and repair-documentation postimages are byte-identical to the qualified patch.
- Focused target-validation tests, formatting, lint, and documentation checks passed. Coverage includes cold/warm restoration, failure cleanup, restrictive permissions, cross-device copying, unsafe parents/symlinks, neighboring-input poisoning, and pending-build binding.
- `pnpm run check` passed in 342512ms, exit 0, output SHA-256 `16f6e6833623527a8bdffe47d2d91fec33b70b4a946d40bc9efac1b567543a29`.
- Fresh native precommit and rebased committed-head reviews passed with no actionable findings. Current-head CI and ClawSweeper review remain required before merge.

## Real Behavior Proof

**Claim:** the real Vite bundle loader can create scratch during validation while ClawSweeper restores the pre-run cache state and preserves checkout identity.

**Surface/scenarios:** real Vite 8.2.2 `loadConfigFromFile` using its bundle loader, invoked through ClawSweeper's native contained changed-gate execution. Tested with the scratch directory initially absent and with genuine warm sentinel files/directories under umask 0077. The fixture records execution from Vite's generated bundle, not merely a mocked file write.

**Environment:** Linux Blacksmith Testbox, Node 24.18.1, pnpm 11.10.0, Corepack 0.36.0; reviewed Vite dependency graph with minimum release age 10080 minutes. The real loader ran in an isolated network namespace with native read-only mounts.

**Observed:** both cold and warm loads passed. The cold scratch directory returned to absence; warm contents and modes matched their baseline. Source and checkout binding were unchanged, and every contained command reported zero background processes. Bundle SHA-256: `de1953704bf521480140261fa612a7a243277970f9a98b99dba2b8c69d2813a8`.

**Trace:** [run 34654403457, attempt 1](https://github.com/openclaw/openclaw/actions/runs/34654403457), job `103443546801`, `native-vite-passed` cold/warm, `vite-check-full`, and `branch-gates-passed:vite` receipts. Qualified composite tree `76344ac99f7b2a913a1ce4163f4dd3729433018c` contains the exact prerequisite and Vite postimages. Native capture SHA-256: `5740bc0b0a87c9c352b50dc4309e7560d2d247604d5cc34fd0e86b23218f0835`. Earlier focused receipts came from [run 34623068156](https://github.com/openclaw/openclaw/actions/runs/34623068156), attempt 1, job `103341476410`.

**Limits:** this is controlled real-tool proof, not a production OpenClaw session or cross-platform live proof. Cross-device and hostile-parent cases have focused regression coverage. Landlock was unavailable; native read-only mounts were observed. The full check was not network-isolated. The overall run later failed in the separate native Knip matrix; only the individually verified Vite receipts are claimed. Current-head CI qualifies integration with main's newer lint/format dependencies.
