### PR TITLE
fix(notify): retain terminal hook outcomes in notification ledgers

### DIFF
--- a/docs/openclaw-event-hooks.md
+++ b/docs/openclaw-event-hooks.md
@@ -4,7 +4,7 @@
 - Owner: ClawSweeper notification and activity-stream maintainers
 - Source of truth: `.github/workflows/github-activity.yml`,
   `.github/workflows/repair-publish-results.yml`, and `src/repair/*notify*`
-- Last verified: `openclaw/clawsweeper@647503ec44b8e777dd172adf974a945367da0d19`
+- Last verified: `openclaw/clawsweeper@42226a81c43c2c8ded17a684a706e58f3a58577a`
 - Update when: hook payloads, delivery policy, activity filtering, runtime setup,
   notification ledgers, or workflow ownership changes
 
@@ -31,8 +31,11 @@ The normal event flow is:
 5. OpenClaw starts an isolated agent turn for the requested `agentId`.
 6. The agent sends the final message to the configured delivery target, or
    replies `NO_REPLY` when the event is intentionally silent.
-7. ClawSweeper records successful sends in the ledger and publishes it to
-   `openclaw/clawsweeper-state`.
+7. ClawSweeper classifies the bounded completion as `delivered`, `suppressed`,
+   `failed`, `unknown`, or `not-requested`. Older admission-only OpenClaw
+   responses are recorded as `admitted`.
+8. ClawSweeper records only conclusive delivery outcomes in the ledger and
+   publishes it to `openclaw/clawsweeper-state`.
 
 The hook call is best-effort by default. A Discord outage or Gateway outage
 must not make an already-completed GitHub mutation roll back or fail the state
@@ -70,7 +73,8 @@ reverse proxy.
   "to": "channel:1499243561407741994",
   "idempotencyKey": "clawsweeper:merge:openclaw/openclaw:123:abc123",
   "thinking": "low",
-  "timeoutSeconds": 300
+  "timeoutSeconds": 300,
+  "waitForCompletion": true
 }
 ```
 
@@ -107,7 +111,9 @@ OpenClaw call itself:
   result, such as repo, PR number, action, and merge commit SHA;
 - check a durable ledger before sending;
 - write a report for attempted, skipped, sent, and failed notifications;
-- write the ledger only after OpenClaw accepted the request;
+- request completion for direct agent hooks and write its bounded delivery
+  classification to the report;
+- write the ledger only for `delivered`, `suppressed`, or `not-requested`;
 - publish the report and ledger with the normal result state.
 
 The message sent to OpenClaw should be explicit enough that the agent does not
@@ -131,11 +137,31 @@ Default behavior:
 - transient OpenClaw HTTP/network failure: retry with the same idempotency key;
 - persistent OpenClaw HTTP failure: record the failed attempt and keep the
   workflow green;
+- a valid legacy `{ok:true,runId}` admission without `completion`: classify as
+  terminal `admitted`, report that delivery observability is unavailable, and
+  preserve prior at-most-once ledger behavior;
+- a present but malformed completion: classify delivery as `unknown` and leave
+  the event retryable;
+- verified delivery: classify as `delivered` even when automatic hook delivery
+  was disabled and the agent used the message tool, or when later terminal
+  fields also report an execution or delivery error;
+- an exact silent reply without verified delivery: classify as `suppressed`,
+  preserving the reported reason or deriving `silent`;
+- a visible reply without verified delivery: classify as `failed` or `unknown`,
+  never intentional suppression;
+- no automatic delivery, message-tool delivery, or model reply evidence:
+  classify as `not-requested`;
+- `status: "skipped"` without explicit silent-reply or suppression evidence:
+  classify as `unknown`;
 - rerun after failure: retry because no success ledger entry exists;
 - rerun after success: skip because the ledger contains the event key.
 
 Set `CLAWSWEEPER_OPENCLAW_HOOK_RETRY_ATTEMPTS` to override the default retry
 count for hook posts.
+
+Deploy OpenClaw first when possible so completion observability is available as
+soon as ClawSweeper requests it. Deploying ClawSweeper first remains safe:
+admission-only responses are terminal `admitted` outcomes and are not retried.
 
 Strict mode is allowed for events whose notification is the product of the
 workflow. Strict mode should fail on OpenClaw delivery errors, but it still
@@ -200,6 +226,10 @@ The GitHub activity notifier posts to `/hooks/agent` with `deliver: false` by
 default. The agent receives the Discord target in the prompt and should use the
 message tool only when the event is surprising, actionable, risky, or otherwise
 operationally useful. For routine events it replies exactly `NO_REPLY`.
+The completion distinguishes verified message-tool delivery from a silent or
+private visible final reply without exposing reply text. The notifier writes
+that classification, plus a bounded suppression reason when present, to its
+report and a concise GitHub step summary.
 
 The workflow skips native and forwarded pull request synchronize events plus
 successful workflow-run events before checkout because the notifier always

--- a/docs/openclaw-event-hooks.md
+++ b/docs/openclaw-event-hooks.md
@@ -150,8 +150,9 @@ Default behavior:
 - an attempted but unacknowledged delivery, with an empty or visible reply:
   classify as `unknown` unless an explicit execution/delivery error establishes
   failure or explicit suppression applies; an attempt alone is not failure evidence;
-- no automatic delivery, message-tool delivery, or model reply evidence:
-  classify as `not-requested`;
+- no automatic delivery, an empty reply, and explicit `delivered: false` plus
+  `deliveryAttempted: false`: classify as `not-requested`; missing delivery flags
+  leave the outcome `unknown`;
 - `status: "skipped"` without explicit silent-reply or suppression evidence:
   classify as `unknown`;
 - rerun after failure: retry because no success ledger entry exists;

--- a/docs/openclaw-event-hooks.md
+++ b/docs/openclaw-event-hooks.md
@@ -147,8 +147,9 @@ Default behavior:
   fields also report an execution or delivery error;
 - an exact silent reply without verified delivery: classify as `suppressed`,
   preserving the reported reason or deriving `silent`;
-- a visible reply without verified delivery: classify as `failed` or `unknown`,
-  never intentional suppression;
+- an attempted but unacknowledged delivery, with an empty or visible reply:
+  classify as `unknown` unless an explicit execution/delivery error establishes
+  failure or explicit suppression applies; an attempt alone is not failure evidence;
 - no automatic delivery, message-tool delivery, or model reply evidence:
   classify as `not-requested`;
 - `status: "skipped"` without explicit silent-reply or suppression evidence:

--- a/docs/proof/notifier-completion/README.md
+++ b/docs/proof/notifier-completion/README.md
@@ -1,0 +1,23 @@
+# Notifier completion proof
+
+Status: active validation recipe. Owner: ClawSweeper notifications.
+Source: the shared OpenClaw hook client and four notifier CLIs.
+Update when completion classification, ledger persistence or report output changes.
+
+```sh
+pnpm run build:node
+node docs/proof/notifier-completion/run-proof.mjs
+```
+
+The real built merge, event, maintainer-report and GitHub-activity CLIs talk to a
+local HTTP server using synthetic hook responses and fixture inputs. Twenty-eight
+scenarios cover delivered, silent and channel-transform suppression, failure, ambiguous completion,
+legacy admission and no requested delivery. Merge/event ledger files survive
+separate CLI invocations: conclusive outcomes deduplicate, while inconclusive
+ones retry the same idempotency key. Event dashboard publication remains
+independent of an inconclusive completion. GitHub activity writes its summary.
+
+The receipt records runtime, source hash and outcomes in `.artifacts/`.
+No production credentials or mutations are used. This proves notifier behavior,
+not a deployed Gateway or Discord send. The upstream completion protocol must
+still be verified on the actual configured OpenClaw endpoint before landing.

--- a/docs/proof/notifier-completion/README.md
+++ b/docs/proof/notifier-completion/README.md
@@ -10,10 +10,10 @@ node docs/proof/notifier-completion/run-proof.mjs
 ```
 
 The real built merge, event, maintainer-report and GitHub-activity CLIs talk to a
-local HTTP server using synthetic hook responses and fixture inputs. Thirty-six
+local HTTP server using synthetic hook responses and fixture inputs. Forty-eight
 scenarios cover delivered, silent and channel-transform suppression, failure, ambiguous completion,
-attempted-but-unacknowledged empty and visible replies, legacy admission and no
-requested delivery. Merge/event ledger files survive
+attempted-but-unacknowledged empty and visible replies, omitted delivery flags,
+legacy admission and no requested delivery. Merge/event ledger files survive
 separate CLI invocations: conclusive outcomes deduplicate, while inconclusive
 ones retry the same idempotency key. Event dashboard publication remains
 independent of an inconclusive completion. GitHub activity writes its summary.

