### PR TITLE
fix(repair): retain validation-fix timeout outcomes

### DIFF
--- a/docs/proof/validation-fix-outcome/README.md
+++ b/docs/proof/validation-fix-outcome/README.md
@@ -1,0 +1,36 @@
+# Validation-fix failure outcome
+
+Status: active validation recipe. Owner: repair execution. Source:
+`src/repair/execute-fix-artifact.ts`, especially `runCodexValidationFix` and the
+outer blocked-outcome handler. Update this proof when worker errors, validation,
+or terminal reporting change.
+
+The executor previously omitted the validation-fix phase from its recognized
+worker timeout/failure errors. A timeout or silent nonzero worker exit therefore
+escaped before the blocked report and recovery request were written.
+
+```sh
+pnpm run build:node
+node --test test/repair/execute-fix-worker-errors.test.ts
+node docs/proof/validation-fix-outcome/run-proof.mjs
+node docs/proof/validation-fix-outcome/run-proof.mjs --timeout
+```
+
+The proof runs the actual built CLI against a real local Git origin and blobless
+checkout. A synthetic edit introduces trailing whitespace. Real Git validation
+rejects it and invokes a validation-fix worker. The first scenario exits silently
+with status 1; the timeout scenario keeps a real subprocess alive until the
+executor's minimum five-minute deadline expires. Both must produce a blocked
+report with `requeue_required: true`, retain exit status 1, and perform no push or
+PR creation. Receipts and diagnostic output are under `.artifacts/validation-fix-*`.
+
+To reproduce the baseline, run the same recipe against a build of
+`d47259a07a62294e032018259aaf117ef12ed4fe` with `--expect-missing-report`.
+That control requires a missing report and an uncaught validation-fix failure.
+
+Limits: Git, validation, process execution, deadlines, and report persistence are
+real; GitHub, the input scanner, and model output use local synthetic adapters.
+No target repository, model service, or production state is mutated. Raw worker
+diagnostics retain their existing classification. This repair does not establish
+the cause of a lost production runner or make slow target validation pass.
+OpenClaw Bay's schema and observer-only controls are unaffected.

