### PR TITLE
docs(changelog): record validation-fix recovery repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Retain blocked execution reports and recovery requests when a validation-fix worker times out or exits without diagnostics, while preserving failed validation and publication gates.
 - Fetch and materialize the pinned commit before creating or resuming replacement repair branches, preserving dirty-checkout and concurrent-head safeguards.
 - Keep dashboard publication counts and time windows through refresh and cached reload, preserving explicit zeroes and incomplete data; thanks @vincentkoc.
 - Preserve PR versus issue identity and retained source provenance in failed-shard recovery; thanks @yetval.


### PR DESCRIPTION
## What Problem This Solves

Records the operator-visible validation-fix outcome repair in the consolidated Unreleased notes.

## Why This Change Was Made

Land after https://github.com/openclaw/clawsweeper/pull/1543. Keeping the note on an independent final branch avoids changelog conflicts between implementation PRs. The note preserves failed validation and publication gates and makes no claim that the production runner incident is resolved.

## User Impact

Release notes explain that known validation-fix timeouts and silent failures now retain blocked reports and recovery requests.

## OpenClaw Bay Impact

None; documentation only.

## Documentation Impact

Adds one line under the existing Unreleased section. Released sections and versions are unchanged.

## Evidence

`git diff --check` passed. Independent local and committed-branch reviews are clean through P2. Runtime proof belongs to the linked implementation PR. No tag or release is requested.