--- a/docs/proof/notifier-completion/README.md
+++ b/docs/proof/notifier-completion/README.md
@@ -10,9 +10,10 @@ node docs/proof/notifier-completion/run-proof.mjs
 ```
 
 The real built merge, event, maintainer-report and GitHub-activity CLIs talk to a
-local HTTP server using synthetic hook responses and fixture inputs. Twenty-eight
+local HTTP server using synthetic hook responses and fixture inputs. Thirty-six
 scenarios cover delivered, silent and channel-transform suppression, failure, ambiguous completion,
-legacy admission and no requested delivery. Merge/event ledger files survive
+attempted-but-unacknowledged empty and visible replies, legacy admission and no
+requested delivery. Merge/event ledger files survive
 separate CLI invocations: conclusive outcomes deduplicate, while inconclusive
 ones retry the same idempotency key. Event dashboard publication remains
 independent of an inconclusive completion. GitHub activity writes its summary.

--- a/docs/proof/notifier-completion/run-proof.mjs
+++ b/docs/proof/notifier-completion/run-proof.mjs
@@ -18,6 +18,9 @@ const responses = {
   unknown: { status: "skipped", delivered: false },
   "unacknowledged-empty": { status: "ok", delivered: false, deliveryAttempted: true, replyDisposition: "empty" },
   "unacknowledged-visible": { status: "ok", delivered: false, deliveryAttempted: true, replyDisposition: "visible" },
+  "missing-flags": { status: "ok", replyDisposition: "empty" },
+  "missing-attempted": { status: "ok", delivered: false, replyDisposition: "empty" },
+  "missing-delivered": { status: "ok", deliveryAttempted: false, replyDisposition: "empty" },
   "not-requested": { status: "ok", delivered: false, deliveryAttempted: false, replyDisposition: "empty" },
 };
 
@@ -90,7 +93,7 @@ async function scenario(surface, outcome) {
       return JSON.parse(readFileSync(report, "utf8"));
     };
     const first = await execute();
-    const expected = outcome.startsWith("unacknowledged-") ? "unknown" : outcome === "channel-transform" ? "suppressed" : outcome === "not-requested" && ledgered ? "unknown" : outcome;
+    const expected = outcome.startsWith("unacknowledged-") || outcome.startsWith("missing-") ? "unknown" : outcome === "channel-transform" ? "suppressed" : outcome === "not-requested" && ledgered ? "unknown" : outcome;
     const actual = ledgered ? first.actions[0].delivery.status : first.delivery.status;
     assert.equal(actual, expected, `${surface}/${outcome}`);
     assert.equal(hooks.length, 1);
@@ -117,7 +120,7 @@ async function scenario(surface, outcome) {
 
 try {
   for (const surface of ["merge", "events", "maintainer-report", "github-activity"])
-    for (const outcome of ["delivered", "suppressed", "channel-transform", "failed", "unknown", "unacknowledged-empty", "unacknowledged-visible", "admitted", "not-requested"])
+    for (const outcome of ["delivered", "suppressed", "channel-transform", "failed", "unknown", "unacknowledged-empty", "unacknowledged-visible", "missing-flags", "missing-attempted", "missing-delivered", "admitted", "not-requested"])
       await scenario(surface, outcome);
   const receipt = { runtime: process.version, source_sha256: createHash("sha256").update(readFileSync(join(repo, "src/repair/openclaw-hook.ts"))).digest("hex"), real_built_clis: 4, scenarios: results.length, results, production_mutations: 0, limits: "Synthetic Gateway responses over real loopback HTTP; deployed OpenClaw compatibility and Discord delivery are not established." };
   mkdirSync(join(repo, ".artifacts"), { recursive: true });

--- a/docs/proof/notifier-completion/run-proof.mjs
+++ b/docs/proof/notifier-completion/run-proof.mjs
@@ -16,6 +16,8 @@ const responses = {
   "channel-transform": { status: "ok", delivered: false, deliveryAttempted: true, replyDisposition: "visible", deliverySuppressionReason: "channel_transform" },
   failed: { status: "error", delivered: false, deliveryAttempted: true, deliveryError: "synthetic delivery failure" },
   unknown: { status: "skipped", delivered: false },
+  "unacknowledged-empty": { status: "ok", delivered: false, deliveryAttempted: true, replyDisposition: "empty" },
+  "unacknowledged-visible": { status: "ok", delivered: false, deliveryAttempted: true, replyDisposition: "visible" },
   "not-requested": { status: "ok", delivered: false, deliveryAttempted: false, replyDisposition: "empty" },
 };
 
@@ -88,7 +90,7 @@ async function scenario(surface, outcome) {
       return JSON.parse(readFileSync(report, "utf8"));
     };
     const first = await execute();
-    const expected = outcome === "channel-transform" ? "suppressed" : outcome === "not-requested" && ledgered ? "unknown" : outcome;
+    const expected = outcome.startsWith("unacknowledged-") ? "unknown" : outcome === "channel-transform" ? "suppressed" : outcome === "not-requested" && ledgered ? "unknown" : outcome;
     const actual = ledgered ? first.actions[0].delivery.status : first.delivery.status;
     assert.equal(actual, expected, `${surface}/${outcome}`);
     assert.equal(hooks.length, 1);
@@ -101,16 +103,21 @@ async function scenario(surface, outcome) {
       const second = await execute();
       assert.equal(hooks.length, conclusive ? 1 : 2);
       if (conclusive) assert.equal(second.skipped, 1);
-      else assert.equal(hooks[0].idempotencyKey, hooks[1].idempotencyKey);
+      else {
+        assert.equal(hooks[0].idempotencyKey, hooks[1].idempotencyKey);
+        assert.equal(second.actions[0].delivery.status, expected);
+        assert.equal(existsSync(ledger) ? JSON.parse(readFileSync(ledger, "utf8")).notifications.length : 0, 0);
+        if (surface === "events") assert.equal(dashboard.length, 2);
+      }
     }
     assert.deepEqual(failures, []);
-    results.push({ surface, outcome: expected, hook_requests: hooks.length, dashboard_requests: dashboard.length, persisted_ledger: ledgered ? conclusive : null, rerun: ledgered ? (conclusive ? "deduped" : "retryable with same key") : "gateway owns idempotency" });
+    results.push({ surface, scenario: outcome, outcome: expected, hook_requests: hooks.length, dashboard_requests: dashboard.length, persisted_ledger: ledgered ? conclusive : null, rerun: ledgered ? (conclusive ? "deduped" : "retryable with same key") : "gateway owns idempotency" });
   } finally { await new Promise(resolve => server.close(resolve)); }
 }
 
 try {
   for (const surface of ["merge", "events", "maintainer-report", "github-activity"])
-    for (const outcome of ["delivered", "suppressed", "channel-transform", "failed", "unknown", "admitted", "not-requested"])
+    for (const outcome of ["delivered", "suppressed", "channel-transform", "failed", "unknown", "unacknowledged-empty", "unacknowledged-visible", "admitted", "not-requested"])
       await scenario(surface, outcome);
   const receipt = { runtime: process.version, source_sha256: createHash("sha256").update(readFileSync(join(repo, "src/repair/openclaw-hook.ts"))).digest("hex"), real_built_clis: 4, scenarios: results.length, results, production_mutations: 0, limits: "Synthetic Gateway responses over real loopback HTTP; deployed OpenClaw compatibility and Discord delivery are not established." };
   mkdirSync(join(repo, ".artifacts"), { recursive: true });

--- a/docs/proof/notifier-completion/run-proof.mjs
+++ b/docs/proof/notifier-completion/run-proof.mjs
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const repo = resolve(import.meta.dirname, "../../..");
+const scratch = mkdtempSync(join(tmpdir(), "notifier-completion-proof-"));
+const date = "2026-09-11";
+const results = [];
+const responses = {
+  delivered: { status: "ok", delivered: true, deliveryAttempted: true, replyDisposition: "visible" },
+  suppressed: { status: "error", delivered: false, deliveryAttempted: false, replyDisposition: "silent" },
+  "channel-transform": { status: "ok", delivered: false, deliveryAttempted: true, replyDisposition: "visible", deliverySuppressionReason: "channel_transform" },
+  failed: { status: "error", delivered: false, deliveryAttempted: true, deliveryError: "synthetic delivery failure" },
+  unknown: { status: "skipped", delivered: false },
+  "not-requested": { status: "ok", delivered: false, deliveryAttempted: false, replyDisposition: "empty" },
+};
+
+async function scenario(surface, outcome) {
+  const root = join(scratch, `${surface}-${outcome}`);
+  mkdirSync(root);
+  const hooks = [];
+  const dashboard = [];
+  const failures = [];
+  const server = createServer(async (request, response) => {
+    try {
+      let body = "";
+      for await (const chunk of request) body += chunk;
+      let result;
+      if (request.url === "/hooks/agent") {
+        assert.equal(request.headers.authorization, "Bearer synthetic-hook-proof");
+        const payload = JSON.parse(body);
+        assert.equal(payload.waitForCompletion, true);
+        assert.equal(request.headers["idempotency-key"], payload.idempotencyKey);
+        hooks.push(payload);
+        result = { ok: true, runId: "synthetic-hook-run", ...(outcome === "admitted" ? {} : { completion: responses[outcome] }) };
+      } else if (request.url === "/events") {
+        dashboard.push(JSON.parse(body));
+        result = { ok: true };
+      } else if (request.url === "/reports/index.json") {
+        const entry = { period: "day", key: date, href: `day/${date}/`, data: `day/${date}/data.json` };
+        result = { latest: { day: entry }, entries: [entry] };
+      } else if (request.url === `/reports/day/${date}/data.json`) {
+        result = { period: { period: "day", key: date, title: "Synthetic report" }, totals: { github: { commits: 1, prsMerged: 1, issueComments: 1 }, discord: { messages: 1 } }, maintainerCount: 1, activeMaintainers: 1, summary: { highlights: ["Synthetic local proof"] }, maintainers: [] };
+      } else throw new Error("Unexpected proof request");
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify(result));
+    } catch (error) {
+      failures.push(error.message);
+      response.writeHead(500).end();
+    }
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  try {
+    const origin = `http://127.0.0.1:${server.address().port}`;
+    const input = join(root, "input.json");
+    const ledger = join(root, "ledger.json");
+    const report = join(root, "report.json");
+    const stepSummary = join(root, "summary.md");
+    const ledgered = surface === "merge" || surface === "events";
+    writeFileSync(input, JSON.stringify(surface === "github-activity" ? {
+      action: "opened", repository: { full_name: "openclaw/clawsweeper" }, sender: { login: "synthetic-contributor" },
+      issue: { number: 123, title: "Synthetic proof", body: "Synthetic local issue", state: "open", html_url: "https://github.com/openclaw/clawsweeper/issues/123", labels: [] },
+    } : [{ repo: "openclaw/clawsweeper", target: "#123", action: "merge_canonical", status: "executed", reason: "merged by clawsweeper-repair", title: "Synthetic proof", merge_commit_sha: "a".repeat(40), run_id: "987", published_at: date+"T10:00:00Z" }]));
+    const args = ["--write-report", "--report", report];
+    if (ledgered) args.push("--input", input, "--ledger", ledger, "--run-id", "987");
+    else if (surface === "maintainer-report") args.push("--base-url", origin+"/reports/", "--public-base-url", origin+"/reports/", "--date", date);
+    else args.push("--input", input, "--event", "issues");
+    const env = {
+      PATH: process.env.PATH, TMPDIR: process.env.TMPDIR, HOME: root,
+      CLAWSWEEPER_OPENCLAW_HOOK_URL: origin+"/hooks", CLAWSWEEPER_OPENCLAW_HOOK_TOKEN: "synthetic-hook-proof",
+      CLAWSWEEPER_DISCORD_TARGET: "channel:123", CLAWSWEEPER_OPENCLAW_HOOK_RETRY_ATTEMPTS: "1",
+      CLAWSWEEPER_MAINTAINER_REPORT_DELIVER: "0", CLAWSWEEPER_GITHUB_ACTIVITY_DELIVER: "0",
+      CLAWSWEEPER_STATUS_INGEST_URL: origin+"/events", CLAWSWEEPER_STATUS_INGEST_TOKEN: "synthetic-status-proof",
+      GITHUB_STEP_SUMMARY: stepSummary,
+    };
+    const execute = async () => {
+      const child = spawn(process.execPath, [join(repo, `dist/repair/notify-${surface}.js`), ...args], { cwd: root, env, stdio: ["ignore", "pipe", "pipe"], timeout: 15000 });
+      let output = "";
+      child.stdout.on("data", chunk => output += chunk);
+      child.stderr.on("data", chunk => output += chunk);
+      const code = await new Promise((resolve, reject) => { child.once("error", reject); child.once("close", resolve); });
+      assert.equal(code, 0, output);
+      assert.ok(existsSync(report), output);
+      return JSON.parse(readFileSync(report, "utf8"));
+    };
+    const first = await execute();
+    const expected = outcome === "channel-transform" ? "suppressed" : outcome === "not-requested" && ledgered ? "unknown" : outcome;
+    const actual = ledgered ? first.actions[0].delivery.status : first.delivery.status;
+    assert.equal(actual, expected, `${surface}/${outcome}`);
+    assert.equal(hooks.length, 1);
+    if (surface === "events") assert.equal(dashboard.length, 1, "dashboard publication survives inconclusive hook completion");
+    if (surface === "github-activity") assert.ok(readFileSync(stepSummary, "utf8").includes(expected));
+    const conclusive = ["delivered", "admitted", "suppressed", "not-requested"].includes(expected);
+    if (ledgered) {
+      const entries = existsSync(ledger) ? JSON.parse(readFileSync(ledger, "utf8")).notifications.length : 0;
+      assert.equal(entries, conclusive ? 1 : 0);
+      const second = await execute();
+      assert.equal(hooks.length, conclusive ? 1 : 2);
+      if (conclusive) assert.equal(second.skipped, 1);
+      else assert.equal(hooks[0].idempotencyKey, hooks[1].idempotencyKey);
+    }
+    assert.deepEqual(failures, []);
+    results.push({ surface, outcome: expected, hook_requests: hooks.length, dashboard_requests: dashboard.length, persisted_ledger: ledgered ? conclusive : null, rerun: ledgered ? (conclusive ? "deduped" : "retryable with same key") : "gateway owns idempotency" });
+  } finally { await new Promise(resolve => server.close(resolve)); }
+}
+
+try {
+  for (const surface of ["merge", "events", "maintainer-report", "github-activity"])
+    for (const outcome of ["delivered", "suppressed", "channel-transform", "failed", "unknown", "admitted", "not-requested"])
+      await scenario(surface, outcome);
+  const receipt = { runtime: process.version, source_sha256: createHash("sha256").update(readFileSync(join(repo, "src/repair/openclaw-hook.ts"))).digest("hex"), real_built_clis: 4, scenarios: results.length, results, production_mutations: 0, limits: "Synthetic Gateway responses over real loopback HTTP; deployed OpenClaw compatibility and Discord delivery are not established." };
+  mkdirSync(join(repo, ".artifacts"), { recursive: true });
+  writeFileSync(join(repo, ".artifacts/notifier-completion-proof.json"), JSON.stringify(receipt, null, 2)+"\n");
+  console.log(JSON.stringify(receipt, null, 2));
+} finally { rmSync(scratch, { recursive: true, force: true }); }

