### PR TITLE
fix(repair): retain command errors on identity rejection

### DIFF
--- a/docs/repair/README.md
+++ b/docs/repair/README.md
@@ -184,6 +184,11 @@ compiler-cache moves. Neighboring ignored inputs remain protected. A pending
 runtime build retains its bound output until archive smoke completes; cache
 restoration does not exempt that output from verification.
 
+When validation fails and also changes protected checkout inputs, the identity
+rejection remains the primary error and retains the command failure as its cause.
+This preserves timeout and compiler diagnostics without accepting changed inputs
+or treating an unfinished build's ownership lock as disposable cache.
+
 If Codex itself fails an edit pass with a transient tool-transport error, such
 as a closed stdin session from the Codex tool router, the executor consumes an
 edit retry and keeps the branch recoverable instead of failing the whole repair

--- a/src/repair/target-validation.ts
+++ b/src/repair/target-validation.ts
@@ -2915,6 +2915,9 @@ function assertValidationCheckoutIdentityWithinCommand(
     if (
       /unsafe validation command mutated checkout identity/.test(String((error as Error).message))
     ) {
+      // Keep the safety rejection primary without losing a timeout or failed
+      // command that prevented the target from cleaning up its artifacts.
+      if (cause !== undefined) (error as Error).cause = cause;
       throw error;
     }
     // oxlint-disable-next-line preserve-caught-error -- A caller-supplied command failure owns the public cause.

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -5452,6 +5452,36 @@ test("changed-gate compiler cache isolation still rejects unrelated ignored-inpu
   assert.equal(fs.existsSync(path.join(artifacts, "tsgo-cache")), false);
 });
 
