### PR TITLE
fix(repair): unblock offline Knip checks on current OpenClaw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Prepare the target's reviewed Knip helper for selected OpenClaw changed-gate scans, including current TypeScript runners and native pnpm 12 cache keys. Restore its offline cache between attempts without weakening frozen dependency or release-age checks.
 - Preserve the original validation failure or timeout when a checkout identity rejection also occurs, keeping protected-input and publication gates intact.
 - Retain blocked execution reports and recovery requests when a validation-fix worker times out or exits without diagnostics, while preserving failed validation and publication gates.
 - Fetch and materialize the pinned commit before creating or resuming replacement repair branches, preserving dirty-checkout and concurrent-head safeguards.

--- a/config/openclaw-knip-6.32.2.pnpm-lock.yaml
+++ b/config/openclaw-knip-6.32.2.pnpm-lock.yaml
@@ -1,0 +1,773 @@
+lockfileVersion: "9.0"
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+  .:
+    dependencies:
+      knip:
+        specifier: 6.32.2
+        version: 6.32.2
+
+packages:
+  "@emnapi/core@1.11.2":
+    resolution:
+      {
+        integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==,
+      }
+
+  "@emnapi/runtime@1.11.2":
+    resolution:
+      {
+        integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==,
+      }
+
+  "@emnapi/wasi-threads@1.2.2":
+    resolution:
+      {
+        integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==,
+      }
+
+  "@napi-rs/wasm-runtime@1.2.3":
+    resolution:
+      {
+        integrity: sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==,
+      }
+    engines: { node: ^20.19.0 || ^22.13.0 || >=23.5.0 }
+    peerDependencies:
+      "@emnapi/core": ^1.7.1 || ^2.0.0-alpha.4
+      "@emnapi/runtime": ^1.7.1 || ^2.0.0-alpha.4
+
+  "@oxc-parser/binding-android-arm-eabi@0.143.0":
+    resolution:
+      {
+        integrity: sha512-n9uozULWflPqBtdmI8lAabLqGKNgLVNN0ZH8HfgCwpKGNtzRzauB76jTiW/3YLkcA7N1zskpi9GdVnZuu1SAvg==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm]
+    os: [android]
+
+  "@oxc-parser/binding-android-arm64@0.143.0":
+    resolution:
+      {
+        integrity: sha512-9BbdjHETk6O3zH/DDid9IgBtF0GlpLabNKN231uraXpRDSfY+iiZxTP5bk1Z63GBownVdhdINFIeddmMz4MzpQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [android]
+
+  "@oxc-parser/binding-darwin-arm64@0.143.0":
+    resolution:
+      {
+        integrity: sha512-gh+6ecoHUy4/sUcolBl/1qPXKBbYNxFY0Pk0ujgQvINTMSftJY7o4yb8gOkDJPeZeB8+a+u7xTe6umoP8N5HFA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [darwin]
+
+  "@oxc-parser/binding-darwin-x64@0.143.0":
+    resolution:
+      {
+        integrity: sha512-qd1hl2d+lXgHv/VQ/M9qm8TrMC5T4RqDBwtOnl+1D0QMjwcz+8AaB4JSg8STgeag0GP6a6L74XEGAsrTSJWNzQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [darwin]
+
+  "@oxc-parser/binding-freebsd-x64@0.143.0":
+    resolution:
+      {
+        integrity: sha512-M5XXcNa7aOqLPKTR41msfghKu2yQ4xWvCm11/gwU0JzOzHNk5sgW//rVEjJ+LO48+VDAMzXTSzurUVxIDKwozw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [freebsd]
+
+  "@oxc-parser/binding-linux-arm-gnueabihf@0.143.0":
+    resolution:
+      {
+        integrity: sha512-T/GXusuOkPNQhCQCSBbcU/N8j0rAypuDBl1IyFK+lyYT594XsVz80clPC/OtbSSpBGyJxj8uYEfctxVuxVYoww==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm]
+    os: [linux]
+
+  "@oxc-parser/binding-linux-arm-musleabihf@0.143.0":
+    resolution:
+      {
+        integrity: sha512-oKu4RcBlXSqo3OC62dp6YTnQaZIurNDpCX3BnAM3+bJxt7s8J2TJKMnC0UYer1qhlRaDCg6wkTaTw+2IlsZ12w==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm]
+    os: [linux]
+
+  "@oxc-parser/binding-linux-arm64-gnu@0.143.0":
+    resolution:
+      {
+        integrity: sha512-WJBbD186AZmMGaSIhlktC+rPl8L3peCTXAh88Ih9uEvK0en2mPojGyCGYiL6mHtV1RPV3JyfJW5t6n5hh0lXhA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  "@oxc-parser/binding-linux-arm64-musl@0.143.0":
+    resolution:
+      {
+        integrity: sha512-t1AcYOwEzgceadT4v5e+vaCCb0AncCA3v5AyzfBAz/tMq11qzVccXKzNHtkWdjBsgvTKwRkaUF3QvT4kot8vcQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  "@oxc-parser/binding-linux-ppc64-gnu@0.143.0":
+    resolution:
+      {
+        integrity: sha512-RsnO/NoD8376LMJq8JS8TwI0ieNaFRTuNe2GVJntQg6gwZNMENZsEbknHdVwjpOmxdGLGodcwaGSbAeRr5Bgjw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  "@oxc-parser/binding-linux-riscv64-gnu@0.143.0":
+    resolution:
+      {
+        integrity: sha512-48fSVfR9TZi5CASZFyv0VC6z6BCoeihFsX031mAD/oSH7d9PYsPgIqza7d9mjP7Z2KTEpTFyH6SIu0Ui6R1vdg==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  "@oxc-parser/binding-linux-riscv64-musl@0.143.0":
+    resolution:
+      {
+        integrity: sha512-T8CpdD+SfE01DnIOD4HpVxu0ZJOfMJ/VhCvikKfaXAxkZ+9veyLM/D2hpi7Y2hFUyPmVQO3FNZHmYzV/WlVR4g==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  "@oxc-parser/binding-linux-s390x-gnu@0.143.0":
+    resolution:
+      {
+        integrity: sha512-QLdeMsCcacenPEFsfxnBUDF1y6opyz5+fmOz9bfD5Y7fiGCMupUCuB3KTPQhNwshIG1P9fPqar9MHxuBDd4bwQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  "@oxc-parser/binding-linux-x64-gnu@0.143.0":
+    resolution:
+      {
+        integrity: sha512-659ujfqLy6k7cuH3sbzhd8b+ztSq+i6E2E9pG78Q0BmHjAExfGIdgc8cGgMdwAozDXeZFHkJ+LXYJdWsaGdgyw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  "@oxc-parser/binding-linux-x64-musl@0.143.0":
+    resolution:
+      {
+        integrity: sha512-/Mw/9j4TfZcnKphPrzOE6t4MMknXadcAAuVUlDRTF/ETWB5xOgQvOJV2Mh9We/bWxZdoxaGAdc+hy4GuYwQ2yQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  "@oxc-parser/binding-openharmony-arm64@0.143.0":
+    resolution:
+      {
+        integrity: sha512-8rIKWR2BFuifbIK/1XB9wTaSdtuJ25dlE7ZQYDnEwj/2xH2vHsxnvIjHT3ZjSVuLLwGGlSslIG/fbOJ8TV8rTw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [openharmony]
+
+  "@oxc-parser/binding-win32-arm64-msvc@0.143.0":
+    resolution:
+      {
+        integrity: sha512-5U9kQYMfRRI6Zq7KDxgbIP0RMnKrfn3gLepRMgJuRkPSUALTiRCk9d/uyhb4lGDjUdzwK7mBkKqhLgzBPCmLpQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [win32]
+
+  "@oxc-parser/binding-win32-ia32-msvc@0.143.0":
+    resolution:
+      {
+        integrity: sha512-25P7AaHk4R88Yv2XH4gToDVmh0cOu+bEURQU10CRrmvgabfRArSGAP5osmwUKeSUHj0VS50upbpbRWWW/m7mHA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [ia32]
+    os: [win32]
+
+  "@oxc-parser/binding-win32-x64-msvc@0.143.0":
+    resolution:
+      {
+        integrity: sha512-ORMh3JE1s6V7ySicdRK7vgaDQnn5o+UHg9ct989PlWHbel8O9ARrmWXM6kZjrBMtNucxNayQ8g69G0VfWzhANw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [win32]
+
+  "@oxc-project/types@0.143.0":
+    resolution:
+      {
+        integrity: sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==,
+      }
+
+  "@oxc-resolver/binding-android-arm-eabi@11.24.2":
+    resolution:
+      {
+        integrity: sha512-y09e0L0SRI2OA2tUIrjBgoV3eH5hvUKXNkJqXmNo5V2WxIjyC7I7aJfRLMEVpA8yi95f90gFDvO0VMgrDw+vwA==,
+      }
+    cpu: [arm]
+    os: [android]
+
+  "@oxc-resolver/binding-android-arm64@11.24.2":
+    resolution:
+      {
+        integrity: sha512-cl4icWaZFnLdg8m6qtnh5rBMuGbxc/ptStFHLeCNwr+2cZjkjNwQu/jYRS0CHlnPecOJMpuS5M6/BH+0J/YkEg==,
+      }
+    cpu: [arm64]
+    os: [android]
+
+  "@oxc-resolver/binding-darwin-arm64@11.24.2":
+    resolution:
+      {
+        integrity: sha512-At29QEMF6HajbQvgY8K6OXnHD1x9rad74xBEfmCB6ZqCGsdq75aK7tOYcTbOanMy8qdIBrfL3SMr3p/lfSlb9w==,
+      }
+    cpu: [arm64]
+    os: [darwin]
+
+  "@oxc-resolver/binding-darwin-x64@11.24.2":
+    resolution:
+      {
+        integrity: sha512-A5Kqr1EUj4oIL5CF4WRssq/o5P0Y11cwoFouMRmQ7YnC/A8V93nv1nb7aSU8HwcgmXropjLNkVTl4MN87cu28Q==,
+      }
+    cpu: [x64]
+    os: [darwin]
+
+  "@oxc-resolver/binding-freebsd-x64@11.24.2":
+    resolution:
+      {
+        integrity: sha512-R5xkRBRRz7ceH/P5Jrc6G7FmdUdgpLYyESFAUDVTNQ9K0sGPxcp4ljiwEwEqsvNcQ4sYbMRrWcHHBCu7ksAJVw==,
+      }
+    cpu: [x64]
+    os: [freebsd]
+
+  "@oxc-resolver/binding-linux-arm-gnueabihf@11.24.2":
+    resolution:
+      {
+        integrity: sha512-k/RuYL4L/R58IBn3wT5ma3Wh4k62bp1eYCFRWCmMsasUOqL+H6sW0VGFadEzKWXFFlz+2uIMoeMk9ySSZJHgbg==,
+      }
+    cpu: [arm]
+    os: [linux]
+
+  "@oxc-resolver/binding-linux-arm-musleabihf@11.24.2":
+    resolution:
+      {
+        integrity: sha512-bnHAak3ujYfH5pKk4NieFNbvYvernfoQDgwLddbZ3OtMYrem87/qjlA+u+aKG0oZcqSLGCful/6/CEA+aeAgaA==,
+      }
+    cpu: [arm]
+    os: [linux]
+
+  "@oxc-resolver/binding-linux-arm64-gnu@11.24.2":
+    resolution:
+      {
+        integrity: sha512-vDT3KHgzYp47gmtNOqL2VNhCyl5Zv643eyxm//A68J8DeUGXrvD1pZFiaT4jSfe+RInfnn1R2yVHye4enx6RnA==,
+      }
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  "@oxc-resolver/binding-linux-arm64-musl@11.24.2":
+    resolution:
+      {
+        integrity: sha512-+kMlQvbzfyEYtu5FcjE4p+ttBLpKW4d/AsAsuE69BxV6V4twZJeIQZFfD8gh/wqglY0MkPSezWXQH0jBV13MUw==,
+      }
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  "@oxc-resolver/binding-linux-ppc64-gnu@11.24.2":
+    resolution:
+      {
+        integrity: sha512-shjfMhmZ3gq9fv/w7bi3PnZlgOPG+2QAOFf0BJF0EgBSIGZ6PMLN2zbGEblTUYB/NKVDRyYhE2ff3dJ1QqNPkA==,
+      }
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  "@oxc-resolver/binding-linux-riscv64-gnu@11.24.2":
+    resolution:
+      {
+        integrity: sha512-zGelwFR5oRo+b69k8Lrzun86DyUHzfKN6cnjbR9l7Z7NIRznOE/2ZvPa1IUKqAL2PzAXOdwkfVqNvO1H2RlpAw==,
+      }
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  "@oxc-resolver/binding-linux-riscv64-musl@11.24.2":
+    resolution:
+      {
+        integrity: sha512-qxZ1SWCXJY0eyhAlP6Lmo9F2Nrtx7EkYj9oCgL8apDPCwXwCEDA2U697bbT81JIc2IrVjxO4KX6WU2N+oN9Z4w==,
+      }
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  "@oxc-resolver/binding-linux-s390x-gnu@11.24.2":
+    resolution:
+      {
+        integrity: sha512-sGCecF3cx2DFlH4t/z7ApnOnXqN48p5p5mlHDEnHTAukQa2P+qMVE4CwyWE9W+q/m3QJ7kKfGrIjax31f44oFQ==,
+      }
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  "@oxc-resolver/binding-linux-x64-gnu@11.24.2":
+    resolution:
+      {
+        integrity: sha512-k/VlMMcSzMlahb3/fENM4rTlsJ0s3fFROA0KXPBmKggqmTSaE383sl8F3KCOXPLmVsYfW6hCitMhXCEtNeZxxg==,
+      }
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  "@oxc-resolver/binding-linux-x64-musl@11.24.2":
+    resolution:
+      {
+        integrity: sha512-8hbnZyNi97b/8wapYaIF9+t9GmZKBW2vunaOc3h9HGJptH7b7XpvZqOTBSm/MpTjr7H497BlgOaSfLUdhmy2bw==,
+      }
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  "@oxc-resolver/binding-openharmony-arm64@11.24.2":
+    resolution:
+      {
+        integrity: sha512-MvyGik3a6pVgZ0t/kWlbmFxFLmXQJwgLsY2eYFHLpy0wGwRbfzeIGgDwQ3kXqE30z+kSXennRkCrT7TUvkptNg==,
+      }
+    cpu: [arm64]
+    os: [openharmony]
+
+  "@oxc-resolver/binding-wasm32-wasi@11.24.2":
+    resolution:
+      {
+        integrity: sha512-vHcssMPwO08RTvj/c0iOBz90attxyG3wQJ0dTcyEQK43LRpcdLWZlV5feBhv6Isn6ahbQIzHbCgfa81+RiML0Q==,
+      }
+    engines: { node: ">=14.0.0" }
+    cpu: [wasm32]
+
+  "@oxc-resolver/binding-win32-arm64-msvc@11.24.2":
+    resolution:
+      {
+        integrity: sha512-uokJqro2iBqkFvJdKQLP7d8/BUmFwESQFVmIJUQKj1Xn1a/LysJoe1vmeECLF5b3jsV8CAL5sEMJXX6SdK9Nhg==,
+      }
+    cpu: [arm64]
+    os: [win32]
+
+  "@oxc-resolver/binding-win32-x64-msvc@11.24.2":
+    resolution:
+      {
+        integrity: sha512-UqGPmo56KDfLlfXFAFIrNflHT8tFxWGEivWg3Zeyp4Uy2NlKN1FGPr6/BxcLGG3+kZ6Wp14g5Uj+n71boqZfiw==,
+      }
+    cpu: [x64]
+    os: [win32]
+
+  "@tybys/wasm-util@0.10.3":
+    resolution:
+      {
+        integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==,
+      }
+
+  fd-package-json@2.0.0:
+    resolution:
+      {
+        integrity: sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==,
+      }
+
+  fdir@6.5.0:
+    resolution:
+      {
+        integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==,
+      }
+    engines: { node: ">=12.0.0" }
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  formatly@0.3.0:
+    resolution:
+      {
+        integrity: sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==,
+      }
+    engines: { node: ">=18.3.0" }
+    hasBin: true
+
+  get-tsconfig@4.14.1:
+    resolution:
+      {
+        integrity: sha512-Dz/6HxkrxgNehhxLVeyv8sad9UzF2xBVeaKBQNDfJ5XiSXmp2gTR0eO0RWiT2NCKS5aGP9jjkOMggTN90qU50A==,
+      }
+
+  jiti@2.7.0:
+    resolution:
+      {
+        integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==,
+      }
+    hasBin: true
+
+  knip@6.32.2:
+    resolution:
+      {
+        integrity: sha512-WXTXbmocrw7gqm1A1TQvFN0OgJ7hUSU6E1g6SPRIzzHFogUBhXByc7cYeOFVtJ2uODg7DP4VbESYBYnfbtBYsg==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    hasBin: true
+
+  oxc-parser@0.143.0:
+    resolution:
+      {
+        integrity: sha512-ov0NzaDCOInknS7mP1cwKdJERt3utPW8ldjtdUXQ8Ty0GEFD08wk422vCUN0d7pST6kqtV7dxoI9w1Zi0l/9TA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+
+  oxc-resolver@11.24.2:
+    resolution:
+      {
+        integrity: sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==,
+      }
+
+  picomatch@4.0.7:
+    resolution:
+      {
+        integrity: sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==,
+      }
+    engines: { node: ">=12" }
+
+  resolve-pkg-maps@1.0.0:
+    resolution:
+      {
+        integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==,
+      }
+
+  smol-toml@1.8.0:
+    resolution:
+      {
+        integrity: sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==,
+      }
+    engines: { node: ">= 18" }
+
+  strip-json-comments@5.0.3:
+    resolution:
+      {
+        integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==,
+      }
+    engines: { node: ">=14.16" }
+
+  tinyglobby@0.2.17:
+    resolution:
+      {
+        integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==,
+      }
+    engines: { node: ">=12.0.0" }
+
+  tslib@2.8.1:
+    resolution:
+      {
+        integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==,
+      }
+
+  unbash@4.0.11:
+    resolution:
+      {
+        integrity: sha512-FoSOKV7NEofQSkAefMVHam4ZPKYMxjAydxiV72UFEDNV/YofxjGfiZ2A9pZjdL/lRJzTjcu4PABo1JYJX8N5iQ==,
+      }
+    engines: { node: ">=14" }
+
+  walk-up-path@4.0.0:
+    resolution:
+      {
+        integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==,
+      }
+    engines: { node: 20 || >=22 }
+
+  yaml@2.9.0:
+    resolution:
+      {
+        integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==,
+      }
+    engines: { node: ">= 14.6" }
+    hasBin: true
+
+  zod@4.5.4:
+    resolution:
+      {
+        integrity: sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==,
+      }
+
+snapshots:
+  "@emnapi/core@1.11.2":
+    dependencies:
+      "@emnapi/wasi-threads": 1.2.2
+      tslib: 2.8.1
+    optional: true
+
+  "@emnapi/runtime@1.11.2":
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  "@emnapi/wasi-threads@1.2.2":
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  "@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)":
+    dependencies:
+      "@emnapi/core": 1.11.2
+      "@emnapi/runtime": 1.11.2
+      "@tybys/wasm-util": 0.10.3
+    optional: true
+
+  "@oxc-parser/binding-android-arm-eabi@0.143.0":
+    optional: true
+
+  "@oxc-parser/binding-android-arm64@0.143.0":
+    optional: true
+
+  "@oxc-parser/binding-darwin-arm64@0.143.0":
+    optional: true
+
+  "@oxc-parser/binding-darwin-x64@0.143.0":
+    optional: true
+
+  "@oxc-parser/binding-freebsd-x64@0.143.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-arm-gnueabihf@0.143.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-arm-musleabihf@0.143.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-arm64-gnu@0.143.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-arm64-musl@0.143.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-ppc64-gnu@0.143.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-riscv64-gnu@0.143.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-riscv64-musl@0.143.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-s390x-gnu@0.143.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-x64-gnu@0.143.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-x64-musl@0.143.0":
+    optional: true
+
+  "@oxc-parser/binding-openharmony-arm64@0.143.0":
+    optional: true
+
+  "@oxc-parser/binding-win32-arm64-msvc@0.143.0":
+    optional: true
+
+  "@oxc-parser/binding-win32-ia32-msvc@0.143.0":
+    optional: true
+
+  "@oxc-parser/binding-win32-x64-msvc@0.143.0":
+    optional: true
+
+  "@oxc-project/types@0.143.0": {}
+
+  "@oxc-resolver/binding-android-arm-eabi@11.24.2":
+    optional: true
+
+  "@oxc-resolver/binding-android-arm64@11.24.2":
+    optional: true
+
+  "@oxc-resolver/binding-darwin-arm64@11.24.2":
+    optional: true
+
+  "@oxc-resolver/binding-darwin-x64@11.24.2":
+    optional: true
+
+  "@oxc-resolver/binding-freebsd-x64@11.24.2":
+    optional: true
+
+  "@oxc-resolver/binding-linux-arm-gnueabihf@11.24.2":
+    optional: true
+
+  "@oxc-resolver/binding-linux-arm-musleabihf@11.24.2":
+    optional: true
+
+  "@oxc-resolver/binding-linux-arm64-gnu@11.24.2":
+    optional: true
+
+  "@oxc-resolver/binding-linux-arm64-musl@11.24.2":
+    optional: true
+
+  "@oxc-resolver/binding-linux-ppc64-gnu@11.24.2":
+    optional: true
+
+  "@oxc-resolver/binding-linux-riscv64-gnu@11.24.2":
+    optional: true
+
+  "@oxc-resolver/binding-linux-riscv64-musl@11.24.2":
+    optional: true
+
+  "@oxc-resolver/binding-linux-s390x-gnu@11.24.2":
+    optional: true
+
+  "@oxc-resolver/binding-linux-x64-gnu@11.24.2":
+    optional: true
+
+  "@oxc-resolver/binding-linux-x64-musl@11.24.2":
+    optional: true
+
+  "@oxc-resolver/binding-openharmony-arm64@11.24.2":
+    optional: true
+
+  "@oxc-resolver/binding-wasm32-wasi@11.24.2":
+    dependencies:
+      "@emnapi/core": 1.11.2
+      "@emnapi/runtime": 1.11.2
+      "@napi-rs/wasm-runtime": 1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+    optional: true
+
+  "@oxc-resolver/binding-win32-arm64-msvc@11.24.2":
+    optional: true
+
+  "@oxc-resolver/binding-win32-x64-msvc@11.24.2":
+    optional: true
+
+  "@tybys/wasm-util@0.10.3":
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  fd-package-json@2.0.0:
+    dependencies:
+      walk-up-path: 4.0.0
+
+  fdir@6.5.0(picomatch@4.0.7):
+    optionalDependencies:
+      picomatch: 4.0.7
+
+  formatly@0.3.0:
+    dependencies:
+      fd-package-json: 2.0.0
+
+  get-tsconfig@4.14.1:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  jiti@2.7.0: {}
+
+  knip@6.32.2:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.7)
+      formatly: 0.3.0
+      get-tsconfig: 4.14.1
+      jiti: 2.7.0
+      oxc-parser: 0.143.0
+      oxc-resolver: 11.24.2
+      picomatch: 4.0.7
+      smol-toml: 1.8.0
+      strip-json-comments: 5.0.3
+      tinyglobby: 0.2.17
+      unbash: 4.0.11
+      yaml: 2.9.0
+      zod: 4.5.4
+
+  oxc-parser@0.143.0:
+    dependencies:
+      "@oxc-project/types": 0.143.0
+    optionalDependencies:
+      "@oxc-parser/binding-android-arm-eabi": 0.143.0
+      "@oxc-parser/binding-android-arm64": 0.143.0
+      "@oxc-parser/binding-darwin-arm64": 0.143.0
+      "@oxc-parser/binding-darwin-x64": 0.143.0
+      "@oxc-parser/binding-freebsd-x64": 0.143.0
+      "@oxc-parser/binding-linux-arm-gnueabihf": 0.143.0
+      "@oxc-parser/binding-linux-arm-musleabihf": 0.143.0
+      "@oxc-parser/binding-linux-arm64-gnu": 0.143.0
+      "@oxc-parser/binding-linux-arm64-musl": 0.143.0
+      "@oxc-parser/binding-linux-ppc64-gnu": 0.143.0
+      "@oxc-parser/binding-linux-riscv64-gnu": 0.143.0
+      "@oxc-parser/binding-linux-riscv64-musl": 0.143.0
+      "@oxc-parser/binding-linux-s390x-gnu": 0.143.0
+      "@oxc-parser/binding-linux-x64-gnu": 0.143.0
+      "@oxc-parser/binding-linux-x64-musl": 0.143.0
+      "@oxc-parser/binding-openharmony-arm64": 0.143.0
+      "@oxc-parser/binding-win32-arm64-msvc": 0.143.0
+      "@oxc-parser/binding-win32-ia32-msvc": 0.143.0
+      "@oxc-parser/binding-win32-x64-msvc": 0.143.0
+
+  oxc-resolver@11.24.2:
+    optionalDependencies:
+      "@oxc-resolver/binding-android-arm-eabi": 11.24.2
+      "@oxc-resolver/binding-android-arm64": 11.24.2
+      "@oxc-resolver/binding-darwin-arm64": 11.24.2
+      "@oxc-resolver/binding-darwin-x64": 11.24.2
+      "@oxc-resolver/binding-freebsd-x64": 11.24.2
+      "@oxc-resolver/binding-linux-arm-gnueabihf": 11.24.2
+      "@oxc-resolver/binding-linux-arm-musleabihf": 11.24.2
+      "@oxc-resolver/binding-linux-arm64-gnu": 11.24.2
+      "@oxc-resolver/binding-linux-arm64-musl": 11.24.2
+      "@oxc-resolver/binding-linux-ppc64-gnu": 11.24.2
+      "@oxc-resolver/binding-linux-riscv64-gnu": 11.24.2
+      "@oxc-resolver/binding-linux-riscv64-musl": 11.24.2
+      "@oxc-resolver/binding-linux-s390x-gnu": 11.24.2
+      "@oxc-resolver/binding-linux-x64-gnu": 11.24.2
+      "@oxc-resolver/binding-linux-x64-musl": 11.24.2
+      "@oxc-resolver/binding-openharmony-arm64": 11.24.2
+      "@oxc-resolver/binding-wasm32-wasi": 11.24.2
+      "@oxc-resolver/binding-win32-arm64-msvc": 11.24.2
+      "@oxc-resolver/binding-win32-x64-msvc": 11.24.2
+
+  picomatch@4.0.7: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  smol-toml@1.8.0: {}
+
+  strip-json-comments@5.0.3: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.7)
+      picomatch: 4.0.7
+
+  tslib@2.8.1:
+    optional: true
+
+  unbash@4.0.11: {}
+
+  walk-up-path@4.0.0: {}
+
+  yaml@2.9.0: {}
+
+  zod@4.5.4: {}

--- a/docs/repair/README.md
+++ b/docs/repair/README.md
@@ -12,13 +12,13 @@
 
 ## Use the right repair document
 
-| Need | Canonical page |
-| --- | --- |
-| Understand repair concepts, modes, artifacts, or local CLI entry points | This page |
-| Run or recover live repair work | [Operations](operations.md) |
-| Change implementation objects, stages, ledgers, or extension points | [Internal feature map](internal-features.md) |
-| Change trusted PR autofix/automerge behavior | [Auto-updating PRs](auto-update-prs.md) |
-| Understand the end-to-end steerable session protocol | [Steerable repair automation](../steerable-repair-automation.md) |
+| Need                                                                    | Canonical page                                                   |
+| ----------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| Understand repair concepts, modes, artifacts, or local CLI entry points | This page                                                        |
+| Run or recover live repair work                                         | [Operations](operations.md)                                      |
+| Change implementation objects, stages, ledgers, or extension points     | [Internal feature map](internal-features.md)                     |
+| Change trusted PR autofix/automerge behavior                            | [Auto-updating PRs](auto-update-prs.md)                          |
+| Understand the end-to-end steerable session protocol                    | [Steerable repair automation](../steerable-repair-automation.md) |
 
 The operations runbook is the single source for live command trust, mutation
 gates, runner selection, token boundaries, routing, recovery, and promotion.
@@ -188,6 +188,15 @@ When validation fails and also changes protected checkout inputs, the identity
 rejection remains the primary error and retains the command failure as its cause.
 This preserves timeout and compiler diagnostics without accepting changed inputs
 or treating an unfinished build's ownership lock as disposable cache.
+
+OpenClaw changed-gate setup recognizes both `deadcode-knip-runner.mts` and the
+older `.mjs` runner. It prepares Knip only when the selected paths require a
+scan. Explicit paths take precedence over staged paths, then the base/head
+range plus tracked and untracked worktree changes. Setup uses a reviewed frozen
+graph and preserves the target's minimum release age. An unsupported pin stops
+setup and names the missing reviewed graph. The helper uses the selected pnpm
+version's cache key, including native pnpm 12, and reseeds each isolated
+validation cache after reset.
 
 If Codex itself fails an edit pass with a transient tool-transport error, such
 as a closed stdin session from the Codex tool router, the executor consumes an

--- a/src/repair/pinned-openclaw-validation-helper.ts
+++ b/src/repair/pinned-openclaw-validation-helper.ts
@@ -7,32 +7,51 @@ import { parse as parseYaml } from "yaml";
 
 import { runContainedCommand } from "./command-runner.js";
 
-const PINNED_OPENCLAW_KNIP_VERSION = "6.8.0";
-const PINNED_OPENCLAW_KNIP_PUBLISHED_AT = "2026-04-29T06:27:29.928Z";
+const PINNED_OPENCLAW_KNIP_RELEASES: Record<string, string> = {
+  "6.8.0": "2026-04-29T06:27:29.928Z",
+  "6.32.2": "2026-08-11T20:34:19.949Z",
+};
 const PREPARED_PNPM_HELPER_CACHE = ".__clawsweeper_pnpm_helper_cache__";
 const MINIMUM_OPENCLAW_RELEASE_AGE_MINUTES = 48 * 60;
-const PINNED_OPENCLAW_KNIP_LOCK = fileURLToPath(
-  new URL("../../config/openclaw-knip-6.8.0.pnpm-lock.yaml", import.meta.url),
-);
+
+type PinnedKnip = { version: string; publishedAt: string; lockPath: string };
 
 export function preparePinnedOpenClawValidationHelper({
   cwd,
   targetRepo,
+  packageManager,
   validationEnv,
   installRegistry,
   remainingTimeoutMs,
 }: {
   cwd: string;
   targetRepo: string;
+  packageManager: string;
   validationEnv: NodeJS.ProcessEnv;
   installRegistry: string;
   remainingTimeoutMs: () => number;
 }): void {
   if (targetRepo !== "openclaw/openclaw") return;
-  const runnerPath = path.join(cwd, "scripts", "deadcode-knip-runner.mjs");
-  if (!fs.existsSync(runnerPath)) return;
+  // Older target branches still use the pre-TypeScript runner and reviewed pin.
+  const runnerPath = ["mts", "mjs"]
+    .map((extension) => path.join(cwd, "scripts", `deadcode-knip-runner.${extension}`))
+    .find((candidate) => fs.existsSync(candidate));
+  if (!runnerPath) return;
   const runner = fs.readFileSync(runnerPath, "utf8");
-  if (!/^const KNIP_VERSION = ["']6\.8\.0["'];/m.test(runner)) return;
+  const version = /^const KNIP_VERSION = ["']([^"']+)["'];/m.exec(runner)?.[1];
+  const publishedAt = version && PINNED_OPENCLAW_KNIP_RELEASES[version];
+  if (!version || !publishedAt || !Object.hasOwn(PINNED_OPENCLAW_KNIP_RELEASES, version)) {
+    throw new Error(
+      `OpenClaw validation requires unsupported Knip ${version ?? "(unrecognized pin)"}; add its reviewed frozen dependency graph before retrying`,
+    );
+  }
+  const pin: PinnedKnip = {
+    version,
+    publishedAt,
+    lockPath: fileURLToPath(
+      new URL(`../../config/openclaw-knip-${version}.pnpm-lock.yaml`, import.meta.url),
+    ),
+  };
 
   // Materialize the complete reviewed dependency graph with frozen resolution;
   // lifecycle scripts and downloaded package code never execute during setup.
@@ -42,17 +61,17 @@ export function preparePinnedOpenClawValidationHelper({
   const helperCache = path.join(String(validationEnv.COREPACK_HOME), PREPARED_PNPM_HELPER_CACHE);
   const minimumReleaseAge = openClawMinimumReleaseAge(cwd);
   const dlxRoot = path.join(helperCache, "pnpm", "dlx");
-  const fullCacheKey = pinnedOpenClawDlxCacheKey(installRegistry);
+  const fullCacheKey = pinnedOpenClawDlxCacheKey(pin.version, packageManager, installRegistry);
   const cacheRoot = path.join(dlxRoot, fullCacheKey);
   const helperProject = path.join(cacheRoot, "pinned");
   fs.mkdirSync(helperProject, { recursive: true, mode: 0o700 });
-  fs.copyFileSync(PINNED_OPENCLAW_KNIP_LOCK, path.join(helperProject, "pnpm-lock.yaml"));
+  fs.copyFileSync(pin.lockPath, path.join(helperProject, "pnpm-lock.yaml"));
   fs.writeFileSync(
     path.join(helperProject, "package.json"),
     JSON.stringify({
       name: "clawsweeper-pinned-openclaw-knip",
       private: true,
-      dependencies: { knip: PINNED_OPENCLAW_KNIP_VERSION },
+      dependencies: { knip: pin.version },
     }),
   );
   fs.writeFileSync(
@@ -82,8 +101,8 @@ export function preparePinnedOpenClawValidationHelper({
   scopePinnedOpenClawJitiCache(helperProject);
   fs.symlinkSync("pinned", path.join(cacheRoot, "pkg"));
   fs.symlinkSync(fullCacheKey, path.join(dlxRoot, fullCacheKey.slice(0, 32)));
-  assertPinnedOpenClawValidationHelperLock(helperCache);
-  seedOfflinePinnedOpenClawMetadata(helperCache, helperProject, installRegistry);
+  assertPinnedOpenClawValidationHelperLock(helperCache, pin.lockPath);
+  seedOfflinePinnedOpenClawMetadata(helperCache, helperProject, installRegistry, pin);
 }
 
 function scopePinnedOpenClawJitiCache(helperProject: string): void {
@@ -98,12 +117,16 @@ function scopePinnedOpenClawJitiCache(helperProject: string): void {
   );
 }
 
-function pinnedOpenClawDlxCacheKey(installRegistry: string): string {
-  const resolvedPackages = [`knip@${PINNED_OPENCLAW_KNIP_VERSION}`];
-  const registries = [
-    ["@jsr", "https://npm.jsr.io/"],
-    ["default", installRegistry],
-  ];
+function pinnedOpenClawDlxCacheKey(
+  version: string,
+  packageManager: string,
+  installRegistry: string,
+): string {
+  const resolvedPackages = [`knip@${version}`];
+  const registries = [["default", installRegistry]];
+  // Native pnpm 12 excludes the builtin JSR route from its dlx key. A legacy
+  // key misses the prepared graph and starts an unfrozen install while offline.
+  if (!packageManager.startsWith("pnpm@12.")) registries.unshift(["@jsr", "https://npm.jsr.io/"]);
   return createHash("sha256")
     .update(JSON.stringify([resolvedPackages, registries]))
     .digest("hex");
@@ -113,6 +136,7 @@ function seedOfflinePinnedOpenClawMetadata(
   helperCache: string,
   helperProject: string,
   installRegistry: string,
+  pin: PinnedKnip,
 ): void {
   const cacheRoot = path.join(helperCache, "pnpm");
   const versions = fs.readdirSync(cacheRoot).filter((entry) => /^v\d+$/.test(entry));
@@ -121,13 +145,13 @@ function seedOfflinePinnedOpenClawMetadata(
   const manifest = JSON.parse(
     fs.readFileSync(path.join(helperProject, "node_modules", "knip", "package.json"), "utf8"),
   ) as Record<string, unknown>;
-  if (manifest.name !== "knip" || manifest.version !== PINNED_OPENCLAW_KNIP_VERSION) {
+  if (manifest.name !== "knip" || manifest.version !== pin.version) {
     throw new Error("pinned OpenClaw Knip package does not match the trusted dependency graph");
   }
-  const lock = parseYaml(fs.readFileSync(PINNED_OPENCLAW_KNIP_LOCK, "utf8")) as {
+  const lock = parseYaml(fs.readFileSync(pin.lockPath, "utf8")) as {
     packages?: Record<string, { resolution?: { integrity?: string } }>;
   };
-  const integrity = lock.packages?.[`knip@${PINNED_OPENCLAW_KNIP_VERSION}`]?.resolution?.integrity;
+  const integrity = lock.packages?.[`knip@${pin.version}`]?.resolution?.integrity;
   if (typeof integrity !== "string" || !integrity.startsWith("sha512-")) {
     throw new Error("pinned OpenClaw Knip integrity is missing from the trusted dependency graph");
   }
@@ -135,15 +159,15 @@ function seedOfflinePinnedOpenClawMetadata(
     ...manifest,
     dist: {
       integrity,
-      tarball: new URL(`knip/-/knip-${PINNED_OPENCLAW_KNIP_VERSION}.tgz`, installRegistry).href,
+      tarball: new URL(`knip/-/knip-${pin.version}.tgz`, installRegistry).href,
     },
   };
   const metadata = {
     name: "knip",
-    "dist-tags": { latest: PINNED_OPENCLAW_KNIP_VERSION },
-    versions: { [PINNED_OPENCLAW_KNIP_VERSION]: version },
-    time: { [PINNED_OPENCLAW_KNIP_VERSION]: PINNED_OPENCLAW_KNIP_PUBLISHED_AT },
-    modified: PINNED_OPENCLAW_KNIP_PUBLISHED_AT,
+    "dist-tags": { latest: pin.version },
+    versions: { [pin.version]: version },
+    time: { [pin.version]: pin.publishedAt },
+    modified: pin.publishedAt,
     cachedAt: Date.now(),
   };
   for (const version of versions) {
@@ -152,7 +176,7 @@ function seedOfflinePinnedOpenClawMetadata(
       fs.mkdirSync(path.dirname(destination), { recursive: true });
       fs.writeFileSync(
         destination,
-        `${JSON.stringify({ modified: PINNED_OPENCLAW_KNIP_PUBLISHED_AT })}\n${JSON.stringify(metadata)}\n`,
+        `${JSON.stringify({ modified: pin.publishedAt })}\n${JSON.stringify(metadata)}\n`,
       );
     }
   }
@@ -175,7 +199,7 @@ function openClawMinimumReleaseAge(cwd: string): number {
     : MINIMUM_OPENCLAW_RELEASE_AGE_MINUTES;
 }
 
-function assertPinnedOpenClawValidationHelperLock(helperCache: string): void {
+function assertPinnedOpenClawValidationHelperLock(helperCache: string, lockPath: string): void {
   const dlxRoot = path.join(helperCache, "pnpm", "dlx");
   const generatedLocks = fs
     .readdirSync(dlxRoot, { withFileTypes: true })
@@ -185,7 +209,7 @@ function assertPinnedOpenClawValidationHelperLock(helperCache: string): void {
   if (generatedLocks.length !== 1) {
     throw new Error("pinned OpenClaw Knip dependency lockfile is missing or ambiguous");
   }
-  const expected = parseYaml(fs.readFileSync(PINNED_OPENCLAW_KNIP_LOCK, "utf8")) as {
+  const expected = parseYaml(fs.readFileSync(lockPath, "utf8")) as {
     importers?: unknown;
     packages?: unknown;
     snapshots?: unknown;

--- a/src/repair/target-validation.ts
+++ b/src/repair/target-validation.ts
@@ -524,6 +524,7 @@ function preparePnpmToolchain({
     preparePinnedOpenClawValidationHelper({
       cwd,
       targetRepo,
+      packageManager,
       validationEnv,
       installRegistry,
       remainingTimeoutMs: () =>
@@ -549,19 +550,72 @@ function openClawValidationNeedsPinnedHelper(
   ) {
     return false;
   }
-  const commands = requiredValidationCommands(validationCommands, cwd, options);
-  if (!commands.some(isOpenClawChangedGateValidationCommand)) return false;
-  const changedPaths = options.pinnedBaseRef
-    ? gitChangedFilesFromRef(cwd, options.pinnedBaseRef)
-    : gitChangedFiles(cwd, DEFAULT_BASE_BRANCH);
-  const untrackedPaths = run("git", ["ls-files", "--others", "--exclude-standard", "-z"], {
-    cwd,
-  })
-    .split("\0")
-    .filter(Boolean);
-  return [...changedPaths, ...untrackedPaths].some((file) =>
-    /^(?:src|extensions|ui|packages)\/.+\.[cm]?[jt]sx?$/.test(file),
+  const commands = requiredValidationCommands(validationCommands, cwd, options).flatMap((command) =>
+    resolveAllowedValidationCommandsWithoutWorkspaceBinding(
+      command,
+      cwd,
+      DEFAULT_BASE_BRANCH,
+      options,
+    ),
   );
+  const isScannedSource = (file: string) =>
+    /^(?:src|extensions|ui|packages|scripts|test)\/.+\.[cm]?[jt]sx?$/.test(
+      file.replaceAll("\\", "/").replace(/^\.\//, ""),
+    );
+  for (const command of commands) {
+    const parts = stripEnvPrefix(command);
+    const requirement = packageScriptRequirement(parts);
+    if (
+      requirement?.packageManager !== "pnpm" ||
+      requirement.name !== "check:changed" ||
+      requirement.workspaceScoped
+    ) {
+      continue;
+    }
+    const scriptIndex = parts.indexOf(requirement.name, packageManagerCommandIndex(parts)!);
+    const args = parts.slice(scriptIndex + 1);
+    const separator = args.indexOf("--");
+    const flags = separator === -1 ? args : args.slice(0, separator);
+    if (flags.some((arg) => ["--no-changes", "--help", "-h"].includes(arg))) continue;
+    const paths = separator === -1 ? [] : args.slice(separator + 1);
+    const refs: Record<string, string> = {
+      "--base": options.pinnedBaseRef ?? `origin/${DEFAULT_BASE_BRANCH}`,
+      "--head": "HEAD",
+    };
+    for (let index = 0; index < flags.length; index++) {
+      const arg = flags[index]!;
+      const ref = /^(--base|--head)(?:=(.*))?$/.exec(arg);
+      if (ref) {
+        const value = ref[2] ?? flags[++index];
+        if (!value || value.startsWith("--")) {
+          throw new Error(`check:changed ${ref[1]} requires a value`);
+        }
+        refs[ref[1]!] = value;
+      } else if (!arg.startsWith("-")) paths.push(arg);
+    }
+    // Match check:changed per command: explicit paths beat staged paths,
+    // which beat the selected base/head range plus worktree changes.
+    if (paths.length === 0) {
+      if (flags.includes("--staged")) {
+        paths.push(
+          ...run("git", ["diff", "--cached", "--name-only", "--diff-filter=ACMRD", "-z"], {
+            cwd,
+          })
+            .split("\0")
+            .filter(Boolean),
+        );
+      } else {
+        paths.push(
+          ...gitChangedFilesFromRef(cwd, refs["--base"]!, refs["--head"]!),
+          ...run("git", ["ls-files", "--others", "--exclude-standard", "-z"], { cwd })
+            .split("\0")
+            .filter(Boolean),
+        );
+      }
+    }
+    if (paths.some(isScannedSource)) return true;
+  }
+  return false;
 }
 
 function isOpenClawChangedGateValidationCommand(command: LooseRecord): boolean {
@@ -5277,10 +5331,9 @@ function validationBaseRef(cwd: string, baseBranch: string, options: TargetValid
   return options.pinnedBaseRef;
 }
 
-function gitChangedFilesFromRef(cwd: string, baseRef: string) {
-  const committed = run("git", ["diff", "--name-only", `${baseRef}...HEAD`], { cwd })
-    .split("\n")
-    .map((line) => line.trim())
+function gitChangedFilesFromRef(cwd: string, baseRef: string, headRef = "HEAD") {
+  const committed = run("git", ["diff", "--name-only", "-z", `${baseRef}...${headRef}`], { cwd })
+    .split("\0")
     .filter(Boolean);
   return uniqueStrings([...committed, ...gitStatusPaths(cwd)]);
 }

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -3903,29 +3903,50 @@ if (args[0] === "enable") {
   );
 });
 
-test(
-  "OpenClaw stages pinned Knip without package execution and restores its offline cache per command",
-  { skip: process.platform === "win32" },
-  () => {
-    const cwd = gitPackageFixture({ first: 'node -e ""', second: 'node -e ""' });
-    const runnerPath = path.join(cwd, "scripts", "deadcode-knip-runner.mjs");
-    fs.mkdirSync(path.dirname(runnerPath), { recursive: true });
-    fs.writeFileSync(runnerPath, 'const KNIP_VERSION = "6.8.0";\n');
-    git(cwd, "add", ".");
-    git(cwd, "commit", "-m", "initial");
-    attachOrigin(cwd);
-    const changedSource = path.join(cwd, "src", "index.ts");
-    fs.mkdirSync(path.dirname(changedSource), { recursive: true });
-    fs.writeFileSync(changedSource, "export const changed = true;\n");
-    git(cwd, "add", "src/index.ts");
+for (const [extension, knipVersion, pnpmVersion] of [
+  ["mjs", "6.8.0", "10.33.0"],
+  ["mts", "6.32.2", "11.10.0"],
+  ["mts", "6.32.2", "12.3.4"],
+]) {
+  test(
+    `OpenClaw stages pinned Knip ${knipVersion} with pnpm ${pnpmVersion} without package execution and restores its offline cache per command`,
+    { skip: process.platform === "win32" },
+    () => {
+      const cwd = gitPackageFixture({ first: 'node -e ""', second: 'node -e ""' });
+      const packagePath = path.join(cwd, "package.json");
+      const packageJson = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+      packageJson.packageManager = `pnpm@${pnpmVersion}`;
+      fs.writeFileSync(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`);
+      const runnerPath = path.join(cwd, "scripts", `deadcode-knip-runner.${extension}`);
+      fs.mkdirSync(path.dirname(runnerPath), { recursive: true });
+      fs.writeFileSync(runnerPath, `const KNIP_VERSION = "${knipVersion}";\n`);
+      fs.mkdirSync(path.join(cwd, "src"), { recursive: true });
+      fs.writeFileSync(path.join(cwd, "src", "unchanged.ts"), "export const unchanged = true;\n");
+      const helperSourcePaths = [
+        "scripts/unchanged.mjs",
+        "scripts/unchanged.mts",
+        "test/consumer.test.js",
+        "test/consumer.test.ts",
+      ];
+      for (const file of helperSourcePaths) {
+        fs.mkdirSync(path.dirname(path.join(cwd, file)), { recursive: true });
+        fs.writeFileSync(path.join(cwd, file), "export {};\n");
+      }
+      git(cwd, "add", ".");
+      git(cwd, "commit", "-m", "initial");
+      attachOrigin(cwd);
+      const changedSource = path.join(cwd, "src", "index.ts");
+      fs.mkdirSync(path.dirname(changedSource), { recursive: true });
+      fs.writeFileSync(changedSource, "export const changed = true;\n");
+      git(cwd, "add", "src/index.ts");
 
-    const hostBin = makeFixtureDir("clawsweeper-knip-prefetch-");
-    const targetBin = makeFixtureDir("clawsweeper-knip-pnpm-");
-    const logPath = path.join(hostBin, "invocations.jsonl");
-    writeNodeCommandShim(
-      targetBin,
-      "pnpm",
-      `#!/usr/bin/env node
+      const hostBin = makeFixtureDir("clawsweeper-knip-prefetch-");
+      const targetBin = makeFixtureDir("clawsweeper-knip-pnpm-");
+      const logPath = path.join(hostBin, "invocations.jsonl");
+      writeNodeCommandShim(
+        targetBin,
+        "pnpm",
+        `#!/usr/bin/env node
 const fs = require("node:fs");
 const path = require("node:path");
 const args = process.argv.slice(2);
@@ -3941,10 +3962,10 @@ if (args[0] === "install") {
     fs.writeFileSync(bin, "#!/bin/sh\\nexit 0\\n", { mode: 0o755 });
     const manifest = path.join(process.cwd(), "node_modules", "knip", "package.json");
     fs.mkdirSync(path.dirname(manifest), { recursive: true });
-    fs.writeFileSync(manifest, JSON.stringify({ name: "knip", version: "6.8.0" }));
+    fs.writeFileSync(manifest, JSON.stringify({ name: "knip", version: "${knipVersion}" }));
     if (fs.existsSync(${JSON.stringify(path.join(hostBin, "tamper-lock"))})) {
       const lock = path.join(process.cwd(), "pnpm-lock.yaml");
-      fs.writeFileSync(lock, fs.readFileSync(lock, "utf8").replace("specifier: 6.8.0", "specifier: 6.8.1"));
+      fs.writeFileSync(lock, fs.readFileSync(lock, "utf8").replace("specifier: ${knipVersion}", "specifier: 0.0.0"));
     }
     const configuredRegistry = args.find((arg) => arg.startsWith("--config.registry="))?.slice("--config.registry=".length);
     const registryHost = new URL(configuredRegistry).host.replace(":", "+");
@@ -3955,9 +3976,10 @@ if (args[0] === "install") {
 }
 if (args.at(-1) === "first" || args.at(-1) === "second") {
   const registry = process.env.PNPM_CONFIG_REGISTRY;
+  const registries = ${pnpmVersion === "12.3.4" ? '[["default", registry]]' : '[["@jsr", "https://npm.jsr.io/"], ["default", registry]]'};
   const fullCacheKey = require("node:crypto")
     .createHash("sha256")
-    .update(JSON.stringify([["knip@6.8.0"], [["@jsr", "https://npm.jsr.io/"], ["default", registry]]]))
+    .update(JSON.stringify([["knip@${knipVersion}"], registries]))
     .digest("hex");
   const cacheKey = fullCacheKey.slice(0, 32);
   const marker = path.join(process.env.XDG_CACHE_HOME, "pnpm", "dlx", cacheKey, "marker");
@@ -3969,19 +3991,19 @@ if (args.at(-1) === "first" || args.at(-1) === "second") {
     path.join(process.env.XDG_CACHE_HOME, "pnpm", "metadata-ff-v1.3", host, "knip.json"),
   ]) {
     const metadata = JSON.parse(fs.readFileSync(metadataPath, "utf8").trim().split("\\n").at(-1));
-    if (Object.keys(metadata.versions).join(",") !== "6.8.0") process.exit(45);
-    if (!metadata.versions["6.8.0"].dist.integrity.startsWith("sha512-")) process.exit(46);
+    if (Object.keys(metadata.versions).join(",") !== "${knipVersion}") process.exit(45);
+    if (!metadata.versions["${knipVersion}"].dist.integrity.startsWith("sha512-")) process.exit(46);
   }
   const knip = path.join(path.dirname(marker), "pinned", "node_modules", ".bin", "knip");
   if (!fs.readFileSync(knip, "utf8").includes("JITI_FS_CACHE=0")) process.exit(43);
   if (args.at(-1) === "first") fs.writeFileSync(marker, "validation mutated its own cache");
 }
 `,
-    );
-    writeNodeCommandShim(
-      hostBin,
-      "corepack",
-      `#!/usr/bin/env node
+      );
+      writeNodeCommandShim(
+        hostBin,
+        "corepack",
+        `#!/usr/bin/env node
 const fs = require("node:fs");
 const path = require("node:path");
 const args = process.argv.slice(2);
@@ -3994,131 +4016,238 @@ if (args[0] === "enable") {
   fs.chmodSync(target, fs.statSync(source).mode);
 }
 `,
-    );
-    const options = {
-      ...validationOptions("openclaw/openclaw", {
-        toolchain: {
-          packageManager: "pnpm",
-          baseValidationCommands: [],
-          changedGate: { command: "pnpm check:changed", requiredScript: "check:changed" },
+      );
+      const options = {
+        ...validationOptions("openclaw/openclaw", {
+          toolchain: {
+            packageManager: "pnpm",
+            baseValidationCommands: [],
+            changedGate: { command: "pnpm check:changed", requiredScript: "check:changed" },
+          },
+        }),
+        installTargetDeps: true,
+        installTimeoutMs: FAKE_TOOLCHAIN_TIMEOUT_MS,
+        setupTimeoutMs: FAKE_TOOLCHAIN_TIMEOUT_MS,
+      };
+
+      withPreparedPnpmToolchain(
+        cwd,
+        hostBin,
+        options,
+        () => {
+          assert.deepEqual(
+            runAllowedValidationCommands(["pnpm first", "pnpm second"], cwd, options),
+            ["pnpm first", "pnpm second"],
+          );
         },
-      }),
-      installTargetDeps: true,
-      installTimeoutMs: FAKE_TOOLCHAIN_TIMEOUT_MS,
-      setupTimeoutMs: FAKE_TOOLCHAIN_TIMEOUT_MS,
-    };
+        ["pnpm check:changed"],
+      );
 
-    withPreparedPnpmToolchain(
-      cwd,
-      hostBin,
-      options,
-      () => {
-        assert.deepEqual(
-          runAllowedValidationCommands(["pnpm first", "pnpm second"], cwd, options),
-          ["pnpm first", "pnpm second"],
-        );
-      },
-      ["pnpm check:changed"],
-    );
+      const invocations = fs
+        .readFileSync(logPath, "utf8")
+        .trim()
+        .split(/\r?\n/)
+        .map((line) => JSON.parse(line));
+      const prefetches = invocations.filter(
+        ({ args, cwd: invocationCwd }) =>
+          args[0] === "install" && invocationCwd.includes(".__clawsweeper_pnpm_helper_cache__"),
+      );
+      assert.equal(prefetches.length, 1, "staged source prepares exactly one helper");
+      const prefetch = prefetches[0];
+      assert.ok(prefetch);
+      assert.notEqual(prefetch.cwd, cwd);
+      assert.match(prefetch.cache, /[/\\]corepack[/\\]\.__clawsweeper_pnpm_helper_cache__$/);
+      assert.equal(prefetch.args[0], "install");
+      assert.ok(prefetch.args.includes("--frozen-lockfile"));
+      assert.ok(prefetch.args.includes("--ignore-scripts"));
+      assert.ok(prefetch.args.includes("--config.minimum-release-age=2880"));
+      assert.ok(prefetch.args.includes("--ignore-pnpmfile"));
+      assert.ok(prefetch.args.includes("--config.enable-pre-post-scripts=false"));
+      assert.ok(prefetch.args.includes("--config.enable-global-virtual-store=false"));
+      const validations = invocations.filter(({ args }) =>
+        ["first", "second"].includes(args.at(-1)),
+      );
+      assert.equal(validations.length, 2);
+      assert.notEqual(validations[0].cache, prefetch.cache);
+      assert.equal(validations[0].cache, validations[1].cache);
+      assert.ok(validations.every(({ jitiFsCache }) => jitiFsCache === undefined));
+      assert.ok(validations.every(({ offline }) => offline === "true"));
+      assert.ok(validations.every(({ legacyOffline }) => legacyOffline === "true"));
+      assert.ok(validations.every(({ registry }) => registry === "https://registry.npmjs.org/"));
 
-    const invocations = fs
-      .readFileSync(logPath, "utf8")
-      .trim()
-      .split(/\r?\n/)
-      .map((line) => JSON.parse(line));
-    const prefetch = invocations.find(
-      ({ args, cwd: invocationCwd }) =>
-        args[0] === "install" && invocationCwd.includes(".__clawsweeper_pnpm_helper_cache__"),
-    );
-    assert.ok(prefetch);
-    assert.notEqual(prefetch.cwd, cwd);
-    assert.match(prefetch.cache, /[/\\]corepack[/\\]\.__clawsweeper_pnpm_helper_cache__$/);
-    assert.equal(prefetch.args[0], "install");
-    assert.ok(prefetch.args.includes("--frozen-lockfile"));
-    assert.ok(prefetch.args.includes("--ignore-scripts"));
-    assert.ok(prefetch.args.includes("--config.minimum-release-age=2880"));
-    assert.ok(prefetch.args.includes("--ignore-pnpmfile"));
-    assert.ok(prefetch.args.includes("--config.enable-pre-post-scripts=false"));
-    assert.ok(prefetch.args.includes("--config.enable-global-virtual-store=false"));
-    const validations = invocations.filter(({ args }) => ["first", "second"].includes(args.at(-1)));
-    assert.equal(validations.length, 2);
-    assert.notEqual(validations[0].cache, prefetch.cache);
-    assert.equal(validations[0].cache, validations[1].cache);
-    assert.ok(validations.every(({ jitiFsCache }) => jitiFsCache === undefined));
-    assert.ok(validations.every(({ offline }) => offline === "true"));
-    assert.ok(validations.every(({ legacyOffline }) => legacyOffline === "true"));
-    assert.ok(validations.every(({ registry }) => registry === "https://registry.npmjs.org/"));
+      withCommandOverridesUnset(["corepack", "pnpm"], () =>
+        withPathOnlyPrefix(hostBin, () => {
+          fs.writeFileSync(path.join(hostBin, "tamper-lock"), "1");
+          assert.throws(
+            () => prepareTargetToolchain(cwd, options, ["pnpm check:changed"]),
+            /dependency lockfile does not match the trusted graph/,
+          );
+          fs.rmSync(path.join(hostBin, "tamper-lock"));
 
-    withCommandOverridesUnset(["corepack", "pnpm"], () =>
-      withPathOnlyPrefix(hostBin, () => {
-        fs.writeFileSync(path.join(hostBin, "tamper-lock"), "1");
-        assert.throws(
-          () => prepareTargetToolchain(cwd, options, ["pnpm check:changed"]),
-          /dependency lockfile does not match the trusted graph/,
-        );
-        fs.rmSync(path.join(hostBin, "tamper-lock"));
+          const previousRegistry = process.env.npm_config_registry;
+          process.env.npm_config_registry = "https://registry.example.invalid:8443/";
+          try {
+            prepareTargetToolchain(cwd, options, ["pnpm check:changed"]);
+            assert.deepEqual(runAllowedValidationCommands(["pnpm first"], cwd, options), [
+              "pnpm first",
+            ]);
+            const customValidation = fs
+              .readFileSync(logPath, "utf8")
+              .trim()
+              .split(/\r?\n/)
+              .map((line) => JSON.parse(line))
+              .findLast(({ args }) => args.at(-1) === "first");
+            assert.equal(customValidation.registry, "https://registry.example.invalid:8443/");
+            assert.equal(customValidation.offline, "true");
+            assert.equal(customValidation.legacyOffline, "true");
+          } finally {
+            restoreEnv("npm_config_registry", previousRegistry);
+          }
 
-        const previousRegistry = process.env.npm_config_registry;
-        process.env.npm_config_registry = "https://registry.example.invalid:8443/";
-        try {
-          prepareTargetToolchain(cwd, options, ["pnpm check:changed"]);
-          assert.deepEqual(runAllowedValidationCommands(["pnpm first"], cwd, options), [
-            "pnpm first",
-          ]);
-          const customValidation = fs
-            .readFileSync(logPath, "utf8")
-            .trim()
-            .split(/\r?\n/)
-            .map((line) => JSON.parse(line))
-            .findLast(({ args }) => args.at(-1) === "first");
-          assert.equal(customValidation.registry, "https://registry.example.invalid:8443/");
-          assert.equal(customValidation.offline, "true");
-          assert.equal(customValidation.legacyOffline, "true");
-        } finally {
-          restoreEnv("npm_config_registry", previousRegistry);
-        }
+          const prefetchCount = () =>
+            fs
+              .readFileSync(logPath, "utf8")
+              .split(/\r?\n/)
+              .filter((line) => {
+                if (!line) return false;
+                const invocation = JSON.parse(line);
+                return (
+                  invocation.args[0] === "install" &&
+                  invocation.cwd.includes(".__clawsweeper_pnpm_helper_cache__")
+                );
+              }).length;
+          const expectPreparation = (label, commands, expected, overrides = {}) => {
+            const before = prefetchCount();
+            prepareTargetToolchain(cwd, { ...options, ...overrides }, commands);
+            assert.equal(prefetchCount() - before, expected, label);
+          };
+          expectPreparation("omitted commands", undefined, 0);
+          expectPreparation("omitted changed gate", ["pnpm first"], 0);
+          expectPreparation("skipped changed gate", ["pnpm check:changed"], 0, {
+            skipOpenClawChangedGate: true,
+          });
+          git(cwd, "reset", "--", "src/index.ts");
+          fs.rmSync(changedSource);
+          fs.writeFileSync(path.join(cwd, "README.md"), "# Docs-only repair\n");
+          git(cwd, "add", "README.md");
+          expectPreparation("docs-only delta", ["pnpm check:changed"], 0);
 
-        const previousPrefetches = fs
-          .readFileSync(logPath, "utf8")
-          .split(/\r?\n/)
-          .filter((line) => {
-            if (!line) return false;
-            const invocation = JSON.parse(line);
-            return (
-              invocation.args[0] === "install" &&
-              invocation.cwd.includes(".__clawsweeper_pnpm_helper_cache__")
-            );
-          }).length;
-        prepareTargetToolchain(cwd, options);
-        prepareTargetToolchain(cwd, { ...options, skipOpenClawChangedGate: true }, [
-          "git diff --check",
-        ]);
-        git(cwd, "reset", "--", "src/index.ts");
-        fs.rmSync(changedSource);
-        fs.writeFileSync(path.join(cwd, "README.md"), "# Docs-only repair\n");
-        git(cwd, "add", "README.md");
-        prepareTargetToolchain(cwd, options, ["pnpm check:changed"]);
-        const untrackedSource = path.join(cwd, "src", "new-feature", "new.ts");
-        fs.mkdirSync(path.dirname(untrackedSource), { recursive: true });
-        fs.writeFileSync(untrackedSource, "export const untracked = true;\n");
-        prepareTargetToolchain(cwd, options, ["pnpm check:changed"]);
-        fs.rmSync(untrackedSource);
-        const subsequentPrefetches = fs
-          .readFileSync(logPath, "utf8")
-          .split(/\r?\n/)
-          .filter((line) => {
-            if (!line) return false;
-            const invocation = JSON.parse(line);
-            return (
-              invocation.args[0] === "install" &&
-              invocation.cwd.includes(".__clawsweeper_pnpm_helper_cache__")
-            );
-          }).length;
-        assert.equal(subsequentPrefetches, previousPrefetches + 1);
-      }),
-    );
-  },
-);
+          fs.writeFileSync(
+            path.join(cwd, "src", "unchanged.ts"),
+            "export const unchanged = false;\n",
+          );
+          expectPreparation(
+            "staged docs ignore unstaged source",
+            ["pnpm check:changed --staged"],
+            0,
+          );
+          expectPreparation(
+            "explicit source overrides staged docs",
+            ["pnpm check:changed --staged -- src/unchanged.ts"],
+            1,
+          );
+          git(cwd, "add", "src/unchanged.ts");
+          expectPreparation("staged source", ["pnpm check:changed --staged"], 1);
+          expectPreparation(
+            "explicit docs override staged source",
+            ["pnpm check:changed --staged -- README.md"],
+            0,
+          );
+          expectPreparation(
+            "no-changes overrides explicit source and staged source",
+            ["pnpm check:changed --no-changes --staged -- src/unchanged.ts"],
+            0,
+          );
+          expectPreparation(
+            "help skips explicit source",
+            ["pnpm check:changed --help -- src/unchanged.ts"],
+            0,
+          );
+
+          git(cwd, "commit", "-m", "source and docs changes");
+          git(cwd, "update-ref", "refs/remotes/origin/main", "HEAD");
+          assert.equal(git(cwd, "status", "--porcelain"), "", "ref scenarios use a clean checkout");
+          expectPreparation("empty default delta", ["pnpm check:changed"], 0);
+          expectPreparation(
+            "explicit refs select committed source instead of the default or pinned base",
+            ["pnpm check:changed --base 'HEAD~1' --head HEAD"],
+            1,
+            { pinnedBaseRef: git(cwd, "rev-parse", "HEAD") },
+          );
+          expectPreparation(
+            "explicit head excludes the newer source commit",
+            ["pnpm check:changed --base='HEAD~1' --head='HEAD~1'"],
+            0,
+          );
+          expectPreparation(
+            "inline refs select committed source",
+            ["pnpm check:changed --base='HEAD~1' --head=HEAD"],
+            1,
+          );
+          expectPreparation(
+            "staged mode ignores the committed range",
+            ["pnpm check:changed --staged --base 'HEAD~1' --head HEAD"],
+            0,
+          );
+          expectPreparation(
+            "explicit docs override the committed range",
+            ["pnpm check:changed --base 'HEAD~1' --head HEAD README.md"],
+            0,
+          );
+          const untrackedSource = path.join(cwd, "src", "new-feature", "new.ts");
+          fs.mkdirSync(path.dirname(untrackedSource), { recursive: true });
+          fs.writeFileSync(untrackedSource, "export const untracked = true;\n");
+          expectPreparation(
+            "default delta includes nested untracked source",
+            ["pnpm check:changed"],
+            1,
+          );
+          expectPreparation(
+            "explicit docs ignore untracked source",
+            ["pnpm check:changed -- README.md"],
+            0,
+          );
+          fs.rmSync(untrackedSource);
+          expectPreparation(
+            "explicit unchanged source in a later command",
+            [
+              "pnpm check:changed -- README.md",
+              "pnpm --silent run check:changed -- src/unchanged.ts",
+            ],
+            1,
+          );
+          for (const file of helperSourcePaths) {
+            expectPreparation(`explicit unchanged ${file}`, [`pnpm check:changed -- ${file}`], 1);
+          }
+          const changedScript = path.join(cwd, "scripts", "unchanged.mts");
+          fs.appendFileSync(changedScript, "// Removed an import.\n");
+          expectPreparation("script-only Git delta", ["pnpm check:changed"], 1);
+          fs.writeFileSync(changedScript, "export {};\n");
+          const deletedConsumer = "test/consumer.test.js";
+          fs.rmSync(path.join(cwd, deletedConsumer));
+          git(cwd, "add", deletedConsumer);
+          expectPreparation("deleted staged test consumer", ["pnpm check:changed --staged"], 1);
+          fs.writeFileSync(path.join(cwd, deletedConsumer), "export {};\n");
+          git(cwd, "add", deletedConsumer);
+          for (const file of ["scripts/check.sh", "scripts/check.py", "test/README.md"]) {
+            fs.writeFileSync(path.join(cwd, file), "fixture\n");
+            expectPreparation(`excluded explicit ${file}`, [`pnpm check:changed -- ${file}`], 0);
+            expectPreparation(`excluded Git delta ${file}`, ["pnpm check:changed"], 0);
+            fs.rmSync(path.join(cwd, file));
+          }
+          fs.writeFileSync(runnerPath, 'const KNIP_VERSION = "99.0.0";\n');
+          const beforeUnsupportedPin = prefetchCount();
+          assert.throws(
+            () => prepareTargetToolchain(cwd, options, ["pnpm check:changed -- src/unchanged.ts"]),
+            /unsupported Knip 99\.0\.0; add its reviewed frozen dependency graph/,
+          );
+          assert.equal(prefetchCount(), beforeUnsupportedPin, "unsupported pins never install");
+          fs.writeFileSync(runnerPath, `const KNIP_VERSION = "${knipVersion}";\n`);
+        }),
+      );
+    },
+  );
+}
 
 test(
   "pnpm validation refreshes the prepared executable within the shared setup identity budget",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where OpenClaw repairs fail offline validation because the prepared Knip helper does not match the current TypeScript runner or pnpm 12 cache key. Setup also prepared the helper for unrelated changes and missed selector-only scans.

## Why This Change Was Made

Keep preparation and cache restoration in the existing target-validation owner. Select the reviewed graph for Knip 6.32.2 or the retained 6.8.0 runner, use the selected pnpm cache-key contract, and match the changed gate's explicit-path, staged, and base/head selection order. Unsupported pins stop before installation and name the missing reviewed graph.

The helper still uses frozen resolution, disabled package hooks, the target's minimum release age, isolated validation caches, and per-command reset. No shared mutable cache or offline network fallback is added.

## User Impact

Current and older OpenClaw repair branches can reuse the prepared Knip graph offline. Docs-only selections avoid unnecessary helper preparation. No operator configuration changes.

## OpenClaw Bay Impact

Unaffected: this changes target validation preparation, not Bay, queue/status schemas, or publication contracts.

## Documentation Impact

Updated the active repair guide's helper-selection and cache lifecycle contract, owned by the target-validation implementation. Future runner pins, pnpm cache contracts, or changed-gate selector changes require rechecking this guidance. Also formatted the existing table using the repository formatter and added release-note context to the ClawSweeper changelog.

## Evidence

- Signed current head: `fba4a43afd8e11c766cffcaf2f3c4ed9da5466b8`; base: `b6bbdd1fe908202dbda9e2ab3e977e82310bc085`.
- Native precommit review: no findings. Fresh committed Codex review of the current head: no findings. It bound the 63,049-byte full-index diff `fe34b990e071355a38e33b407ed0893b6bba54461a40b649ed768d9f4bd11bdf`; the reviewer exited 0 and its process tree joined.
- [Earlier focused proof](https://github.com/openclaw/openclaw/actions/runs/34670474732/attempts/1), job `103490771216`: old helper/caller built successfully, then the regression failed at missing native pnpm 12 key `603102cdc6f3bd0800ff972e1cd70585`; restored current code passed. Preparation tests, the full target-validation test file, and docs checks passed.
- That earlier run stopped at an existing README table formatting issue. It did not run the native matrix or full check; those are not claimed from that run.
- Rebase retained the same Knip production/test patch. Historical tests are scoped to that unchanged contract, not treated as full qualification of the updated dependency graph.
- The final integration adds only main's command-error cause preservation, its regression, and documentation. It does not change helper preparation, pnpm keys, frozen graphs, selectors, profile reset, dependencies, or successful identity checks. The six identity-clean native scans below remain evidence for the unchanged Knip contract on their recorded source; they are not relabeled as executions on the rebased head.
- Fresh [CI run 34672207365, attempt 1](https://github.com/openclaw/clawsweeper/actions/runs/34672207365/attempts/1), job `103495564674`, passed `pnpm run check` on current head `fba4a43afd8e11c766cffcaf2f3c4ed9da5466b8`: all three builds, static checks, lint, focused coverage (13 passed), and the full suite (6,066 passed, 18 skipped, no failures or cancellations). The cause-retention, fallback-identity, and timeout-identity regressions each passed. Log SHA256: `8eefc5d4b15f2d89dfde1c50d46663de513244e8a0670aed1f657e2d541189c8`.
- Production TypeScript: +123/-46 (net +77); tests: +283/-154; 773 lines of frozen dependency-lock data. Growth implements the current runner/pnpm contract and command-aware selection in the existing owner, replacing the single-pin and coarse Git-delta assumptions.

## Real Behavior Proof

Claim: the existing preparation owner installs the reviewed helper graph only for eligible commands, and successive contained validations reuse that graph without network access or leftover private CAS state.

Executed on [Testbox run 34671517175, attempt 1](https://github.com/openclaw/openclaw/actions/runs/34671517175/attempts/1), job `103493621973`, lease `tbx_01m29vx12f932zh8f9nepkey13` (`blacksmith-testbox`, native Linux), against signed source `a9eaa6fb6e41e10b056d45de6a4a148e4d59d7c4` before the final integration described above. Node 24.18.1 / Corepack 0.36.0; fresh frozen ClawSweeper install with pnpm 11.10.0. Hydration used OpenClaw `a9ff79407881ec0dd084cdb7d4ac2eeb2719b7e1`; the fixture used hash-verified upstream runner bytes from OpenClaw `88898e08d335c9e2553760ef366de15206eb4f26` (.mts) and `dabe1915362e20c25704af91612a32a8f4c96e83` (.mjs).

The fixture invokes `prepareTargetToolchain`, then `runAllowedValidationCommands` with `pnpm check:changed -- src/index.ts` and a second scan. Its fixture script runs the real upstream Knip runner against a known used/unused export pair; it does not replace pnpm or Knip with mocks.

| pnpm | Knip / runner | Native scans |
| --- | --- | --- |
| 12.3.4 | 6.32.2 / .mts | 2 passed |
| 11.10.0 | 6.32.2 / .mts | 2 passed |
| 11.10.0 | 6.8.0 / .mjs | 2 passed |

Every scan found the unused export, invoked the prepared wrapper, started with empty private CAS state, restored the wrapper after profile reset, and ran in an isolated network namespace with native read-only mounts. Source identity stayed unchanged. The real pnpm 12 preparation cases also verified no helper installation for omitted commands, docs-only selections, no changes, equal refs, and staged docs with unstaged source; staged source and the requested committed range selected it. Both frozen graphs were checked against registry integrity and release timestamps (62 packages for 6.32.2; 67 for 6.8.0). Helper installs retained frozen resolution, disabled hooks, and the fixture's 10,080-minute minimum release age.

Locked oxfmt 0.67.0 and targeted lint passed. `pnpm run check` passed on that exact recorded source; fresh CI for the integrated head is listed separately above. The complete controlled proof took 380,078 ms; native Run and Stop exited 0, the provider completed, the claim was removed, and owned child processes joined. Successful native temporary logs were removed automatically; no additional report artifacts were created.

Machine-readable scan receipts are summarized above. Payload SHA256: `9404d74be644cf6dad69860f03b8c250ccc66199f70c49ee0370e94bc423c2eb`; source tree: `475979c83c0b18d23617baff83fd7cd22ee65c9c`. The retained earlier focused capture is `08be5750db78285d70246953a55cf40ab8d92236d5b5fc1a461427c45f5d23ca`, explicitly from the formatting-failed run.

## Limits And Follow-Up

This proof exercises real pnpm and Knip inside controlled native containment, not a live repair publication or arbitrary target dependency graph. The separate extension-package-boundary receipt restoration issue remains follow-up work; this PR does not claim to repair that lifecycle.
