### PR TITLE
docs(changelog): record validation failure diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Preserve the original validation failure or timeout when a checkout identity rejection also occurs, keeping protected-input and publication gates intact.
 - Retain blocked execution reports and recovery requests when a validation-fix worker times out or exits without diagnostics, while preserving failed validation and publication gates.
 - Fetch and materialize the pinned commit before creating or resuming replacement repair branches, preserving dirty-checkout and concurrent-head safeguards.
 - Keep dashboard publication counts and time windows through refresh and cached reload, preserving explicit zeroes and incomplete data; thanks @vincentkoc.


### PR DESCRIPTION
## What Problem This Solves

Record the validation diagnostic repair under Unreleased: an identity rejection retains the original failed command or timeout as its cause.

## Why This Change Was Made

Keep this batch's changelog in one independent notes PR. Land it after https://github.com/openclaw/clawsweeper/pull/1545. Released sections, versions, validation budgets, and production settings are unchanged.

## User Impact

The release notes describe the additional failure evidence without claiming that the production target validates successfully.

## OpenClaw Bay Impact

None; this is a release-note-only change.

## Evidence

`git diff --check` passes. Independent pre-commit and committed-branch reviews are clean through P2. Exact-head CI: https://github.com/openclaw/clawsweeper/actions/runs/34670620463; require its successful final conclusion before landing. No release or tag is requested.