--- a/docs/repair/operations.md
+++ b/docs/repair/operations.md
@@ -4,7 +4,7 @@
 - Owner: ClawSweeper maintainers and the authorized repair operator
 - Source of truth: repair workflows/source, current gates, focused tests, and
   live read-only GitHub state where needed
-- Last verified: `openclaw/clawsweeper@647503ec44b8e777dd172adf974a945367da0d19`
+- Last verified: `openclaw/clawsweeper@42226a81c43c2c8ded17a684a706e58f3a58577a`
 - Update when: commands, trust checks, gates, tokens, runners, routing,
   publication, recovery, or promotion rules change
 
@@ -208,6 +208,21 @@ Successful event notifications are recorded in
 `openclaw/clawsweeper-state`, keyed by event type, repo, target, action, status,
 and stable mutation evidence. This prevents duplicate Discord posts when the
 publish workflow reruns.
+
+The notifier waits for the direct OpenClaw hook completion and records a
+bounded delivery classification in its report. `delivered`, `suppressed`, and
+`not-requested` are terminal and may enter the notification ledger. A valid
+admission-only response from an older OpenClaw is terminal `admitted`: its
+report states that delivery observability is unavailable, and ledgered
+notifiers preserve their prior at-most-once behavior. `failed` and `unknown`
+remain non-ledgered so the existing rerun path can retry them.
+Verified message-tool delivery wins even when automatic hook delivery was
+disabled or later completion fields report an error. Exact silent replies and
+explicit suppression evidence become `suppressed`; bare `skipped` and visible
+replies without verified delivery remain nonconclusive. Deploy OpenClaw first
+when possible so ClawSweeper receives completion observability immediately.
+OpenClaw Bay is unaffected because its public status and event contracts do not
+consume notification reports or ledgers.
 
 ## Autonomous Flow
 

--- a/src/repair/notify-events.ts
+++ b/src/repair/notify-events.ts
@@ -7,12 +7,17 @@ import { asJsonObject } from "./json-types.js";
 import { parseArgs, repoRoot } from "./lib.js";
 import { readJsonFile, writeJsonFile } from "./json-file.js";
 import {
+  describeHookDelivery,
   errorText,
+  hookDeliveryFromError,
+  hookDeliveryReport,
+  isConclusiveHookDelivery,
   postOpenClawAgentHook,
   resolveOpenClawHookConfig,
   stringArg,
   stringOrNull,
 } from "./openclaw-hook.js";
+import type { OpenClawHookDelivery } from "./openclaw-hook.js";
 
 type EventSeverity = "info" | "warning" | "error";
 type EventStatus = "sent" | "planned" | "failed" | "skipped";
@@ -388,8 +393,24 @@ export async function runClawSweeperEventNotifier(
         } catch (error) {
           dashboardDelivered = false;
           dashboardStatus = `status dashboard failed: ${errorText(error)}`;
-          reportActions.push(reportRow(event, "failed", dashboardStatus, result.runId));
+          reportActions.push(
+            reportRow(event, "failed", dashboardStatus, result.runId, result.delivery),
+          );
         }
+      }
+      if (!isConclusiveHookDelivery(result.delivery)) {
+        if (dashboardDelivered) {
+          reportActions.push(
+            reportRow(
+              event,
+              "failed",
+              describeHookDelivery(result.delivery),
+              result.runId,
+              result.delivery,
+            ),
+          );
+        }
+        continue;
       }
       if (dashboardDelivered) {
         const notifiedAt = now().toISOString();
@@ -400,10 +421,19 @@ export async function runClawSweeperEventNotifier(
         });
       }
       reportActions.push(
-        reportRow(event, "sent", `sent to OpenClaw hook; ${dashboardStatus}`, result.runId),
+        reportRow(
+          event,
+          "sent",
+          `${describeHookDelivery(result.delivery)}; ${dashboardStatus}`,
+          result.runId,
+          result.delivery,
+        ),
       );
     } catch (error) {
-      reportActions.push(reportRow(event, "failed", errorText(error)));
+      const delivery = hookDeliveryFromError(error);
+      reportActions.push(
+        reportRow(event, "failed", describeHookDelivery(delivery), null, delivery),
+      );
     }
   }
 