--- a/docs/proof/validation-fix-outcome/run-proof.mjs
+++ b/docs/proof/validation-fix-outcome/run-proof.mjs
@@ -1,0 +1,205 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const repo = path.resolve(import.meta.dirname, "../../..");
+const timeout = process.argv.includes("--timeout");
+const baseline = process.argv.includes("--expect-missing-report");
+const executor =
+  process.env.PROOF_EXECUTOR ?? path.join(repo, "dist/repair/execute-fix-artifact.js");
+const { writeFakeScanner } = await import(
+  pathToFileURL(path.join(repo, "test/agent-input-scan-helpers.ts"))
+);
+fs.mkdirSync(path.join(repo, ".artifacts"), { recursive: true });
+const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "full-executor-proof-"));
+const realGit = execFileSync("which", ["git"], { encoding: "utf8" }).trim();
+const gitConfig = path.join(scratch, "global.gitconfig");
+fs.writeFileSync(gitConfig, "", { mode: 0o600 });
+const gitEnv = { ...process.env, GIT_CONFIG_GLOBAL: gitConfig, GIT_CONFIG_NOSYSTEM: "1" };
+const git = (cwd, ...args) =>
+  execFileSync(realGit, args, {
+    cwd,
+    env: gitEnv,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+try {
+  const writer = path.join(scratch, "writer"),
+    target = path.join(scratch, "target"),
+    remote = path.join(scratch, "remote.git"),
+    bin = path.join(scratch, "bin");
+  fs.mkdirSync(writer);
+  fs.mkdirSync(bin);
+  writeFakeScanner(bin);
+  git(writer, "init", "-b", "main");
+  git(writer, "config", "user.name", "Synthetic fixture");
+  git(writer, "config", "user.email", "fixture@example.invalid");
+  fs.writeFileSync(path.join(writer, "README.md"), "base A\n");
+  git(writer, "add", ".");
+  git(writer, "-c", "commit.gpgsign=false", "commit", "-m", "fixture base A");
+  git(scratch, "clone", "--bare", writer, remote);
+  git(scratch, "--git-dir", remote, "config", "uploadpack.allowFilter", "true");
+  git(scratch, "clone", "--filter=blob:none", pathToFileURL(remote).href, target);
+  assert.equal(git(target, "config", "--get", "remote.origin.promisor"), "true");
+  const oldHead = git(target, "rev-parse", "HEAD");
+  fs.writeFileSync(path.join(writer, "README.md"), "base B\n");
+  git(writer, "add", ".");
+  git(writer, "-c", "commit.gpgsign=false", "commit", "-m", "fixture base B");
+  git(writer, "push", remote, "main");
+  const fetchedHead = git(writer, "rev-parse", "HEAD");
+  assert.notEqual(oldHead, fetchedHead);
+  const capture = path.join(scratch, "capture.json");
+  const missingCapture = path.join(scratch, "missing-blob.json");
+  const newBlob = git(writer, "rev-parse", `${fetchedHead}:README.md`);
+  fs.writeFileSync(
+    path.join(bin, "git"),
+    `#!/bin/sh\nexec '${process.execPath}' '${path.join(bin, "git.cjs")}' "$@"\n`,
+    { mode: 0o755 },
+  );
+  fs.writeFileSync(
+    path.join(bin, "git.cjs"),
+    `const {spawnSync}=require('node:child_process'),fs=require('node:fs');const args=process.argv.slice(2).map(x=>x==='https://github.com/openclaw/fixture.git'?${JSON.stringify(pathToFileURL(remote).href)}:x);if(args.includes('push')||args.some(x=>/^https?:/.test(x)))throw Error('unexpected publication/network Git');const r=spawnSync(${JSON.stringify(realGit)},args,{stdio:'inherit',env:process.env});if(r.status===0&&args.includes('fetch')&&args.includes('--filter=blob:none')&&!args.includes('--no-filter')){const probe=spawnSync(${JSON.stringify(realGit)},['--git-dir='+${JSON.stringify(path.join(target, ".git"))},'-c','protocol.allow=never','cat-file','-e',${JSON.stringify(newBlob)}],{stdio:'pipe',env:{...process.env,GIT_NO_LAZY_FETCH:'1'}});fs.writeFileSync(${JSON.stringify(missingCapture)},JSON.stringify({missing:probe.status!==0}));}process.exit(r.status??1);`,
+  );
+  const gh = path.join(bin, "gh.cjs");
+  fs.writeFileSync(
+    gh,
+    `const a=process.argv.slice(2);if(a[0]==='api'&&a[1].includes('/git/ref/')){console.error('Not Found (HTTP 404)');process.exit(1)}if(a[0]==='pr'&&a[1]==='list'){console.log(a.includes('--jq')?'':'[]');process.exit(0)}console.error('unexpected gh '+JSON.stringify(a));process.exit(1);`,
+  );
+  const codex = path.join(bin, "codex");
+  fs.writeFileSync(
+    codex,
+    `#!${process.execPath}\nconst fs=require('node:fs'),{execFileSync}=require('node:child_process');const a=process.argv.slice(2);if(a.includes('--version')){console.log('codex-cli 0.153.3');process.exit(0)}const prompt=fs.readFileSync(0,'utf8');if(prompt.startsWith('Fix the current repair patch so the changed-surface validation gate passes.')){if(${timeout}){setInterval(()=>{},1000);}else{process.exit(1);}return;}fs.writeFileSync(${JSON.stringify(capture)},JSON.stringify({head:execFileSync(${JSON.stringify(realGit)},['rev-parse','HEAD'],{encoding:'utf8'}).trim(),branch:execFileSync(${JSON.stringify(realGit)},['symbolic-ref','--short','HEAD'],{encoding:'utf8'}).trim(),source:fs.readFileSync('README.md','utf8')}));fs.writeFileSync('README.md','synthetic repair with trailing whitespace \\n');fs.writeFileSync(a[a.indexOf('--output-last-message')+1],'Synthetic repair ready for validation.');`,
+    { mode: 0o755 },
+  );
+  const job = path.join(scratch, "job.md"),
+    result = path.join(scratch, "result.json");
+  fs.writeFileSync(
+    job,
+    '---\nrepo: openclaw/fixture\ncluster_id: fresh-base-fixture\nmode: autonomous\nsource: manual\nallowed_actions: [fix, raise_pr]\nallow_fix_pr: true\ncandidates: ["#1"]\ncanonical: ["#1"]\n---\nSynthetic local proof\n',
+  );
+  fs.writeFileSync(
+    result,
+    JSON.stringify({
+      repo: "openclaw/fixture",
+      cluster_id: "fresh-base-fixture",
+      mode: "autonomous",
+      actions: [{ action: "fix_needed", target: "#1", status: "planned" }],
+      fix_artifact: {
+        summary: "Synthetic proof",
+        pr_title: "fix: synthetic proof",
+        pr_body: "Synthetic local proof",
+        affected_surfaces: ["docs"],
+        likely_files: ["README.md"],
+        linked_refs: ["https://github.com/openclaw/fixture/issues/1"],
+        validation_commands: ["git diff --check"],
+        credit_notes: ["Synthetic local fixture"],
+        changelog_required: false,
+        repair_strategy: "new_fix_pr",
+        source_prs: [],
+      },
+    }),
+  );
+  const child = spawnSync(
+    process.execPath,
+    [executor, job, result, "--target-dir", target, "--defer-publication"],
+    {
+      encoding: "utf8",
+      timeout: timeout ? 360000 : 120000,
+      env: {
+        PATH: bin + path.delimiter + process.env.PATH,
+        HOME: scratch,
+        TMPDIR: process.env.TMPDIR,
+        GIT_CONFIG_GLOBAL: gitConfig,
+        GIT_CONFIG_NOSYSTEM: "1",
+        GH_BIN: process.execPath,
+        GH_BIN_ARGS: JSON.stringify([gh]),
+        CODEX_BIN: codex,
+        GH_TOKEN: "synthetic-proof",
+        GITHUB_TOKEN: "",
+        CLAWSWEEPER_ALLOW_EXECUTE: "1",
+        CLAWSWEEPER_ALLOW_FIX_PR: "1",
+        CLAWSWEEPER_ALLOWED_OWNER: "openclaw",
+        CLAWSWEEPER_MODEL: "codex",
+        CLAWSWEEPER_INSTALL_TARGET_DEPS: "0",
+        CLAWSWEEPER_BRANCH_PUSH_SETTLE_SECONDS: "0",
+        CLAWSWEEPER_CLOSE_SUPERSEDED_SOURCE_PRS: "0",
+        CLAWSWEEPER_FIX_EDIT_ATTEMPTS: "1",
+        CLAWSWEEPER_FIX_CODEX_TIMEOUT_MS: "300000",
+        CLAWSWEEPER_ACTION_LEDGER_DISABLED: "1",
+      },
+    },
+  );
+  fs.writeFileSync(
+    path.join(
+      repo,
+      ".artifacts",
+      `validation-fix-${baseline ? "baseline" : timeout ? "timeout" : "failed"}.log`,
+    ),
+    child.stdout + child.stderr,
+  );
+  assert.ok(fs.existsSync(capture), child.stdout + child.stderr);
+  const seen = JSON.parse(fs.readFileSync(capture, "utf8"));
+  assert.equal(seen.head, fetchedHead);
+  assert.equal(seen.branch, "clawsweeper/fresh-base-fixture");
+  assert.equal(seen.source, "base B\n");
+  assert.equal(JSON.parse(fs.readFileSync(missingCapture, "utf8")).missing, true);
+  const reportPath = path.join(scratch, "fix-execution-report.json");
+  assert.equal(child.status, 1, child.stdout + child.stderr);
+  if (baseline) {
+    assert.equal(fs.existsSync(reportPath), false);
+    assert.match(child.stderr, /Codex validation-fix worker failed/);
+  } else {
+    assert.equal(fs.existsSync(reportPath), true, child.stdout + child.stderr);
+    const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+    assert.equal(report.status, "blocked");
+    assert.match(
+      report.reason,
+      timeout
+        ? /Codex validation-fix worker timed out after 300000ms/
+        : /Codex validation-fix worker failed/,
+    );
+    assert.equal(report.actions.at(-1).requeue_required, true);
+  }
+  const receipt = {
+    entrypoint: "dist/repair/execute-fix-artifact.js",
+    result: "passed",
+    scenario: timeout ? "real five-minute worker timeout" : "empty-output worker failure",
+    baseline,
+    terminal_report_written: fs.existsSync(reportPath),
+    exit_code: child.status,
+    production_mutations: 0,
+    limits:
+      "Full built executor and real Git/validation/process execution; local GitHub/scanner/model adapters. No live provider or production repair is claimed.",
+  };
+  receipt.head = git(repo, "rev-parse", "HEAD");
+  receipt.runtime = process.version;
+  receipt.executor_source_sha256 = createHash("sha256")
+    .update(
+      baseline
+        ? git(
+            repo,
+            "show",
+            "d47259a07a62294e032018259aaf117ef12ed4fe:src/repair/execute-fix-artifact.ts",
+          ) + "\n"
+        : fs.readFileSync(path.join(repo, "src/repair/execute-fix-artifact.ts")),
+    )
+    .digest("hex");
+  receipt.executor_build_sha256 = createHash("sha256")
+    .update(fs.readFileSync(executor))
+    .digest("hex");
+  fs.writeFileSync(
+    path.join(
+      repo,
+      ".artifacts",
+      `validation-fix-${baseline ? "baseline" : timeout ? "timeout" : "failed"}.json`,
+    ),
+    JSON.stringify(receipt, null, 2) + "\n",
+  );
+  console.log(JSON.stringify(receipt, null, 2));
+} finally {
+  fs.rmSync(scratch, { recursive: true, force: true });
+}

--- a/docs/repair/README.md
+++ b/docs/repair/README.md
@@ -188,7 +188,11 @@ If Codex itself fails an edit pass with a transient tool-transport error, such
 as a closed stdin session from the Codex tool router, the executor consumes an
 edit retry and keeps the branch recoverable instead of failing the whole repair
 worker immediately. Timeouts and validation failures still use their dedicated
-timeout, validation-fix, and review-fix paths.
+timeout, validation-fix, and review-fix paths. Validation-fix worker timeouts and
+empty-output failures retain a blocked
+execution report and the existing recovery request while returning a failing exit
+status; they do not permit publication or count as passing validation. See the
+[validation-fix outcome proof](../proof/validation-fix-outcome/README.md).
 
 Full worker prompts, Codex transcripts, and raw artifacts stay in GitHub Actions. The committed ledger keeps only the cluster summary, run URL, action counts, apply outcomes, closed targets, and human-review entries.
 

--- a/src/repair/execute-fix-artifact.ts
+++ b/src/repair/execute-fix-artifact.ts
@@ -769,7 +769,7 @@ function isBlockedFixError(error: JsonValue) {
   if (isRepairBranchPushBlocked(error)) return true;
   if (isRetryableCodexErrorMessage(String(error?.message ?? error))) return true;
   if (isCodexContextLimitError(String(error?.message ?? error))) return true;
-  return /external base blocker|Codex produced no target repo changes|Codex \/review did not pass|Codex (?:fix worker|review-fix worker|\/review) timed out|Codex (?:fix worker|review-fix worker|\/review) failed|validation command failed|command timed out after \d+ms: git (?:fetch|push)|rebase (?:conflicts remain unresolved|produced additional conflicts)/i.test(
+  return /external base blocker|Codex produced no target repo changes|Codex \/review did not pass|Codex (?:fix worker|review-fix worker|validation-fix worker|\/review) timed out|Codex (?:fix worker|review-fix worker|validation-fix worker|\/review) failed|validation command failed|command timed out after \d+ms: git (?:fetch|push)|rebase (?:conflicts remain unresolved|produced additional conflicts)/i.test(
     String(error?.message ?? error),
   );
 }

--- a/test/repair/execute-fix-worker-errors.test.ts
+++ b/test/repair/execute-fix-worker-errors.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { stripTypeScriptTypes } from "node:module";
+import test from "node:test";
+import * as transient from "../../src/codex-transient.ts";
+import * as pushErrors from "../../src/repair/repair-branch-push-errors.ts";
+
+const source = fs.readFileSync("src/repair/execute-fix-artifact.ts", "utf8");
+const start = source.indexOf("function isRetryableCodexFailure(");
+const end = source.indexOf("function shouldFallbackToReplacementAfterRepairError(", start);
+assert.ok(start >= 0 && end > start);
+const dependencies = { ...transient, ...pushErrors };
+const { isBlockedFixError, isRetryableCodexFailure } = new Function(
+  ...Object.keys(dependencies),
+  `${stripTypeScriptTypes(source.slice(start, end))}; return { isBlockedFixError, isRetryableCodexFailure };`,
+)(...Object.values(dependencies));
+
+for (const phase of ["fix worker", "review-fix worker", "validation-fix worker", "/review"]) {
+  for (const failure of ["timed out after 1800000ms", "failed"]) {
+    test(`${phase} ${failure} retains the blocked recovery outcome`, () => {
+      const message = `Codex ${phase} ${failure}`;
+      assert.equal(isBlockedFixError(new Error(message)), true);
+      assert.equal(isRetryableCodexFailure(message), true);
+    });
+  }
+}
+
+test("validation-fix reporting does not make persistent setup failures retryable", () => {
+  assert.equal(
+    isRetryableCodexFailure("Codex validation-fix worker failed: login required"),
+    false,
+  );
+  assert.equal(isRetryableCodexFailure("Codex validation-fix worker failed: bwrap setup"), false);
+  assert.equal(isBlockedFixError(new Error("unexpected executor invariant failure")), false);
+});


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where a validation-fix worker timeout or silent nonzero exit escaped before ClawSweeper wrote its blocked execution report. Operators lost the terminal reason and the existing recovery route had no report to consume.

Investigated after https://github.com/openclaw/clawsweeper/actions/runs/34661028558. The saved artifacts prove the pinned checkout repair worked and the target edit/tests ran. Target validation later encountered an existing test-shard boundary failure and slow type-aware lint; GitHub also records lost runner communication. The complete job log remains unavailable, so the exact terminating exception and OOM are not established. This PR fixes a separately reproduced reporting omission and does not claim to resolve the runner incident.

## Why This Change Was Made

Recognize the validation-fix phase alongside the existing edit and review-fix timeout/fallback-error cases. Those errors reach the existing blocked-report and recovery classification, retain a nonzero exit, and cannot reach publication. Timeouts, validation commands, scanner controls, and raw-diagnostic classification are unchanged.

## User Impact

A timed-out validation-fix pass leaves an actionable blocked outcome instead of losing its report. Failed validation still prevents publication.

## OpenClaw Bay Impact

No schema or public-control change. The existing repair outcome/recovery path is retained; Bay remains an observer of existing status contracts.

## Documentation Impact

The active repair reference now states this outcome. The new active proof recipe identifies its repair-execution owner, source, update triggers, and limits. The changelog bullet is isolated in the final notes PR.

## Evidence

- Node 24.20.0; both executor builds passed.
- 30 focused tests passed. Before the repair, the new nine-case regression suite failed exactly the validation-fix timeout and fallback-failure cases; both pass afterward.
- Documentation checks and diff checks passed.
- Paired real-executor failure proof: baseline exits 1 with no report; candidate exits 1 with a blocked report and `requeue_required: true`. No push or PR creation occurs.
- Independent pre-commit and committed-branch reviews are clean through P2.
- The real five-minute timeout proof passed on `30852a2ef7275b049d8eab934c9d292bb8c58f2a`: blocked report persisted, recovery requested, exit 1, zero production mutations. Executor source SHA-256: `f7399866c69293d70d32ca66010218b7a63bd4286566d31b37f577af16689e59`.

## Real Behavior Proof

Claim: known validation-fix timeouts and silent failures retain a durable blocked outcome without allowing publication.

Surface: the actual built `dist/repair/execute-fix-artifact.js` CLI, real local Git origin/blobless checkout, Git validation, child processes, and persisted report. A synthetic edit introduces trailing whitespace; real validation rejects it, then the validation-fix subprocess exits silently or remains alive until the real five-minute minimum deadline.

Commands:

```sh
pnpm run build:node
node --test test/repair/execute-fix-worker-errors.test.ts test/repair/execute-fix-artifact-source.test.ts
node docs/proof/validation-fix-outcome/run-proof.mjs
node docs/proof/validation-fix-outcome/run-proof.mjs --timeout
```

Recipe: `docs/proof/validation-fix-outcome/README.md`; receipts: `.artifacts/validation-fix-{baseline,failed,timeout}.json`. GitHub, scanner and model responses use local synthetic adapters. The adapters reject all pushes and unexpected network/publication operations. No live model, foreign-repository repair, or production mutation is claimed.

## Production Verification After Landing

The original checkout failure is no longer the observed blocker. A fresh dispatch on current main is still required to verify the production job; rerunning the old attempt retains old code:

```sh
gh workflow run repair-cluster-worker.yml --repo openclaw/clawsweeper --ref main -f job=jobs/openclaw/inbox/issue-openclaw-openclaw-145371.md -f mode=autonomous
```

A successful repair requires the target validation and runner condition to settle. A blocked report is evidence of this reporting repair, not a successful implementation run.

## CodeQL Annotation Disposition

The three `js/bad-code-sanitization` annotations on the synthetic worker fixture are non-actionable in this execution context. They identify `JSON.stringify(capture)` and two `JSON.stringify(realGit)` interpolations. Those become JavaScript string literals in a standalone Node executable: one pathname for `fs.writeFileSync`, and a Git executable pathname for `execFileSync` with fixed argument arrays.

The rule's documented `</script>` breakout requires an HTML parser. This fixture is never embedded in HTML; these calls do not invoke a shell. The values come from the proof runner's own temporary directory and pre-existing executable search path, not issue/PR/model/network content. JSON serialization preserves their JavaScript string boundaries. Independent source tracing confirmed all three sinks and this disposition. No check or alert was disabled or dismissed.
