### PR TITLE
fix(review): unblock exact WebVNC redaction fixtures

### DIFF
--- a/src/agent-input-scan-fixtures.ts
+++ b/src/agent-input-scan-fixtures.ts
@@ -116,6 +116,21 @@ const REVIEWED_FIXTURES: readonly ReviewedFixture[] = [
     sources: ["worker/test/fleet.test.ts"],
   },
   {
+    // Reviewed WebVNC writer-redaction fixtures (Crabbox #544).
+    fixtureSha256: "18cd62c666a4b48f9968cacc2acc34a27c1f15682219d4f45bfb903cfb3d60fc",
+    rawSha256: "d72aa985328cd8b6b8d13182b028f5e5c06e574b9acfddc31dc5ab0655896050",
+    lineSha256s: ["83b93f401c1c6526ce80cca9860fdbf59825c92e70644a6f087e6a1b46b295e8"],
+    decoders: ["PLAIN"],
+    sources: ["internal/cli/webvnc_test.go"],
+  },
+  {
+    fixtureSha256: "5f63e971f3b95e10c500e2c40cfaf423b47c60e1bbb3c1dad9633cef0aa1a10f",
+    rawSha256: "6a160b5adb896b7ae8e5347258bce211ebcb35f422aa9fc0931d2406403e72ae",
+    lineSha256s: ["83b93f401c1c6526ce80cca9860fdbf59825c92e70644a6f087e6a1b46b295e8"],
+    decoders: ["PLAIN"],
+    sources: ["internal/cli/webvnc_test.go"],
+  },
+  {
     // Approved Mac dashboard subframe rejection witness in OpenClaw 9ba01d6c7b1c.
     fixtureSha256: "97c60d02f5114db97718cfe1c3686c0a36fb5138840611c8793c7abbd9c64f71",
     rawSha256: "43690a8c13d4028ed731bc4dfeb37f83adaa4e5849d2e0fa13f746843adec333",

--- a/test/agent-input-scan-fixtures.test.ts
+++ b/test/agent-input-scan-fixtures.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+test("WebVNC fixture policy retains both exact native identities and source witnesses", () => {
+  // Inspect only the static policy data, without copying credential-shaped fixture values.
+  const source = readFileSync(
+    new URL("../src/agent-input-scan-fixtures.ts", import.meta.url),
+    "utf8",
+  );
+  const declaration = source.match(/const REVIEWED_FIXTURES:[^\n]* = \[([\s\S]*?)\n\];/);
+  assert.ok(declaration);
+  const flatObjects = (array: string) => {
+    const data = array.replace(/\/\/[^\n]*/g, "");
+    assert.equal(data.replace(/\{([^{}]*)\}/g, "").replace(/[\s,]/g, ""), "");
+    return [...data.matchAll(/\{([^{}]*)\}/g)].map((match) => match[1]!);
+  };
+  for (const unsupported of ["wrap({})", "{ nested: {} }", "...other, {}"])
+    assert.throws(() => flatObjects(unsupported));
+  const records = flatObjects(declaration[1]!)
+    .filter((body) => body.includes('"internal/cli/webvnc_test.go"'))
+    .map((body) => {
+      const property = /([A-Za-z]\w*):\s*("(?:[^"\\]|\\.)*"|\[[^\[\]]*\]),/g;
+      const entries = [...body.matchAll(property)].map((match) => {
+        const value: unknown = JSON.parse(match[2]!);
+        assert.ok(
+          typeof value === "string" ||
+            (Array.isArray(value) && value.every((part) => typeof part === "string")),
+        );
+        return [match[1]!, value] as const;
+      });
+      assert.equal(body.replace(property, "").trim(), "");
+      assert.equal(new Set(entries.map(([key]) => key)).size, entries.length);
+      return Object.fromEntries(entries);
+    });
+  assert.deepEqual(records, [
+    {
+      fixtureSha256: "18cd62c666a4b48f9968cacc2acc34a27c1f15682219d4f45bfb903cfb3d60fc",
+      rawSha256: "d72aa985328cd8b6b8d13182b028f5e5c06e574b9acfddc31dc5ab0655896050",
+      lineSha256s: ["83b93f401c1c6526ce80cca9860fdbf59825c92e70644a6f087e6a1b46b295e8"],
+      decoders: ["PLAIN"],
+      sources: ["internal/cli/webvnc_test.go"],
+    },
+    {
+      fixtureSha256: "5f63e971f3b95e10c500e2c40cfaf423b47c60e1bbb3c1dad9633cef0aa1a10f",
+      rawSha256: "6a160b5adb896b7ae8e5347258bce211ebcb35f422aa9fc0931d2406403e72ae",
+      lineSha256s: ["83b93f401c1c6526ce80cca9860fdbf59825c92e70644a6f087e6a1b46b295e8"],
+      decoders: ["PLAIN"],
+      sources: ["internal/cli/webvnc_test.go"],
+    },
+  ]);
+});