@@ -684,6 +714,7 @@ function reportRow(
   status: EventStatus,
   reason: string,
   hookRunId: string | null = null,
+  delivery: OpenClawHookDelivery | null = null,
 ): JsonObject {
   return {
     key: event.key,
@@ -699,6 +730,7 @@ function reportRow(
     run_id: event.runId,
     cluster_id: event.clusterId,
     hook_run_id: hookRunId,
+    delivery: delivery ? hookDeliveryReport(delivery) : null,
     url: event.url,
   };
 }

--- a/src/repair/notify-github-activity.ts
+++ b/src/repair/notify-github-activity.ts
@@ -9,12 +9,17 @@ import { writeJsonFile } from "./json-file.js";
 import { parseArgs, repoRoot } from "./lib.js";
 import {
   boolEnv,
+  describeHookDelivery,
   errorText,
+  hookDeliveryFromError,
+  hookDeliveryReport,
+  isConclusiveHookDelivery,
   postOpenClawAgentHook,
   resolveOpenClawHookConfig,
   stringArg,
   stringOrNull,
 } from "./openclaw-hook.js";
+import type { OpenClawHookDelivery } from "./openclaw-hook.js";
 
 export type GithubActivity = {
   type: string;
@@ -344,6 +349,7 @@ export async function runGithubActivityNotifier(
   }
 
   let hookRunId: string | null = null;
+  let delivery: OpenClawHookDelivery | null = null;
   let failed = 0;
   let reason: string | null = null;
   if (!dryRun) {
@@ -362,9 +368,15 @@ export async function runGithubActivityNotifier(
         },
       });
       hookRunId = result.runId;
+      delivery = result.delivery;
+      if (!isConclusiveHookDelivery(delivery)) {
+        failed = 1;
+        reason = describeHookDelivery(delivery);
+      }
     } catch (error) {
+      delivery = hookDeliveryFromError(error);
       failed = 1;
-      reason = errorText(error);
+      reason = describeHookDelivery(delivery);
     }
   }
 
@@ -377,10 +389,14 @@ export async function runGithubActivityNotifier(
       dry_run: dryRun,
       deliver,
       hook_run_id: hookRunId,
+      delivery: delivery ? hookDeliveryReport(delivery) : null,
       failed,
       reason,
       activity,
     });
+  }
+  if (delivery && env.GITHUB_STEP_SUMMARY) {
+    appendGithubStepSummary(env.GITHUB_STEP_SUMMARY, delivery);
   }
 
   const summary = summaryRow("ok", failed ? 0 : 1, failed, reason);
@@ -688,6 +704,16 @@ function summaryRow(
   reason: string | null,
 ): GithubActivityNotifierSummary {
   return { status, sent, failed, exitCode: 0, reason };
+}
+
+function appendGithubStepSummary(summaryPath: string, delivery: OpenClawHookDelivery): void {
+  const suppression = delivery.suppressionReason
+    ? ` (${delivery.suppressionReason.replaceAll("`", "'")})`
+    : "";
+  fs.appendFileSync(
+    summaryPath,
+    `### OpenClaw notification\n\n- Delivery: \`${delivery.status}\`${suppression}\n`,
+  );
 }
 
 async function main() {

--- a/src/repair/notify-maintainer-report.ts
+++ b/src/repair/notify-maintainer-report.ts
@@ -8,12 +8,17 @@ import { writeJsonFile } from "./json-file.js";
 import { parseArgs, repoRoot } from "./lib.js";
 import {
   boolEnv,
+  describeHookDelivery,
   errorText,
+  hookDeliveryFromError,
+  hookDeliveryReport,
+  isConclusiveHookDelivery,
   postOpenClawAgentHook,
   resolveOpenClawHookConfig,
   stringArg,
   stringOrNull,
 } from "./openclaw-hook.js";
+import type { OpenClawHookDelivery } from "./openclaw-hook.js";
 
 export type MaintainerReportPointer = {
   date: string;
@@ -159,6 +164,7 @@ export async function runMaintainerReportNotifier(
   }
 
   let hookRunId: string | null = null;
+  let delivery: OpenClawHookDelivery | null = null;
   let failed = 0;
   let reason: string | null = null;
   if (!dryRun) {
@@ -174,9 +180,15 @@ export async function runMaintainerReportNotifier(
         },
       });
       hookRunId = result.runId;
+      delivery = result.delivery;
+      if (!isConclusiveHookDelivery(delivery)) {
+        failed = 1;
+        reason = describeHookDelivery(delivery);
+      }
     } catch (error) {
+      delivery = hookDeliveryFromError(error);
       failed = 1;
-      reason = errorText(error);
+      reason = describeHookDelivery(delivery);
     }
   }
 
@@ -184,6 +196,7 @@ export async function runMaintainerReportNotifier(
     writeJsonFile(reportPath, {
       ...reportPayload({ now, dryRun, deliver, pointer, message }),
       hook_run_id: hookRunId,
+      delivery: delivery ? hookDeliveryReport(delivery) : null,
       failed,
       reason,
     });

--- a/src/repair/notify-merge.ts
+++ b/src/repair/notify-merge.ts
@@ -7,13 +7,18 @@ import { asJsonObject } from "./json-types.js";
 import { parseArgs, repoRoot } from "./lib.js";
 import { readJsonFile, writeJsonFile } from "./json-file.js";
 import {
+  describeHookDelivery,
   errorText,
+  hookDeliveryFromError,
+  hookDeliveryReport,
+  isConclusiveHookDelivery,
   normalizeString,
   postOpenClawAgentHook,
   resolveOpenClawHookConfig,
   stringArg,
   stringOrNull,
 } from "./openclaw-hook.js";
+import type { OpenClawHookDelivery } from "./openclaw-hook.js";
 import type {
   CollectionResult,
   MergeLedgerEntry,
@@ -227,15 +232,29 @@ export async function runMergeNotifier(
           deliver: true,
         },
       });
-      const notifiedAt = now().toISOString();
-      nextLedger = addLedgerEntry(nextLedger, notification, {
-        notifiedAt,
-        hookRunId: result.runId,
-        discordTarget: config.discordTarget,
-      });
-      reportActions.push(reportRow(notification, "sent", "sent to OpenClaw hook", result.runId));
+      const conclusive = isConclusiveHookDelivery(result.delivery);
+      if (conclusive) {
+        const notifiedAt = now().toISOString();
+        nextLedger = addLedgerEntry(nextLedger, notification, {
+          notifiedAt,
+          hookRunId: result.runId,
+          discordTarget: config.discordTarget,
+        });
+      }
+      reportActions.push(
+        reportRow(
+          notification,
+          conclusive ? "sent" : "failed",
+          describeHookDelivery(result.delivery),
+          result.runId,
+          result.delivery,
+        ),
+      );
     } catch (error) {
-      reportActions.push(reportRow(notification, "failed", errorText(error)));
+      const delivery = hookDeliveryFromError(error);
+      reportActions.push(
+        reportRow(notification, "failed", describeHookDelivery(delivery), null, delivery),
+      );
     }
   }
 
@@ -342,6 +361,7 @@ function reportRow(
   status: "failed" | "planned" | "sent",
   reason: string,
   hookRunId: string | null = null,
+  delivery: OpenClawHookDelivery | null = null,
 ): JsonObject {
   return {
     key: notification.key,
@@ -355,6 +375,7 @@ function reportRow(
     merged_at: notification.mergedAt,
     run_id: notification.runId,
     hook_run_id: hookRunId,
+    delivery: delivery ? hookDeliveryReport(delivery) : null,
     url: notification.prUrl,
   };
 }

--- a/src/repair/openclaw-hook.ts
+++ b/src/repair/openclaw-hook.ts
@@ -18,8 +18,23 @@ export type OpenClawHookPost = {
   deliver: boolean;
 };
 
+export type OpenClawHookDeliveryStatus =
+  | "delivered"
+  | "admitted"
+  | "suppressed"
+  | "failed"
+  | "unknown"
+  | "not-requested";
+
+export type OpenClawHookDelivery = {
+  status: OpenClawHookDeliveryStatus;
+  suppressionReason: string | null;
+  error: string | null;
+};
+
 export type OpenClawHookPostResult = {
   runId: string | null;
+  delivery: OpenClawHookDelivery;
 };
 
 const DEFAULT_AGENT_ID = "clawsweeper";
@@ -28,6 +43,8 @@ const DEFAULT_THINKING = "low";
 const DEFAULT_TIMEOUT_SECONDS = 60;
 const DEFAULT_RETRY_ATTEMPTS = 3;
 const DEFAULT_RETRY_DELAYS_MS = [1000, 4000];
+const MAX_DIAGNOSTIC_CHARS = 500;
+const MAX_SUPPRESSION_REASON_CHARS = 80;
 
 export function resolveOpenClawHookConfig(env: NodeJS.ProcessEnv): OpenClawHookConfig | null {
   const hookUrl = normalizeString(env.CLAWSWEEPER_OPENCLAW_HOOK_URL);
@@ -119,13 +136,25 @@ async function postOpenClawAgentHookOnce({
       thinking: config.thinking,
       timeoutSeconds: config.timeoutSeconds,
       message: post.message,
+      waitForCompletion: true,
     }),
   });
   const body = await response.text();
   if (!response.ok) {
-    throw new OpenClawHookHttpError(response.status, body);
+    throw new OpenClawHookHttpError(
+      response.status,
+      boundedText(body, MAX_DIAGNOSTIC_CHARS, [config.token]) ?? "",
+    );
   }