+test("checkout identity rejection retains the failed validation command as its cause", () => {
+  const cwd = gitPackageFixture({ "check:changed": "node scripts/check-changed.mjs" });
+  fs.appendFileSync(path.join(cwd, ".gitignore"), ".artifacts/\n");
+  git(cwd, "add", ".");
+  git(cwd, "commit", "-m", "initial");
+  attachOrigin(cwd);
+  fs.mkdirSync(path.join(cwd, ".artifacts"));
+  fs.writeFileSync(path.join(cwd, ".artifacts", "stable.txt"), "original\n");
+  const binDir = makeFixtureDir("clawsweeper-failed-validation-identity-");
+  writeNodeCommandShim(
+    binDir,
+    "pnpm",
+    [
+      'require("node:fs").writeFileSync(".artifacts/stable.txt", "changed\\n");',
+      'console.error("validation failed before cleanup");',
+      "process.exit(23);",
+    ].join("\n"),
+  );
+
+  assert.throws(
+    () => runOpenClawChangedGate(cwd, binDir),
+    (error: Error & { cause?: Error }) => {
+      assert.match(error.message, /unsafe validation command mutated checkout identity/);
+      assert.match(error.message, /changed runtime roots: \.artifacts/);
+      assert.equal(error.cause?.message, "validation failed before cleanup");
+      return true;
+    },
+  );
+});
+
 test("runtime root diagnostics identify same-size poisoning even when its timestamp is restored", () => {
   const cwd = gitPackageFixture({ verify: "node scripts/verify.mjs" });
   git(cwd, "add", ".");


### PR DESCRIPTION
## What Problem This Solves

When a target validation command fails or times out and leaves a protected checkout input changed, the executor reports the identity rejection but discards the original command error. Operators cannot distinguish a compiler failure from a timeout using the final exception.

The production replay at https://github.com/openclaw/clawsweeper/actions/runs/34668102227 terminated with an `.artifacts` identity rejection and exit code 1. The runner completed cleanup and uploaded artifacts; its job annotation does not report lost communication. This change repairs the loss of diagnostic evidence. It does not claim that target validation now succeeds.

## Why This Change Was Made

Attach the existing command failure as the identity error's cause before rethrowing the same error. Preserve its original stack and primary message. The identity check still rejects modified inputs; budgets, retries, publication, and cleanup rules are unchanged. In particular, an unfinished compiler's ownership lock is not treated as disposable cache.

## User Impact

Failure logs retain the timeout or compiler error alongside the protected-input rejection, so the next investigation can identify both failures.

## OpenClaw Bay Impact

No Bay change is needed: the patch changes only an executor exception's cause. No report schema, lifecycle, queue, dashboard, or public observer contract changes.

## Documentation Impact

The repair reference documents the failure precedence. https://github.com/openclaw/clawsweeper/pull/1546 carries the sole Unreleased entry and must land after this implementation.

## Evidence

- The new regression fails on main because `error.cause` is absent; it passes with this change while still requiring the identity rejection.
- Nine focused tests passed, including compiler-cache isolation and protected runtime-input diagnostics.
- Formatting, focused lint, documentation checks, and diff checks passed.
- Pre-commit and committed-branch reviews are clean through P2. The full AWS `pnpm run check` passed: 6,071 tests passed, 11 existing platform/configuration skips, zero failures. Exact-head CI: https://github.com/openclaw/clawsweeper/actions/runs/34670605287; require its successful final conclusion before landing.

## Real Behavior Proof

Claim: a timed-out validation command that leaves its ownership lock retains both the identity failure and the original timeout, while an otherwise identical command with enough runtime succeeds and releases the lock.

Surface: the actual built `runAllowedValidationCommands` executor, real Linux process containment, filesystem state, and the published `@openclaw/fs-safe@0.8.5` file-lock implementation with `retainOnExit: true`.

Environment: Node 24.18.1 on AWS Linux, Crabbox lease `cbx_1491cf00e4bf` (`c7a.8xlarge`), using the repository's Linux namespace prerequisites. The baseline was compiled from the main source archive, and the candidate was compiled from the reviewed source. No runtime containment was bypassed.

Scenario: an existing `.artifacts` tree and empty ownership directory; a synthetic three-second command acquires its lock, completes work, then releases it. A 3,000-ms validation window interrupts it; a 12,000-ms window permits completion. The real executor reserves part of each window for identity verification.

Commands: build the main source archive and candidate with the repository compiler, then invoke `node .batch4-proof/prove-validation-budget.mjs <source-root> <baseline|candidate>`. The fixture invokes `pnpm check:changed` through a local command adapter. Runtime results and the complete validation trace are linked below.

Limits: the timed workload and package-manager adapter are synthetic. This proves the failure propagation and ownership behavior, not the exact leaf changed in the production replay. That replay did not retain a post-command artifact listing. No model request, GitHub mutation, production replay, or foreign-repository repair was performed by this proof.

## Production Diagnosis and Remaining Gate

The executor caps each validation command at eight minutes, with up to 30 seconds reserved before execution for identity verification. In the production edit trace, core-test typechecking alone took 574.27 seconds; the preceding graph and core checks took another 74.31 seconds. The cold gate therefore exceeded the deterministic child budget before reaching its unchanged-base `retainedMachine` TypeScript error.

Timeout followed by retained compiler ownership is the leading explanation for the final identity rejection, supported by the controlled proof. The saved production evidence does not establish the exact changed artifact or prove OOM. A scoped validation-budget decision and resolution of the target's baseline TypeScript failure remain separate gates; this PR does not increase budgets or authorize a replay.

### Captured runtime results

[Full AWS trace](https://crabbox.openclaw.ai/portal/runs/run_974ddc5355eb37526c0253f219bfde03), four successful scenario assertions:

| Source | Budget | Observable result |
| --- | --- | --- |
| Main baseline | 3,000 ms | Identity rejection; lock retained; original timeout lost |
| Main baseline | 12,000 ms | Validation passed; lock released |
| Candidate | 3,000 ms | Same identity rejection and retained lock; cause includes `command timed out after 1498ms` and `LOCK_ACQUIRED` |
| Candidate | 12,000 ms | Validation passed; lock released |

The protected sibling input remained byte-identical in all four runs. The first setup attempts exposed missing fixture payload, baseline package-manager auto-install, and Linux namespace prerequisites; none was counted as passing behavior proof.

Candidate worktree contents were committed unchanged as `9d04e748c8359656d58e85c26c5a081a206e9f85`; this was a raw synchronized proof, not a fresh PR checkout. Target-validation source SHA-256: `9f83b9462376eea2cdf3a1389b36427fc03accc9cb5a5e8b71f91478acd3ea9a`.