--- a/test/agent-input-scan-fixtures.test.ts
+++ b/test/agent-input-scan-fixtures.test.ts
@@ -20,7 +20,7 @@ test("WebVNC fixture policy retains both exact native identities and source witn
   const records = flatObjects(declaration[1]!)
     .filter((body) => body.includes('"internal/cli/webvnc_test.go"'))
     .map((body) => {
-      const property = /([A-Za-z]\w*):\s*("(?:[^"\\]|\\.)*"|\[[^\[\]]*\]),/g;
+      const property = /([A-Za-z]\w*):\s*("(?:[^"\\]|\\.)*"|\[[^[\]]*\]),/g;
       const entries = [...body.matchAll(property)].map((match) => {
         const value: unknown = JSON.parse(match[2]!);
         assert.ok(


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where Crabbox review input is refused because two intentional WebVNC writer-redaction test fixtures have no exact host-owned attribution. This blocks the source review needed for https://github.com/openclaw/crabbox/pull/2075.

## Why This Change Was Made

Add two entries to the existing `REVIEWED_FIXTURES` owner, each binding the native `RawV2` digest, distinct native `Raw` digest, complete original source-line digest, `PLAIN` decoder, and only `internal/cli/webvnc_test.go`. The existing regular-file, native metadata, source-reference, unique-literal and complete-scan checks are unchanged. These are revision-independent byte/path/line bindings, not a test-file or domain exemption.

Fixture purpose was established from the immutable test's direct construction, stable single-use binding to its package writer and test-local `bytes.Buffer`, plus the verified introduction edge associated with https://github.com/openclaw/crabbox/pull/544 (WebVNC credential redaction). Both native pairs were independently bound to the same original test literal. No credential endpoint was contacted and no raw values are included here.

The existing fleet sanitization fixture already qualifies. No fleet entry, classifier, validator, scanner, decoder, runtime export, dependency, or fallback changed. No obsolete path was removed. Production growth is 15 lines of exact policy data; tests add 52 lines. Two separate entries are necessary because the observed native pairs differ; a broader rule would weaken the owner boundary.

## User Impact

Review input containing these exact redaction fixtures can proceed after the normal complete scan. Changed values, lines, paths, modes, decoder variants, verified findings, malformed metadata, and unrelated findings remain blocking. This is the release-note context; `CHANGELOG.md` remains release-owned.

## OpenClaw Bay Impact

None. This changes static input attribution only, not review publication, workflow, queue, status, telemetry, or dashboard contracts.

## Documentation Impact

Reviewed `README.md`'s exact-fixture attribution contract and `CONTRIBUTING.md`. The existing byte/path/mode/line and whole-input admission rules remain accurate; no new operator setting or procedure is introduced.

## Evidence

- Base: `1853caed03ed1175b38412520c3a1f927e4674c3`.
- Signed candidate: `b813a0b6c8c6b1c7776bae6edf88a9ca0c7dcaa5`; tree `ed9e8ba004df14a516e2c2090a8c4fbf4477e60e`. The policy bytes match the validated candidate. The only follow-up removes a redundant regex escape in the hash-only test; its focused test and pre-commit review passed, and no production proof input changed.
- Candidate policy SHA-256: `c8299644637f5a415e75c8e1cae5be27d1d3c37405b31e8e4b05d34f180372f6`.
- `node --test test/agent-input-scan-fixtures.test.ts` on Node 24.16.0: 1 passed. This hash-only regression locks both full policy records and rejects unsupported data-construction syntax without copying credential-shaped fixture values.
- `git diff --check`: passed.
- The existing generic classifier suite remains unchanged. Full `pnpm run check`, including current formatting, builds, lint and coverage, passed on the final head in [CI run 34707392103, attempt 1](https://github.com/openclaw/clawsweeper/actions/runs/34707392103). Windows launcher, Linux review-network sandbox and sparse repair builds also passed. [CodeQL run 34707392091](https://github.com/openclaw/clawsweeper/actions/runs/34707392091) passed.
- Fresh native pre-commit and committed-branch Codex reviews of the original complete diff: no findings. The test-only lint correction passed fresh pre-commit review; the final committed whole-branch review of `b813a0b6c8c6b1c7776bae6edf88a9ca0c7dcaa5` against the exact base also found no actionable regression.
- Initial CI caught a redundant escape in the new test. It was repaired without changing matcher semantics; the final-head CI above is green.

## Real Behavior Proof

**Claim and surface:** the actual unchanged `scanAgentInput` and fixture classifier admit the exact reviewed fixtures after a complete native scan, without weakening refusal behavior.

**Scenario and environment:** Node 24.16.0 on macOS arm64; checksum-verified TruffleHog 3.97.1; candidate policy above and the four unchanged owner modules loaded from the exact base source. Crabbox source comparison was `fd2039ff398a220db7bf6d7daaa1a0d7ba24789a` to `3edd4c23a8f6b327a555bec9b7a899f6fd5cf7cc`. The Go source is regular mode `100644`, blob `4e583538bc5d645253dba7592ee0edf20aa469d0`.

**Command and containment:** a privately retained, independently reviewed `node uri-provenance-local.mjs` harness invoked the production `scanAgentInput` once. Native arguments were unchanged: `filesystem <private-stage> --results=verified,unknown --fail --fail-on-scan-errors --no-update --json --no-color`. A sandbox denied all network access, with an actual `EPERM` probe before source handling. The harness preserved the original native result and classifier outcome, suppressed raw values, bounded time/storage/output, and verified its owned process group and private staging were gone.

**Observed native trace:** 6,561,210 staged bytes; complete source and record accounting; 3 emitted URI/PLAIN records, each `Verified=false` with a real nonempty native `VerificationError`. The classifier admitted the exact Go pair at physical line 642, column 128, plus the already-reviewed fleet base/head records. `canonicalOutcome=admitted`, `productionNativeAdmission=true`, `findingCount=3`, `networkDeniedVerified=true`, `ownedWorkRemoved=true`, `ownedProcessGroupGone=true`.

**Separate deterministic coverage:** 46 explicitly synthetic classifier cases passed against the same candidate bytes. Both actual native pairs passed individually and together. Independent Raw, RawV2, line, path, mode, decoder, verified-state, metadata, source-reference and mixed-unknown mutations refused as expected. Shared valid references and repeated identical native rows retained the existing legacy aggregation contract. Synthetic verification-error fields in these unit inputs are not native-verification evidence.

**Identity and limits:** a prior single pinned no-verification acquisition bound both native pairs to the two physical occurrences at 642:128 and 642:190 in the same original test literal and full source line. It was identity proof only, not admission. The production scan was not rerun to force both variants. The original hosted prompt and schema were unavailable, so this is not a replay of the archived hosted failure or a completed review of the Crabbox PR. AST observations establish this narrow test purpose, not global absence of I/O. New source, prompt, schema, or policy still needs normal fresh whole-input admission and review.