-  return { runId: readHookRunId(body) };
+  const parsed = parseHookBody(body);
+  const runId = boundedText(parsed.runId, 128) ?? boundedText(parsed.run_id, 128);
+  return {
+    runId,
+    delivery:
+      parsed.ok === true && runId && !Object.hasOwn(parsed, "completion")
+        ? hookDelivery("admitted")
+        : classifyHookDelivery(parsed.completion, post.deliver, config.token),
+  };
 }
 
 export class OpenClawHookHttpError extends Error {
@@ -148,14 +177,41 @@ export function isTransientOpenClawHookError(error: unknown): boolean {
   );
 }
 
-export function readHookRunId(body: string): string | null {
-  try {
-    const parsed = JSON.parse(body);
-    if (!isJsonObject(parsed)) return null;
-    return stringOrNull(parsed.runId) ?? stringOrNull(parsed.run_id);
-  } catch {
-    return null;
+export function isConclusiveHookDelivery(delivery: OpenClawHookDelivery): boolean {
+  return ["delivered", "admitted", "suppressed", "not-requested"].includes(delivery.status);
+}
+
+export function hookDeliveryReport(delivery: OpenClawHookDelivery): {
+  status: OpenClawHookDeliveryStatus;
+  suppression_reason: string | null;
+  error: string | null;
+} {
+  return {
+    status: delivery.status,
+    suppression_reason: delivery.suppressionReason,
+    error: delivery.error,
+  };
+}
+
+export function describeHookDelivery(delivery: OpenClawHookDelivery): string {
+  if (delivery.status === "admitted") {
+    return "OpenClaw delivery observability unavailable after legacy admission";
   }
+  if (delivery.status === "suppressed" && delivery.suppressionReason) {
+    return `OpenClaw delivery suppressed: ${delivery.suppressionReason}`;
+  }
+  if (delivery.status === "failed" && delivery.error) {
+    return `OpenClaw delivery failed: ${delivery.error}`;
+  }
+  return `OpenClaw delivery ${delivery.status}`;
+}
+
+export function hookDeliveryFromError(error: unknown): OpenClawHookDelivery {
+  return hookDelivery(
+    error instanceof OpenClawHookHttpError ? "failed" : "unknown",
+    null,
+    errorText(error),
+  );
 }
 
 export function positiveInt(value: string | undefined, fallback: number): number {
@@ -183,7 +239,97 @@ export function normalizeString(value: string | undefined): string | undefined {
 }
 
 export function errorText(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
+  return (
+    boundedText(error instanceof Error ? error.message : String(error), MAX_DIAGNOSTIC_CHARS) ?? ""
+  );
+}
+
+function classifyHookDelivery(
+  value: unknown,
+  deliveryRequested: boolean,
+  token: string,
+): OpenClawHookDelivery {
+  if (!isJsonObject(value)) {
+    return hookDelivery("unknown");
+  }
+  const status = value.status;
+  if (status !== "ok" && status !== "error" && status !== "skipped") {
+    return hookDelivery("unknown");
+  }
+
+  const error = boundedText(value.deliveryError, MAX_DIAGNOSTIC_CHARS, [token]);
+  const suppressionReason = boundedText(
+    value.deliverySuppressionReason,
+    MAX_SUPPRESSION_REASON_CHARS,
+  );
+  const replyDisposition =
+    value.replyDisposition === "visible" ||
+    value.replyDisposition === "silent" ||
+    value.replyDisposition === "empty"
+      ? value.replyDisposition
+      : null;
+  if (value.delivered === true) {
+    return hookDelivery("delivered");
+  }
+  if (replyDisposition === "silent") {
+    return hookDelivery("suppressed", suppressionReason ?? "silent");
+  }
+  if (status === "error" || error) {
+    return hookDelivery("failed", null, error);
+  }
+  if (suppressionReason) {
+    return hookDelivery("suppressed", suppressionReason);
+  }
+  if (replyDisposition === "visible") {
+    return hookDelivery(value.deliveryAttempted === true ? "failed" : "unknown");
+  }
+  if (
+    status === "ok" &&
+    !deliveryRequested &&
+    replyDisposition === "empty" &&
+    value.delivered !== true &&
+    value.deliveryAttempted !== true
+  ) {
+    return hookDelivery("not-requested");
+  }
+  if (value.delivered === false && value.deliveryAttempted === true) {
+    return hookDelivery("failed");
+  }
+  return hookDelivery("unknown");
+}
+
+function parseHookBody(body: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(body);
+    return isJsonObject(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function hookDelivery(
+  status: OpenClawHookDeliveryStatus,
+  suppressionReason: string | null = null,
+  error: string | null = null,
+): OpenClawHookDelivery {
+  return { status, suppressionReason, error };
+}
+
+function boundedText(
+  value: unknown,
+  limit: number,
+  redactions: readonly string[] = [],
+): string | null {
+  if (typeof value !== "string") return null;
+  let text = value
+    .replace(/\p{Cc}+/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  for (const redaction of redactions) {
+    if (redaction) text = text.replaceAll(redaction, "<redacted>");
+  }
+  if (!text) return null;
+  return text.length <= limit ? text : `${text.slice(0, limit - 3)}...`;
 }
 
 function delay(ms: number): Promise<void> {

--- a/src/repair/openclaw-hook.ts
+++ b/src/repair/openclaw-hook.ts
@@ -284,8 +284,8 @@ function classifyHookDelivery(
     status === "ok" &&
     !deliveryRequested &&
     replyDisposition === "empty" &&
-    value.delivered !== true &&
-    value.deliveryAttempted !== true
+    value.delivered === false &&
+    value.deliveryAttempted === false
   ) {
     return hookDelivery("not-requested");
   }

--- a/src/repair/openclaw-hook.ts
+++ b/src/repair/openclaw-hook.ts
@@ -280,9 +280,6 @@ function classifyHookDelivery(
   if (suppressionReason) {
     return hookDelivery("suppressed", suppressionReason);
   }
-  if (replyDisposition === "visible") {
-    return hookDelivery(value.deliveryAttempted === true ? "failed" : "unknown");
-  }
   if (
     status === "ok" &&
     !deliveryRequested &&
@@ -291,9 +288,6 @@ function classifyHookDelivery(
     value.deliveryAttempted !== true
   ) {
     return hookDelivery("not-requested");
-  }
-  if (value.delivered === false && value.deliveryAttempted === true) {
-    return hookDelivery("failed");
   }
   return hookDelivery("unknown");
 }

--- a/test/repair/notify-events.test.ts
+++ b/test/repair/notify-events.test.ts
@@ -13,6 +13,34 @@ import {
   runClawSweeperEventNotifier,
 } from "../../dist/repair/notify-events.js";
 
+function createNotifierEventRoot(prefix: string): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  fs.writeFileSync(
+    path.join(root, "repair-apply-report.json"),
+    `${JSON.stringify([
+      {
+        repo: "openclaw/openclaw",
+        target: "#456",
+        action: "close_duplicate",
+        status: "executed",
+        run_id: "987",
+        published_at: "2026-05-02T10:00:00Z",
+      },
+    ])}\n`,
+  );
+  return root;
+}
+
+function notifierEnvironment(): NodeJS.ProcessEnv {
+  return {
+    CLAWSWEEPER_OPENCLAW_HOOK_URL: "https://claw.example/hooks",
+    CLAWSWEEPER_OPENCLAW_HOOK_TOKEN: "secret",
+    CLAWSWEEPER_DISCORD_TARGET: "channel:123",
+    CLAWSWEEPER_STATUS_INGEST_URL: "https://status.example/api/events",
+    CLAWSWEEPER_STATUS_INGEST_TOKEN: "status-secret",
+  };
+}
+
 test("buildApplyEvent maps ClawSweeper merge, close, and blocked events", () => {
   const merge = buildApplyEvent({
     repo: "openclaw/openclaw",
@@ -179,8 +207,15 @@ test("runClawSweeperEventNotifier posts hook payloads and records ledger", async
       body: JSON.parse(String(init?.body)),
       auth: new Headers(init?.headers).get("authorization"),
     });
-    return new Response(JSON.stringify({ ok: true, runId: `hook-${requests.length}` }), {
-      status: 200,
+    return Response.json({
+      ok: true,
+      runId: `hook-${requests.length}`,
+      completion: {
+        status: "ok",
+        replyDisposition: "visible",
+        delivered: true,
+        deliveryAttempted: true,
+      },
     });
   };
 
@@ -203,6 +238,7 @@ test("runClawSweeperEventNotifier posts hook payloads and records ledger", async
   assert.equal(requests.length, 2);
   assert.equal(requests[0]?.auth, "Bearer secret");
   assert.equal(requests[0]?.body.deliver, true);
+  assert.equal(requests[0]?.body.waitForCompletion, true);
   assert.match(String(requests[0]?.body.message), /clawsweeper.pr_merged/);
   assert.match(String(requests[1]?.body.message), /clawsweeper.fix_pr_opened/);
 
@@ -244,7 +280,15 @@ test("runClawSweeperEventNotifier mirrors events to the live status dashboard", 
       return new Response(JSON.stringify({ ok: true }), { status: 200 });
     }
     hookRequests.push(request);
-    return new Response(JSON.stringify({ ok: true, runId: "hook-1" }), { status: 200 });
+    return Response.json({
+      ok: true,
+      runId: "hook-1",
+      completion: {
+        status: "skipped",
+        replyDisposition: "silent",
+        deliverySuppressionReason: "silent",
+      },
+    });
   };
 
   const summary = await runClawSweeperEventNotifier(["--run-id", "987"], {
@@ -277,6 +321,136 @@ test("runClawSweeperEventNotifier mirrors events to the live status dashboard", 
     title: "Duplicate issue",
     note: "duplicate",
   });
+  const report = JSON.parse(
+    fs.readFileSync(path.join(root, "notifications/clawsweeper-event-report.json"), "utf8"),
+  );
+  assert.deepEqual(report.actions[0].delivery, {
+    status: "suppressed",
+    suppression_reason: "silent",
+    error: null,
+  });
+});
+
+for (const scenario of [
+  {
+    name: "failed",
+    completion: {
+      status: "error",
+      replyDisposition: "visible",
+      delivered: false,
+      deliveryAttempted: true,
+      deliveryError: "delivery-failed",
+    },
+    delivery: {
+      status: "failed",
+      suppression_reason: null,
+      error: "delivery-failed",
+    },
+  },
+  {
+    name: "unknown",
+    completion: {
+      status: "ok",
+      replyDisposition: "visible",
+      delivered: false,
+      deliveryAttempted: false,
+      privateDiagnostic: "not public",
+    },
+    delivery: {
+      status: "unknown",
+      suppression_reason: null,
+      error: null,
+    },
+  },
+] as const) {
+  test(`runClawSweeperEventNotifier publishes dashboard but retries ${scenario.name} completion`, async () => {
+    const root = createNotifierEventRoot(`clawsweeper-events-${scenario.name}-`);
+
+    let hookRequests = 0;
+    let dashboardRequests = 0;
+    const fetcher: typeof fetch = async (input) => {
+      if (String(input).startsWith("https://status.example/")) {
+        dashboardRequests += 1;
+        return Response.json({ ok: true });
+      }
+      hookRequests += 1;
+      return Response.json({
+        ok: true,
+        runId: `hook-${hookRequests}`,
+        completion: scenario.completion,
+      });
+    };
+    const runtime = {
+      root,
+      fetch: fetcher,
+      now: () => new Date("2026-05-02T11:00:00Z"),
+      log: () => undefined,
+      env: notifierEnvironment(),
+    };
+
+    const first = await runClawSweeperEventNotifier(["--run-id", "987"], runtime);
+    const second = await runClawSweeperEventNotifier(["--run-id", "987"], runtime);
+
+    assert.equal(first.sent, 0);
+    assert.equal(first.failed, 1);
+    assert.equal(second.sent, 0);
+    assert.equal(second.failed, 1);
+    assert.equal(hookRequests, 2);
+    assert.equal(dashboardRequests, 2);
+    assert.equal(
+      fs.existsSync(path.join(root, "notifications/clawsweeper-event-ledger.json")),
+      false,
+    );
+    const report = JSON.parse(
+      fs.readFileSync(path.join(root, "notifications/clawsweeper-event-report.json"), "utf8"),
+    );
+    assert.equal(report.actions.length, 1);
+    assert.equal(report.actions[0].status, "failed");
+    assert.equal(report.actions[0].hook_run_id, "hook-2");
+    assert.deepEqual(report.actions[0].delivery, scenario.delivery);
+    assert.doesNotMatch(JSON.stringify(report), /not public/);
+  });
+}
+
+test("runClawSweeperEventNotifier reports one failure when delivery and dashboard fail", async () => {
+  const root = createNotifierEventRoot("clawsweeper-events-double-fail-");
+
+  const summary = await runClawSweeperEventNotifier(["--run-id", "987"], {
+    root,
+    fetch: async (input) => {
+      if (String(input).startsWith("https://status.example/")) {
+        return new Response("bad token", { status: 401 });
+      }
+      return Response.json({
+        ok: true,
+        runId: "hook-1",
+        completion: {
+          status: "error",
+          replyDisposition: "visible",
+          delivered: false,
+          deliveryAttempted: true,
+          deliveryError: "delivery-failed",
+        },
+      });
+    },
+    now: () => new Date("2026-05-02T11:00:00Z"),
+    log: () => undefined,
+    env: notifierEnvironment(),
+  });
+
+  assert.equal(summary.sent, 0);
+  assert.equal(summary.failed, 1);
+  const report = JSON.parse(
+    fs.readFileSync(path.join(root, "notifications/clawsweeper-event-report.json"), "utf8"),
+  );
+  assert.equal(report.actions.length, 1);
+  assert.equal(report.actions[0].status, "failed");
+  assert.match(report.actions[0].reason, /dashboard ingest returned 401/);
+  assert.deepEqual(report.actions[0].delivery, {
+    status: "failed",
+    suppression_reason: null,
+    error: "delivery-failed",
+  });
 });
 
 test("runClawSweeperEventNotifier retries events after dashboard ingest failures", async () => {
@@ -301,7 +475,16 @@ test("runClawSweeperEventNotifier retries events after dashboard ingest failures
       if (String(input).startsWith("https://status.example/")) {
         return new Response("bad token", { status: 401 });
       }
-      return new Response(JSON.stringify({ ok: true, runId: "hook-1" }), { status: 200 });
+      return Response.json({
+        ok: true,
+        runId: "hook-1",
+        completion: {
+          status: "ok",
+          replyDisposition: "visible",
+          delivered: true,
+          deliveryAttempted: true,
+        },
+      });
     },
     now: () => new Date("2026-05-02T11:00:00Z"),
     log: () => undefined,

--- a/test/repair/notify-github-activity.test.ts
+++ b/test/repair/notify-github-activity.test.ts
@@ -285,10 +285,20 @@ test("runGithubActivityNotifier posts one bounded forwarded push event", async (
       body: JSON.parse(String(init?.body)),
       auth: new Headers(init?.headers).get("authorization"),
     });
-    return new Response(JSON.stringify({ ok: true, runId: "hook-run-1" }), { status: 200 });
+    return Response.json({
+      ok: true,
+      runId: "hook-run-1",
+      completion: {
+        status: "ok",
+        replyDisposition: "silent",
+        delivered: true,
+        deliveryAttempted: true,
+      },
+    });
   };
 
   const observedAt = new Date("2026-09-05T07:24:31.000Z");
+  const stepSummaryPath = path.join(root, "step-summary.md");
   const summary = await runGithubActivityNotifier(["--write-report"], {
     root,
     fetch: mockFetch,
@@ -301,6 +311,7 @@ test("runGithubActivityNotifier posts one bounded forwarded push event", async (
       CLAWSWEEPER_OPENCLAW_HOOK_URL: "https://claw.example/hooks",
       CLAWSWEEPER_OPENCLAW_HOOK_TOKEN: "secret",
       CLAWSWEEPER_DISCORD_TARGET: "channel:123",
+      GITHUB_STEP_SUMMARY: stepSummaryPath,
     },
   });
 
@@ -308,6 +319,7 @@ test("runGithubActivityNotifier posts one bounded forwarded push event", async (
   assert.equal(requests.length, 1);
   assert.equal(requests[0]?.auth, "Bearer secret");
   assert.equal(requests[0]?.body.deliver, false);
+  assert.equal(requests[0]?.body.waitForCompletion, true);
   assert.match(String(requests[0]?.body.message), /use the message tool/);
   assert.match(String(requests[0]?.body.message), /channel:123/);
   assert.match(String(requests[0]?.body.message), /one exact GitHub event/);
@@ -320,6 +332,12 @@ test("runGithubActivityNotifier posts one bounded forwarded push event", async (
     fs.readFileSync(path.join(root, "notifications/github-activity-report.json"), "utf8"),
   );
   assert.equal(report.generated_at, observedAt.toISOString());
+  assert.deepEqual(report.delivery, {
+    status: "delivered",
+    suppression_reason: null,
+    error: null,
+  });
+  assert.match(fs.readFileSync(stepSummaryPath, "utf8"), /Delivery: `delivered`/);
 });
 
 test("runGithubActivityNotifier skips routine noisy GitHub activity before posting hooks", async () => {

--- a/test/repair/notify-maintainer-report.test.ts
+++ b/test/repair/notify-maintainer-report.test.ts
@@ -110,7 +110,15 @@ test("runMaintainerReportNotifier fetches the live report and posts the hook", a
       body: JSON.parse(String(init?.body)),
       idempotency: new Headers(init?.headers).get("idempotency-key"),
     });
-    return Response.json({ runId: "hook-run-1" });
+    return Response.json({
+      runId: "hook-run-1",
+      completion: {
+        status: "ok",
+        replyDisposition: "visible",
+        delivered: true,
+        deliveryAttempted: true,
+      },
+    });
   };
 
   const summary = await runMaintainerReportNotifier(["--write-report"], {
@@ -133,6 +141,7 @@ test("runMaintainerReportNotifier fetches the live report and posts the hook", a
   assert.equal(requests[0]?.url, "https://claw.example/hooks/agent");
   assert.equal(requests[0]?.idempotency, "maintainer-report:2026-05-22");
   assert.equal(requests[0]?.body?.deliver, true);
+  assert.equal(requests[0]?.body?.waitForCompletion, true);
   assert.deepEqual(reportFetchHeaders, ["access-id", "access-id"]);
   assert.match(
     String(requests[0]?.body?.message),
@@ -143,6 +152,11 @@ test("runMaintainerReportNotifier fetches the live report and posts the hook", a
     fs.readFileSync(path.join(root, "notifications/maintainer-report-discord.json"), "utf8"),
   );
   assert.equal(notification.hook_run_id, "hook-run-1");
+  assert.deepEqual(notification.delivery, {
+    status: "delivered",
+    suppression_reason: null,
+    error: null,
+  });
   assert.equal(notification.report_url, "https://reports.openclaw.ai/day/2026-05-22/");
 });
 

--- a/test/repair/notify-merge.test.ts
+++ b/test/repair/notify-merge.test.ts
@@ -214,7 +214,16 @@ test("runMergeNotifier posts hook payloads and records sent ledger", async () =>
       body: JSON.parse(String(init?.body)),
       auth: new Headers(init?.headers).get("authorization"),
     });
-    return new Response(JSON.stringify({ ok: true, runId: "hook-run-1" }), { status: 200 });
+    return Response.json({
+      ok: true,
+      runId: "hook-run-1",
+      completion: {
+        status: "ok",
+        replyDisposition: "visible",
+        delivered: true,
+        deliveryAttempted: true,
+      },
+    });
   };
 
   const summary = await runMergeNotifier(["--run-id", "987"], {
@@ -235,6 +244,7 @@ test("runMergeNotifier posts hook payloads and records sent ledger", async () =>
   assert.equal(requests[0]?.auth, "Bearer secret");
   assert.equal(requests[0]?.body.agentId, "clawsweeper");
   assert.equal(requests[0]?.body.to, "channel:123");
+  assert.equal(requests[0]?.body.waitForCompletion, true);
   assert.match(String(requests[0]?.body.message), /Fix config parsing/);
 
   const ledger = JSON.parse(
@@ -242,6 +252,14 @@ test("runMergeNotifier posts hook payloads and records sent ledger", async () =>
   );
   assert.equal(ledger.notifications[0].hookRunId, "hook-run-1");
   assert.equal(ledger.notifications[0].discordTarget, "channel:123");
+  const report = JSON.parse(
+    fs.readFileSync(path.join(root, "notifications/clawsweeper-merge-report.json"), "utf8"),
+  );
+  assert.deepEqual(report.actions[0].delivery, {
+    status: "delivered",
+    suppression_reason: null,
+    error: null,
+  });
 
   const rerun = await runMergeNotifier(["--run-id", "987"], {
     root,
@@ -256,6 +274,90 @@ test("runMergeNotifier posts hook payloads and records sent ledger", async () =>
   assert.equal(rerun.sent, 0);
   assert.equal(rerun.skipped, 1);
   assert.equal(requests.length, 1);
+});
+
+test("runMergeNotifier keeps unknown completion retryable and out of the ledger", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-notify-unknown-"));
+  fs.writeFileSync(
+    path.join(root, "repair-apply-report.json"),
+    `${JSON.stringify([
+      {
+        repo: "openclaw/openclaw",
+        target: "#123",
+        action: "merge_candidate",
+        status: "executed",
+        merge_commit_sha: "abc123",
+        run_id: "987",
+      },
+    ])}\n`,
+  );
+
+  const summary = await runMergeNotifier(["--run-id", "987", "--write-report"], {
+    root,
+    fetch: async () =>
+      Response.json({ ok: true, runId: "hook-run-1", completion: { status: "skipped" } }),
+    log: () => undefined,
+    env: {
+      CLAWSWEEPER_OPENCLAW_HOOK_URL: "https://claw.example/hooks",
+      CLAWSWEEPER_OPENCLAW_HOOK_TOKEN: "secret",
+      CLAWSWEEPER_DISCORD_TARGET: "channel:123",
+    },
+  });
+
+  assert.equal(summary.sent, 0);
+  assert.equal(summary.failed, 1);
+  assert.equal(
+    fs.existsSync(path.join(root, "notifications/clawsweeper-merge-ledger.json")),
+    false,
+  );
+  const report = JSON.parse(
+    fs.readFileSync(path.join(root, "notifications/clawsweeper-merge-report.json"), "utf8"),
+  );
+  assert.equal(report.actions[0].delivery.status, "unknown");
+});
+
+test("runMergeNotifier ledgers legacy admission to preserve at-most-once delivery", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-notify-admitted-"));
+  fs.writeFileSync(
+    path.join(root, "repair-apply-report.json"),
+    `${JSON.stringify([
+      {
+        repo: "openclaw/openclaw",
+        target: "#123",
+        action: "merge_candidate",
+        status: "executed",
+        merge_commit_sha: "abc123",
+        run_id: "987",
+      },
+    ])}\n`,
+  );
+
+  let calls = 0;
+  const summary = await runMergeNotifier(["--run-id", "987", "--write-report"], {
+    root,
+    fetch: async () => {
+      calls += 1;
+      return Response.json({ ok: true, runId: "legacy-run" });
+    },
+    log: () => undefined,
+    env: {
+      CLAWSWEEPER_OPENCLAW_HOOK_URL: "https://claw.example/hooks",
+      CLAWSWEEPER_OPENCLAW_HOOK_TOKEN: "secret",
+      CLAWSWEEPER_DISCORD_TARGET: "channel:123",
+    },
+  });
+
+  assert.equal(summary.sent, 1);
+  assert.equal(calls, 1);
+  const ledger = JSON.parse(
+    fs.readFileSync(path.join(root, "notifications/clawsweeper-merge-ledger.json"), "utf8"),
+  );
+  assert.equal(ledger.notifications[0].hookRunId, "legacy-run");
+  const report = JSON.parse(
+    fs.readFileSync(path.join(root, "notifications/clawsweeper-merge-report.json"), "utf8"),
+  );
+  assert.equal(report.actions[0].delivery.status, "admitted");
+  assert.match(report.actions[0].reason, /observability unavailable/);
 });
 
 test("runMergeNotifier returns a strict failure when the hook rejects", async () => {

--- a/test/repair/openclaw-hook.test.ts
+++ b/test/repair/openclaw-hook.test.ts
@@ -28,11 +28,25 @@ const post = {
 
 test("postOpenClawAgentHook retries transient hook failures with the same idempotency key", async () => {
   const calls: string[] = [];
+  const bodies: Record<string, unknown>[] = [];
   const fetcher: typeof fetch = async (_input, init) => {
     calls.push(new Headers(init?.headers).get("idempotency-key") ?? "");
+    bodies.push(JSON.parse(String(init?.body)));
     if (calls.length === 1) return new Response("bad gateway", { status: 502 });
     if (calls.length === 2) throw new Error("read ECONNRESET");
-    return new Response(JSON.stringify({ runId: "run-123" }), { status: 200 });
+    return new Response(
+      JSON.stringify({
+        runId: "run-123",
+        completion: {
+          status: "skipped",
+          replyDisposition: "silent",
+          delivered: false,
+          deliveryAttempted: false,
+          deliverySuppressionReason: "silent",
+        },
+      }),
+      { status: 200 },
+    );
   };
 
   const result = await postOpenClawAgentHook({
@@ -43,7 +57,16 @@ test("postOpenClawAgentHook retries transient hook failures with the same idempo
   });
 
   assert.equal(result.runId, "run-123");
+  assert.deepEqual(result.delivery, {
+    status: "suppressed",
+    suppressionReason: "silent",
+    error: null,
+  });
   assert.deepEqual(calls, ["github-activity:test", "github-activity:test", "github-activity:test"]);
+  assert.equal(
+    bodies.every((body) => body.waitForCompletion === true),
+    true,
+  );
 });
 
 test("postOpenClawAgentHook does not retry non-transient hook failures", async () => {
@@ -61,6 +84,182 @@ test("postOpenClawAgentHook does not retry non-transient hook failures", async (
     /OpenClaw hook returned 401/,
   );
   assert.equal(calls, 1);
+});
+
+test("postOpenClawAgentHook accepts legacy admission without retrying", async () => {
+  let calls = 0;
+  const result = await postOpenClawAgentHook({
+    config,
+    fetcher: async () => {
+      calls += 1;
+      return Response.json({ ok: true, runId: "legacy-run" });
+    },
+    post,
+    retryDelaysMs: [0, 0],
+  });
+
+  assert.equal(calls, 1);
+  assert.equal(result.runId, "legacy-run");
+  assert.deepEqual(result.delivery, {
+    status: "admitted",
+    suppressionReason: null,
+    error: null,
+  });
+});
+
+test("postOpenClawAgentHook classifies bounded completion results", async () => {
+  const cases = [
+    {
+      name: "deliver false with verified message-tool delivery",
+      deliver: false,
+      completion: {
+        status: "ok",
+        replyDisposition: "silent",
+        delivered: true,
+        deliveryAttempted: true,
+      },
+      expected: { status: "delivered", suppressionReason: null, error: null },
+    },
+    {
+      name: "deliver false with exact silent reply",
+      deliver: false,
+      completion: {
+        status: "ok",
+        replyDisposition: "silent",
+        delivered: false,
+        deliveryAttempted: false,
+      },
+      expected: { status: "suppressed", suppressionReason: "silent", error: null },
+    },
+    {
+      name: "exact silent reply wins over later error fields",
+      deliver: false,
+      completion: {
+        status: "error",
+        replyDisposition: "silent",
+        delivered: false,
+        deliveryAttempted: true,
+        deliveryError: "delivery-failed",
+      },
+      expected: { status: "suppressed", suppressionReason: "silent", error: null },
+    },
+    {
+      name: "deliver false with private visible reply",
+      deliver: false,
+      completion: {
+        status: "ok",
+        replyDisposition: "visible",
+        delivered: false,
+        deliveryAttempted: false,
+      },
+      expected: { status: "unknown", suppressionReason: null, error: null },
+    },
+    {
+      name: "deliver false with no delivery or model reply",
+      deliver: false,
+      completion: {
+        status: "ok",
+        replyDisposition: "empty",
+        delivered: false,
+        deliveryAttempted: false,
+      },
+      expected: { status: "not-requested", suppressionReason: null, error: null },
+    },
+    {
+      name: "automatic delivery with explicit suppression",
+      deliver: true,
+      completion: {
+        status: "skipped",
+        replyDisposition: "empty",
+        delivered: false,
+        deliveryAttempted: false,
+        deliverySuppressionReason: "heartbeat",
+      },
+      expected: { status: "suppressed", suppressionReason: "heartbeat", error: null },
+    },
+    {
+      name: "visible reply intentionally suppressed by the channel transform",
+      deliver: true,
+      completion: {
+        status: "ok",
+        replyDisposition: "visible",
+        delivered: false,
+        deliveryAttempted: true,
+        deliverySuppressionReason: "channel_transform",
+      },
+      expected: { status: "suppressed", suppressionReason: "channel_transform", error: null },
+    },
+    {
+      name: "verified delivery wins over terminal errors",
+      deliver: true,
+      completion: {
+        status: "error",
+        replyDisposition: "visible",
+        delivered: true,
+        deliveryAttempted: true,
+        deliveryError: "delivery-failed",
+      },
+      expected: { status: "delivered", suppressionReason: null, error: null },
+    },
+    {
+      name: "terminal delivery error",
+      deliver: true,
+      completion: {
+        status: "error",
+        replyDisposition: "empty",
+        deliveryError: `secret\n${"x".repeat(600)}`,
+      },
+      expectedStatus: "failed",
+    },
+    {
+      name: "deliver false skipped without explicit suppression evidence",
+      deliver: false,
+      completion: {
+        status: "skipped",
+        replyDisposition: "empty",
+        delivered: false,
+        deliveryAttempted: false,
+      },
+      expected: { status: "unknown", suppressionReason: null, error: null },
+    },
+    {
+      name: "missing reply disposition",
+      deliver: false,
+      completion: { status: "ok", deliveryAttempted: false },
+      expected: { status: "unknown", suppressionReason: null, error: null },
+    },
+  ] as const;
+
+  for (const fixture of cases) {
+    const result = await postOpenClawAgentHook({
+      config,
+      fetcher: async () => Response.json({ runId: "run-123", completion: fixture.completion }),
+      post: { ...post, deliver: fixture.deliver },
+    });
+    if ("expected" in fixture) {
+      assert.deepEqual(result.delivery, fixture.expected);
+      continue;
+    }
+    assert.equal(result.delivery.status, fixture.expectedStatus);
+    assert.equal(result.delivery.error?.includes("\n"), false);
+    assert.equal(result.delivery.error?.includes("secret"), false);
+    assert.equal(result.delivery.error?.length, 500);
+  }
+});
+
+test("postOpenClawAgentHook rejects malformed completion as unknown", async () => {
+  const result = await postOpenClawAgentHook({
+    config,
+    fetcher: async () =>
+      Response.json({ ok: true, runId: "run-123", completion: { status: "skipped" } }),
+    post,
+  });
+
+  assert.deepEqual(result.delivery, {
+    status: "unknown",
+    suppressionReason: null,
+    error: null,
+  });
 });
 
 test("resolveOpenClawHookConfig supports explicit retry attempts", () => {

--- a/test/repair/openclaw-hook.test.ts
+++ b/test/repair/openclaw-hook.test.ts
@@ -283,6 +283,25 @@ for (const replyDisposition of ["empty", "visible"]) {
   }
 }
 
+for (const fixture of [
+  { name: "both flags", flags: {} },
+  { name: "deliveryAttempted", flags: { delivered: false } },
+  { name: "delivered", flags: { deliveryAttempted: false } },
+]) {
+  test(`postOpenClawAgentHook preserves unknown when completion lacks ${fixture.name}`, async () => {
+    const result = await postOpenClawAgentHook({
+      config,
+      fetcher: async () =>
+        Response.json({
+          runId: "run-123",
+          completion: { status: "ok", replyDisposition: "empty", ...fixture.flags },
+        }),
+      post: { ...post, deliver: false },
+    });
+    assert.deepEqual(result.delivery, { status: "unknown", suppressionReason: null, error: null });
+  });
+}
+
 test("postOpenClawAgentHook rejects malformed completion as unknown", async () => {
   const result = await postOpenClawAgentHook({
     config,

--- a/test/repair/openclaw-hook.test.ts
+++ b/test/repair/openclaw-hook.test.ts
@@ -247,6 +247,42 @@ test("postOpenClawAgentHook classifies bounded completion results", async () => 
   }
 });
 
+for (const replyDisposition of ["empty", "visible"]) {
+  for (const deliver of [false, true]) {
+    test(`postOpenClawAgentHook preserves unknown ${replyDisposition} acknowledgement with deliver=${deliver}`, async () => {
+      const completion = {
+        status: "ok",
+        replyDisposition,
+        delivered: false,
+        deliveryAttempted: true,
+      };
+      const result = await postOpenClawAgentHook({
+        config,
+        fetcher: async () => Response.json({ runId: "run-123", completion }),
+        post: { ...post, deliver },
+      });
+      assert.deepEqual(result.delivery, {
+        status: "unknown",
+        suppressionReason: null,
+        error: null,
+      });
+
+      for (const failure of [
+        { status: "error" },
+        { deliveryError: "synthetic delivery failure" },
+      ]) {
+        const failed = await postOpenClawAgentHook({
+          config,
+          fetcher: async () =>
+            Response.json({ runId: "run-123", completion: { ...completion, ...failure } }),
+          post: { ...post, deliver },
+        });
+        assert.equal(failed.delivery.status, "failed");
+      }
+    });
+  }
+}
+
 test("postOpenClawAgentHook rejects malformed completion as unknown", async () => {
   const result = await postOpenClawAgentHook({
     config,


### PR DESCRIPTION
Addresses https://github.com/openclaw/clawsweeper/issues/1450. Replacement for https://github.com/openclaw/clawsweeper/pull/1451; Vincent Koc's contribution is preserved.

## Problem and impact

ClawSweeper observed only OpenClaw hook admission, so operators could not distinguish delivered notifications, intentional suppression, failed delivery, and unknown acknowledgements. Notification ledgers also lacked completion evidence.

## Change

One shared hook client requests bounded completion outcomes for the merge, event, maintainer-report, and GitHub-activity notifiers. Verified delivery and explicit suppression remain conclusive even when later terminal fields contain an error. Failed and unknown outcomes remain retryable with the same idempotency key; attempted delivery and omitted acknowledgement flags alone do not establish success or failure. Event dashboard publication remains independent.

Legacy `{ok:true,runId}` admission responses retain terminal `admitted` behavior and existing deduplication. Deployment order is compatible: the [pre-completion Gateway normalizer](https://github.com/openclaw/openclaw/blob/d0137988844d201423fbe1918e8c5acef8ddfa8e/src/gateway/hooks.ts#L689) ignores the added completion flag, and the client handles its original response. The [upstream completion protocol](https://github.com/openclaw/openclaw/pull/139155) enables richer observability when deployed. No configured-production delivery is claimed by this proof.

OpenClaw Bay is unaffected: these notification reports and ledgers do not change Bay's public observer contracts. Active hook documentation, the proof recipe, and the changelog describe the final behavior.

## Executed proof

[Native AWS proof and full gate](https://crabbox.openclaw.ai/portal/runs/run_af30673be732837dcb7577adbc7bdc84): lease `cbx_b5fe89a1e9fa`, image `ami-0461d919be7deb53c`, Node 24.18.1. All four built CLIs send real loopback HTTP requests and write real report, ledger, and step-summary files.

```sh
pnpm run build:node
node --test test/repair/openclaw-hook.test.ts test/repair/notify-merge.test.ts test/repair/notify-events.test.ts test/repair/notify-maintainer-report.test.ts test/repair/notify-github-activity.test.ts
node docs/proof/notifier-completion/run-proof.mjs
pnpm run check
```

All **52 scenarios passed**: delivery, silent/channel suppression, explicit suppression with later errors, failure, ambiguous completion, unacknowledged empty/visible replies, three omitted-flag combinations, legacy admission, and no requested delivery. Conclusive merge/event outcomes persist one ledger entry and deduplicate the next invocation. Failed and unknown cases remain unledgered and retry the same key. Event dashboard writes survive inconclusive hook delivery; GitHub activity summaries report the outcome.

Shared hook source SHA-256: `b7d2b1b442be1e129123ab6eb9b979f6ee31b5ea4d8a0258c87bc0ada89dd6f8`. The proof recipe and fixture are committed in `docs/proof/notifier-completion/`. Limits: synthetic Gateway responses over real HTTP, with no production credentials, Discord send, or deployment.

## Validation and review

The 49 focused tests passed. Full native validation passed 6,115 cases: 6,104 passed and 11 existing skips; the separate 13-test coverage gate passed. Main integration preserves the validated notifier code and proof source.

Accepted review finding: a visible reply with explicit channel suppression and a later terminal error was incorrectly marked failed. The new regression failed before the shared precedence fix; the expanded real CLI proof verifies conclusive ledger behavior across all four surfaces. Existing failed/unknown controls remain intact. Isolated Codex local and integration reviews are clean through P2; committed review, exact-head CI, and current ClawSweeper review gate landing.
