### PR TITLE
fix: avoid rejecting reviewed Matrix URL fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,6 +657,16 @@ and their exact native metadata shape. Any emitted subset and order may qualify;
 duplicate exact findings, unknown variants, lossy decoder buckets, or an
 unqualified deduplicated blob reference refuse admission.
 
+The same table qualifies the exact embedded-credential rejection fixture in
+OpenClaw's `extensions/matrix/src/matrix/client.test.ts` for URI detector 17,
+only with `PLAIN` or `HTML` attribution. Both raw-value digests, the complete
+source line, path, regular-file mode, and committed base/head references must
+match. Retained source-only native scans observed PLAIN findings; the original
+hosted refusal identified HTML for its first finding but did not retain the
+second finding's details. Constructed HTML regression records are not recovered
+hosted evidence. Qualification does not waive that unknown finding or replace
+fresh whole-input admission and a completed review.
+
 One source path may contain multiple independently reviewed fixtures; each
 digest/path/mode tuple must match exactly, so source membership alone never
 qualifies a finding.

--- a/src/agent-input-scan-fixtures.ts
+++ b/src/agent-input-scan-fixtures.ts
@@ -214,6 +214,8 @@ const CRABBOX_POSTGRES_DOC_ATTRIBUTIONS: readonly ReviewedAttribution[] = [
 
 // oxfmt-ignore
 const REVIEWED_ATTRIBUTIONS: readonly ReviewedAttribution[] = [
+  [17, "URI", "PLAIN", "e26b2ccf9953c3e0e675998528577649327e1d3e1072233ff86cad586ca5c05d", "e26b2ccf9953c3e0e675998528577649327e1d3e1072233ff86cad586ca5c05d", "04e4f717532e6f38582816622367e020b28d8db6ced6e714667328853a422484", "extensions/matrix/src/matrix/client.test.ts", "100644"],
+  [17, "URI", "HTML", "e26b2ccf9953c3e0e675998528577649327e1d3e1072233ff86cad586ca5c05d", "e26b2ccf9953c3e0e675998528577649327e1d3e1072233ff86cad586ca5c05d", "04e4f717532e6f38582816622367e020b28d8db6ced6e714667328853a422484", "extensions/matrix/src/matrix/client.test.ts", "100644"],
   [17, "URI", "ESCAPED_UNICODE", "31ff9f3ec446cbcc27e6fc08f3cd96b5d95d8b436b4144f3a098d7c524a863f7", "0d9e27039ed24044fe06ab5145d7b04569ced32d3ff6fe8eb9acf04a75663919", "47171b920ebd0800ac107a92ad80b7279677f0096fad5a367f82fe3b1955c790", "src/logging/redact.test.ts", "100644"],
   [17, "URI", "ESCAPED_UNICODE", "a460200b4a488bc178d0dac30bc5fe027ff86d9c7c94554f5c9d915580bc4239", "839b16fa1dd892daf47ab10d50f7c1957a16ace282fe9e6df67fefc40f7f06ff", "232cce5bf0c7b495e2f008fdc45cbd2bd9afc5394906576e4466411f6841d260", "src/logging/redact.test.ts", "100644"],
   [17, "URI", "ESCAPED_UNICODE", "de7dcbd8612764d80691e85407d899f6e3686afd9ab40964943c3874ffe9571c", "198d323e34c2a045b86adbc72b8cd54bb8f9582175c5c25e6c68b4e374d8873f", "8ff8c788b296b7eb81abaf7f2f48bb4be717f6e8bef76200e7c842dbeea8a15c", "src/logging/redact.test.ts", "100644"],
@@ -249,6 +251,10 @@ function validateReviewedAttributions(rows: readonly ReviewedAttribution[]): voi
       !(
         (source === "src/logging/redact.test.ts" &&
           (decoder === "PLAIN" || decoder === "ESCAPED_UNICODE")) ||
+        (source === "extensions/matrix/src/matrix/client.test.ts" &&
+          detectorType === 17 &&
+          detectorName === "URI" &&
+          (decoder === "PLAIN" || decoder === "HTML")) ||
         (source === "docs/operations.md" &&
           detectorType === 968 &&
           detectorName === "Postgres" &&

--- a/test/agent-input-scan.test.ts
+++ b/test/agent-input-scan.test.ts
@@ -1032,6 +1032,208 @@ function classifyWithProductionPolicy(
   );
 }
 
+function matrixCredentialFixture(decoder: "PLAIN" | "HTML" = "PLAIN") {
+  const source = "extensions/matrix/src/matrix/client.test.ts";
+  const uri = new URL("https://matrix.example.org");
+  uri.username = "user";
+  uri.password = "pass";
+  const raw = uri.href.slice(0, -1);
+  const line = `          homeserver: ${JSON.stringify(raw)},`;
+  const inputs = new Map<string, StagedScanInput>();
+  const findings = (["base", "head"] as const).map((role, index) => {
+    const id = String(index).repeat(40);
+    const file = `/private/scanner/${id}`;
+    const literalLine = index === 0 ? 268 : 314;
+    inputs.set(file, {
+      kind: "blob",
+      id,
+      bytes: Buffer.from(`${"// context\n".repeat(literalLine - 1)}${line}\n`),
+      references: [{ source, mode: "100644", revision: id, role }],
+    });
+    return {
+      SourceType: 15,
+      DetectorType: 17,
+      DetectorName: "URI",
+      DecoderName: decoder,
+      Verified: false,
+      VerificationError: "synthetic verification error",
+      Raw: raw,
+      RawV2: raw,
+      SourceMetadata: { Data: { Filesystem: { file, line: literalLine } } },
+      SecretParts: { host: uri.host, username: uri.username, password: uri.password },
+      ExtraData: null,
+      StructuredData: null,
+    };
+  });
+  return { source, raw, line, inputs, findings };
+}
+
+test("reviewed Matrix fixture qualifies exact base/head and shared references", () => {
+  // These decoder variants are constructed controls, not recovered hosted records.
+  for (const decoder of ["PLAIN", "HTML"] as const) {
+    const f = matrixCredentialFixture(decoder);
+    for (const findings of [f.findings, f.findings.toReversed(), [f.findings[0]!]]) {
+      const result = classifyWithProductionPolicy(findings, f.inputs);
+      assert.equal(result.kind, "classified", decoder);
+      if (result.kind === "classified") {
+        assert.equal(result.notices.length, 1);
+        assert.equal(result.notices[0]!.source, f.source);
+        assert.deepEqual(
+          result.notices[0]!.findings.map(({ literalLine }) => literalLine).sort(),
+          findings.map((finding) => finding.SourceMetadata.Data.Filesystem.line).sort(),
+        );
+      }
+    }
+    const first = f.findings[0]!;
+    const file = first.SourceMetadata.Data.Filesystem.file;
+    const input = f.inputs.get(file)!;
+    assert.ok(input.kind === "blob");
+    f.inputs.set(file, {
+      ...input,
+      references: [
+        ...input.references,
+        { ...input.references[0]!, role: "head", revision: "b".repeat(40) },
+      ],
+    });
+    const shared = classifyWithProductionPolicy([first], f.inputs);
+    assert.equal(shared.kind, "classified");
+    if (shared.kind === "classified")
+      assert.deepEqual(shared.notices[0]!.findings.map(({ role }) => role).sort(), [
+        "base",
+        "head",
+      ]);
+  }
+});
+
+test("reviewed Matrix fixture refuses changed identities and every unqualified reference", () => {
+  const f = matrixCredentialFixture();
+  const first = f.findings[0]!;
+  const file = first.SourceMetadata.Data.Filesystem.file;
+  const input = f.inputs.get(file)!;
+  assert.ok(input.kind === "blob");
+  const refuses = (
+    findings: readonly Record<string, unknown>[],
+    inputs: ReadonlyMap<string, StagedScanInput>,
+    reason: string,
+  ) => {
+    const result = classifyWithProductionPolicy(findings, inputs);
+    assert.equal(result.kind, "refused");
+    assert.equal("notices" in result, false);
+    if (result.kind === "refused") assert.equal(result.diagnostic.reason, reason);
+  };
+  for (const change of [{ Raw: `${f.raw}/changed` }, { RawV2: `${f.raw}/changed` }])
+    refuses([{ ...first, ...change }], f.inputs, "literal_not_reviewed");
+  for (const change of [
+    { DecoderName: "BASE64" },
+    { DecoderName: "ESCAPED_UNICODE" },
+    { DetectorType: 895, DetectorName: "MongoDB" },
+    { Verified: true },
+    { VerificationError: "" },
+    { SourceType: 16 },
+  ])
+    refuses([{ ...first, ...change }], f.inputs, "finding_not_reviewed");
+  refuses([{ ...first, SecretParts: { host: "other" } }], f.inputs, "metadata_mismatch");
+  for (const bytes of [
+    Buffer.from(`${f.line} // changed\n`),
+    Buffer.from(`${f.line}\n${f.line}\n`),
+    Buffer.from(Buffer.from(f.raw).toString("base64")),
+  ])
+    refuses([first], new Map([[file, { ...input, bytes }]]), "literal_mismatch");
+  for (const reference of [
+    { ...input.references[0]!, source: "other.test.ts" },
+    { ...input.references[0]!, mode: "100755" },
+    ...(["index", "tree", "worktree"] as const).map((role) => ({
+      ...input.references[0]!,
+      role,
+    })),
+  ]) {
+    for (const references of [[reference], [...input.references, reference]])
+      refuses([first], new Map([[file, { ...input, references }]]), "source_not_reviewed");
+  }
+  for (const kind of ["prompt", "schema", "additional", "patch", "raw_diff"] as const)
+    refuses(
+      [first],
+      new Map([
+        [
+          file,
+          { kind, id: input.id, bytes: input.bytes, from: "a".repeat(40), to: "b".repeat(40) },
+        ],
+      ]),
+      "material_not_reviewed",
+    );
+  refuses(
+    [first, { ...first, Raw: "unreviewed", RawV2: "unreviewed" }],
+    f.inputs,
+    "literal_not_reviewed",
+  );
+  refuses([first, first], f.inputs, "duplicate_finding");
+});
+
+for (const scenario of ["PLAIN", "HTML", "mixed unknown"] as const) {
+  test(`reviewed Matrix fixture admission: ${scenario}`, (t) => {
+    const matrix = matrixCredentialFixture();
+    const f = fixture(t);
+    const notices: unknown[][] = [];
+    t.mock.method(console, "error", (...args: unknown[]) => notices.push(args));
+    const target = join(f.cwd, matrix.source);
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, `// before\n${"// context\n".repeat(20)}${matrix.line}\n`);
+    const baseSha = f.commit();
+    writeFileSync(target, `// after\n${"// context\n".repeat(20)}${matrix.line}\n`);
+    const headSha = f.commit();
+    const receipt = join(f.root, "scan-root");
+    useFakeScanner(
+      t,
+      String.raw`
+fs.writeFileSync(${JSON.stringify(receipt)}, path.dirname(inputDir));
+const template = ${JSON.stringify(matrix.findings[0])};
+const findings = inputs.filter(({name}) => /^[a-f0-9]{40}$/.test(name)).map(({name}) => ({
+  ...template,
+  DecoderName: ${JSON.stringify(scenario === "HTML" ? "HTML" : "PLAIN")},
+  SourceMetadata: {Data: {Filesystem: {file: path.join(inputDir, name), line: 22}}},
+}));
+assert.equal(findings.length, 2);
+if (${scenario === "mixed unknown"}) findings.push({...findings[0], Raw: 'unreviewed', RawV2: 'unreviewed'});
+process.stdout.write(findings.map(finding => JSON.stringify(finding)).join('\n') + '\n');
+process.stderr.write(JSON.stringify({
+  level: 'info-0', logger: 'trufflehog', msg: 'finished scanning',
+  trufflehog_version: '3.97.1', chunks: 2, bytes: 1000,
+  verified_secrets: 0, unverified_secrets: findings.length,
+}) + '\n');
+process.exit(183);
+`,
+    );
+    const run = () => f.run({ kind: "committed", baseSha, headSha });
+    if (scenario === "mixed unknown") {
+      assert.throws(run, (error) => {
+        assert.ok(error instanceof AgentInputScanError);
+        assert.equal(error.reason, "findings");
+        assert.equal(error.scanDiagnostic?.kind, "unclassified_finding");
+        if (error.scanDiagnostic?.kind === "unclassified_finding") {
+          assert.equal(error.scanDiagnostic.reason, "literal_not_reviewed");
+          assert.equal(error.scanDiagnostic.findingIndex, 2);
+        }
+        return true;
+      });
+      assert.equal(existsSync(f.calls), false);
+      assert.deepEqual(notices, []);
+    } else {
+      assert.equal(run().status, 0);
+      assert.equal(readFileSync(f.calls, "utf8"), "called");
+      assert.equal(notices.length, 1);
+      const notice = JSON.parse(String(notices[0]![0]));
+      assert.equal(notice.event, "agent_input_scan_classified");
+      assert.equal(notice.source, matrix.source);
+      assert.deepEqual(notice.findings.map(({ role }: { role: string }) => role).sort(), [
+        "base",
+        "head",
+      ]);
+      assert.equal(JSON.stringify(notices).includes(matrix.raw), false);
+    }
+    assert.equal(existsSync(readFileSync(receipt, "utf8")), false);
+  });
+}
+
 test("reviewed Signal fixtures preserve exact source, line, decoder, and verification bindings", () => {
   const sources = [
     "extensions/signal/src/client.test.ts",


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed. This is a same-repository branch;
maintainers can update it through repository permissions.

</details>

Related: https://github.com/openclaw/openclaw/pull/146081

## What Problem This Solves

Resolves a problem where review admission rejects the unchanged Matrix test
fixture that verifies embedded URL credentials are rejected. The retained
failure is from
https://github.com/openclaw/clawsweeper/actions/runs/34701393615.

## Why This Change Was Made

Qualifies only the reviewed URI detector 17 PLAIN and HTML attributions through
the existing exact-match table. Both raw-value hashes, complete source line,
path, regular-file mode, metadata, and every committed base/head reference must
match. Scanner flags, version, whole-input coverage, and fail-closed behavior
are unchanged; this is not a path, domain, or test-file exemption.

## User Impact

Reviews can admit this exact negative fixture without changing its target
test or bypassing scanning. Any other finding must independently qualify or
stop admission before a model runs. This does not certify that the blocked
Matrix review will pass its next complete scan.

## OpenClaw Bay Impact

No Bay change is needed. The existing classification notice and review
lifecycle remain unchanged; no dashboard field, API, queue, or action is added.

## Documentation Impact

The active README Safety Model now documents the exact fixture boundary and
evidence limits. The host attribution table remains the source of truth;
fixture, detector, decoder, or attribution-contract changes require renewed
qualification.

## Evidence

- Production-default causal RED: the retained complete native records were
  refused with `literal_not_reviewed` at base line 268 before this change.
  The same records then classified both base/head locations.
- Five focused cases passed, including every-reference checks, PLAIN/HTML
  variants, wrong identities and materials, mixed-known/unknown refusal, and
  no success notice or model callback on refusal.
- Precommit review found no actionable defects. The full repository check
  reported 6,066 passes, five failures and 18 skips; the five failures are in
  unchanged terminal-proof/watchdog owners. One pristine-base control, with
  freshly built base code and the current environment unchanged, selected only
  those five cases and reproduced all five identical assertions. Its detached
  descendants settled naturally at 15:56:16 UTC on September 12, 2026,
  separately verified after runner exit.
- That comparison establishes preexistence on this host, not harmlessness,
  root cause, full-suite parity, or a green full check. The bounded disposition
  was reviewed and accepted. Required precommit and fresh committed-base
  reviews completed with no P0-P2 findings. No tests were rerun for those
  reviews.
- Exact-head CI and a current hosted review are still required before landing.
- No workflow dispatch, live sweep change, Matrix branch change, or hosted
  acceptance is claimed.

## Real Behavior Proof

**Claim and surface:** the production `scanAgentInput` path admits the exact
reviewed Matrix fixture using the unchanged native scanner and production
attribution table.

**Scenario and command:** on Linux with Node 24, a private committed Git fixture
was built from all eight byte-verified source blobs retained from the blocked
Matrix base/head, with a controlled prompt and schema. The production admission
API invoked the installed pinned TruffleHog 3.97.1 with its normal filesystem
flags. A transparent observer retained real child results without changing
arguments or output.

**Observed result:** the scanner returned 183 with two unverified findings;
host classification succeeded, emitted one notice for base line 268 and head
line 314, and removed staging. This fresh local scan observed base PLAIN and
head HTML. The target source was not executed and no model was launched.

**Trace:** retained native output hashes are
`2bf256166ab1c1996c7b6314152b7460900d276983bfab17355baf48d201e0da`
(stdout) and
`28271bd859cfdfe4be434cb9e913f1e41493ed038bea87ff8ba3765befeda491`
(stderr). Private raw records are not published.

**Limits:** the earlier source-only rescan observed PLAIN; HTML test records
are constructed controls, distinct from the fresh native observation.
Neither local run recovers the original hosted second finding or replays its
unretained prompt/schema. After this host qualification is active, the Matrix
review still requires fresh whole-input admission and a completed review.
